### PR TITLE
feat: protocol correctness tests + fix openclaw-channel test-utils subpath

### DIFF
--- a/packages/openclaw-channel/package.json
+++ b/packages/openclaw-channel/package.json
@@ -11,14 +11,16 @@
   "files": [
     "dist",
     "!dist/__tests__",
-    "!dist/test-utils",
     "openclaw.plugin.json"
   ],
   "main": "./dist/channel.js",
   "types": "./dist/channel.d.ts",
   "exports": {
     ".": "./dist/channel.js",
-    "./test-utils": "./src/test-utils/container-core.ts"
+    "./test-utils": {
+      "import": "./dist/test-utils/container-core.js",
+      "types": "./dist/test-utils/container-core.d.ts"
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/packages/server-core/src/__tests__/integration/23-reactions.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/23-reactions.integration.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { startTestServer, stopTestServer, resetTestDb } from "./helpers.js";
+import { registerAndConnect } from "./helpers.js";
+
+beforeAll(async () => {
+  await startTestServer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("Reactions", () => {
+  it("add reaction broadcasts event to conversation participants", async () => {
+    const alice = await registerAndConnect("alice-react");
+    const bob = await registerAndConnect("bob-react");
+
+    const conv = (await alice.client.rpc("conversations/create", {
+      type: "dm",
+      participants: [{ type: "agent", id: bob.agentId }],
+    })) as { conversation: { id: string } };
+
+    const msg = (await alice.client.rpc("messages/send", {
+      conversationId: conv.conversation.id,
+      parts: [{ type: "text", text: "React to this" }],
+    })) as { message: { id: string } };
+
+    const bobReactPromise = bob.client.waitForEvent("messages/reacted");
+    await alice.client.rpc("messages/react", {
+      messageId: msg.message.id,
+      emoji: "👍",
+      action: "add",
+    });
+
+    const reactEvent = await bobReactPromise;
+    const data = reactEvent.data as {
+      messageId: string;
+      emoji: string;
+      action: string;
+    };
+    expect(data.messageId).toBe(msg.message.id);
+    expect(data.emoji).toBe("👍");
+    expect(data.action).toBe("add");
+  });
+
+  it("remove reaction broadcasts event", async () => {
+    const alice = await registerAndConnect("alice-unreact");
+    const bob = await registerAndConnect("bob-unreact");
+
+    const conv = (await alice.client.rpc("conversations/create", {
+      type: "dm",
+      participants: [{ type: "agent", id: bob.agentId }],
+    })) as { conversation: { id: string } };
+
+    const msg = (await alice.client.rpc("messages/send", {
+      conversationId: conv.conversation.id,
+      parts: [{ type: "text", text: "Unreact test" }],
+    })) as { message: { id: string } };
+
+    await alice.client.rpc("messages/react", {
+      messageId: msg.message.id,
+      emoji: "🔥",
+      action: "add",
+    });
+    await bob.client.waitForEvent("messages/reacted");
+
+    const bobRemovePromise = bob.client.waitForEvent("messages/reacted");
+    await alice.client.rpc("messages/react", {
+      messageId: msg.message.id,
+      emoji: "🔥",
+      action: "remove",
+    });
+
+    const removeEvent = await bobRemovePromise;
+    const data = removeEvent.data as { action: string; emoji: string };
+    expect(data.action).toBe("remove");
+    expect(data.emoji).toBe("🔥");
+  });
+});

--- a/packages/server-core/src/__tests__/integration/24-read-receipts.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/24-read-receipts.integration.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { startTestServer, stopTestServer, resetTestDb } from "./helpers.js";
+import { registerAndConnect } from "./helpers.js";
+
+beforeAll(async () => {
+  await startTestServer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("Read Receipts", () => {
+  it("messages/read broadcasts MessageRead event to sender", async () => {
+    const alice = await registerAndConnect("alice-read");
+    const bob = await registerAndConnect("bob-read");
+
+    const conv = (await alice.client.rpc("conversations/create", {
+      type: "dm",
+      participants: [{ type: "agent", id: bob.agentId }],
+    })) as { conversation: { id: string } };
+
+    const bobMsgPromise = bob.client.waitForEvent("messages/received");
+    const msg = (await alice.client.rpc("messages/send", {
+      conversationId: conv.conversation.id,
+      parts: [{ type: "text", text: "Read me" }],
+    })) as { message: { id: string; seq: number } };
+
+    await bobMsgPromise;
+
+    const aliceReadPromise = alice.client.waitForEvent("messages/read");
+    await bob.client.rpc("messages/read", {
+      conversationId: conv.conversation.id,
+      seq: msg.message.seq,
+    });
+
+    const readEvent = await aliceReadPromise;
+    const data = readEvent.data as {
+      conversationId: string;
+      participant: { type: string; id: string };
+      seq: number;
+    };
+    expect(data.conversationId).toBe(conv.conversation.id);
+    expect(data.participant.id).toBe(bob.agentId);
+    expect(data.seq).toBe(msg.message.seq);
+  });
+});

--- a/packages/server-core/src/__tests__/integration/25-typing-indicators.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/25-typing-indicators.integration.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { startTestServer, stopTestServer, resetTestDb } from "./helpers.js";
+import { registerAndConnect } from "./helpers.js";
+
+beforeAll(async () => {
+  await startTestServer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("Typing Indicators", () => {
+  it("typing/send broadcasts TypingIndicator event to conversation", async () => {
+    const alice = await registerAndConnect("alice-typing");
+    const bob = await registerAndConnect("bob-typing");
+
+    const conv = (await alice.client.rpc("conversations/create", {
+      type: "dm",
+      participants: [{ type: "agent", id: bob.agentId }],
+    })) as { conversation: { id: string } };
+
+    const bobTypingPromise = bob.client.waitForEvent("typing/indicator");
+    await alice.client.rpc("typing/send", {
+      conversationId: conv.conversation.id,
+    });
+
+    const typingEvent = await bobTypingPromise;
+    const data = typingEvent.data as {
+      conversationId: string;
+      participant: { type: string; id: string };
+    };
+    expect(data.conversationId).toBe(conv.conversation.id);
+    expect(data.participant.id).toBe(alice.agentId);
+    expect(data.participant.type).toBe("agent");
+  });
+});

--- a/packages/server-core/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { startTestServer, stopTestServer, resetTestDb } from "./helpers.js";
+import { registerAndConnect } from "./helpers.js";
+
+beforeAll(async () => {
+  await startTestServer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("Presence Lifecycle", () => {
+  it("subscribe returns online status for connected agent", async () => {
+    const alice = await registerAndConnect("alice-pres");
+    const bob = await registerAndConnect("bob-pres");
+
+    const result = (await alice.client.rpc("presence/subscribe", {
+      participants: [{ type: "agent", id: bob.agentId }],
+    })) as { statuses: Array<{ participant: { id: string }; status: string }> };
+
+    expect(result.statuses).toHaveLength(1);
+    expect(result.statuses[0]!.status).toBe("online");
+  });
+
+  it("presence/update pushes PresenceChanged to subscribers", async () => {
+    const alice = await registerAndConnect("alice-away");
+    const bob = await registerAndConnect("bob-away");
+
+    await alice.client.rpc("presence/subscribe", {
+      participants: [{ type: "agent", id: bob.agentId }],
+    });
+
+    const presPromise = alice.client.waitForEvent("presence/changed");
+    await bob.client.rpc("presence/update", { status: "away" });
+
+    const event = await presPromise;
+    const data = event.data as {
+      participant: { id: string };
+      status: string;
+    };
+    expect(data.participant.id).toBe(bob.agentId);
+    expect(data.status).toBe("away");
+  });
+
+  it("presence cycles through online → away → offline", async () => {
+    const alice = await registerAndConnect("alice-cycle");
+    const bob = await registerAndConnect("bob-cycle");
+
+    await alice.client.rpc("presence/subscribe", {
+      participants: [{ type: "agent", id: bob.agentId }],
+    });
+
+    // away
+    const awayPromise = alice.client.waitForEvent("presence/changed");
+    await bob.client.rpc("presence/update", { status: "away" });
+    const awayEvent = await awayPromise;
+    expect((awayEvent.data as { status: string }).status).toBe("away");
+
+    // back online
+    const onlinePromise = alice.client.waitForEvent("presence/changed");
+    await bob.client.rpc("presence/update", { status: "online" });
+    const onlineEvent = await onlinePromise;
+    expect((onlineEvent.data as { status: string }).status).toBe("online");
+
+    // offline
+    const offlinePromise = alice.client.waitForEvent("presence/changed");
+    await bob.client.rpc("presence/update", { status: "offline" });
+    const offlineEvent = await offlinePromise;
+    expect((offlineEvent.data as { status: string }).status).toBe("offline");
+  });
+});

--- a/packages/server-core/src/__tests__/integration/27-message-deletion.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/27-message-deletion.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { startTestServer, stopTestServer, resetTestDb } from "./helpers.js";
+import { registerAndConnect } from "./helpers.js";
+
+beforeAll(async () => {
+  await startTestServer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("Message Deletion", () => {
+  it("messages/delete broadcasts MessageDeleted and excludes from history", async () => {
+    const alice = await registerAndConnect("alice-del");
+    const bob = await registerAndConnect("bob-del");
+
+    const conv = (await alice.client.rpc("conversations/create", {
+      type: "dm",
+      participants: [{ type: "agent", id: bob.agentId }],
+    })) as { conversation: { id: string } };
+
+    await bob.client.waitForEvent("conversations/created");
+
+    const msg = (await alice.client.rpc("messages/send", {
+      conversationId: conv.conversation.id,
+      parts: [{ type: "text", text: "Delete me" }],
+    })) as { message: { id: string } };
+
+    await bob.client.waitForEvent("messages/received");
+
+    const bobDeletePromise = bob.client.waitForEvent("messages/deleted");
+    await alice.client.rpc("messages/delete", {
+      messageId: msg.message.id,
+    });
+
+    const deleteEvent = await bobDeletePromise;
+    const data = deleteEvent.data as {
+      messageId: string;
+      conversationId: string;
+    };
+    expect(data.messageId).toBe(msg.message.id);
+    expect(data.conversationId).toBe(conv.conversation.id);
+
+    // Deleted message should not appear in history
+    const history = (await alice.client.rpc("messages/list", {
+      conversationId: conv.conversation.id,
+    })) as { messages: Array<{ id: string }> };
+    expect(
+      history.messages.find((m) => m.id === msg.message.id),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

5 new integration test files covering protocol features that had no dedicated tests:
- **23-reactions**: add/remove reaction broadcasts events
- **24-read-receipts**: messages/read broadcasts MessageRead event
- **25-typing-indicators**: typing/send broadcasts TypingIndicator
- **26-presence-lifecycle**: subscribe snapshot, away/online/offline cycle
- **27-message-deletion**: delete broadcasts event, excluded from history

Tech debt: openclaw-channel test-utils subpath now points to dist/.

22 integration test files, 36 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)