### PR TITLE
refactor: extract shared CLI action wrapper and participant resolver

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -65,32 +65,6 @@ The socket server accumulates `buffer += chunk.toString()` with no max size. A c
 
 **Depends on:** Nothing.
 
-## CLI
-
-### Extract shared error handling wrapper
-
-**Priority:** P3
-
-Every CLI command repeats the same `try { ... } catch (err) { console.error(...); process.exit(1); }` pattern (~26 times across 10 files). The deleted `withService()` wrapper had centralized this.
-
-**Why:** DRY. A `wrapAction(fn)` utility would eliminate 26 identical catch blocks and ensure consistent error formatting.
-
-**Files:** `packages/client/src/cli/commands/*.ts`
-
-**Depends on:** Nothing.
-
-### Extract shared participant resolution
-
-**Priority:** P3
-
-The `resolveParticipant()` logic (UUID check + `agents/lookupByName` fallback) is inlined 3 times in `conversations.ts` (create, addParticipant, removeParticipant). The original `resolve.ts` was deleted when the CLI was refactored to use the socket client.
-
-**Why:** DRY. Same UUID regex and lookup logic repeated 3 times. Extract to a utility that takes a `request` function parameter.
-
-**Files:** `packages/client/src/cli/commands/conversations.ts`
-
-**Depends on:** Nothing.
-
 ## Completed
 
 ### `moltzap updates` CLI command
@@ -98,3 +72,15 @@ The `resolveParticipant()` logic (UUID check + `agents/lookupByName` fallback) i
 **Completed:** 2026-04-08
 
 Implemented as `moltzap history <convId> --session-key <key>` in the socket client refactor. The agent reads full messages from other conversations via the history command with session-key tracking for *NEW* markers.
+
+### Extract shared error handling wrapper
+
+**Completed:** 2026-04-08
+
+Extracted `action()` wrapper in `socket-client.ts`. Eliminated 20 identical try/catch blocks across CLI commands.
+
+### Extract shared participant resolution
+
+**Completed:** 2026-04-08
+
+Extracted `resolveParticipant()` in `socket-client.ts`. Replaced 3 identical inline UUID-or-lookup patterns in `conversations.ts`.

--- a/packages/client/src/__tests__/service.integration.test.ts
+++ b/packages/client/src/__tests__/service.integration.test.ts
@@ -629,10 +629,11 @@ describe("Cross-Conversation Context", () => {
     await regC.client.connect(regC.apiKey);
     const service = await connectService(regA.apiKey);
 
-    const convB = (await service.sendRpc("conversations/create", {
+    // convB created to establish the conversation but not referenced directly
+    await service.sendRpc("conversations/create", {
       type: "dm",
       participants: [{ type: "agent", id: regB.agentId }],
-    })) as { conversation: { id: string } };
+    });
     const convC = (await service.sendRpc("conversations/create", {
       type: "dm",
       participants: [{ type: "agent", id: regC.agentId }],

--- a/packages/client/src/cli/commands/agents.ts
+++ b/packages/client/src/cli/commands/agents.ts
@@ -1,48 +1,41 @@
 import { Command } from "commander";
-import { request } from "../socket-client.js";
+import { request, action } from "../socket-client.js";
 import type { AgentCard } from "@moltzap/protocol";
 
 export const agentsCommand = new Command("agents").description(
   "List and look up agents on MoltZap",
 );
 
-agentsCommand
-  .option("--json", "Output as JSON")
-  .action(async (opts: { json?: boolean }) => {
-    try {
-      const result = (await request("agents/list", {})) as {
-        agents: Record<string, AgentCard>;
-      };
-      const entries = Object.values(result.agents);
-      if (opts.json) {
-        console.log(JSON.stringify(result.agents, null, 2));
-        return;
-      }
-      if (entries.length === 0) {
-        console.log("No agents found.");
-        return;
-      }
-      for (const agent of entries) {
-        let line = agent.name;
-        if (agent.displayName) line += ` (${agent.displayName})`;
-        line += `\n  ID: ${agent.id}\n  Status: ${agent.status}`;
-        if (agent.description) line += `\n  Description: ${agent.description}`;
-        console.log(line + "\n");
-      }
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
+agentsCommand.option("--json", "Output as JSON").action(
+  action(async (opts: { json?: boolean }) => {
+    const result = (await request("agents/list", {})) as {
+      agents: Record<string, AgentCard>;
+    };
+    const entries = Object.values(result.agents);
+    if (opts.json) {
+      console.log(JSON.stringify(result.agents, null, 2));
+      return;
     }
-  });
+    if (entries.length === 0) {
+      console.log("No agents found.");
+      return;
+    }
+    for (const agent of entries) {
+      let line = agent.name;
+      if (agent.displayName) line += ` (${agent.displayName})`;
+      line += `\n  ID: ${agent.id}\n  Status: ${agent.status}`;
+      if (agent.description) line += `\n  Description: ${agent.description}`;
+      console.log(line + "\n");
+    }
+  }),
+);
 
 agentsCommand
   .command("lookup")
   .description("Look up agents by name")
   .argument("<names...>", "Agent names to look up")
-  .action(async (names: string[]) => {
-    try {
+  .action(
+    action(async (names: string[]) => {
       const result = (await request("agents/lookupByName", { names })) as {
         agents: AgentCard[];
       };
@@ -55,10 +48,5 @@ agentsCommand
         if (agent.description) line += `\n  Description: ${agent.description}`;
         console.log(line + "\n");
       }
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/packages/client/src/cli/commands/contacts.ts
+++ b/packages/client/src/cli/commands/contacts.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { request } from "../socket-client.js";
+import { request, action } from "../socket-client.js";
 import type { Contact } from "@moltzap/protocol";
 
 export const contactsCommand = new Command("contacts").description(
@@ -11,8 +11,8 @@ contactsCommand
   .description("List contacts")
   .option("--status <status>", "Filter by status (pending, accepted, blocked)")
   .option("--json", "Output as JSON")
-  .action(async (opts: { status?: string; json?: boolean }) => {
-    try {
+  .action(
+    action(async (opts: { status?: string; json?: boolean }) => {
       const params: Record<string, unknown> = {};
       if (opts.status) params.status = opts.status;
 
@@ -33,20 +33,15 @@ contactsCommand
         const target = c.targetName ?? c.targetPhone ?? c.targetId;
         console.log(`  ${c.id}  ${c.status}  ${requester} -> ${target}`);
       }
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 contactsCommand
   .command("add")
   .description("Add a contact by phone number or user ID")
   .argument("<identifier>", "Phone number (+E.164) or user ID")
-  .action(async (identifier: string) => {
-    try {
+  .action(
+    action(async (identifier: string) => {
       const params: Record<string, string> = {};
       if (identifier.startsWith("+")) {
         params.phone = identifier;
@@ -60,60 +55,40 @@ contactsCommand
       console.log(
         `Contact request sent (id: ${result.contactId}, status: ${result.status})`,
       );
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 contactsCommand
   .command("accept")
   .description("Accept a contact request")
   .argument("<contactId>", "Contact ID to accept")
-  .action(async (contactId: string) => {
-    try {
+  .action(
+    action(async (contactId: string) => {
       const result = (await request("contacts/accept", { contactId })) as {
         contact: Contact;
       };
       console.log(`Contact accepted: ${result.contact.id}`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 contactsCommand
   .command("block")
   .description("Block a contact")
   .argument("<contactId>", "Contact ID to block")
-  .action(async (contactId: string) => {
-    try {
+  .action(
+    action(async (contactId: string) => {
       await request("contacts/block", { contactId });
       console.log(`Contact ${contactId} blocked.`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 contactsCommand
   .command("remove")
   .description("Remove a contact")
   .argument("<contactId>", "Contact ID to remove")
-  .action(async (contactId: string) => {
-    try {
+  .action(
+    action(async (contactId: string) => {
       await request("contacts/remove", { contactId });
       console.log(`Contact ${contactId} removed.`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/packages/client/src/cli/commands/conversations.ts
+++ b/packages/client/src/cli/commands/conversations.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { request } from "../socket-client.js";
+import { request, action, resolveParticipant } from "../socket-client.js";
 import type { ConversationSummary } from "@moltzap/protocol";
 
 export const conversationsCommand = new Command("conversations").description(
@@ -11,8 +11,8 @@ conversationsCommand
   .description("List conversations with unread counts")
   .option("--limit <n>", "Max conversations to list", "20")
   .option("--json", "Output as JSON")
-  .action(async (opts: { limit: string; json?: boolean }) => {
-    try {
+  .action(
+    action(async (opts: { limit: string; json?: boolean }) => {
       const result = (await request("conversations/list", {
         limit: parseInt(opts.limit, 10),
       })) as { conversations: ConversationSummary[] };
@@ -33,13 +33,8 @@ conversationsCommand
           console.log(`    Last: ${c.lastMessagePreview}`);
         }
       }
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 conversationsCommand
   .command("create")
@@ -48,33 +43,9 @@ conversationsCommand
   .argument("<participant...>", "Participants (e.g. agent:bob)")
   .option("--type <type>", "Conversation type: dm or group")
   .action(
-    async (name: string, participants: string[], opts: { type?: string }) => {
-      try {
-        // Resolve participant names to IDs via the service
-        const parsed = await Promise.all(
-          participants.map(async (p) => {
-            const colon = p.indexOf(":");
-            if (colon === -1)
-              throw new Error(`Invalid: "${p}". Use agent:name`);
-            const type = p.slice(0, colon);
-            const value = p.slice(colon + 1);
-            if (
-              /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-                value,
-              )
-            ) {
-              return { type, id: value };
-            }
-            if (type !== "agent") throw new Error(`Cannot resolve "${p}"`);
-            const result = (await request("agents/lookupByName", {
-              names: [value],
-            })) as { agents: Array<{ id: string }> };
-            if (result.agents.length === 0)
-              throw new Error(`Agent "${value}" not found`);
-            return { type: "agent", id: result.agents[0]!.id };
-          }),
-        );
-
+    action(
+      async (name: string, participants: string[], opts: { type?: string }) => {
+        const parsed = await Promise.all(participants.map(resolveParticipant));
         const convType = opts.type ?? (parsed.length === 1 ? "dm" : "group");
         const result = (await request("conversations/create", {
           type: convType,
@@ -84,38 +55,28 @@ conversationsCommand
         console.log(
           `Conversation created: ${result.conversation.id} (${result.conversation.type})`,
         );
-      } catch (err) {
-        console.error(
-          `Failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );
 
 conversationsCommand
   .command("leave")
   .description("Leave a conversation")
   .argument("<conversationId>", "Conversation ID")
-  .action(async (conversationId: string) => {
-    try {
+  .action(
+    action(async (conversationId: string) => {
       await request("conversations/leave", { conversationId });
       console.log(`Left conversation ${conversationId}.`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 conversationsCommand
   .command("mute")
   .description("Mute a conversation")
   .argument("<conversationId>", "Conversation ID")
   .option("--until <datetime>", "Mute until ISO datetime")
-  .action(async (conversationId: string, opts: { until?: string }) => {
-    try {
+  .action(
+    action(async (conversationId: string, opts: { until?: string }) => {
       const params: Record<string, string> = { conversationId };
       if (opts.until) params.until = opts.until;
       await request("conversations/mute", params);
@@ -124,37 +85,27 @@ conversationsCommand
           ? `Conversation ${conversationId} muted until ${opts.until}.`
           : `Conversation ${conversationId} muted.`,
       );
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 conversationsCommand
   .command("unmute")
   .description("Unmute a conversation")
   .argument("<conversationId>", "Conversation ID")
-  .action(async (conversationId: string) => {
-    try {
+  .action(
+    action(async (conversationId: string) => {
       await request("conversations/unmute", { conversationId });
       console.log(`Conversation ${conversationId} unmuted.`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 conversationsCommand
   .command("update")
   .description("Update conversation settings")
   .argument("<conversationId>", "Conversation ID")
   .requiredOption("--name <name>", "New conversation name")
-  .action(async (conversationId: string, opts: { name: string }) => {
-    try {
+  .action(
+    action(async (conversationId: string, opts: { name: string }) => {
       const result = (await request("conversations/update", {
         conversationId,
         name: opts.name,
@@ -162,92 +113,40 @@ conversationsCommand
       console.log(
         `Conversation updated: ${result.conversation.id} (name: ${result.conversation.name})`,
       );
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 conversationsCommand
   .command("add-participant")
   .description("Add a participant to a conversation")
   .argument("<conversationId>", "Conversation ID")
   .argument("<participant>", "Participant (e.g. agent:bob)")
-  .action(async (conversationId: string, participant: string) => {
-    try {
-      // Inline resolve (same as create)
-      const colon = participant.indexOf(":");
-      if (colon === -1) throw new Error(`Invalid: "${participant}"`);
-      const type = participant.slice(0, colon);
-      const value = participant.slice(colon + 1);
-      let ref: { type: string; id: string };
-      if (
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-          value,
-        )
-      ) {
-        ref = { type, id: value };
-      } else {
-        const result = (await request("agents/lookupByName", {
-          names: [value],
-        })) as { agents: Array<{ id: string }> };
-        if (result.agents.length === 0)
-          throw new Error(`Agent "${value}" not found`);
-        ref = { type: "agent", id: result.agents[0]!.id };
-      }
+  .action(
+    action(async (conversationId: string, participant: string) => {
+      const ref = await resolveParticipant(participant);
       await request("conversations/addParticipant", {
         conversationId,
         participant: ref,
       });
       console.log(`Added ${participant} to ${conversationId}.`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 conversationsCommand
   .command("remove-participant")
   .description("Remove a participant from a conversation")
   .argument("<conversationId>", "Conversation ID")
   .argument("<participant>", "Participant (e.g. agent:bob)")
-  .action(async (conversationId: string, participant: string) => {
-    try {
-      const colon = participant.indexOf(":");
-      if (colon === -1) throw new Error(`Invalid: "${participant}"`);
-      const type = participant.slice(0, colon);
-      const value = participant.slice(colon + 1);
-      let ref: { type: string; id: string };
-      if (
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-          value,
-        )
-      ) {
-        ref = { type, id: value };
-      } else {
-        const result = (await request("agents/lookupByName", {
-          names: [value],
-        })) as { agents: Array<{ id: string }> };
-        if (result.agents.length === 0)
-          throw new Error(`Agent "${value}" not found`);
-        ref = { type: "agent", id: result.agents[0]!.id };
-      }
+  .action(
+    action(async (conversationId: string, participant: string) => {
+      const ref = await resolveParticipant(participant);
       await request("conversations/removeParticipant", {
         conversationId,
         participant: ref,
       });
       console.log(`Removed ${participant} from ${conversationId}.`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );
 
 interface HistoryMessage {
   seq: number;
@@ -263,53 +162,45 @@ async function showHistory(
   conversationId: string,
   opts: { limit: string; json?: boolean; sessionKey?: string },
 ): Promise<void> {
-  try {
-    const result = (await request("history", {
-      conversationId,
-      limit: parseInt(opts.limit, 10),
-      sessionKey: opts.sessionKey,
-    })) as {
-      messages: HistoryMessage[];
-      hasMore: boolean;
-      conversationMeta?: { type: string; name?: string };
-      newCount: number;
-    };
+  const result = (await request("history", {
+    conversationId,
+    limit: parseInt(opts.limit, 10),
+    sessionKey: opts.sessionKey,
+  })) as {
+    messages: HistoryMessage[];
+    hasMore: boolean;
+    conversationMeta?: { type: string; name?: string };
+    newCount: number;
+  };
 
-    if (opts.json) {
-      console.log(JSON.stringify(result, null, 2));
-      return;
-    }
-    if (result.messages.length === 0) {
-      console.log("No messages.");
-      return;
-    }
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  if (result.messages.length === 0) {
+    console.log("No messages.");
+    return;
+  }
 
-    if (opts.sessionKey && result.conversationMeta) {
-      const label =
-        result.conversationMeta.name ?? result.conversationMeta.type;
-      console.log(
-        `Conversation: ${label} (${conversationId}) | ${result.newCount} new`,
-      );
-      console.log("");
-    }
-
-    for (const m of result.messages) {
-      const ago = Math.max(
-        0,
-        Math.round((Date.now() - new Date(m.createdAt).getTime()) / 60_000),
-      );
-      const newMarker = m.isNew ? " *" : "";
-      console.log(`  [${ago}m ago] ${m.senderName}: ${m.text}${newMarker}`);
-    }
-
-    if (result.hasMore) {
-      console.log("  ... more messages available");
-    }
-  } catch (err) {
-    console.error(
-      `Failed: ${err instanceof Error ? err.message : String(err)}`,
+  if (opts.sessionKey && result.conversationMeta) {
+    const label = result.conversationMeta.name ?? result.conversationMeta.type;
+    console.log(
+      `Conversation: ${label} (${conversationId}) | ${result.newCount} new`,
     );
-    process.exit(1);
+    console.log("");
+  }
+
+  for (const m of result.messages) {
+    const ago = Math.max(
+      0,
+      Math.round((Date.now() - new Date(m.createdAt).getTime()) / 60_000),
+    );
+    const newMarker = m.isNew ? " *" : "";
+    console.log(`  [${ago}m ago] ${m.senderName}: ${m.text}${newMarker}`);
+  }
+
+  if (result.hasMore) {
+    console.log("  ... more messages available");
   }
 }
 
@@ -320,7 +211,7 @@ conversationsCommand
   .option("--limit <n>", "Max messages to show", "50")
   .option("--json", "Output as JSON")
   .option("--session-key <key>", "Session key for cross-conversation context")
-  .action(showHistory);
+  .action(action(showHistory));
 
 export const historyCommand = new Command("history")
   .description("Show message history for a conversation")
@@ -328,4 +219,4 @@ export const historyCommand = new Command("history")
   .option("--limit <n>", "Max messages to show", "50")
   .option("--json", "Output as JSON")
   .option("--session-key <key>", "Session key for cross-conversation context")
-  .action(showHistory);
+  .action(action(showHistory));

--- a/packages/client/src/cli/commands/delete.ts
+++ b/packages/client/src/cli/commands/delete.ts
@@ -1,17 +1,12 @@
 import { Command } from "commander";
-import { request } from "../socket-client.js";
+import { request, action } from "../socket-client.js";
 
 export const deleteCommand = new Command("delete")
   .description("Delete a message")
   .argument("<messageId>", "Message ID to delete")
-  .action(async (messageId: string) => {
-    try {
+  .action(
+    action(async (messageId: string) => {
       await request("messages/delete", { messageId });
       console.log(`Message ${messageId} deleted.`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/packages/client/src/cli/commands/presence.ts
+++ b/packages/client/src/cli/commands/presence.ts
@@ -1,30 +1,25 @@
 import { Command } from "commander";
-import { request } from "../socket-client.js";
+import { request, action } from "../socket-client.js";
 
 export const presenceCommand = new Command("presence")
   .description("Update or show presence status (online, offline, away)")
   .argument("[status]", "Status to set: online, offline, or away")
-  .action(async (status?: string) => {
-    if (!status) {
-      console.log("Usage: moltzap presence <online|offline|away>");
-      return;
-    }
+  .action(
+    action(async (status?: string) => {
+      if (!status) {
+        console.log("Usage: moltzap presence <online|offline|away>");
+        return;
+      }
 
-    const valid = ["online", "offline", "away"];
-    if (!valid.includes(status)) {
-      console.error(
-        `Invalid status "${status}". Must be one of: ${valid.join(", ")}`,
-      );
-      process.exit(1);
-    }
+      const valid = ["online", "offline", "away"];
+      if (!valid.includes(status)) {
+        console.error(
+          `Invalid status "${status}". Must be one of: ${valid.join(", ")}`,
+        );
+        process.exit(1);
+      }
 
-    try {
       await request("presence/update", { status });
       console.log(`Presence set to ${status}.`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/packages/client/src/cli/commands/react.ts
+++ b/packages/client/src/cli/commands/react.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { request } from "../socket-client.js";
+import { request, action } from "../socket-client.js";
 
 export const reactCommand = new Command("react")
   .description("React to a message with an emoji")
@@ -7,8 +7,8 @@ export const reactCommand = new Command("react")
   .argument("<emoji>", "Emoji to react with")
   .option("--remove", "Remove the reaction instead of adding it")
   .action(
-    async (messageId: string, emoji: string, opts: { remove?: boolean }) => {
-      try {
+    action(
+      async (messageId: string, emoji: string, opts: { remove?: boolean }) => {
         await request("messages/react", {
           messageId,
           emoji,
@@ -19,11 +19,6 @@ export const reactCommand = new Command("react")
             ? `Reaction ${emoji} removed from ${messageId}`
             : `Reacted ${emoji} to ${messageId}`,
         );
-      } catch (err) {
-        console.error(
-          `Failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );

--- a/packages/client/src/cli/commands/send.test.ts
+++ b/packages/client/src/cli/commands/send.test.ts
@@ -3,9 +3,13 @@ import { sendCommand } from "./send.js";
 
 const mockRequest = vi.fn().mockResolvedValue({ message: { id: "msg-123" } });
 
-vi.mock("../socket-client.js", () => ({
-  request: (...args: unknown[]) => mockRequest(...args),
-}));
+vi.mock("../socket-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../socket-client.js")>();
+  return {
+    ...actual,
+    request: (...args: unknown[]) => mockRequest(...args),
+  };
+});
 
 describe("send command", () => {
   const originalExit = process.exit;

--- a/packages/client/src/cli/commands/send.ts
+++ b/packages/client/src/cli/commands/send.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { request } from "../socket-client.js";
+import { request, action } from "../socket-client.js";
 
 export const sendCommand = new Command("send")
   .description("Send a message to a conversation or DM")
@@ -7,8 +7,8 @@ export const sendCommand = new Command("send")
   .argument("<message>", "Message text")
   .option("--reply-to <messageId>", "Reply to a specific message")
   .action(
-    async (target: string, message: string, opts: { replyTo?: string }) => {
-      try {
+    action(
+      async (target: string, message: string, opts: { replyTo?: string }) => {
         const params: Record<string, unknown> = {
           parts: [{ type: "text", text: message }],
         };
@@ -23,11 +23,6 @@ export const sendCommand = new Command("send")
           message: { id: string };
         };
         console.log(`Message sent (id: ${result.message.id})`);
-      } catch (err) {
-        console.error(
-          `Failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );

--- a/packages/client/src/cli/commands/status.ts
+++ b/packages/client/src/cli/commands/status.ts
@@ -1,10 +1,10 @@
 import { Command } from "commander";
-import { request } from "../socket-client.js";
+import { request, action } from "../socket-client.js";
 
 export const statusCommand = new Command("status")
   .description("Show agent connection status and conversation summary")
-  .action(async () => {
-    try {
+  .action(
+    action(async () => {
       const result = (await request("status")) as {
         agentId: string;
         connected: boolean;
@@ -13,10 +13,5 @@ export const statusCommand = new Command("status")
       console.log(`Agent ID:       ${result.agentId ?? "none"}`);
       console.log(`Connected:      ${result.connected}`);
       console.log(`Conversations:  ${result.conversations}`);
-    } catch (err) {
-      console.error(
-        `Failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/packages/client/src/cli/socket-client.ts
+++ b/packages/client/src/cli/socket-client.ts
@@ -71,6 +71,44 @@ export async function request(
   });
 }
 
+/**
+ * Wrap a Commander action to catch errors and exit cleanly.
+ * Commander's .action() accepts (...args: any[]) => void, so the
+ * generic signature here just preserves the caller's argument types.
+ */
+export function action<A extends unknown[]>(
+  fn: (...args: A) => Promise<void>,
+): (...args: A) => void {
+  return (...args) => {
+    fn(...args).catch((err: unknown) => {
+      console.error(
+        `Failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    });
+  };
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Resolve "agent:name" or "agent:<uuid>" to { type, id }. */
+export async function resolveParticipant(
+  raw: string,
+): Promise<{ type: string; id: string }> {
+  const colon = raw.indexOf(":");
+  if (colon === -1) throw new Error(`Invalid: "${raw}". Use agent:name`);
+  const type = raw.slice(0, colon);
+  const value = raw.slice(colon + 1);
+  if (UUID_RE.test(value)) return { type, id: value };
+  if (type !== "agent") throw new Error(`Cannot resolve "${raw}"`);
+  const result = (await request("agents/lookupByName", {
+    names: [value],
+  })) as { agents: Array<{ id: string }> };
+  if (result.agents.length === 0) throw new Error(`Agent "${value}" not found`);
+  return { type: "agent", id: result.agents[0]!.id };
+}
+
 export function isServiceRunning(): boolean {
   return fs.existsSync(MoltZapService.SOCKET_PATH);
 }

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -22,7 +22,7 @@ import {
   extractTypingIndicator,
   mapMessageToEnvelope,
 } from "./mapping.js";
-import { EventNames, type EventFrame, type Message } from "@moltzap/protocol";
+import { EventNames } from "@moltzap/protocol";
 
 const DEFAULT_ACCOUNT_ID = "default";
 const CHANNEL_ID = "moltzap" as const;
@@ -543,7 +543,7 @@ export const moltzapChannelPlugin = {
       );
 
       try {
-        const helloOk = await service.connect();
+        await service.connect();
         service.startSocketServer();
         log?.info?.(
           `MoltZap: connected as ${account.agentName} (${service.ownAgentId})`,

--- a/scripts/generate-protocol-docs.ts
+++ b/scripts/generate-protocol-docs.ts
@@ -5,12 +5,7 @@
  */
 import { writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
-import {
-  Kind,
-  type TSchema,
-  type TObject,
-  type TProperties,
-} from "@sinclair/typebox";
+import { Kind, type TSchema, type TProperties } from "@sinclair/typebox";
 
 // Import all schemas
 import {
@@ -588,10 +583,6 @@ function getTypeName(schema: TSchema): string {
   return kind?.toLowerCase() ?? "unknown";
 }
 
-function isRequired(schema: TSchema): boolean {
-  return schema[Kind] !== "Optional" && schema[Kind] !== "Undefined";
-}
-
 function extractProperties(schema: TSchema): Array<{
   name: string;
   type: string;
@@ -643,22 +634,6 @@ function extractProperties(schema: TSchema): Array<{
 
 function slugify(method: string): string {
   return method.replace(/\//g, "-");
-}
-
-function iconFor(category: string): string {
-  const icons: Record<string, string> = {
-    auth: "key",
-    agents: "robot",
-    users: "user",
-    messages: "message",
-    contacts: "address-book",
-    conversations: "comments",
-    invites: "envelope",
-    presence: "signal",
-    push: "bell",
-    surfaces: "window-maximize",
-  };
-  return icons[category] ?? "code";
 }
 
 function escapeFrontmatter(s: string): string {


### PR DESCRIPTION
## Summary
- Extract `action()` wrapper in `socket-client.ts` that wraps Commander actions with catch-and-exit, eliminating 20 identical try/catch blocks
- Extract `resolveParticipant()` that replaces 3 identical inline UUID-or-lookup patterns in conversations.ts
- Fix all lint warnings across the repo: unused imports (EventFrame, Message), unused variable (helloOk), unused functions (isRequired, iconFor), unused type import (TObject)
- Fix unused variable lint warning in integration tests

Net: -178 lines across 14 files. Zero lint warnings, zero type errors.

## Test Coverage
All existing tests pass (45/45). No new application code paths to audit (pure refactor + lint cleanup).

## Pre-Landing Review
No issues found.

## TODOS
This PR completes:
- "CLI: extract shared error handling wrapper" (P3)
- "CLI: extract shared participant resolution" (P3)

## Test plan
- [x] All vitest tests pass (45/45)
- [x] Build compiles clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm typecheck` — 0 errors, all guards passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)