### PR TITLE
fix: socket client bugs found by cross-model review

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -32,3 +32,65 @@ The CLI runs as a subprocess (via OpenClaw's exec tool) so it can't access the i
 4. Run EVAL-008 with `contextAdapter` disabled (separate container config for isolation-only vs awareness scenarios)
 
 **Why it matters:** Cross-conversation awareness is only useful if the agent can use information strategically without leaking it verbatim. The evals are correctly catching the gap between "has the info" and "uses it wisely."
+
+## Socket server: batch agent name resolution in history handler
+
+Sequential `resolveAgentName()` calls in the `history` handler make one RPC per unknown agent. The server's `agents/lookup` RPC already accepts an `agentIds` array, so all unknowns could be resolved in a single call. Also, `messages/list` and `conversations/get` are independent and could run concurrently with `Promise.all`.
+
+**Why:** Each `history` request currently does `1 + N + 1` serial RPCs (messages, N agent lookups, conversation metadata) where it could do `1 + 1` (batch lookup with messages, concurrent conversation fetch). Matters when conversations have many unique senders.
+
+**Files:** `packages/client/src/service.ts` (handleSocketRequest, `history` case around line 230)
+
+**Depends on:** Nothing.
+
+## Socket server: symlink race conditions in multi-account mode
+
+When multiple `MoltZapService` instances call `startSocketServer()` concurrently, they race on the default symlink (`~/.moltzap/service.sock`). Last writer wins silently. `stopSocketServer()` has a TOCTOU race where `readlinkSync` + conditional `unlinkSync` could delete another instance's symlink.
+
+**Why:** Multi-account configs (OpenClaw channel with multiple accounts) will have multiple services running. The current symlink-based discovery is last-write-wins with no coordination.
+
+**Options:** Lock file, explicit CLI `--account` flag, or a registry file listing all active sockets.
+
+**Files:** `packages/client/src/service.ts` (startSocketServer, stopSocketServer)
+
+**Depends on:** Nothing, but low priority since multi-account is rare.
+
+## Socket server: input validation at the socket boundary
+
+The socket server accepts `params` as `Record<string, unknown>` with no runtime validation. Callers can pass wrong types (e.g., `conversationId: 42` instead of a string) that silently propagate to the MoltZap server RPC.
+
+**Why:** The protocol layer uses AJV validators for RPC params, but the socket server bypasses that layer. Adding lightweight type checks (`typeof convId !== 'string'`) or reusing the existing AJV validators at the socket boundary would catch bugs earlier.
+
+**Files:** `packages/client/src/service.ts` (handleSocketRequest)
+
+**Depends on:** Nothing.
+
+## Socket server: unbounded buffer and missing idle timeout
+
+The socket server accumulates `buffer += chunk.toString()` with no max size. A client sending data without newlines grows memory without bound. There's also no idle timeout on connections.
+
+**Why:** Low risk since the socket is local (Unix domain socket), but defense-in-depth for long-running services.
+
+**Files:** `packages/client/src/service.ts` (startSocketServer, line ~134)
+
+**Depends on:** Nothing.
+
+## CLI: extract shared error handling wrapper
+
+Every CLI command repeats the same `try { ... } catch (err) { console.error(...); process.exit(1); }` pattern (~26 times across 10 files). The deleted `withService()` wrapper had centralized this.
+
+**Why:** DRY. A `wrapAction(fn)` utility would eliminate 26 identical catch blocks and ensure consistent error formatting.
+
+**Files:** `packages/client/src/cli/commands/*.ts`
+
+**Depends on:** Nothing.
+
+## CLI: extract shared participant resolution
+
+The `resolveParticipant()` logic (UUID check + `agents/lookupByName` fallback) is inlined 3 times in `conversations.ts` (create, addParticipant, removeParticipant). The original `resolve.ts` was deleted when the CLI was refactored to use the socket client.
+
+**Why:** DRY. Same UUID regex and lookup logic repeated 3 times. Extract to a utility that takes a `request` function parameter.
+
+**Files:** `packages/client/src/cli/commands/conversations.ts` (lines ~54, ~171, ~216)
+
+**Depends on:** Nothing.

--- a/packages/client/src/__tests__/service.integration.test.ts
+++ b/packages/client/src/__tests__/service.integration.test.ts
@@ -1198,7 +1198,9 @@ describe("Socket Server", () => {
         limit: 10,
       })) as { messages: Array<{ text: string }> };
 
-      const msg = result.messages.find((m) => m.text.includes("Check this out"));
+      const msg = result.messages.find((m) =>
+        m.text.includes("Check this out"),
+      );
       expect(msg).toBeDefined();
       expect(msg!.text).toContain("[image]");
     } finally {
@@ -1214,11 +1216,9 @@ describe("Socket Server", () => {
     service.startSocketServer();
     const pathAtStart = service.socketPath;
     try {
-      const result = (await socketRequest(
-        "ping",
-        undefined,
-        pathAtStart,
-      )) as { ok: boolean };
+      const result = (await socketRequest("ping", undefined, pathAtStart)) as {
+        ok: boolean;
+      };
       expect(result.ok).toBe(true);
     } finally {
       service.close();

--- a/packages/client/src/__tests__/service.integration.test.ts
+++ b/packages/client/src/__tests__/service.integration.test.ts
@@ -1067,4 +1067,176 @@ describe("Socket Server", () => {
       regD.client.close();
     }
   });
+
+  it("socket request resolves without 10s hang (timer leak regression)", async () => {
+    const reg = await registerAgent("sock-timer");
+    const service = await connectService(reg.apiKey);
+    service.startSocketServer();
+    try {
+      const start = performance.now();
+      await socketRequest("ping");
+      const elapsed = performance.now() - start;
+      expect(elapsed).toBeLessThan(2000);
+    } finally {
+      service.close();
+      reg.client.close();
+    }
+  });
+
+  it("two services use separate socket paths", async () => {
+    const regA = await registerAgent("sock-multi-a");
+    const regB = await registerAgent("sock-multi-b");
+    const serviceA = await connectService(regA.apiKey);
+    const serviceB = await connectService(regB.apiKey);
+    serviceA.startSocketServer();
+    serviceB.startSocketServer();
+    try {
+      expect(serviceA.socketPath).not.toBe(serviceB.socketPath);
+
+      // Both respond via their own socket path
+      const resultA = (await socketRequest(
+        "ping",
+        undefined,
+        serviceA.socketPath,
+      )) as { agentId: string };
+      const resultB = (await socketRequest(
+        "ping",
+        undefined,
+        serviceB.socketPath,
+      )) as { agentId: string };
+      expect(resultA.agentId).toBe(regA.agentId);
+      expect(resultB.agentId).toBe(regB.agentId);
+    } finally {
+      serviceA.close();
+      serviceB.close();
+      regA.client.close();
+      regB.client.close();
+    }
+  });
+
+  it("lastRead advances monotonically and afterSeq enables pagination", async () => {
+    const regA = await registerAgent("sock-page-a");
+    const regB = await registerAgent("sock-page-b");
+    await regB.client.connect(regB.apiKey);
+    const service = await connectService(regA.apiKey);
+    service.startSocketServer();
+    try {
+      const conv = (await socketRequest("conversations/create", {
+        type: "dm",
+        participants: [{ type: "agent", id: regB.agentId }],
+      })) as { conversation: { id: string } };
+
+      // Send 5 messages from B
+      for (let i = 0; i < 5; i++) {
+        await sendAndSettle(
+          regB.client,
+          conv.conversation.id,
+          `paginate-msg-${i}`,
+        );
+      }
+
+      // Read with limit=2 — gets newest 2 messages, advances lastRead
+      const hist1 = (await socketRequest("history", {
+        conversationId: conv.conversation.id,
+        sessionKey: "page-test-session",
+        limit: 2,
+      })) as {
+        newCount: number;
+        messages: Array<{ seq: number; isNew: boolean; text: string }>;
+      };
+      expect(hist1.messages.length).toBe(2);
+
+      // New message arrives after read
+      await sendAndSettle(
+        regB.client,
+        conv.conversation.id,
+        "paginate-msg-new",
+      );
+
+      // Read again — only the new message should be marked new
+      const hist2 = (await socketRequest("history", {
+        conversationId: conv.conversation.id,
+        sessionKey: "page-test-session",
+        limit: 10,
+      })) as {
+        newCount: number;
+        messages: Array<{ isNew: boolean; text: string }>;
+      };
+      expect(hist2.newCount).toBe(1);
+      const newMsg = hist2.messages.find((m) => m.isNew);
+      expect(newMsg?.text).toBe("paginate-msg-new");
+    } finally {
+      service.close();
+      regA.client.close();
+      regB.client.close();
+    }
+  });
+
+  it("non-text message parts render as markers in socket history", async () => {
+    const regA = await registerAgent("sock-attach-a");
+    const regB = await registerAgent("sock-attach-b");
+    await regB.client.connect(regB.apiKey);
+    const service = await connectService(regA.apiKey);
+    service.startSocketServer();
+    try {
+      const conv = (await socketRequest("conversations/create", {
+        type: "dm",
+        participants: [{ type: "agent", id: regB.agentId }],
+      })) as { conversation: { id: string } };
+
+      await regB.client.rpc("messages/send", {
+        conversationId: conv.conversation.id,
+        parts: [
+          { type: "text", text: "Check this out" },
+          { type: "image", url: "https://example.com/photo.jpg" },
+        ],
+      });
+      await new Promise((r) => setTimeout(r, 500));
+
+      const result = (await socketRequest("history", {
+        conversationId: conv.conversation.id,
+        limit: 10,
+      })) as { messages: Array<{ text: string }> };
+
+      const msg = result.messages.find((m) => m.text.includes("Check this out"));
+      expect(msg).toBeDefined();
+      expect(msg!.text).toContain("[image]");
+    } finally {
+      service.close();
+      regA.client.close();
+      regB.client.close();
+    }
+  });
+
+  it("socketPath is stable after connect (cached at startSocketServer time)", async () => {
+    const reg = await registerAgent("sock-stable");
+    const service = await connectService(reg.apiKey);
+    service.startSocketServer();
+    const pathAtStart = service.socketPath;
+    try {
+      const result = (await socketRequest(
+        "ping",
+        undefined,
+        pathAtStart,
+      )) as { ok: boolean };
+      expect(result.ok).toBe(true);
+    } finally {
+      service.close();
+      reg.client.close();
+    }
+  });
+
+  it("unknown socket method rejects with error", async () => {
+    const reg = await registerAgent("sock-unknown");
+    const service = await connectService(reg.apiKey);
+    service.startSocketServer();
+    try {
+      await expect(
+        socketRequest("nonexistent/method", { foo: "bar" }),
+      ).rejects.toThrow();
+    } finally {
+      service.close();
+      reg.client.close();
+    }
+  });
 });

--- a/packages/client/src/cli/socket-client.ts
+++ b/packages/client/src/cli/socket-client.ts
@@ -9,10 +9,20 @@ import { MoltZapService } from "../service.js";
 export async function request(
   method: string,
   params?: Record<string, unknown>,
+  socketPath?: string,
 ): Promise<unknown> {
+  const sockPath = socketPath ?? MoltZapService.SOCKET_PATH;
   return new Promise((resolve, reject) => {
-    const conn = net.createConnection(MoltZapService.SOCKET_PATH);
+    const conn = net.createConnection(sockPath);
     let buffer = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      conn.destroy();
+      reject(new Error("Socket request timed out"));
+    }, 10_000);
 
     conn.on("connect", () => {
       conn.write(JSON.stringify({ method, params }) + "\n");
@@ -24,26 +34,31 @@ export async function request(
       if (idx !== -1) {
         const line = buffer.slice(0, idx);
         conn.end();
-        const response = JSON.parse(line) as {
-          result?: unknown;
-          error?: string;
-        };
-        if (response.error) {
-          reject(new Error(response.error));
-        } else {
-          resolve(response.result);
+        clearTimeout(timer);
+        if (settled) return;
+        settled = true;
+        try {
+          const response = JSON.parse(line) as {
+            result?: unknown;
+            error?: string;
+          };
+          if (response.error) {
+            reject(new Error(response.error));
+          } else {
+            resolve(response.result);
+          }
+        } catch {
+          reject(new Error("Malformed response from service"));
         }
       }
     });
 
     conn.on("error", (err) => {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        reject(
-          new Error(
-            "MoltZap service is not running. Start the OpenClaw channel plugin first.",
-          ),
-        );
-      } else if ((err as NodeJS.ErrnoException).code === "ECONNREFUSED") {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ECONNREFUSED") {
         reject(
           new Error(
             "MoltZap service is not running. Start the OpenClaw channel plugin first.",
@@ -53,11 +68,6 @@ export async function request(
         reject(err);
       }
     });
-
-    setTimeout(() => {
-      conn.destroy();
-      reject(new Error("Socket request timed out"));
-    }, 10_000);
   });
 }
 

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -2,7 +2,12 @@ import * as net from "node:net";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { type EventFrame, type Message, EventNames } from "@moltzap/protocol";
+import {
+  type EventFrame,
+  type Message,
+  type Part,
+  EventNames,
+} from "@moltzap/protocol";
 import { MoltZapWsClient, type WsClientLogger } from "./ws-client.js";
 
 export interface ConversationMeta {
@@ -38,6 +43,19 @@ interface HelloOk {
 }
 
 const MAX_MESSAGES_PER_CONV = 20;
+
+function renderPart(p: Part): string {
+  switch (p.type) {
+    case "text":
+      return p.text;
+    case "image":
+      return "[image]";
+    case "file":
+      return `[file: ${p.name}]`;
+    default:
+      return `[${(p as { type: string }).type}]`;
+  }
+}
 
 /**
  * Stateful MoltZap client that manages connection, conversation tracking,
@@ -107,17 +125,28 @@ export class MoltZapService {
   // --- Socket Server ---
 
   private socketServer: net.Server | null = null;
+  private activeSocketPath: string | null = null;
+
+  /** Default socket path for CLI discovery. Per-instance path uses agentId. */
   static readonly SOCKET_PATH = path.join(
     os.homedir(),
     ".moltzap",
     "service.sock",
   );
 
+  /** Per-instance socket path based on connected agentId. */
+  get socketPath(): string {
+    const id = this.ownAgentId ?? "default";
+    return path.join(os.homedir(), ".moltzap", `service-${id}.sock`);
+  }
+
   startSocketServer(): void {
+    const sockPath = this.socketPath;
+    this.activeSocketPath = sockPath;
     try {
-      fs.unlinkSync(MoltZapService.SOCKET_PATH);
+      fs.unlinkSync(sockPath);
     } catch {}
-    fs.mkdirSync(path.dirname(MoltZapService.SOCKET_PATH), { recursive: true });
+    fs.mkdirSync(path.dirname(sockPath), { recursive: true });
 
     this.socketServer = net.createServer((conn) => {
       let buffer = "";
@@ -131,14 +160,29 @@ export class MoltZapService {
         }
       });
     });
-    this.socketServer.listen(MoltZapService.SOCKET_PATH);
+    this.socketServer.listen(sockPath);
+
+    // Symlink default path to this instance for CLI discovery
+    try {
+      fs.unlinkSync(MoltZapService.SOCKET_PATH);
+    } catch {}
+    try {
+      fs.symlinkSync(sockPath, MoltZapService.SOCKET_PATH);
+    } catch {}
   }
 
   stopSocketServer(): void {
     this.socketServer?.close();
     this.socketServer = null;
+    const sockPath = this.activeSocketPath ?? this.socketPath;
+    this.activeSocketPath = null;
     try {
-      fs.unlinkSync(MoltZapService.SOCKET_PATH);
+      fs.unlinkSync(sockPath);
+    } catch {}
+    // Remove default symlink if it points to this instance
+    try {
+      const target = fs.readlinkSync(MoltZapService.SOCKET_PATH);
+      if (target === sockPath) fs.unlinkSync(MoltZapService.SOCKET_PATH);
     } catch {}
   }
 
@@ -184,10 +228,14 @@ export class MoltZapService {
         const convId = params.conversationId as string;
         const limit = (params.limit as number) ?? 10;
         const sessionKey = params.sessionKey as string | undefined;
+        const afterSeq = params.afterSeq as number | undefined;
+        const beforeSeq = params.beforeSeq as number | undefined;
 
         const result = (await this.sendRpc("messages/list", {
           conversationId: convId,
           limit,
+          ...(afterSeq !== undefined ? { afterSeq } : {}),
+          ...(beforeSeq !== undefined ? { beforeSeq } : {}),
         })) as { messages: Message[]; hasMore: boolean };
 
         // Resolve agent names
@@ -215,10 +263,7 @@ export class MoltZapService {
         const lastReadSeq = readMarkers?.get(convId) ?? 0;
 
         const messages = result.messages.map((m) => {
-          const text = m.parts
-            .filter((p) => p.type === "text" && "text" in p)
-            .map((p) => (p as { text: string }).text)
-            .join(" ");
+          const text = m.parts.map(renderPart).join(" ");
           return {
             seq: m.seq,
             senderId: m.sender.id,
@@ -233,13 +278,18 @@ export class MoltZapService {
           };
         });
 
-        // Advance lastRead marker for this session → this conversation
+        // Advance lastRead to the highest seq in the returned page.
+        // The agent has seen these messages; older ones (if paginated) remain
+        // accessible via afterSeq/beforeSeq cursors.
         if (sessionKey && result.messages.length > 0) {
           const maxSeq = Math.max(...result.messages.map((m) => m.seq));
           if (!this.lastRead.has(sessionKey)) {
             this.lastRead.set(sessionKey, new Map());
           }
-          this.lastRead.get(sessionKey)!.set(convId, maxSeq);
+          const current = this.lastRead.get(sessionKey)!.get(convId) ?? 0;
+          if (maxSeq > current) {
+            this.lastRead.get(sessionKey)!.set(convId, maxSeq);
+          }
         }
 
         // Get conversation metadata
@@ -360,10 +410,7 @@ export class MoltZapService {
         0,
         Math.round((Date.now() - new Date(last.createdAt).getTime()) / 60_000),
       );
-      const text = last.parts
-        .filter((p) => p.type === "text" && "text" in p)
-        .map((p) => (p as { text: string }).text)
-        .join(" ");
+      const text = last.parts.map(renderPart).join(" ");
 
       updates.push(
         `@${senderName} (${ago}m ago): (${reportable.length} new) "${text.slice(0, 120)}"`,


### PR DESCRIPTION
## Summary

Fixes 6 bugs in the socket client implementation found by Codex (gpt-5.4) code review
and Claude adversarial review of the `feat/cli-socket-service` branch.

**Bug fixes:**
- **P1 timer leak** — `setTimeout` was never cleared, causing every CLI command to hang 10s
- **Multi-account socket isolation** — per-instance `socketPath` based on agentId with symlink discovery
- **lastRead pagination** — monotonic advancement with `afterSeq`/`beforeSeq` cursor passthrough
- **Attachment rendering** — non-text parts render as `[image]`/`[file: name]` instead of empty strings
- **JSON.parse safety** — try/catch prevents malformed responses from hanging forever
- **Socket path stability** — cached `activeSocketPath` at start time to prevent path drift

**Code quality (from /simplify):**
- Extracted shared `renderPart()` helper, used in both `handleSocketRequest` and `getContext`
- Collapsed duplicate ENOENT/ECONNREFUSED error branches
- Removed dead `?? "attachment"` fallback (FilePartSchema has `name` required)

**TODOs added:** 6 deferred items from review findings (batch resolution, symlink races,
input validation, unbounded buffer, shared error handling, shared participant resolution)

## Test Coverage

6 regression tests added, 45 total tests passing:
- Timer leak regression (elapsed < 2s)
- Multi-account socket path isolation
- lastRead monotonic advancement with pagination
- Non-text part rendering markers
- Socket path stability after connect
- Unknown method rejection

## Pre-Landing Review
Eng Review: CLEAR. Adversarial review ran (Claude + Codex). All findings addressed.

## Test plan
- [x] All tests pass (45/45)
- [x] Build compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)