### PR TITLE
feat: make @moltzap/evals a consumable library

### DIFF
--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -1,11 +1,21 @@
 {
   "name": "@moltzap/evals",
-  "version": "0.1.0",
-  "private": true,
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
+    "build": "tsc",
     "eval:e2e": "tsx src/e2e-infra/index.ts",
     "build:docker": "bash scripts/build-eval-agent.sh"
+  },
+  "exports": {
+    "./logger": { "import": "./dist/e2e-infra/logger.js", "types": "./dist/e2e-infra/logger.d.ts" },
+    "./rate-limiter": { "import": "./dist/e2e-infra/rate-limiter.js", "types": "./dist/e2e-infra/rate-limiter.d.ts" },
+    "./ai": { "import": "./dist/e2e-infra/ai.js", "types": "./dist/e2e-infra/ai.d.ts" },
+    "./model-config": { "import": "./dist/e2e-infra/model-config.js", "types": "./dist/e2e-infra/model-config.d.ts" },
+    "./types": { "import": "./dist/e2e-infra/types.js", "types": "./dist/e2e-infra/types.d.ts" },
+    "./report": { "import": "./dist/e2e-infra/report.js", "types": "./dist/e2e-infra/report.d.ts" },
+    "./llm-judge": { "import": "./dist/e2e-infra/llm-judge.js", "types": "./dist/e2e-infra/llm-judge.d.ts" },
+    "./docker-manager": { "import": "./dist/e2e-infra/docker-manager.js", "types": "./dist/e2e-infra/docker-manager.d.ts" }
   },
   "dependencies": {
     "@genkit-ai/google-genai": "^1.24.0",

--- a/packages/evals/src/e2e-infra/docker-manager.ts
+++ b/packages/evals/src/e2e-infra/docker-manager.ts
@@ -8,12 +8,15 @@
  */
 
 import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import {
   buildOpenClawConfig,
   startRawContainer,
   waitForGateway,
   getLogs,
   stopContainer as stopRawContainer,
+  OPENCLAW_STATE_DIR,
   type ContainerModelConfig,
   type OpenClawContainer,
 } from "@moltzap/openclaw-channel/test-utils";
@@ -58,6 +61,7 @@ export class DockerManager {
     moltzapApiKey?: string;
     configOverride?: Record<string, unknown>;
     extraEnv?: Record<string, string>;
+    workspaceFiles?: Array<{ relativePath: string; content: string }>;
   }): Promise<AgentContainer> {
     let openclawConfig: Record<string, unknown>;
 
@@ -97,6 +101,20 @@ export class DockerManager {
       agentName: opts.name,
       envVars,
     });
+
+    // Write custom workspace files into the container after creation.
+    if (opts.workspaceFiles) {
+      for (const file of opts.workspaceFiles) {
+        const filePath = path.join(raw.tmpDir, "workspace", file.relativePath);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, file.content);
+      }
+      // Copy updated workspace into the running container and fix ownership.
+      execSync(`docker cp ${raw.tmpDir}/workspace/. ${raw.containerId}:${OPENCLAW_STATE_DIR}/workspace/`);
+      execSync(
+        `docker exec -u root ${raw.containerId} sh -lc "chown -R node:node ${OPENCLAW_STATE_DIR}/workspace"`,
+      );
+    }
 
     await waitForGateway(raw.containerId, 60_000);
 

--- a/packages/evals/src/e2e-infra/llm-judge.ts
+++ b/packages/evals/src/e2e-infra/llm-judge.ts
@@ -196,35 +196,83 @@ export const evaluationFlow = ai.defineFlow(
   },
 );
 
+/** Run a single judge evaluation with a custom or default prompt. */
+async function runJudge(opts: {
+  scenario: EvalScenario;
+  agentResponse: string;
+  conversationContext: string;
+  evalModel: string;
+  buildPrompt?: (opts: { scenario: EvalScenario; agentResponse: string; conversationContext: string }) => string;
+}): Promise<JudgeResult> {
+  if (opts.buildPrompt) {
+    const evalPrompt = opts.buildPrompt({
+      scenario: opts.scenario,
+      agentResponse: opts.agentResponse,
+      conversationContext: opts.conversationContext,
+    });
+
+    const estimatedTokens = Math.ceil(evalPrompt.length / 2.5);
+    const judgeModel = resolveJudgeModel(opts.evalModel);
+
+    await rateLimiter.acquirePermit(judgeModel, estimatedTokens);
+
+    const response = await ai.generate({
+      prompt: evalPrompt,
+      model: `googleai/${opts.evalModel}`,
+      output: { schema: JudgeResultSchema },
+    });
+
+    const result = response.output;
+    if (!result) {
+      throw new Error("No output from judge model");
+    }
+
+    return {
+      pass: result.pass,
+      reason: result.reason || "No reason provided",
+      issues: result.issues || [],
+    };
+  }
+
+  const result = await evaluationFlow({
+    scenarioId: opts.scenario.id,
+    scenarioName: opts.scenario.name,
+    scenarioDescription: opts.scenario.description,
+    setupMessage: opts.scenario.setupMessage,
+    expectedBehavior: opts.scenario.expectedBehavior,
+    validationChecks: opts.scenario.validationChecks,
+    agentResponse: opts.agentResponse,
+    conversationContext: opts.conversationContext,
+    evalModel: opts.evalModel,
+  });
+
+  return {
+    pass: result.pass,
+    reason: result.reason,
+    issues: result.issues,
+  };
+}
+
 /** Evaluate a single agent response using the LLM judge. */
 export async function judgeAgentResponse(opts: {
   scenario: EvalScenario;
   agentResponse: string;
   conversationContext: string;
   evalModel?: string;
+  buildPrompt?: (opts: { scenario: EvalScenario; agentResponse: string; conversationContext: string }) => string;
 }): Promise<JudgeResult> {
   const evalModel = opts.evalModel ?? DEFAULT_JUDGE_MODEL;
 
   const maxRetries = 3;
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
-      const result = await evaluationFlow({
-        scenarioId: opts.scenario.id,
-        scenarioName: opts.scenario.name,
-        scenarioDescription: opts.scenario.description,
-        setupMessage: opts.scenario.setupMessage,
-        expectedBehavior: opts.scenario.expectedBehavior,
-        validationChecks: opts.scenario.validationChecks,
+      return await runJudge({
+        scenario: opts.scenario,
         agentResponse: opts.agentResponse,
         conversationContext: opts.conversationContext,
         evalModel,
+        buildPrompt: opts.buildPrompt,
       });
-
-      return {
-        pass: result.pass,
-        reason: result.reason,
-        issues: result.issues,
-      };
     } catch (e: unknown) {
       if (attempt === maxRetries - 1) {
         const err = e as Error;

--- a/packages/evals/tsconfig.json
+++ b/packages/evals/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
   },
-  "include": ["src"],
-  "exclude": ["dist", "node_modules"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Adds subpath exports, build script, and extension points (workspaceFiles, buildPrompt) so the evals package can be consumed as a workspace dependency by downstream repos like moltzap-arena.