### PR TITLE
fix: conversations/get LEFT JOIN UUID cast mismatch

### DIFF
--- a/packages/server-core/src/__tests__/integration/28-conversations-get.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/28-conversations-get.integration.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  registerAndConnect,
+} from "./helpers.js";
+
+let baseUrl: string;
+let wsUrl: string;
+
+beforeAll(async () => {
+  const server = await startTestServer();
+  baseUrl = server.baseUrl;
+  wsUrl = server.wsUrl;
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("Scenario 28: conversations/get with UUID columns", () => {
+  it("returns conversation details and participants for a DM", async () => {
+    const alice = await registerAndConnect("alice-get");
+    const bob = await registerAndConnect("bob-get");
+
+    // Create a DM
+    const conv = (await alice.client.rpc("conversations/create", {
+      type: "dm",
+      participants: [{ type: "agent", id: bob.agentId }],
+    })) as { conversation: { id: string; type: string } };
+
+    const conversationId = conv.conversation.id;
+
+    // Get the conversation — this exercises the LEFT JOIN with UUID columns
+    const result = (await alice.client.rpc("conversations/get", {
+      conversationId,
+    })) as {
+      conversation: { id: string; type: string; name: string | null };
+      participants: Array<{
+        participant: { type: string; id: string };
+        role: string;
+      }>;
+    };
+
+    expect(result.conversation.id).toBe(conversationId);
+    expect(result.conversation.type).toBe("dm");
+    expect(result.participants).toHaveLength(2);
+
+    const participantIds = result.participants.map((p) => p.participant.id);
+    expect(participantIds).toContain(alice.agentId);
+    expect(participantIds).toContain(bob.agentId);
+  });
+
+  it("returns conversation details for a group with agent names", async () => {
+    const alice = await registerAndConnect("alice-grp-get");
+    const bob = await registerAndConnect("bob-grp-get");
+
+    // Create a group
+    const conv = (await alice.client.rpc("conversations/create", {
+      type: "group",
+      name: "Test Group",
+      participants: [{ type: "agent", id: bob.agentId }],
+    })) as { conversation: { id: string; type: string; name: string } };
+
+    const conversationId = conv.conversation.id;
+
+    // Get the conversation — the LEFT JOIN on agents table must work with UUID columns
+    const result = (await alice.client.rpc("conversations/get", {
+      conversationId,
+    })) as {
+      conversation: { id: string; type: string; name: string };
+      participants: Array<{
+        participant: { type: string; id: string };
+        role: string;
+        agentName?: string;
+      }>;
+    };
+
+    expect(result.conversation.id).toBe(conversationId);
+    expect(result.conversation.type).toBe("group");
+    expect(result.conversation.name).toBe("Test Group");
+    expect(result.participants).toHaveLength(2);
+  });
+});

--- a/packages/server-core/src/services/conversation.service.ts
+++ b/packages/server-core/src/services/conversation.service.ts
@@ -246,7 +246,7 @@ export class ConversationService {
       .selectFrom("conversation_participants as cp")
       .leftJoin("agents as a", (join) =>
         join.on(
-          sql`cp.participant_type = 'agent' AND cp.participant_id = a.id::text`,
+          sql`cp.participant_type = 'agent' AND cp.participant_id::text = a.id::text`,
         ),
       )
       .select([


### PR DESCRIPTION
## Problem

`ConversationService.get()` has a LEFT JOIN with raw SQL:
```sql
cp.participant_id = a.id::text
```

This compares `UUID = TEXT` — PostgreSQL rejects this without an explicit cast.

The error manifests as: `operator does not exist: uuid = text` when any client calls `conversations/get`.

## Fix

Cast both sides to text:
```sql
cp.participant_id::text = a.id::text
```

## Test

Added integration test 28 (`28-conversations-get.integration.test.ts`) that exercises `conversations/get` for both DM and group conversations, verifying the LEFT JOIN works correctly with UUID columns.

All 24 integration test files pass (40 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)