### PR TITLE
fix: add input validation at socket server boundary

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -41,18 +41,6 @@ Sequential `resolveAgentName()` calls in the `history` handler make one RPC per 
 
 **Depends on:** Nothing.
 
-### Socket server: input validation at the socket boundary
-
-**Priority:** P3
-
-The socket server accepts `params` as `Record<string, unknown>` with no runtime validation. Callers can pass wrong types (e.g., `conversationId: 42` instead of a string) that silently propagate to the MoltZap server RPC.
-
-**Why:** The protocol layer uses AJV validators for RPC params, but the socket server bypasses that layer. Adding lightweight type checks or reusing the existing AJV validators at the socket boundary would catch bugs earlier.
-
-**Files:** `packages/client/src/service.ts` (handleSocketRequest)
-
-**Depends on:** Nothing.
-
 ### Socket server: unbounded buffer and missing idle timeout
 
 **Priority:** P4
@@ -66,6 +54,12 @@ The socket server accumulates `buffer += chunk.toString()` with no max size. A c
 **Depends on:** Nothing.
 
 ## Completed
+
+### Socket server: input validation at the socket boundary
+
+**Completed:** 2026-04-08
+
+Added runtime type checks for `method`, `params`, `conversationId`, and `limit` at the socket boundary. Malformed requests now return clear error messages instead of silently propagating wrong types.
 
 ### `moltzap updates` CLI command
 

--- a/packages/client/src/__tests__/service.integration.test.ts
+++ b/packages/client/src/__tests__/service.integration.test.ts
@@ -1240,4 +1240,27 @@ describe("Socket Server", () => {
       reg.client.close();
     }
   });
+
+  it("history rejects when conversationId is missing or wrong type", async () => {
+    const reg = await registerAgent("sock-validate");
+    const service = await connectService(reg.apiKey);
+    service.startSocketServer();
+    try {
+      await expect(socketRequest("history", {})).rejects.toThrow(
+        "conversationId is required",
+      );
+      await expect(
+        socketRequest("history", { conversationId: 123 }),
+      ).rejects.toThrow("conversationId is required");
+      await expect(
+        socketRequest("history", {
+          conversationId: "abc",
+          limit: "not-a-number",
+        }),
+      ).rejects.toThrow("limit must be a number");
+    } finally {
+      service.close();
+      reg.client.close();
+    }
+  });
 });

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -191,14 +191,15 @@ export class MoltZapService {
     conn: net.Socket,
   ): Promise<void> {
     try {
-      const req = JSON.parse(line) as {
-        method: string;
-        params?: Record<string, unknown>;
-      };
-      const result = await this.handleSocketRequest(
-        req.method,
-        req.params ?? {},
-      );
+      const req = JSON.parse(line) as Record<string, unknown>;
+      if (typeof req.method !== "string" || !req.method) {
+        throw new Error("method is required and must be a string");
+      }
+      const params =
+        req.params != null && typeof req.params === "object"
+          ? (req.params as Record<string, unknown>)
+          : {};
+      const result = await this.handleSocketRequest(req.method, params);
       conn.write(JSON.stringify({ result }) + "\n");
     } catch (err) {
       conn.write(
@@ -225,7 +226,16 @@ export class MoltZapService {
         };
 
       case "history": {
-        const convId = params.conversationId as string;
+        if (
+          typeof params.conversationId !== "string" ||
+          !params.conversationId
+        ) {
+          throw new Error("conversationId is required and must be a string");
+        }
+        if (params.limit !== undefined && typeof params.limit !== "number") {
+          throw new Error("limit must be a number");
+        }
+        const convId = params.conversationId;
         const limit = (params.limit as number) ?? 10;
         const sessionKey = params.sessionKey as string | undefined;
         const afterSeq = params.afterSeq as number | undefined;


### PR DESCRIPTION
## Summary
- Validate `method` is a non-empty string and `params` is an object at the socket line handler
- Validate `conversationId` (required string) and `limit` (must be number) in the history handler
- Malformed requests now return clear error messages instead of silently propagating wrong types

## Test Coverage
1 new regression test: "history rejects when conversationId is missing or wrong type"
46/46 tests passing.

## TODOS
Completes: "Socket server: input validation at the socket boundary" (P3)

## Test plan
- [x] All vitest tests pass (46/46)
- [x] Build compiles clean
- [x] 0 lint warnings, 0 type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)