### PR TITLE
fix: bump waitForGateway timeout to 180s

### DIFF
--- a/packages/evals/src/e2e-infra/docker-manager.ts
+++ b/packages/evals/src/e2e-infra/docker-manager.ts
@@ -163,7 +163,7 @@ export class DockerManager {
       );
     }
 
-    await waitForGateway(raw.containerId, 60_000);
+    await waitForGateway(raw.containerId, 180_000);
 
     const agent: AgentContainer & { _raw: OpenClawContainer } = {
       containerId: raw.containerId,


### PR DESCRIPTION
## Summary
Bump `waitForGateway` timeout from 60s to 180s in `packages/evals/src/e2e-infra/docker-manager.ts`.

Under heavy Docker Desktop load (many containers starting in parallel), the OpenClaw gateway can take 70s+ to emit its first log line. The previous 60s timeout caused intermittent startup failures in both evals and the moltzap-arena project.

## Test plan
- [x] Verified locally: arena containers now start reliably after Docker restart under load
- [x] No behavior change on fast startups (just a longer ceiling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)