### PR TITLE
feat: thread contextAdapter through setupAgentContainers

### DIFF
--- a/packages/evals/src/e2e-infra/docker-manager.ts
+++ b/packages/evals/src/e2e-infra/docker-manager.ts
@@ -205,6 +205,11 @@ export async function setupAgentContainers(opts: {
   workspaceFiles?: (
     name: string,
   ) => Array<{ relativePath: string; content: string }>;
+  contextAdapter?: {
+    type: string;
+    maxConversations?: number;
+    maxMessagesPerConv?: number;
+  };
 }): Promise<{
   dockerManager: DockerManager;
   containers: AgentContainer[];
@@ -224,6 +229,7 @@ export async function setupAgentContainers(opts: {
           moltzapApiKey: cred.apiKey,
           agentModelId: modelId,
           workspaceFiles: opts.workspaceFiles?.(cred.name),
+          contextAdapter: opts.contextAdapter,
         }),
       ),
     );


### PR DESCRIPTION
## Summary
- Adds `contextAdapter?` option to `setupAgentContainers()` so callers can enable cross-conversation context for all agents in a batch
- Passes it through to each `dockerManager.startAgent()` call (which already supports it)

## Test plan
- [x] Existing evals pass (no behavior change without the option)
- [x] Verified in moltzap-arena: agents receive cross-conversation system reminders when option is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)