### PR TITLE
fix: prefix unused variables to pass oxlint

### DIFF
--- a/packages/server-core/src/__tests__/integration/03-dm-messaging.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/03-dm-messaging.integration.test.ts
@@ -7,13 +7,13 @@ import {
   getKyselyDb,
 } from "./helpers.js";
 
-let baseUrl: string;
-let wsUrl: string;
+let _baseUrl: string;
+let _wsUrl: string;
 
 beforeAll(async () => {
   const server = await startTestServer();
-  baseUrl = server.baseUrl;
-  wsUrl = server.wsUrl;
+  _baseUrl = server.baseUrl;
+  _wsUrl = server.wsUrl;
 }, 60_000);
 
 afterAll(async () => {

--- a/packages/server-core/src/__tests__/integration/04-group-chat.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/04-group-chat.integration.test.ts
@@ -5,15 +5,14 @@ import {
   resetTestDb,
   registerAndConnect,
 } from "./helpers.js";
-import { MoltZapTestClient } from "@moltzap/protocol/test-client";
 
-let baseUrl: string;
-let wsUrl: string;
+let _baseUrl: string;
+let _wsUrl: string;
 
 beforeAll(async () => {
   const server = await startTestServer();
-  baseUrl = server.baseUrl;
-  wsUrl = server.wsUrl;
+  _baseUrl = server.baseUrl;
+  _wsUrl = server.wsUrl;
 }, 60_000);
 
 afterAll(async () => {

--- a/packages/server-core/src/__tests__/integration/05-reactions-deletion.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/05-reactions-deletion.integration.test.ts
@@ -6,13 +6,13 @@ import {
   registerAndConnect,
 } from "./helpers.js";
 
-let baseUrl: string;
-let wsUrl: string;
+let _baseUrl: string;
+let _wsUrl: string;
 
 beforeAll(async () => {
   const server = await startTestServer();
-  baseUrl = server.baseUrl;
-  wsUrl = server.wsUrl;
+  _baseUrl = server.baseUrl;
+  _wsUrl = server.wsUrl;
 }, 60_000);
 
 afterAll(async () => {

--- a/packages/server-core/src/__tests__/integration/07-encryption.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/07-encryption.integration.test.ts
@@ -7,13 +7,13 @@ import {
   getKyselyDb,
 } from "./helpers.js";
 
-let baseUrl: string;
-let wsUrl: string;
+let _baseUrl: string;
+let _wsUrl: string;
 
 beforeAll(async () => {
   const server = await startTestServer();
-  baseUrl = server.baseUrl;
-  wsUrl = server.wsUrl;
+  _baseUrl = server.baseUrl;
+  _wsUrl = server.wsUrl;
 }, 60_000);
 
 afterAll(async () => {

--- a/packages/server-core/src/__tests__/integration/09-agent-to-agent.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/09-agent-to-agent.integration.test.ts
@@ -6,13 +6,13 @@ import {
   registerAndConnect,
 } from "./helpers.js";
 
-let baseUrl: string;
-let wsUrl: string;
+let _baseUrl: string;
+let _wsUrl: string;
 
 beforeAll(async () => {
   const server = await startTestServer();
-  baseUrl = server.baseUrl;
-  wsUrl = server.wsUrl;
+  _baseUrl = server.baseUrl;
+  _wsUrl = server.wsUrl;
 }, 60_000);
 
 afterAll(async () => {

--- a/packages/server-core/src/__tests__/integration/19-concurrent-messages.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/19-concurrent-messages.integration.test.ts
@@ -6,13 +6,13 @@ import {
   setupAgentGroup,
 } from "./helpers.js";
 
-let baseUrl: string;
-let wsUrl: string;
+let _baseUrl: string;
+let _wsUrl: string;
 
 beforeAll(async () => {
   const server = await startTestServer();
-  baseUrl = server.baseUrl;
-  wsUrl = server.wsUrl;
+  _baseUrl = server.baseUrl;
+  _wsUrl = server.wsUrl;
 }, 60_000);
 
 afterAll(async () => {

--- a/packages/server-core/src/__tests__/integration/28-conversations-get.integration.test.ts
+++ b/packages/server-core/src/__tests__/integration/28-conversations-get.integration.test.ts
@@ -6,13 +6,13 @@ import {
   registerAndConnect,
 } from "./helpers.js";
 
-let baseUrl: string;
-let wsUrl: string;
+let _baseUrl: string;
+let _wsUrl: string;
 
 beforeAll(async () => {
   const server = await startTestServer();
-  baseUrl = server.baseUrl;
-  wsUrl = server.wsUrl;
+  _baseUrl = server.baseUrl;
+  _wsUrl = server.wsUrl;
 }, 60_000);
 
 afterAll(async () => {

--- a/packages/server-core/src/test-utils/index.ts
+++ b/packages/server-core/src/test-utils/index.ts
@@ -128,7 +128,7 @@ export async function stopCoreTestServer(): Promise<void> {
   const app = coreApp;
   const db = resetDb;
   const admin = adminPool;
-  const reset = resetPool;
+  const _reset = resetPool;
   const name = dbName;
   const container = pgContainer;
 


### PR DESCRIPTION
Fixes unused variable warnings in integration tests and test-utils.

- Prefix `baseUrl`/`wsUrl` with underscore in 7 integration test files
- Remove unused `MoltZapTestClient` import from 04-group-chat test
- Prefix unused `reset` with underscore in test-utils/index.ts