### PR TITLE
chore: auto-format pre-commit hook + husky prepare

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,9 @@
 #!/usr/bin/env sh
 
-echo "[pre-commit] running oxfmt..."
 pnpm exec oxfmt .
 if ! git diff --quiet; then
   echo ""
-  echo "[pre-commit] oxfmt fixed formatting. Run: git add -u && git commit"
+  echo "oxfmt fixed formatting. Run: git add -u && git commit"
   exit 1
 fi
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,11 @@
 #!/usr/bin/env sh
 
-# Auto-fix formatting on staged files, then re-stage them
-STAGED=$(git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json')
-if [ -n "$STAGED" ]; then
-  echo "$STAGED" | xargs pnpm exec oxfmt
-  echo "$STAGED" | xargs git add
+echo "[pre-commit] running oxfmt..."
+pnpm exec oxfmt .
+if ! git diff --quiet; then
+  echo ""
+  echo "[pre-commit] oxfmt fixed formatting. Run: git add -u && git commit"
+  exit 1
 fi
 
 pnpm check

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 
-pnpm format:check
+# Auto-fix formatting on staged files, then re-stage them
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json')
+if [ -n "$STAGED" ]; then
+  echo "$STAGED" | xargs pnpm exec oxfmt
+  echo "$STAGED" | xargs git add
+fi
+
 pnpm check
 pnpm typecheck
 ./scripts/sloppy-code-guard.sh

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "docs": "cd docs && mintlify dev",
     "docs:generate": "cd packages/protocol && npx tsx ../../scripts/generate-protocol-docs.ts",
     "docs:check": "cd docs && mintlify broken-links",
-    "docs:check:drift": "cd packages/protocol && npx tsx ../../scripts/generate-protocol-docs.ts && cd ../.. && git diff --exit-code docs/protocol/"
+    "docs:check:drift": "cd packages/protocol && npx tsx ../../scripts/generate-protocol-docs.ts && cd ../.. && git diff --exit-code docs/protocol/",
+    "prepare": "husky"
   },
   "devDependencies": {
     "husky": "^9.0.0",


### PR DESCRIPTION
## Summary
- Pre-commit hook now runs `oxfmt .` and blocks commit if files changed, telling you to `git add -u && git commit`
- Adds `"prepare": "husky"` to package.json so hooks are installed automatically on `pnpm install`

## Why
CI was catching formatting issues after push, wasting a round-trip. Now formatting is caught locally before commit.

## Test plan
- [x] Verified: ugly file → commit → hook formats it → blocks → re-stage → commit succeeds with formatted code

🤖 Generated with [Claude Code](https://claude.com/claude-code)