### PR TITLE
feat: CLI socket service + eval container cleanup

### DIFF
--- a/packages/evals/scripts/cleanup-eval-containers.sh
+++ b/packages/evals/scripts/cleanup-eval-containers.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Kill moltzap eval containers older than MAX_AGE seconds (default: 1 hour).
+# Run manually or as a pre-step before evals to clean up leftovers.
+
+MAX_AGE=${1:-3600}
+NOW=$(date +%s)
+KILLED=0
+
+# Label-based cleanup (containers created with --label moltzap-eval=true)
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  id=$(echo "$line" | awk '{print $1}')
+  started=$(echo "$line" | awk '{print $2}')
+  if [ -n "$started" ] && [ "$((NOW - started))" -gt "$MAX_AGE" ]; then
+    age=$((NOW - started))
+    echo "Killing stale container $id (age: ${age}s)"
+    docker rm -f "$id" 2>/dev/null
+    KILLED=$((KILLED + 1))
+  fi
+done < <(docker ps --filter "label=moltzap-eval=true" --format '{{.ID}} {{.Label "moltzap-eval-started"}}' 2>/dev/null)
+
+# Name-based fallback for pre-label containers
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  echo "Killing old container $id (matched by name pattern)"
+  docker rm -f "$id" 2>/dev/null
+  KILLED=$((KILLED + 1))
+done < <(docker ps --filter "name=moltzap-e2e-" --format '{{.ID}} {{.RunningFor}}' 2>/dev/null | grep -E 'hours|days' | awk '{print $1}')
+
+if [ "$KILLED" -gt 0 ]; then
+  echo "Cleaned up $KILLED stale eval container(s)"
+else
+  echo "No stale eval containers found"
+fi

--- a/packages/evals/src/e2e-infra/index.ts
+++ b/packages/evals/src/e2e-infra/index.ts
@@ -3,6 +3,7 @@
 /** CLI entry point for the E2E eval runner. */
 
 import { config } from "dotenv";
+import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -21,6 +22,31 @@ import {
   resolveAllAgentModels,
 } from "./model-config.js";
 import { setupLogger, logger } from "./logger.js";
+
+// --- Signal handling: ensure eval containers are cleaned up on exit ---
+const shutdownController = new AbortController();
+let shuttingDown = false;
+
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, () => {
+    if (shuttingDown) process.exit(1); // second signal = hard exit
+    shuttingDown = true;
+    console.error(`\nReceived ${sig}, shutting down eval containers...`);
+    shutdownController.abort();
+    // Fallback: force-kill labeled containers if graceful shutdown hangs
+    setTimeout(() => {
+      try {
+        execSync(
+          'docker ps -q --filter "label=moltzap-eval=true" | xargs -r docker rm -f',
+          { stdio: "pipe" },
+        );
+      } catch {
+        // best effort
+      }
+      process.exit(1);
+    }, 10_000).unref();
+  });
+}
 
 async function main(): Promise<void> {
   const argv = await yargs(hideBin(process.argv))
@@ -109,6 +135,7 @@ async function main(): Promise<void> {
         resultsDir,
         cleanResults: argv["clean-results"],
         logLevel: argv["log-level"],
+        signal: shutdownController.signal,
       });
 
       logger.info(

--- a/packages/evals/src/e2e-infra/runner.ts
+++ b/packages/evals/src/e2e-infra/runner.ts
@@ -337,6 +337,7 @@ export async function runE2EEvals(opts: {
   resultsDir?: string;
   cleanResults?: boolean;
   logLevel?: string;
+  signal?: AbortSignal;
 }): Promise<E2ERunResult> {
   const {
     scenarios: scenarioFilter,
@@ -500,6 +501,11 @@ export async function runE2EEvals(opts: {
     let completedJobs = 0;
 
     for (const scenario of selectedScenarios) {
+      if (opts.signal?.aborted) {
+        logger.warn("Eval run aborted by signal, skipping remaining scenarios");
+        break;
+      }
+
       for (let run = 1; run <= runsPerScenario; run++) {
         // Drain stale events between scenarios — previous agent responses
         // can leak into the next scenario's waitForEvent since DM conversations

--- a/packages/openclaw-channel/src/test-utils/container-core.ts
+++ b/packages/openclaw-channel/src/test-utils/container-core.ts
@@ -90,6 +90,8 @@ export function buildOpenClawConfig(opts: {
         ],
       },
     },
+    heartbeat: { enabled: false },
+    healthMonitor: { enabled: false },
     gateway: {
       mode: "local",
       controlUi: {
@@ -148,6 +150,7 @@ export function startRawContainer(
   );
 
   const containerName = `moltzap-e2e-${opts.name}-${Date.now()}`;
+  const startedEpoch = Math.floor(Date.now() / 1000);
   const envParts = [`-e OPENCLAW_STATE_DIR=${OPENCLAW_STATE_DIR}`];
   if (opts.envVars) {
     for (const [k, v] of Object.entries(opts.envVars)) {
@@ -159,6 +162,9 @@ export function startRawContainer(
     [
       "docker create",
       `--name ${containerName}`,
+      `--label moltzap-eval=true`,
+      `--label moltzap-eval-started=${startedEpoch}`,
+      `--stop-timeout 5`,
       ...envParts,
       `--add-host host.docker.internal:host-gateway`,
       `-p ${controlPort}:${CONTROL_UI_PORT}`,


### PR DESCRIPTION
## Summary
- CLI commands communicate via Unix socket to running MoltZapService instead of creating separate WebSocket connections
- Add signal handlers and Docker labels to eval infrastructure to prevent orphaned containers from burning API tokens (240M tokens burned in one incident)
- Cleanup script for stale eval containers

## Test plan
- [ ] Run `moltzap send` / `moltzap history` via socket client
- [ ] Ctrl+C during eval run, verify containers are cleaned up
- [ ] Run `cleanup-eval-containers.sh`, verify stale container removal
- [ ] `pnpm test` passes in client and openclaw-channel packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)