### PR TITLE
feat: simplify eval container management + auto-build + signal handling

### DIFF
--- a/docs/development/evals.mdx
+++ b/docs/development/evals.mdx
@@ -9,18 +9,56 @@ description: E2E evaluation framework with LLM judges
 
 ## Architecture
 
-1. Docker containers run eval agent images
-2. Agents communicate through a real MoltZap server
-3. LLM judges score conversation quality across dimensions
+1. Docker containers run OpenClaw agents with the MoltZap channel plugin
+2. Agents communicate through a real MoltZap server (testcontainers PostgreSQL)
+3. An LLM judge (Google AI via genkit) scores conversation quality
 4. Results are aggregated into reports with pass/fail verdicts
+
+## Prerequisites
+
+- Docker running locally
+- A `packages/evals/.env` file with API keys (see below)
+- The eval agent Docker image is auto-built on first run (no manual step needed)
+
+## Model configuration
+
+There are two separate model roles:
+
+**Agent model** — the model the OpenClaw agent runs with inside Docker. Pass any
+`provider/model` string via `--model`. OpenClaw resolves it internally. All `*_API_KEY`
+env vars are auto-forwarded to containers. Model IDs are case-sensitive and must match
+OpenClaw's catalog (e.g. `minimax/MiniMax-M2.7-highspeed`, not `minimax/minimax-2.7-highspeed`).
+
+**Judge model** — the LLM-as-judge that scores agent responses. Currently hardwired to
+Google AI via genkit (`googleai/` prefix). Requires `GEMINI_API_KEY`. Default: `gemini-3-flash-preview`.
+
+Env var resolution for agent models uses OpenClaw's `getProviderEnvVars()` SDK, so there's
+no hardcoded mapping to maintain. Adding a new model means just passing its ID string.
+
+### `.env` file
+
+```bash
+# Agent model keys (any *_API_KEY env var is auto-forwarded to containers)
+GEMINI_API_KEY=...
+ZAI_API_KEY=...
+MINIMAX_API_KEY=...
+ANTHROPIC_API_KEY=...
+
+# Judge model uses GEMINI_API_KEY (google AI via genkit)
+```
 
 ## Running evals
 
 ```bash
-pnpm --filter @moltzap/evals test
-```
+# Run with a specific agent model
+pnpm --filter @moltzap/evals eval:e2e --model minimax/MiniMax-M2.7-highspeed
 
-Evals require Docker and an API key for the LLM judge (OpenAI or Anthropic).
+# Run a single scenario
+pnpm --filter @moltzap/evals eval:e2e --model google/gemini-3-flash-preview --scenario EVAL-018
+
+# Override the judge model
+pnpm --filter @moltzap/evals eval:e2e --model zai/glm-5.1 --eval-model gemini-2.5-flash
+```
 
 ## Writing scenarios
 
@@ -28,11 +66,11 @@ Scenarios define the setup, stimulus, and expected behavior:
 
 ```typescript
 {
-  name: "basic-dm-exchange",
-  agents: ["alice", "bob"],
-  stimulus: "Alice sends a greeting to Bob",
-  expectedBehavior: "Bob responds with a relevant reply",
-  scoringDimensions: ["relevance", "coherence", "latency"],
+  id: "EVAL-018",
+  name: "Agent DM greeting response",
+  setupMessage: "Hello! I'm another agent on this MoltZap server. Can you tell me a bit about you",
+  expectedBehavior: "Agent responds with a friendly greeting and self-introduction",
+  validationChecks: ["Agent responds within timeout", "Response is conversational"],
 }
 ```
 

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -36,6 +36,7 @@
     "@types/pg": "^8.11.0",
     "@types/ws": "^8.5.0",
     "@types/yargs": "^17.0.0",
+    "openclaw": "2026.3.31",
     "kysely": "^0.27.0",
     "testcontainers": "^10.18.0",
     "tsx": "^4.19.0",

--- a/packages/evals/scripts/cleanup-eval-containers.sh
+++ b/packages/evals/scripts/cleanup-eval-containers.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Kill moltzap eval containers older than MAX_AGE seconds (default: 1 hour).
+# Run manually or as a pre-step before evals to clean up leftovers.
+
+MAX_AGE=${1:-3600}
+NOW=$(date +%s)
+KILLED=0
+
+# Label-based cleanup (containers created with --label moltzap-eval=true)
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  id=$(echo "$line" | awk '{print $1}')
+  started=$(echo "$line" | awk '{print $2}')
+  if [ -n "$started" ] && [ "$((NOW - started))" -gt "$MAX_AGE" ]; then
+    age=$((NOW - started))
+    echo "Killing stale container $id (age: ${age}s)"
+    docker rm -f "$id" 2>/dev/null
+    KILLED=$((KILLED + 1))
+  fi
+done < <(docker ps --filter "label=moltzap-eval=true" --format '{{.ID}} {{.Label "moltzap-eval-started"}}' 2>/dev/null)
+
+# Name-based fallback for pre-label containers
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  echo "Killing old container $id (matched by name pattern)"
+  docker rm -f "$id" 2>/dev/null
+  KILLED=$((KILLED + 1))
+done < <(docker ps --filter "name=moltzap-e2e-" --format '{{.ID}} {{.RunningFor}}' 2>/dev/null | grep -E 'hours|days' | awk '{print $1}')
+
+if [ "$KILLED" -gt 0 ]; then
+  echo "Cleaned up $KILLED stale eval container(s)"
+else
+  echo "No stale eval containers found"
+fi

--- a/packages/evals/scripts/cleanup-eval-containers.sh
+++ b/packages/evals/scripts/cleanup-eval-containers.sh
@@ -14,18 +14,22 @@ while IFS= read -r line; do
   if [ -n "$started" ] && [ "$((NOW - started))" -gt "$MAX_AGE" ]; then
     age=$((NOW - started))
     echo "Killing stale container $id (age: ${age}s)"
-    docker rm -f "$id" 2>/dev/null
-    KILLED=$((KILLED + 1))
+    docker rm -f "$id" 2>/dev/null && KILLED=$((KILLED + 1))
   fi
 done < <(docker ps --filter "label=moltzap-eval=true" --format '{{.ID}} {{.Label "moltzap-eval-started"}}' 2>/dev/null)
 
-# Name-based fallback for pre-label containers
-while IFS= read -r id; do
-  [ -z "$id" ] && continue
-  echo "Killing old container $id (matched by name pattern)"
-  docker rm -f "$id" 2>/dev/null
-  KILLED=$((KILLED + 1))
-done < <(docker ps --filter "name=moltzap-e2e-" --format '{{.ID}} {{.RunningFor}}' 2>/dev/null | grep -E 'hours|days' | awk '{print $1}')
+# Name-based fallback for pre-label containers: use creation timestamp
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  id=$(echo "$line" | awk '{print $1}')
+  created=$(echo "$line" | awk '{print $2}')
+  [ -z "$created" ] && continue
+  created_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${created%%.*}" +%s 2>/dev/null || date -d "${created%%.*}" +%s 2>/dev/null || continue)
+  if [ "$((NOW - created_epoch))" -gt "$MAX_AGE" ]; then
+    echo "Killing old container $id (matched by name pattern)"
+    docker rm -f "$id" 2>/dev/null && KILLED=$((KILLED + 1))
+  fi
+done < <(docker ps --filter "name=moltzap-e2e-" --format '{{.ID}} {{.CreatedAt}}' 2>/dev/null)
 
 if [ "$KILLED" -gt 0 ]; then
   echo "Cleaned up $KILLED stale eval container(s)"

--- a/packages/evals/src/e2e-infra/docker-manager.ts
+++ b/packages/evals/src/e2e-infra/docker-manager.ts
@@ -21,8 +21,7 @@ import {
   type OpenClawContainer,
 } from "@moltzap/openclaw-channel/test-utils";
 import {
-  type AgentModelConfig,
-  resolveAgentModel,
+  validateAgentModelEnv,
   DEFAULT_AGENT_MODEL_ID,
 } from "./model-config.js";
 import { logger } from "./logger.js";
@@ -35,6 +34,24 @@ export interface AgentContainer {
   name: string;
 }
 
+/** Find the monorepo root by walking up from this file looking for the build script. */
+function findMonorepoRoot(): string | null {
+  let dir = path.resolve(new URL(import.meta.url).pathname, "../../../..");
+  for (let i = 0; i < 10; i++) {
+    if (
+      fs.existsSync(
+        path.join(dir, "packages/evals/scripts/build-eval-agent.sh"),
+      )
+    ) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
 export class DockerManager {
   private containers: Array<AgentContainer & { _raw: OpenClawContainer }> = [];
   private readonly imageName: string;
@@ -43,23 +60,49 @@ export class DockerManager {
     this.imageName = opts?.imageName ?? DEFAULT_EVAL_AGENT_IMAGE;
   }
 
-  async verifyImage(): Promise<void> {
+  /** Ensure the eval agent Docker image exists, auto-building if missing. */
+  async ensureImage(): Promise<void> {
     try {
       execSync(`docker image inspect ${this.imageName}`, { stdio: "pipe" });
+      logger.info(`Docker image "${this.imageName}" verified`);
+      return;
     } catch {
+      // Image missing, try to auto-build
+    }
+
+    logger.info(
+      `Docker image "${this.imageName}" not found, attempting auto-build...`,
+    );
+    const root = findMonorepoRoot();
+    if (!root) {
       throw new Error(
-        `Docker image "${this.imageName}" not found.\n` +
-          `Build it:\n` +
+        `Docker image "${this.imageName}" not found and could not locate monorepo root to auto-build.\n` +
+          `Build manually:\n` +
           `  cd <monorepo-root>\n` +
           `  bash packages/evals/scripts/build-eval-agent.sh`,
       );
     }
-    logger.info(`Docker image "${this.imageName}" verified`);
+
+    try {
+      execSync("bash packages/evals/scripts/build-eval-agent.sh", {
+        cwd: root,
+        stdio: "inherit",
+      });
+      logger.info(`Auto-built Docker image "${this.imageName}"`);
+    } catch (err) {
+      throw new Error(
+        `Failed to auto-build Docker image "${this.imageName}".\n` +
+          `Try building manually:\n` +
+          `  cd ${root}\n` +
+          `  bash packages/evals/scripts/build-eval-agent.sh\n` +
+          `Error: ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 
   async startAgent(opts: {
     name: string;
-    agentModel?: AgentModelConfig;
+    agentModelId?: string;
     moltzapServerUrl?: string;
     moltzapApiKey?: string;
     configOverride?: Record<string, unknown>;
@@ -76,14 +119,9 @@ export class DockerManager {
     if (opts.configOverride) {
       openclawConfig = opts.configOverride;
     } else {
-      const containerModel: ContainerModelConfig = opts.agentModel
-        ? {
-            provider: opts.agentModel.provider,
-            modelId: opts.agentModel.modelId,
-            modelString: opts.agentModel.id,
-            envVar: opts.agentModel.envVar,
-          }
-        : { provider: "zai", modelId: "glm-4.7", modelString: "zai/glm-4.7" };
+      const containerModel: ContainerModelConfig = {
+        modelString: opts.agentModelId ?? DEFAULT_AGENT_MODEL_ID,
+      };
 
       openclawConfig = buildOpenClawConfig({
         model: containerModel,
@@ -172,20 +210,25 @@ export async function setupAgentContainers(opts: {
   containers: AgentContainer[];
 }> {
   const modelId = opts.modelId ?? DEFAULT_AGENT_MODEL_ID;
-  const agentModel = resolveAgentModel(modelId);
+  validateAgentModelEnv(modelId);
   const dockerManager = new DockerManager();
-  await dockerManager.verifyImage();
+  await dockerManager.ensureImage();
 
   const containers: AgentContainer[] = [];
-  for (const cred of opts.agentCredentials) {
-    const container = await dockerManager.startAgent({
-      name: cred.name,
-      moltzapServerUrl: `ws://127.0.0.1:${opts.serverPort}`,
-      moltzapApiKey: cred.apiKey,
-      agentModel,
-      workspaceFiles: opts.workspaceFiles?.(cred.name),
-    });
-    containers.push(container);
+  try {
+    for (const cred of opts.agentCredentials) {
+      const container = await dockerManager.startAgent({
+        name: cred.name,
+        moltzapServerUrl: `ws://127.0.0.1:${opts.serverPort}`,
+        moltzapApiKey: cred.apiKey,
+        agentModelId: modelId,
+        workspaceFiles: opts.workspaceFiles?.(cred.name),
+      });
+      containers.push(container);
+    }
+  } catch (err) {
+    await dockerManager.stopAll();
+    throw err;
   }
 
   return { dockerManager, containers };

--- a/packages/evals/src/e2e-infra/index.ts
+++ b/packages/evals/src/e2e-infra/index.ts
@@ -3,6 +3,7 @@
 /** CLI entry point for the E2E eval runner. */
 
 import { config } from "dotenv";
+import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -21,6 +22,31 @@ import {
   resolveAllAgentModels,
 } from "./model-config.js";
 import { setupLogger, logger } from "./logger.js";
+
+// --- Signal handling: ensure eval containers are cleaned up on exit ---
+const shutdownController = new AbortController();
+let shuttingDown = false;
+
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, () => {
+    if (shuttingDown) process.exit(1); // second signal = hard exit
+    shuttingDown = true;
+    console.error(`\nReceived ${sig}, shutting down eval containers...`);
+    shutdownController.abort();
+    // Fallback: force-kill labeled containers if graceful shutdown hangs
+    setTimeout(() => {
+      try {
+        execSync(
+          'docker ps -q --filter "label=moltzap-eval=true" | xargs -r docker rm -f',
+          { stdio: "pipe" },
+        );
+      } catch {
+        // best effort
+      }
+      process.exit(1);
+    }, 10_000).unref();
+  });
+}
 
 async function main(): Promise<void> {
   const argv = await yargs(hideBin(process.argv))
@@ -109,6 +135,7 @@ async function main(): Promise<void> {
         resultsDir,
         cleanResults: argv["clean-results"],
         logLevel: argv["log-level"],
+        signal: shutdownController.signal,
       });
 
       logger.info(

--- a/packages/evals/src/e2e-infra/index.ts
+++ b/packages/evals/src/e2e-infra/index.ts
@@ -16,14 +16,14 @@ import { hideBin } from "yargs/helpers";
 import { runE2EEvals } from "./runner.js";
 import { TIER5_SCENARIOS } from "./scenarios.js";
 import {
-  AGENT_MODELS,
+  DEFAULT_AGENT_MODEL_ID,
   DEFAULT_JUDGE_MODEL,
-  resolveAgentModel,
-  resolveAllAgentModels,
+  validateAgentModelEnv,
 } from "./model-config.js";
 import { setupLogger, logger } from "./logger.js";
 
 // --- Signal handling: ensure eval containers are cleaned up on exit ---
+const EVAL_CONTAINER_LABEL = "moltzap-eval=true";
 const shutdownController = new AbortController();
 let shuttingDown = false;
 
@@ -36,10 +36,15 @@ for (const sig of ["SIGINT", "SIGTERM"] as const) {
     // Fallback: force-kill labeled containers if graceful shutdown hangs
     setTimeout(() => {
       try {
-        execSync(
-          'docker ps -q --filter "label=moltzap-eval=true" | xargs -r docker rm -f',
-          { stdio: "pipe" },
-        );
+        const ids = execSync(
+          `docker ps -q --filter "label=${EVAL_CONTAINER_LABEL}"`,
+          { encoding: "utf-8" },
+        ).trim();
+        if (ids) {
+          execSync(`docker rm -f ${ids.split("\n").join(" ")}`, {
+            stdio: "pipe",
+          });
+        }
       } catch {
         // best effort
       }
@@ -52,13 +57,9 @@ async function main(): Promise<void> {
   const argv = await yargs(hideBin(process.argv))
     .option("model", {
       type: "string",
-      description: "Agent model to run evals against (e.g., zai/glm-4.7)",
-      choices: AGENT_MODELS.map((m) => m.id),
-    })
-    .option("all-models", {
-      type: "boolean",
-      description: "Run evals against all configured agent models",
-      default: false,
+      description:
+        "Agent model to run evals against (e.g., anthropic/claude-sonnet-4-20250514)",
+      default: DEFAULT_AGENT_MODEL_ID,
     })
     .option("scenario", {
       type: "string",
@@ -91,65 +92,48 @@ async function main(): Promise<void> {
       default: "info",
       choices: ["debug", "info", "warn", "error"],
     })
-    .check((args) => {
-      if (!args.model && !args["all-models"]) {
-        throw new Error(
-          "Must specify --model <provider/model-id> or --all-models.\n" +
-            `Available models: ${AGENT_MODELS.map((m) => m.id).join(", ")}`,
-        );
-      }
-      if (args.model && args["all-models"]) {
-        throw new Error("Cannot specify both --model and --all-models.");
-      }
-      return true;
-    })
     .help()
     .alias("h", "help")
     .strict().argv;
 
   setupLogger(argv.results, argv["log-level"]);
 
-  // Resolve which agent models to run
-  const agentModels = argv["all-models"]
-    ? resolveAllAgentModels()
-    : [resolveAgentModel(argv.model!)];
+  const modelId = argv.model!;
+  validateAgentModelEnv(modelId);
 
-  for (const agentModel of agentModels) {
+  logger.info(
+    `\n${"=".repeat(60)}\nRunning evals with agent model: ${modelId}\n${"=".repeat(60)}`,
+  );
+  logger.info(
+    `Scenarios: ${argv.scenario?.join(", ") ?? "all"} | Runs: ${argv["runs-per-scenario"]} | Judge: ${argv["eval-model"]}`,
+  );
+
+  const resultsDir =
+    argv.results ?? `results/output-${modelId.replace(/[/:]/g, "_")}`;
+
+  try {
+    const result = await runE2EEvals({
+      scenarios: argv.scenario,
+      agentModelId: modelId,
+      runsPerScenario: argv["runs-per-scenario"],
+      evalModel: argv["eval-model"],
+      resultsDir,
+      cleanResults: argv["clean-results"],
+      logLevel: argv["log-level"],
+      signal: shutdownController.signal,
+    });
+
     logger.info(
-      `\n${"=".repeat(60)}\nRunning evals with agent model: ${agentModel.id}\n${"=".repeat(60)}`,
-    );
-    logger.info(
-      `Scenarios: ${argv.scenario?.join(", ") ?? "all"} | Runs: ${argv["runs-per-scenario"]} | Judge: ${argv["eval-model"]}`,
+      `[${modelId}] Done: ${result.summary.passed}/${result.summary.total} passed (${result.summary.avgLatencyMs.toFixed(0)}ms avg)`,
     );
 
-    const resultsDir =
-      argv.results ?? `results/output-${agentModel.id.replace(/[/:]/g, "_")}`;
-
-    try {
-      const result = await runE2EEvals({
-        scenarios: argv.scenario,
-        model: agentModel.id,
-        agentModel,
-        runsPerScenario: argv["runs-per-scenario"],
-        evalModel: argv["eval-model"],
-        resultsDir,
-        cleanResults: argv["clean-results"],
-        logLevel: argv["log-level"],
-        signal: shutdownController.signal,
-      });
-
-      logger.info(
-        `[${agentModel.id}] Done: ${result.summary.passed}/${result.summary.total} passed (${result.summary.avgLatencyMs.toFixed(0)}ms avg)`,
-      );
-
-      if (result.summary.failed > 0) {
-        process.exitCode = 1;
-      }
-    } catch (e: unknown) {
-      const err = e as Error;
-      logger.error(`[${agentModel.id}] Fatal: ${err.message}`);
-      process.exitCode = 2;
+    if (result.summary.failed > 0) {
+      process.exitCode = 1;
     }
+  } catch (e: unknown) {
+    const err = e as Error;
+    logger.error(`[${modelId}] Fatal: ${err.message}`);
+    process.exitCode = 2;
   }
 
   process.exit(process.exitCode ?? 0);

--- a/packages/evals/src/e2e-infra/model-config.ts
+++ b/packages/evals/src/e2e-infra/model-config.ts
@@ -1,6 +1,23 @@
-/** Model configuration for E2E evals, mirroring OpenClaw's models.ts pattern. */
+/**
+ * Model configuration for E2E evals.
+ *
+ * Two separate model roles:
+ *
+ *   Agent model — the model the OpenClaw agent runs with inside Docker.
+ *     Pass any "provider/model" string via --model. OpenClaw resolves it
+ *     internally; env var lookup uses openclaw/plugin-sdk/provider-env-vars.
+ *     Model IDs are case-sensitive and must match OpenClaw's catalog exactly
+ *     (e.g. "minimax/MiniMax-M2.7-highspeed", not "minimax/minimax-2.7-highspeed").
+ *     All *_API_KEY env vars are auto-forwarded to containers.
+ *
+ *   Judge model — the LLM-as-judge used to score agent responses.
+ *     Currently hardwired to Google AI via genkit (googleai/ prefix).
+ *     Requires GEMINI_API_KEY.
+ */
 
-/** Judge/eval model configuration (used for LLM-as-judge scoring). */
+import { getProviderEnvVars } from "openclaw/plugin-sdk/provider-env-vars";
+
+/** Judge/eval model configuration (used for LLM-as-judge scoring via genkit). */
 export interface ModelConfig {
   provider: string;
   modelId: string;
@@ -9,21 +26,9 @@ export interface ModelConfig {
   tokensPerMinute: number;
 }
 
-/** Agent model configuration (the model the OpenClaw agent runs with). */
-export interface AgentModelConfig {
-  /** OpenClaw provider/model format, e.g. "zai/glm-4.7" */
-  id: string;
-  /** OpenClaw provider name for config injection */
-  provider: string;
-  /** Model ID within the provider */
-  modelId: string;
-  /** Environment variable that must contain the API key */
-  envVar: string;
-}
+export const DEFAULT_JUDGE_MODEL = "gemini-3-flash-preview";
 
-export const DEFAULT_JUDGE_MODEL = "gemini-2.5-flash";
-
-export const DEFAULT_AGENT_MODEL_ID = "minimax/minimax-2.7-highspeed";
+export const DEFAULT_AGENT_MODEL_ID = "minimax/MiniMax-M2.7-highspeed";
 
 export const MODELS: ModelConfig[] = [
   {
@@ -56,46 +61,6 @@ export const MODELS: ModelConfig[] = [
   },
 ];
 
-/** Models the OpenClaw agent can be configured to use during evals. */
-export const AGENT_MODELS: AgentModelConfig[] = [
-  {
-    id: "zai/glm-5.1",
-    provider: "zai",
-    modelId: "glm-5.1",
-    envVar: "ZAI_API_KEY",
-  },
-  {
-    id: "zai/glm-4.7",
-    provider: "zai",
-    modelId: "glm-4.7",
-    envVar: "ZAI_API_KEY",
-  },
-  {
-    id: "anthropic/claude-sonnet-4-20250514",
-    provider: "anthropic",
-    modelId: "claude-sonnet-4-20250514",
-    envVar: "ANTHROPIC_API_KEY",
-  },
-  {
-    id: "google/gemini-2.5-flash",
-    provider: "google",
-    modelId: "gemini-2.5-flash",
-    envVar: "GEMINI_API_KEY",
-  },
-  {
-    id: "openai/gpt-5-mini",
-    provider: "openai",
-    modelId: "gpt-5-mini",
-    envVar: "OPENAI_API_KEY",
-  },
-  {
-    id: "minimax/minimax-2.7-highspeed",
-    provider: "minimax",
-    modelId: "minimax-2.7-highspeed",
-    envVar: "MINIMAX_API_KEY",
-  },
-];
-
 export function getModelConfig(): ModelConfig {
   const provider = process.env["EVAL_LLM_PROVIDER"] ?? "anthropic";
 
@@ -106,35 +71,22 @@ export function getModelConfig(): ModelConfig {
   return MODELS[0]!;
 }
 
-/** Resolve and validate an agent model by ID. Crashes if the required API key is missing. */
-export function resolveAgentModel(modelId: string): AgentModelConfig {
-  const model = AGENT_MODELS.find((m) => m.id === modelId);
-  if (!model) {
+/** Pre-flight: crash early if the API key for this model's provider isn't set. */
+export function validateAgentModelEnv(modelId: string): void {
+  const slash = modelId.indexOf("/");
+  if (slash < 1)
     throw new Error(
-      `Unknown agent model "${modelId}". Available: ${AGENT_MODELS.map((m) => m.id).join(", ")}`,
+      `Invalid model ID "${modelId}" — expected "provider/model"`,
+    );
+  const provider = modelId.slice(0, slash);
+  const envVars = getProviderEnvVars(provider);
+  if (!envVars.length)
+    throw new Error(
+      `Unknown provider "${provider}" in model "${modelId}"`,
+    );
+  if (!envVars.some((v) => process.env[v])) {
+    throw new Error(
+      `No API key for provider "${provider}". Set one of: ${envVars.join(", ")}`,
     );
   }
-
-  const apiKey = process.env[model.envVar];
-  if (!apiKey) {
-    throw new Error(`${model.envVar} required for model ${model.id}`);
-  }
-
-  return model;
-}
-
-/** Resolve all agent models. Crashes if ANY required API key is missing. */
-export function resolveAllAgentModels(): AgentModelConfig[] {
-  const missing: string[] = [];
-  for (const model of AGENT_MODELS) {
-    if (!process.env[model.envVar]) {
-      missing.push(`${model.envVar} required for model ${model.id}`);
-    }
-  }
-  if (missing.length > 0) {
-    throw new Error(
-      `Missing API keys for --all-models:\n  ${missing.join("\n  ")}`,
-    );
-  }
-  return AGENT_MODELS;
 }

--- a/packages/evals/src/e2e-infra/model-config.ts
+++ b/packages/evals/src/e2e-infra/model-config.ts
@@ -81,9 +81,7 @@ export function validateAgentModelEnv(modelId: string): void {
   const provider = modelId.slice(0, slash);
   const envVars = getProviderEnvVars(provider);
   if (!envVars.length)
-    throw new Error(
-      `Unknown provider "${provider}" in model "${modelId}"`,
-    );
+    throw new Error(`Unknown provider "${provider}" in model "${modelId}"`);
   if (!envVars.some((v) => process.env[v])) {
     throw new Error(
       `No API key for provider "${provider}". Set one of: ${envVars.join(", ")}`,

--- a/packages/evals/src/e2e-infra/runner.ts
+++ b/packages/evals/src/e2e-infra/runner.ts
@@ -337,6 +337,7 @@ export async function runE2EEvals(opts: {
   resultsDir?: string;
   cleanResults?: boolean;
   logLevel?: string;
+  signal?: AbortSignal;
 }): Promise<E2ERunResult> {
   const {
     scenarios: scenarioFilter,
@@ -494,6 +495,11 @@ export async function runE2EEvals(opts: {
     let completedJobs = 0;
 
     for (const scenario of selectedScenarios) {
+      if (opts.signal?.aborted) {
+        logger.warn("Eval run aborted by signal, skipping remaining scenarios");
+        break;
+      }
+
       for (let run = 1; run <= runsPerScenario; run++) {
         // Drain stale events between scenarios — previous agent responses
         // can leak into the next scenario's waitForEvent since DM conversations

--- a/packages/evals/src/e2e-infra/runner.ts
+++ b/packages/evals/src/e2e-infra/runner.ts
@@ -19,8 +19,7 @@ import { DockerManager } from "./docker-manager.js";
 import { TIER5_SCENARIOS } from "./scenarios.js";
 import { judgeAgentResponse, analysisFlow } from "./llm-judge.js";
 import { generateReport, generateSummaryMarkdown } from "./report.js";
-import { getModelConfig, DEFAULT_JUDGE_MODEL } from "./model-config.js";
-import type { AgentModelConfig } from "./model-config.js";
+import { DEFAULT_JUDGE_MODEL, DEFAULT_AGENT_MODEL_ID } from "./model-config.js";
 import { logger } from "./logger.js";
 import type {
   EvalScenario,
@@ -330,8 +329,7 @@ async function generateResult(opts: {
 
 export async function runE2EEvals(opts: {
   scenarios?: string[];
-  model?: string;
-  agentModel?: AgentModelConfig;
+  agentModelId?: string;
   runsPerScenario?: number;
   evalModel?: string;
   resultsDir?: string;
@@ -347,8 +345,7 @@ export async function runE2EEvals(opts: {
     cleanResults = false,
   } = opts;
 
-  const modelConfig = getModelConfig();
-  const modelName = opts.model ?? modelConfig.modelId;
+  const modelName = opts.agentModelId ?? DEFAULT_AGENT_MODEL_ID;
 
   // Filter scenarios
   let selectedScenarios = TIER5_SCENARIOS;
@@ -380,7 +377,7 @@ export async function runE2EEvals(opts: {
 
   try {
     // Verify Docker image exists
-    await dockerManager.verifyImage();
+    await dockerManager.ensureImage();
 
     // Phase 0: Start test infrastructure
     logger.info("Starting MoltZap core test server (testcontainers)...");
@@ -445,7 +442,7 @@ export async function runE2EEvals(opts: {
       name: "openclaw-eval-agent",
       moltzapServerUrl: testServerWsUrl,
       moltzapApiKey: agentReg.apiKey,
-      agentModel: opts.agentModel,
+      agentModelId: opts.agentModelId,
       contextAdapter: needsContextAwareness
         ? { type: "cross-conversation" }
         : undefined,

--- a/packages/openclaw-channel/src/__tests__/openclaw-container.ts
+++ b/packages/openclaw-channel/src/__tests__/openclaw-container.ts
@@ -7,10 +7,10 @@ import type { ContainerModelConfig } from "../test-utils/container-core.js";
 /** Echo model config — no API key required. */
 export function echoModelConfig(echoPort: number): ContainerModelConfig {
   return {
-    provider: "echo",
-    modelId: "echo-1",
     modelString: "echo/echo-1",
     providerConfig: {
+      provider: "echo",
+      modelId: "echo-1",
       baseUrl: `http://host.docker.internal:${echoPort}`,
       api: "openai-completions",
       apiKey: "test",

--- a/packages/openclaw-channel/src/test-utils/container-core.ts
+++ b/packages/openclaw-channel/src/test-utils/container-core.ts
@@ -90,6 +90,8 @@ export function buildOpenClawConfig(opts: {
         ],
       },
     },
+    heartbeat: { enabled: false },
+    healthMonitor: { enabled: false },
     gateway: {
       mode: "local",
       controlUi: {
@@ -148,6 +150,7 @@ export function startRawContainer(
   );
 
   const containerName = `moltzap-e2e-${opts.name}-${Date.now()}`;
+  const startedEpoch = Math.floor(Date.now() / 1000);
   const envParts = [`-e OPENCLAW_STATE_DIR=${OPENCLAW_STATE_DIR}`];
   if (opts.envVars) {
     for (const [k, v] of Object.entries(opts.envVars)) {
@@ -159,6 +162,9 @@ export function startRawContainer(
     [
       "docker create",
       `--name ${containerName}`,
+      `--label moltzap-eval=true`,
+      `--label moltzap-eval-started=${startedEpoch}`,
+      `--stop-timeout 5`,
       ...envParts,
       `--add-host host.docker.internal:host-gateway`,
       `-p ${controlPort}:${CONTROL_UI_PORT}`,

--- a/packages/openclaw-channel/src/test-utils/container-core.ts
+++ b/packages/openclaw-channel/src/test-utils/container-core.ts
@@ -13,15 +13,14 @@ export const IMAGE_NAME = "moltzap-eval-agent:local";
 export const OPENCLAW_STATE_DIR = "/home/node/.openclaw";
 
 export type ContainerModelConfig = {
-  provider: string;
-  modelId: string;
   modelString: string;
   providerConfig?: {
+    provider: string;
+    modelId: string;
     baseUrl: string;
     api: string;
     apiKey: string;
   };
-  envVar?: string;
 };
 
 export type OpenClawContainer = {
@@ -90,8 +89,6 @@ export function buildOpenClawConfig(opts: {
         ],
       },
     },
-    heartbeat: { enabled: false },
-    healthMonitor: { enabled: false },
     gateway: {
       mode: "local",
       controlUi: {
@@ -107,13 +104,14 @@ export function buildOpenClawConfig(opts: {
   };
 
   if (opts.model.providerConfig) {
+    const pc = opts.model.providerConfig;
     (config as Record<string, Record<string, unknown>>).models = {
       providers: {
-        [opts.model.provider]: {
-          baseUrl: opts.model.providerConfig.baseUrl,
-          api: opts.model.providerConfig.api,
-          apiKey: opts.model.providerConfig.apiKey,
-          models: [{ id: opts.model.modelId, name: opts.model.modelId }],
+        [pc.provider]: {
+          baseUrl: pc.baseUrl,
+          api: pc.api,
+          apiKey: pc.apiKey,
+          models: [{ id: pc.modelId, name: pc.modelId }],
         },
       },
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       kysely:
         specifier: ^0.27.0
         version: 0.27.6
+      openclaw:
+        specifier: 2026.3.31
+        version: 2026.3.31(@cfworker/json-schema@4.1.1)(@napi-rs/canvas@0.1.97)
       testcontainers:
         specifier: ^10.18.0
         version: 10.28.0
@@ -3289,6 +3292,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -8491,7 +8495,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@google/genai@1.47.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
+  '@google/genai@1.47.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
@@ -8968,9 +8972,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -8980,11 +8984,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1021.0
-      '@google/genai': 1.47.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))
+      '@google/genai': 1.47.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))
       '@mistralai/mistralai': 1.14.1
       '@sinclair/typebox': 0.34.49
       ajv: 8.18.0
@@ -9004,11 +9008,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.64.0
       '@silvia-odwyer/photon-node': 0.3.4
       ajv: 8.18.0
@@ -14994,9 +14998,9 @@ snapshots:
       '@homebridge/ciao': 1.3.6
       '@line/bot-sdk': 10.6.0
       '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.64.0
       '@matrix-org/matrix-sdk-crypto-wasm': 18.0.0
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)


### PR DESCRIPTION
## Summary
- **Delete hardcoded model registry** — `AgentModelConfig`, `AGENT_MODELS` array (6×4 fields), `resolveAgentModel()`, `resolveAllAgentModels()`, `--all-models` all gone
- **Use OpenClaw SDK** — `getProviderEnvVars()` from `openclaw/plugin-sdk/provider-env-vars` resolves env vars at runtime. No hardcoded env var names
- **Auto-build Docker image** — `ensureImage()` replaces `verifyImage()`. Missing image triggers automatic build. No manual `build-eval-agent.sh` step
- **Signal handling** — SIGINT/SIGTERM graceful shutdown via AbortController + 10s force-kill fallback
- **Container labels** — `moltzap-eval=true` + `moltzap-eval-started=<epoch>` for cleanup script discovery
- **Orphan protection** — `setupAgentContainers()` stops already-started containers if a later one fails
- **Simplified types** — `ContainerModelConfig` reduced to `{ modelString, providerConfig? }`. Agent model is a plain string everywhere
- **macOS compatibility** — replaced GNU `xargs -r` with shell-native approach in force-kill fallback
- **Cleanup script fix** — epoch-based age check instead of locale-dependent duration strings

Adding a new model = just `--model newprovider/whatever`. No code changes, no registry updates.

## Test plan
- [x] `pnpm build` passes (all 7 workspace packages)
- [x] `pnpm test` passes (204 tests across protocol, server-core, client, openclaw-channel)
- [x] E2E: `--model minimax/MiniMax-M2.7-highspeed --scenario EVAL-018` — 1/1 PASS
- [x] E2E: 3 scenarios (EVAL-018, 019, 005) — 3/3 PASS
- [x] Auto-build: deleted image, ran eval, `ensureImage()` rebuilt automatically and eval passed
- [x] `validateAgentModelEnv()` correctly resolves env vars for google, zai, anthropic, minimax, openai via OpenClaw SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)