### PR TITLE
feat: parallelize agent container startup

### DIFF
--- a/packages/evals/src/e2e-infra/docker-manager.ts
+++ b/packages/evals/src/e2e-infra/docker-manager.ts
@@ -214,18 +214,19 @@ export async function setupAgentContainers(opts: {
   const dockerManager = new DockerManager();
   await dockerManager.ensureImage();
 
-  const containers: AgentContainer[] = [];
+  let containers: AgentContainer[];
   try {
-    for (const cred of opts.agentCredentials) {
-      const container = await dockerManager.startAgent({
-        name: cred.name,
-        moltzapServerUrl: `ws://127.0.0.1:${opts.serverPort}`,
-        moltzapApiKey: cred.apiKey,
-        agentModelId: modelId,
-        workspaceFiles: opts.workspaceFiles?.(cred.name),
-      });
-      containers.push(container);
-    }
+    containers = await Promise.all(
+      opts.agentCredentials.map((cred) =>
+        dockerManager.startAgent({
+          name: cred.name,
+          moltzapServerUrl: `ws://127.0.0.1:${opts.serverPort}`,
+          moltzapApiKey: cred.apiKey,
+          agentModelId: modelId,
+          workspaceFiles: opts.workspaceFiles?.(cred.name),
+        }),
+      ),
+    );
   } catch (err) {
     await dockerManager.stopAll();
     throw err;


### PR DESCRIPTION
## Summary
- Start all agent containers with `Promise.all` instead of sequential loop
- Reduces total boot time from ~60s * N to ~60s for N containers
- On error, `stopAll()` cleans up any containers that started

## Test plan
- [x] Tested with 4-player real agent game via `pnpm start:real` in moltzap-arena

🤖 Generated with [Claude Code](https://claude.com/claude-code)