### PR TITLE
perf: batch agent lookup and concurrent conversation fetch

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -29,18 +29,6 @@
 
 ## Client
 
-### Batch agent name resolution in history handler
-
-**Priority:** P3
-
-Sequential `resolveAgentName()` calls in the `history` handler make one RPC per unknown agent. The server's `agents/lookup` RPC already accepts an `agentIds` array, so all unknowns could be resolved in a single call. Also, `messages/list` and `conversations/get` are independent and could run concurrently with `Promise.all`.
-
-**Why:** Each `history` request currently does `1 + N + 1` serial RPCs (messages, N agent lookups, conversation metadata) where it could do `1 + 1` (batch lookup with messages, concurrent conversation fetch). Matters when conversations have many unique senders.
-
-**Files:** `packages/client/src/service.ts` (handleSocketRequest, `history` case)
-
-**Depends on:** Nothing.
-
 ### Socket server: unbounded buffer and missing idle timeout
 
 **Priority:** P4
@@ -54,6 +42,12 @@ The socket server accumulates `buffer += chunk.toString()` with no max size. A c
 **Depends on:** Nothing.
 
 ## Completed
+
+### Batch agent name resolution in history handler
+
+**Completed:** 2026-04-08
+
+Single batch `agents/lookup` call instead of N sequential RPCs. `conversations/get` now runs concurrently via `Promise.all`.
 
 ### Socket server: input validation at the socket boundary
 

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -248,19 +248,37 @@ export class MoltZapService {
           ...(beforeSeq !== undefined ? { beforeSeq } : {}),
         })) as { messages: Message[]; hasMore: boolean };
 
-        // Resolve agent names
-        const agentIds = [
+        // Resolve agent names (batch) + fetch conversation metadata (concurrent)
+        const unknownAgentIds = [
           ...new Set(
             result.messages
               .filter((m) => m.sender.type === "agent")
               .map((m) => m.sender.id),
           ),
-        ];
-        for (const id of agentIds) {
-          if (!this.agentNames.has(id)) {
-            await this.resolveAgentName(id);
-          }
-        }
+        ].filter((id) => !this.agentNames.has(id));
+
+        const [, convMeta] = await Promise.all([
+          unknownAgentIds.length > 0
+            ? this.sendRpc("agents/lookup", { agentIds: unknownAgentIds }).then(
+                (res) => {
+                  for (const a of (
+                    res as { agents: Array<{ id: string; name: string }> }
+                  ).agents) {
+                    this.agentNames.set(a.id, a.name);
+                  }
+                },
+              )
+            : Promise.resolve(),
+          this.sendRpc("conversations/get", { conversationId: convId })
+            .then(
+              (res) =>
+                (res as { conversation: { type: string; name?: string } })
+                  .conversation,
+            )
+            .catch(
+              () => undefined as { type: string; name?: string } | undefined,
+            ),
+        ]);
 
         // Determine what's "new" using lastRead (not lastNotified).
         // lastNotified is advanced by getContext() (system-reminder).
@@ -301,15 +319,6 @@ export class MoltZapService {
             this.lastRead.get(sessionKey)!.set(convId, maxSeq);
           }
         }
-
-        // Get conversation metadata
-        let convMeta: { type: string; name?: string } | undefined;
-        try {
-          const convResult = (await this.sendRpc("conversations/get", {
-            conversationId: convId,
-          })) as { conversation: { type: string; name?: string } };
-          convMeta = convResult.conversation;
-        } catch {}
 
         return {
           messages,


### PR DESCRIPTION
## Summary
- Replace N sequential `resolveAgentName()` RPCs with a single batch `agents/lookup` call
- Run `conversations/get` concurrently with agent resolution via `Promise.all`
- History handler goes from `1+N+1` serial RPCs to `1+1` concurrent

## TODOS
Completes: "Batch agent name resolution in history handler" (P3)

## Test plan
- [x] All vitest tests pass (46/46)
- [x] Build compiles clean
- [x] 0 lint warnings, 0 type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)