### PR TITLE
refactor: absorb CLI into @moltzap/client package

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 
+pnpm format:check
 pnpm check
 pnpm typecheck
 ./scripts/sloppy-code-guard.sh

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ metadata:
       {
         "emoji": "💬",
         "requires": { "bins": ["moltzap"] },
-        "install": "npm install @moltzap/cli@latest",
+        "install": "npm install @moltzap/client@latest",
       },
   }
 ---
@@ -34,7 +34,7 @@ If `moltzap` is not installed yet, run these steps in order:
 ### Step 1: Install the CLI and channel plugin
 
 ```bash
-npm install @moltzap/cli@latest
+npm install @moltzap/client@latest
 openclaw plugins install @moltzap/openclaw-channel
 ```
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,6 +13,9 @@
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "moltzap": "./dist/cli/index.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -26,6 +29,7 @@
   },
   "dependencies": {
     "@moltzap/protocol": "workspace:*",
+    "commander": "^13.0.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/client/src/cli/commands/agents.ts
+++ b/packages/client/src/cli/commands/agents.ts
@@ -1,0 +1,56 @@
+import { Command } from "commander";
+import { withService } from "../with-service.js";
+import type { AgentCard } from "@moltzap/protocol";
+
+export const agentsCommand = new Command("agents").description(
+  "List and look up agents on MoltZap",
+);
+
+agentsCommand
+  .option("--json", "Output as JSON")
+  .action(async (opts: { json?: boolean }) => {
+    await withService(async (service) => {
+      const result = (await service.sendRpc("agents/list", {})) as {
+        agents: Record<string, AgentCard>;
+      };
+      const entries = Object.values(result.agents);
+      if (opts.json) {
+        console.log(JSON.stringify(result.agents, null, 2));
+        return;
+      }
+      if (entries.length === 0) {
+        console.log("No agents found.");
+        return;
+      }
+      for (const agent of entries) {
+        let line = agent.name;
+        if (agent.displayName) line += ` (${agent.displayName})`;
+        line += `\n  ID: ${agent.id}\n  Status: ${agent.status}`;
+        if (agent.description) line += `\n  Description: ${agent.description}`;
+        console.log(line + "\n");
+      }
+    });
+  });
+
+agentsCommand
+  .command("lookup")
+  .description("Look up agents by name")
+  .argument("<names...>", "Agent names to look up")
+  .action(async (names: string[]) => {
+    await withService(async (service) => {
+      const result = (await service.sendRpc("agents/lookupByName", {
+        names,
+      })) as { agents: AgentCard[] };
+
+      if (result.agents.length === 0) {
+        console.log("No agents found.");
+        return;
+      }
+
+      for (const agent of result.agents) {
+        let line = `Agent: ${agent.name}\n  ID: ${agent.id}\n  Status: ${agent.status}`;
+        if (agent.description) line += `\n  Description: ${agent.description}`;
+        console.log(line + "\n");
+      }
+    });
+  });

--- a/packages/client/src/cli/commands/contacts.ts
+++ b/packages/client/src/cli/commands/contacts.ts
@@ -1,0 +1,97 @@
+import { Command } from "commander";
+import { withService } from "../with-service.js";
+import type { Contact } from "@moltzap/protocol";
+
+export const contactsCommand = new Command("contacts").description(
+  "Manage contacts",
+);
+
+contactsCommand
+  .command("list")
+  .description("List contacts")
+  .option("--status <status>", "Filter by status (pending, accepted, blocked)")
+  .option("--json", "Output as JSON")
+  .action(async (opts: { status?: string; json?: boolean }) => {
+    await withService(async (service) => {
+      const params: Record<string, unknown> = {};
+      if (opts.status) params.status = opts.status;
+
+      const result = (await service.sendRpc("contacts/list", params)) as {
+        contacts: Contact[];
+      };
+
+      if (opts.json) {
+        console.log(JSON.stringify(result.contacts, null, 2));
+        return;
+      }
+
+      if (result.contacts.length === 0) {
+        console.log("No contacts found.");
+        return;
+      }
+
+      for (const c of result.contacts) {
+        const requester = c.requesterName ?? c.requesterPhone ?? c.requesterId;
+        const target = c.targetName ?? c.targetPhone ?? c.targetId;
+        console.log(`  ${c.id}  ${c.status}  ${requester} -> ${target}`);
+      }
+    });
+  });
+
+contactsCommand
+  .command("add")
+  .description("Add a contact by phone number or user ID")
+  .argument("<identifier>", "Phone number (+E.164) or user ID")
+  .action(async (identifier: string) => {
+    await withService(async (service) => {
+      const params: Record<string, string> = {};
+      if (identifier.startsWith("+")) {
+        params.phone = identifier;
+      } else {
+        params.userId = identifier;
+      }
+
+      const result = (await service.sendRpc("contacts/add", params)) as {
+        contactId: string;
+        status: string;
+      };
+      console.log(
+        `Contact request sent (id: ${result.contactId}, status: ${result.status})`,
+      );
+    });
+  });
+
+contactsCommand
+  .command("accept")
+  .description("Accept a contact request")
+  .argument("<contactId>", "Contact ID to accept")
+  .action(async (contactId: string) => {
+    await withService(async (service) => {
+      const result = (await service.sendRpc("contacts/accept", {
+        contactId,
+      })) as { contact: Contact };
+      console.log(`Contact accepted: ${result.contact.id}`);
+    });
+  });
+
+contactsCommand
+  .command("block")
+  .description("Block a contact")
+  .argument("<contactId>", "Contact ID to block")
+  .action(async (contactId: string) => {
+    await withService(async (service) => {
+      await service.sendRpc("contacts/block", { contactId });
+      console.log(`Contact ${contactId} blocked.`);
+    });
+  });
+
+contactsCommand
+  .command("remove")
+  .description("Remove a contact")
+  .argument("<contactId>", "Contact ID to remove")
+  .action(async (contactId: string) => {
+    await withService(async (service) => {
+      await service.sendRpc("contacts/remove", { contactId });
+      console.log(`Contact ${contactId} removed.`);
+    });
+  });

--- a/packages/client/src/cli/commands/conversations.ts
+++ b/packages/client/src/cli/commands/conversations.ts
@@ -1,0 +1,239 @@
+import { Command } from "commander";
+import { withService } from "../with-service.js";
+import { resolveParticipant } from "../resolve.js";
+import type { MoltZapService } from "../../service.js";
+import type { ConversationSummary, Message } from "@moltzap/protocol";
+
+export const conversationsCommand = new Command("conversations").description(
+  "Manage conversations",
+);
+
+conversationsCommand
+  .command("list")
+  .description("List conversations with unread counts")
+  .option("--limit <n>", "Max conversations to list", "20")
+  .option("--json", "Output as JSON")
+  .action(async (opts: { limit: string; json?: boolean }) => {
+    await withService(async (service) => {
+      const result = (await service.sendRpc("conversations/list", {
+        limit: parseInt(opts.limit, 10),
+      })) as { conversations: ConversationSummary[] };
+
+      if (opts.json) {
+        console.log(JSON.stringify(result.conversations, null, 2));
+        return;
+      }
+      if (result.conversations.length === 0) {
+        console.log("No conversations.");
+        return;
+      }
+      for (const c of result.conversations) {
+        const unread = c.unreadCount > 0 ? ` (${c.unreadCount} unread)` : "";
+        const name = c.name ?? c.type;
+        console.log(`  ${c.id}  ${name}${unread}`);
+        if (c.lastMessagePreview) {
+          console.log(`    Last: ${c.lastMessagePreview}`);
+        }
+      }
+    });
+  });
+
+conversationsCommand
+  .command("create")
+  .description("Create a new conversation")
+  .argument("<name>", "Conversation name")
+  .argument("<participant...>", "Participants (e.g. agent:bob)")
+  .option("--type <type>", "Conversation type: dm or group")
+  .action(
+    async (name: string, participants: string[], opts: { type?: string }) => {
+      await withService(async (service) => {
+        const parsed = await Promise.all(
+          participants.map((p) => resolveParticipant(service, p)),
+        );
+        const convType = opts.type ?? (parsed.length === 1 ? "dm" : "group");
+        const result = (await service.sendRpc("conversations/create", {
+          type: convType,
+          name,
+          participants: parsed,
+        })) as { conversation: { id: string; type: string } };
+        console.log(
+          `Conversation created: ${result.conversation.id} (${result.conversation.type})`,
+        );
+      });
+    },
+  );
+
+conversationsCommand
+  .command("leave")
+  .description("Leave a conversation")
+  .argument("<conversationId>", "Conversation ID")
+  .action(async (conversationId: string) => {
+    await withService(async (service) => {
+      await service.sendRpc("conversations/leave", { conversationId });
+      console.log(`Left conversation ${conversationId}.`);
+    });
+  });
+
+conversationsCommand
+  .command("mute")
+  .description("Mute a conversation")
+  .argument("<conversationId>", "Conversation ID")
+  .option("--until <datetime>", "Mute until ISO datetime")
+  .action(async (conversationId: string, opts: { until?: string }) => {
+    await withService(async (service) => {
+      const params: Record<string, string> = { conversationId };
+      if (opts.until) params.until = opts.until;
+      await service.sendRpc("conversations/mute", params);
+      console.log(
+        opts.until
+          ? `Conversation ${conversationId} muted until ${opts.until}.`
+          : `Conversation ${conversationId} muted.`,
+      );
+    });
+  });
+
+conversationsCommand
+  .command("unmute")
+  .description("Unmute a conversation")
+  .argument("<conversationId>", "Conversation ID")
+  .action(async (conversationId: string) => {
+    await withService(async (service) => {
+      await service.sendRpc("conversations/unmute", { conversationId });
+      console.log(`Conversation ${conversationId} unmuted.`);
+    });
+  });
+
+conversationsCommand
+  .command("update")
+  .description("Update conversation settings")
+  .argument("<conversationId>", "Conversation ID")
+  .requiredOption("--name <name>", "New conversation name")
+  .action(async (conversationId: string, opts: { name: string }) => {
+    await withService(async (service) => {
+      const result = (await service.sendRpc("conversations/update", {
+        conversationId,
+        name: opts.name,
+      })) as { conversation: { id: string; name: string } };
+      console.log(
+        `Conversation updated: ${result.conversation.id} (name: ${result.conversation.name})`,
+      );
+    });
+  });
+
+conversationsCommand
+  .command("add-participant")
+  .description("Add a participant to a conversation")
+  .argument("<conversationId>", "Conversation ID")
+  .argument("<participant>", "Participant (e.g. agent:bob)")
+  .action(async (conversationId: string, participant: string) => {
+    await withService(async (service) => {
+      const ref = await resolveParticipant(service, participant);
+      await service.sendRpc("conversations/addParticipant", {
+        conversationId,
+        participant: ref,
+      });
+      console.log(`Added ${participant} to ${conversationId}.`);
+    });
+  });
+
+conversationsCommand
+  .command("remove-participant")
+  .description("Remove a participant from a conversation")
+  .argument("<conversationId>", "Conversation ID")
+  .argument("<participant>", "Participant (e.g. agent:bob)")
+  .action(async (conversationId: string, participant: string) => {
+    await withService(async (service) => {
+      const ref = await resolveParticipant(service, participant);
+      await service.sendRpc("conversations/removeParticipant", {
+        conversationId,
+        participant: ref,
+      });
+      console.log(`Removed ${participant} from ${conversationId}.`);
+    });
+  });
+
+async function resolveAgentNames(
+  service: MoltZapService,
+  agentIds: string[],
+): Promise<Map<string, string>> {
+  const nameMap = new Map<string, string>();
+  if (agentIds.length === 0) return nameMap;
+  try {
+    const result = (await service.sendRpc("agents/lookup", { agentIds })) as {
+      agents: Array<{ id: string; name: string; displayName?: string }>;
+    };
+    for (const agent of result.agents) {
+      nameMap.set(agent.id, agent.displayName ?? agent.name);
+    }
+  } catch {
+    // Fall back to truncated IDs
+  }
+  return nameMap;
+}
+
+async function showHistory(
+  conversationId: string,
+  opts: { limit: string; json?: boolean },
+): Promise<void> {
+  await withService(async (service) => {
+    const result = (await service.sendRpc("messages/list", {
+      conversationId,
+      limit: parseInt(opts.limit, 10),
+    })) as { messages: Message[]; hasMore: boolean };
+
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    if (result.messages.length === 0) {
+      console.log("No messages.");
+      return;
+    }
+
+    const agentIds = [
+      ...new Set(
+        result.messages
+          .filter((m) => m.sender.type === "agent")
+          .map((m) => m.sender.id),
+      ),
+    ];
+    const nameMap = await resolveAgentNames(service, agentIds);
+
+    for (const m of result.messages) {
+      const sender =
+        m.sender.type === "agent"
+          ? (nameMap.get(m.sender.id) ?? `agent:${m.sender.id.slice(0, 8)}`)
+          : `${m.sender.type}:${m.sender.id.slice(0, 8)}`;
+      const text = m.parts
+        .map((p) => {
+          if (p.type === "text") return p.text;
+          if (p.type === "image")
+            return `[image${p.altText ? `: ${p.altText}` : ""}]`;
+          if (p.type === "file") return `[file: ${p.name}]`;
+          return "[unknown]";
+        })
+        .join(" ");
+      const deleted = m.isDeleted ? " [deleted]" : "";
+      console.log(`  [${m.createdAt}] ${sender}: ${text}${deleted}`);
+    }
+
+    if (result.hasMore) {
+      console.log("  ... more messages available");
+    }
+  });
+}
+
+conversationsCommand
+  .command("history")
+  .description("Show message history for a conversation")
+  .argument("<conversationId>", "Conversation ID")
+  .option("--limit <n>", "Max messages to show", "50")
+  .option("--json", "Output as JSON")
+  .action(showHistory);
+
+export const historyCommand = new Command("history")
+  .description("Show message history for a conversation")
+  .argument("<conversationId>", "Conversation ID")
+  .option("--limit <n>", "Max messages to show", "50")
+  .option("--json", "Output as JSON")
+  .action(showHistory);

--- a/packages/client/src/cli/commands/delete.ts
+++ b/packages/client/src/cli/commands/delete.ts
@@ -1,0 +1,12 @@
+import { Command } from "commander";
+import { withService } from "../with-service.js";
+
+export const deleteCommand = new Command("delete")
+  .description("Delete a message")
+  .argument("<messageId>", "Message ID to delete")
+  .action(async (messageId: string) => {
+    await withService(async (service) => {
+      await service.sendRpc("messages/delete", { messageId });
+      console.log(`Message ${messageId} deleted.`);
+    });
+  });

--- a/packages/client/src/cli/commands/invite.ts
+++ b/packages/client/src/cli/commands/invite.ts
@@ -1,0 +1,13 @@
+import { Command } from "commander";
+
+export const inviteCommand = new Command("invite")
+  .description("Invite management (human-only via web dashboard)")
+  .action(() => {
+    console.log(
+      "Invite management is available through the MoltZap web dashboard at https://moltzap.xyz.",
+    );
+    console.log(
+      "Agents cannot create invites directly — ask your human owner to create one.",
+    );
+    process.exit(0);
+  });

--- a/packages/client/src/cli/commands/listen.ts
+++ b/packages/client/src/cli/commands/listen.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import { MoltZapService } from "../../service.js";
+import { resolveAuth, getServerUrl } from "../config.js";
+
+export const listenCommand = new Command("listen")
+  .description("Listen for real-time events via WebSocket (JSON output)")
+  .action(async () => {
+    const service = new MoltZapService({
+      serverUrl: getServerUrl(),
+      agentKey: resolveAuth().agentKey,
+    });
+
+    process.on("SIGINT", () => {
+      service.close();
+      process.exit(0);
+    });
+
+    try {
+      await service.connect();
+
+      service.on("rawEvent", (event) => {
+        console.log(JSON.stringify(event));
+      });
+
+      // Keep the process running — MoltZapService auto-reconnects
+      await new Promise(() => {});
+    } catch (err) {
+      console.error(
+        `Connection failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
+  });

--- a/packages/client/src/cli/commands/ping.ts
+++ b/packages/client/src/cli/commands/ping.ts
@@ -1,0 +1,23 @@
+import { Command } from "commander";
+import { getHttpUrl } from "../config.js";
+
+export const pingCommand = new Command("ping")
+  .description("Check if the MoltZap server is reachable")
+  .action(async () => {
+    const url = `${getHttpUrl()}/health`;
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+      if (res.ok) {
+        console.log("Server reachable");
+        process.exit(0);
+      } else {
+        console.error(`Server unreachable: HTTP ${res.status}`);
+        process.exit(1);
+      }
+    } catch (err) {
+      console.error(
+        `Server unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
+  });

--- a/packages/client/src/cli/commands/presence.ts
+++ b/packages/client/src/cli/commands/presence.ts
@@ -1,0 +1,25 @@
+import { Command } from "commander";
+import { withService } from "../with-service.js";
+
+export const presenceCommand = new Command("presence")
+  .description("Update or show presence status (online, offline, away)")
+  .argument("[status]", "Status to set: online, offline, or away")
+  .action(async (status?: string) => {
+    if (!status) {
+      console.log("Usage: moltzap presence <online|offline|away>");
+      return;
+    }
+
+    const valid = ["online", "offline", "away"];
+    if (!valid.includes(status)) {
+      console.error(
+        `Invalid status "${status}". Must be one of: ${valid.join(", ")}`,
+      );
+      process.exit(1);
+    }
+
+    await withService(async (service) => {
+      await service.sendRpc("presence/update", { status });
+      console.log(`Presence set to ${status}.`);
+    });
+  });

--- a/packages/client/src/cli/commands/react.ts
+++ b/packages/client/src/cli/commands/react.ts
@@ -1,0 +1,24 @@
+import { Command } from "commander";
+import { withService } from "../with-service.js";
+
+export const reactCommand = new Command("react")
+  .description("React to a message with an emoji")
+  .argument("<messageId>", "Message ID to react to")
+  .argument("<emoji>", "Emoji to react with")
+  .option("--remove", "Remove the reaction instead of adding it")
+  .action(
+    async (messageId: string, emoji: string, opts: { remove?: boolean }) => {
+      await withService(async (service) => {
+        await service.sendRpc("messages/react", {
+          messageId,
+          emoji,
+          action: opts.remove ? "remove" : "add",
+        });
+        console.log(
+          opts.remove
+            ? `Reaction ${emoji} removed from ${messageId}`
+            : `Reacted ${emoji} to ${messageId}`,
+        );
+      });
+    },
+  );

--- a/packages/client/src/cli/commands/register.test.ts
+++ b/packages/client/src/cli/commands/register.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerCommand } from "./register.js";
+
+const mockRegisterAgent = vi.fn().mockResolvedValue({
+  agentId: "agent-123",
+  apiKey: "moltzap_agent_testkey",
+  claimUrl: "https://moltzap.xyz/claim/tok_abc",
+});
+
+vi.mock("../http-client.js", () => ({
+  registerAgent: (...args: unknown[]) => mockRegisterAgent(...args),
+}));
+
+vi.mock("../config.js", () => ({
+  updateConfig: vi.fn(),
+}));
+
+describe("register command", () => {
+  const originalExit = process.exit;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exit = vi.fn() as never;
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+  });
+
+  it("parses: register <name> <invite-code>", async () => {
+    await registerCommand.parseAsync([
+      "node",
+      "test",
+      "my-agent",
+      "inv_abc123",
+    ]);
+
+    expect(mockRegisterAgent).toHaveBeenCalledWith(
+      "my-agent",
+      "inv_abc123",
+      undefined,
+    );
+  });
+
+  it("parses: register <name> <invite-code> -d <description>", async () => {
+    await registerCommand.parseAsync([
+      "node",
+      "test",
+      "my-agent",
+      "inv_abc123",
+      "-d",
+      "A test agent",
+    ]);
+
+    expect(mockRegisterAgent).toHaveBeenCalledWith(
+      "my-agent",
+      "inv_abc123",
+      "A test agent",
+    );
+  });
+
+  it("exits with error on registration failure", async () => {
+    mockRegisterAgent.mockRejectedValueOnce(new Error("Invalid invite code"));
+
+    await registerCommand.parseAsync(["node", "test", "my-agent", "inv_bad"]);
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/client/src/cli/commands/register.ts
+++ b/packages/client/src/cli/commands/register.ts
@@ -1,0 +1,91 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { Command } from "commander";
+import { registerAgent } from "../http-client.js";
+import { getServerUrl, updateConfig } from "../config.js";
+
+const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/;
+
+/** Write channel config directly to the OpenClaw JSON file.
+ * Avoids `openclaw config set` which triggers both a file-watcher restart
+ * AND an internal notification — causing a double-SIGUSR1 race that leaves
+ * the gateway stuck in draining mode. Direct file write triggers only the
+ * file watcher → one clean restart. */
+function writeOpenClawChannelConfig(account: {
+  apiKey: string;
+  serverUrl: string;
+  agentName: string;
+}): void {
+  const configDir = path.join(os.homedir(), ".openclaw");
+  const configPath = path.join(configDir, "openclaw.json");
+
+  let config: Record<string, unknown> = {};
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+  } catch {
+    // No existing config — start fresh
+  }
+
+  const channels = (config.channels ?? {}) as Record<string, unknown>;
+  channels.moltzap = {
+    accounts: [{ id: "default", ...account }],
+  };
+  config.channels = channels;
+
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+}
+
+export const registerCommand = new Command("register")
+  .description("Register a new agent on MoltZap (requires invite code)")
+  .argument("<name>", "Agent name (lowercase alphanumeric, 3-32 chars)")
+  .argument("<invite-code>", "Invite code from your invite URL")
+  .option("-d, --description <desc>", "Agent description")
+  .action(
+    async (
+      name: string,
+      inviteCode: string,
+      opts: { description?: string },
+    ) => {
+      if (!NAME_PATTERN.test(name)) {
+        console.error(
+          `Invalid agent name "${name}". Must be 3-32 chars, lowercase alphanumeric and hyphens, cannot start or end with a hyphen.`,
+        );
+        process.exit(1);
+        return;
+      }
+
+      try {
+        const result = await registerAgent(name, inviteCode, opts.description);
+
+        const serverUrl = getServerUrl();
+
+        updateConfig(() => ({
+          serverUrl,
+          apiKey: result.apiKey,
+          agentName: name,
+        }));
+
+        writeOpenClawChannelConfig({
+          apiKey: result.apiKey,
+          serverUrl,
+          agentName: name,
+        });
+
+        console.log(`Agent "${name}" registered and channel configured.`);
+        console.log(`  Agent ID:   ${result.agentId}`);
+        console.log(`  API Key:    ${result.apiKey}`);
+        console.log(`  Server URL: ${serverUrl}`);
+        console.log(`  Claim URL:  ${result.claimUrl}`);
+        console.log(
+          `\nShare the claim URL with the agent's owner to verify ownership.`,
+        );
+      } catch (err) {
+        console.error(
+          `Registration failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+    },
+  );

--- a/packages/client/src/cli/commands/send.test.ts
+++ b/packages/client/src/cli/commands/send.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { sendCommand } from "./send.js";
+
+const mockSendRpc = vi.fn().mockResolvedValue({ message: { id: "msg-123" } });
+const mockConnect = vi.fn().mockResolvedValue({});
+const mockClose = vi.fn();
+
+vi.mock("../../service.js", () => ({
+  MoltZapService: vi.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    sendRpc: mockSendRpc,
+    close: mockClose,
+  })),
+}));
+
+vi.mock("../config.js", () => ({
+  resolveAuth: vi.fn().mockReturnValue({ agentKey: "test-key" }),
+  getServerUrl: vi.fn().mockReturnValue("ws://localhost:9999"),
+}));
+
+describe("send command", () => {
+  const originalExit = process.exit;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendRpc.mockResolvedValue({ message: { id: "msg-123" } });
+    process.exit = vi.fn() as never;
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+  });
+
+  it("sends to conversation by conv: prefix", async () => {
+    await sendCommand.parseAsync(["node", "test", "conv:abc-123", "Hello world"]);
+
+    expect(mockSendRpc).toHaveBeenCalledWith("messages/send", {
+      conversationId: "abc-123",
+      parts: [{ type: "text", text: "Hello world" }],
+    });
+  });
+
+  it("sends to agent target without conv: prefix", async () => {
+    await sendCommand.parseAsync(["node", "test", "agent:alice", "Hi Alice"]);
+
+    expect(mockSendRpc).toHaveBeenCalledWith("messages/send", {
+      to: "agent:alice",
+      parts: [{ type: "text", text: "Hi Alice" }],
+    });
+  });
+
+  it("includes replyToId when --reply-to is provided", async () => {
+    await sendCommand.parseAsync([
+      "node",
+      "test",
+      "conv:abc-123",
+      "Reply text",
+      "--reply-to",
+      "msg-original",
+    ]);
+
+    expect(mockSendRpc).toHaveBeenCalledWith("messages/send", {
+      conversationId: "abc-123",
+      parts: [{ type: "text", text: "Reply text" }],
+      replyToId: "msg-original",
+    });
+  });
+});

--- a/packages/client/src/cli/commands/send.test.ts
+++ b/packages/client/src/cli/commands/send.test.ts
@@ -32,7 +32,12 @@ describe("send command", () => {
   });
 
   it("sends to conversation by conv: prefix", async () => {
-    await sendCommand.parseAsync(["node", "test", "conv:abc-123", "Hello world"]);
+    await sendCommand.parseAsync([
+      "node",
+      "test",
+      "conv:abc-123",
+      "Hello world",
+    ]);
 
     expect(mockSendRpc).toHaveBeenCalledWith("messages/send", {
       conversationId: "abc-123",

--- a/packages/client/src/cli/commands/send.ts
+++ b/packages/client/src/cli/commands/send.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import { withService } from "../with-service.js";
+
+export const sendCommand = new Command("send")
+  .description("Send a message to a conversation or DM")
+  .argument("<target>", "Target (agent:<name> or conv:<id>)")
+  .argument("<message>", "Message text")
+  .option("--reply-to <messageId>", "Reply to a specific message")
+  .action(
+    async (target: string, message: string, opts: { replyTo?: string }) => {
+      await withService(async (service) => {
+        const params: Record<string, unknown> = {
+          parts: [{ type: "text", text: message }],
+        };
+        if (target.startsWith("conv:")) {
+          params.conversationId = target.slice(5);
+        } else {
+          params.to = target;
+        }
+        if (opts.replyTo) params.replyToId = opts.replyTo;
+
+        const result = (await service.sendRpc("messages/send", params)) as {
+          message: { id: string };
+        };
+        console.log(`Message sent (id: ${result.message.id})`);
+      });
+    },
+  );

--- a/packages/client/src/cli/commands/status.ts
+++ b/packages/client/src/cli/commands/status.ts
@@ -1,0 +1,17 @@
+import { Command } from "commander";
+import { withService } from "../with-service.js";
+
+export const statusCommand = new Command("status")
+  .description("Show agent connection status and conversation summary")
+  .action(async () => {
+    await withService(async (service, hello) => {
+      const totalUnread = Object.values(hello.unreadCounts ?? {}).reduce(
+        (sum: number, n: number) => sum + n,
+        0,
+      );
+
+      console.log(`Agent ID:       ${service.ownAgentId ?? "none"}`);
+      console.log(`Conversations:  ${service.getConversations().length}`);
+      console.log(`Unread total:   ${totalUnread}`);
+    });
+  });

--- a/packages/client/src/cli/commands/whoami.ts
+++ b/packages/client/src/cli/commands/whoami.ts
@@ -1,0 +1,20 @@
+import { Command } from "commander";
+import { readConfig, getConfigPath } from "../config.js";
+
+export const whoamiCommand = new Command("whoami")
+  .description("Show current agent and config")
+  .action(() => {
+    const config = readConfig();
+
+    console.log(`Config: ${getConfigPath()}`);
+    console.log(`Server: ${config.serverUrl}`);
+
+    if (config.agentName && config.apiKey) {
+      const masked =
+        config.apiKey.slice(0, 20) + "..." + config.apiKey.slice(-4);
+      console.log(`\nAgent: ${config.agentName}`);
+      console.log(`  API Key: ${masked}`);
+    } else {
+      console.log(`\nNo agent registered.`);
+    }
+  });

--- a/packages/client/src/cli/config.test.ts
+++ b/packages/client/src/cli/config.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+
+vi.mock("node:fs");
+
+import { resolveAuth } from "./config.js";
+
+function mockConfigFile(config: object) {
+  vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(config));
+}
+
+describe("resolveAuth", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.MOLTZAP_API_KEY;
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("MOLTZAP_API_KEY env var takes highest priority", () => {
+    process.env.MOLTZAP_API_KEY = "moltzap_agent_envkey123";
+    mockConfigFile({
+      serverUrl: "wss://test",
+      apiKey: "moltzap_agent_configkey",
+      agentName: "myagent",
+    });
+
+    const result = resolveAuth();
+    expect(result).toEqual({ agentKey: "moltzap_agent_envkey123" });
+  });
+
+  it("config apiKey is used when no env var", () => {
+    mockConfigFile({
+      serverUrl: "wss://test",
+      apiKey: "moltzap_agent_configkey",
+      agentName: "myagent",
+    });
+
+    const result = resolveAuth();
+    expect(result).toEqual({ agentKey: "moltzap_agent_configkey" });
+  });
+
+  it("throws if no env var and no config apiKey", () => {
+    mockConfigFile({ serverUrl: "wss://test" });
+
+    expect(() => resolveAuth()).toThrow("No agent registered");
+  });
+
+  it("throws if config file missing", () => {
+    // readFileSync throws ENOENT (set in beforeEach)
+    expect(() => resolveAuth()).toThrow("No agent registered");
+  });
+});

--- a/packages/client/src/cli/config.ts
+++ b/packages/client/src/cli/config.ts
@@ -1,0 +1,61 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+export interface MoltZapConfig {
+  serverUrl: string;
+  apiKey?: string;
+  agentName?: string;
+}
+
+const CONFIG_DIR = path.join(os.homedir(), ".moltzap");
+const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
+
+const DEFAULT_CONFIG: MoltZapConfig = {
+  serverUrl: "wss://api.moltzap.xyz",
+};
+
+export function getConfigPath(): string {
+  return CONFIG_PATH;
+}
+
+export function readConfig(): MoltZapConfig {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+    return JSON.parse(raw) as MoltZapConfig;
+  } catch {
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+export function writeConfig(config: MoltZapConfig): void {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", {
+    mode: 0o600,
+  });
+}
+
+export function updateConfig(
+  updater: (config: MoltZapConfig) => MoltZapConfig,
+): void {
+  const config = readConfig();
+  writeConfig(updater(config));
+}
+
+export function getServerUrl(): string {
+  return process.env.MOLTZAP_SERVER_URL ?? readConfig().serverUrl;
+}
+
+export function getHttpUrl(): string {
+  const wsUrl = getServerUrl();
+  return wsUrl.replace(/^wss:/, "https:").replace(/^ws:/, "http:");
+}
+
+/** Resolve agent API key: MOLTZAP_API_KEY env var → config → fail. */
+export function resolveAuth(): { agentKey: string } {
+  const envKey = process.env.MOLTZAP_API_KEY;
+  if (envKey) return { agentKey: envKey };
+  const config = readConfig();
+  if (config.apiKey) return { agentKey: config.apiKey };
+  throw new Error("No agent registered. Run `moltzap register` first.");
+}

--- a/packages/client/src/cli/http-client.ts
+++ b/packages/client/src/cli/http-client.ts
@@ -1,0 +1,45 @@
+import { getHttpUrl, resolveAuth } from "./config.js";
+import type { RegisterResult } from "@moltzap/protocol";
+
+function authHeaders(): Record<string, string> {
+  const { agentKey } = resolveAuth();
+  return { "X-API-Key": agentKey };
+}
+
+async function request<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  opts?: { noAuth?: boolean },
+): Promise<T> {
+  const baseUrl = getHttpUrl();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!opts?.noAuth) {
+    Object.assign(headers, authHeaders());
+  }
+  const res = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status}: ${text}`);
+  }
+  return (await res.json()) as T;
+}
+
+export async function registerAgent(
+  name: string,
+  inviteCode: string,
+  description?: string,
+): Promise<RegisterResult> {
+  return request<RegisterResult>(
+    "POST",
+    "/api/v1/auth/register",
+    { name, inviteCode, description },
+    { noAuth: true },
+  );
+}

--- a/packages/client/src/cli/index.ts
+++ b/packages/client/src/cli/index.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { Command } from "commander";
+import { registerCommand } from "./commands/register.js";
+import { whoamiCommand } from "./commands/whoami.js";
+import { sendCommand } from "./commands/send.js";
+import { listenCommand } from "./commands/listen.js";
+import { contactsCommand } from "./commands/contacts.js";
+import {
+  conversationsCommand,
+  historyCommand,
+} from "./commands/conversations.js";
+import { inviteCommand } from "./commands/invite.js";
+import { reactCommand } from "./commands/react.js";
+import { deleteCommand } from "./commands/delete.js";
+import { presenceCommand } from "./commands/presence.js";
+import { pingCommand } from "./commands/ping.js";
+import { statusCommand } from "./commands/status.js";
+import { agentsCommand } from "./commands/agents.js";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../../package.json") as { version: string };
+
+const program = new Command();
+
+program
+  .name("moltzap")
+  .description("MoltZap CLI — messaging for OpenClaw AI agents")
+  .version(version);
+
+program.addCommand(registerCommand);
+program.addCommand(whoamiCommand);
+program.addCommand(sendCommand);
+program.addCommand(listenCommand);
+program.addCommand(contactsCommand);
+program.addCommand(conversationsCommand);
+program.addCommand(historyCommand);
+program.addCommand(inviteCommand);
+program.addCommand(reactCommand);
+program.addCommand(deleteCommand);
+program.addCommand(presenceCommand);
+program.addCommand(pingCommand);
+program.addCommand(statusCommand);
+program.addCommand(agentsCommand);
+
+program.parse();

--- a/packages/client/src/cli/resolve.ts
+++ b/packages/client/src/cli/resolve.ts
@@ -1,0 +1,44 @@
+import type { MoltZapService } from "../service.js";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve "agent:<name-or-uuid>" to { type, id } with a real UUID.
+ * If the id portion is already a UUID, returns it directly.
+ * If it's a name, looks it up via agents/lookupByName.
+ */
+export async function resolveParticipant(
+  service: MoltZapService,
+  ref: string,
+): Promise<{ type: string; id: string }> {
+  const colon = ref.indexOf(":");
+  if (colon === -1) {
+    throw new Error(
+      `Invalid participant "${ref}". Use format type:name (e.g. agent:alice).`,
+    );
+  }
+  const type = ref.slice(0, colon);
+  const value = ref.slice(colon + 1);
+
+  if (UUID_RE.test(value)) {
+    return { type, id: value };
+  }
+
+  if (type !== "agent") {
+    throw new Error(
+      `Cannot resolve "${ref}" — only agent names are supported.`,
+    );
+  }
+
+  const result = (await service.sendRpc("agents/lookupByName", {
+    names: [value],
+  })) as {
+    agents: Array<{ id: string; name: string }>;
+  };
+
+  if (result.agents.length === 0) {
+    throw new Error(`Agent "${value}" not found.`);
+  }
+  return { type: "agent", id: result.agents[0]!.id };
+}

--- a/packages/client/src/cli/with-service.ts
+++ b/packages/client/src/cli/with-service.ts
@@ -1,0 +1,32 @@
+import { MoltZapService } from "../service.js";
+import { resolveAuth, getServerUrl } from "./config.js";
+
+interface HelloOk {
+  agentId: string;
+  conversations?: unknown[];
+  unreadCounts?: Record<string, number>;
+}
+
+/**
+ * Connect to MoltZap, run a callback, close the connection, handle errors.
+ * All CLI commands should use this instead of manually constructing MoltZapService.
+ */
+export async function withService<T>(
+  fn: (service: MoltZapService, hello: HelloOk) => Promise<T>,
+): Promise<T> {
+  const service = new MoltZapService({
+    serverUrl: getServerUrl(),
+    agentKey: resolveAuth().agentKey,
+  });
+  try {
+    const hello = await service.connect();
+    return await fn(service, hello as HelloOk);
+  } catch (err) {
+    console.error(
+      `Failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  } finally {
+    service.close();
+  }
+}

--- a/packages/evals/Dockerfile.eval-agent
+++ b/packages/evals/Dockerfile.eval-agent
@@ -13,14 +13,14 @@ RUN mkdir -p /home/node/.openclaw/extensions/openclaw-channel \
     && node -e "const p=require('./package.json'); delete p.devDependencies; delete p.peerDependencies; require('fs').writeFileSync('./package.json', JSON.stringify(p,null,2))" \
     && npm install --ignore-scripts --no-package-lock --omit=peer /tmp/moltzap-protocol-*.tgz /tmp/moltzap-client-*.tgz
 
-# Install MoltZap CLI in a persistent directory and symlink the binary.
+# Install MoltZap CLI from the client package (CLI is bundled in @moltzap/client).
 USER root
 RUN mkdir -p /opt/moltzap-cli && cd /opt/moltzap-cli \
-    && tar xzf /tmp/moltzap-cli-*.tgz --strip-components=1 \
-    && node -e "const p=require('./package.json'); delete p.devDependencies; p.dependencies['@moltzap/protocol']='*'; require('fs').writeFileSync('./package.json', JSON.stringify(p,null,2))" \
+    && tar xzf /tmp/moltzap-client-*.tgz --strip-components=1 \
+    && node -e "const p=require('./package.json'); delete p.devDependencies; require('fs').writeFileSync('./package.json', JSON.stringify(p,null,2))" \
     && npm install --ignore-scripts --no-package-lock /tmp/moltzap-protocol-*.tgz \
-    && chmod +x dist/index.js \
-    && ln -s /opt/moltzap-cli/dist/index.js /usr/local/bin/moltzap
+    && chmod +x dist/cli/index.js \
+    && ln -s /opt/moltzap-cli/dist/cli/index.js /usr/local/bin/moltzap
 USER node
 
 # Configure exec approvals for full access (eval containers only — not production)

--- a/packages/evals/scripts/build-eval-agent.sh
+++ b/packages/evals/scripts/build-eval-agent.sh
@@ -25,13 +25,11 @@ echo "Building protocol + client + channel plugin..."
 pnpm --filter @moltzap/protocol build
 pnpm --filter @moltzap/client build
 pnpm --filter @moltzap/openclaw-channel build
-pnpm --filter @moltzap/cli build
 
 echo "Packing tarballs..."
 (cd packages/protocol && pnpm pack && mv moltzap-protocol-*.tgz ../evals/)
 (cd packages/client && pnpm pack && mv moltzap-client-*.tgz ../evals/)
 (cd packages/openclaw-channel && pnpm pack && mv moltzap-openclaw-channel-*.tgz ../evals/)
-(cd packages/cli && pnpm pack && mv moltzap-cli-*.tgz ../evals/)
 
 # Copy SKILL.md into build context (Docker can't reference files outside context)
 cp SKILL.md packages/evals/SKILL.md

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@moltzap/protocol':
         specifier: workspace:*
         version: link:../protocol
+      commander:
+        specifier: ^13.0.0
+        version: 13.1.0
       ws:
         specifier: ^8.18.0
         version: 8.20.0


### PR DESCRIPTION
## Summary

Moves all 14 CLI commands from `@moltzap/cli` into `@moltzap/client/src/cli/`. The CLI now uses `MoltZapService` via a `withService()` helper instead of its own standalone `WsClient`.

**Changes:**
- 20 CLI source files moved to `packages/client/src/cli/`
- `withService()` helper centralizes connect/close/error handling (eliminates ~20 identical try/catch blocks)
- JWT dead code removed (was never reachable from `resolveAuth()`)
- Dockerfile updated to install CLI from `@moltzap/client` tarball
- SKILL.md install instructions updated to `@moltzap/client`

**Depends on:** PR #10 (cross-conversation context, creates @moltzap/client)

## Test plan
- [x] All client tests pass (30 tests: 4 config + 3 register + 3 send + 20 integration)
- [x] All channel plugin tests pass (127 tests)
- [x] All protocol tests pass (45 tests)
- [x] All packages build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)