### PR TITLE
feat(client): add sendToAgent() helper, refactor openclaw-channel to use it

### DIFF
--- a/packages/client/src/service.test.ts
+++ b/packages/client/src/service.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { MoltZapService } from "./service.js";
+
+class FakeMoltZapService extends MoltZapService {
+  calls: Array<{ method: string; params: unknown }> = [];
+  responses = new Map<string, unknown>();
+
+  constructor() {
+    super({ serverUrl: "ws://test.invalid", agentKey: "test-key" });
+  }
+
+  override async sendRpc(method: string, params?: unknown): Promise<unknown> {
+    this.calls.push({ method, params });
+    if (this.responses.has(method)) {
+      return this.responses.get(method);
+    }
+    throw new Error(`FakeMoltZapService: no canned response for ${method}`);
+  }
+}
+
+describe("MoltZapService.sendToAgent", () => {
+  let service: FakeMoltZapService;
+
+  beforeEach(() => {
+    service = new FakeMoltZapService();
+    service.responses.set("agents/lookupByName", {
+      agent: { id: "agent-alice-id" },
+    });
+    service.responses.set("conversations/create", {
+      conversation: { id: "conv-alice" },
+    });
+    service.responses.set("messages/send", {});
+  });
+
+  it("resolves agent name, creates a DM, and sends the message on first call", async () => {
+    await service.sendToAgent("alice", "hello");
+
+    expect(service.calls).toEqual([
+      { method: "agents/lookupByName", params: { name: "alice" } },
+      {
+        method: "conversations/create",
+        params: {
+          type: "dm",
+          participants: [{ type: "agent", id: "agent-alice-id" }],
+        },
+      },
+      {
+        method: "messages/send",
+        params: {
+          conversationId: "conv-alice",
+          parts: [{ type: "text", text: "hello" }],
+        },
+      },
+    ]);
+  });
+
+  it("caches the conversation id and skips lookup on subsequent calls", async () => {
+    await service.sendToAgent("alice", "first");
+    service.calls = [];
+
+    await service.sendToAgent("alice", "second");
+
+    expect(service.calls).toEqual([
+      {
+        method: "messages/send",
+        params: {
+          conversationId: "conv-alice",
+          parts: [{ type: "text", text: "second" }],
+        },
+      },
+    ]);
+  });
+
+  it("forwards replyTo to messages/send as replyToId", async () => {
+    await service.sendToAgent("alice", "reply text", { replyTo: "msg-123" });
+
+    const sendCall = service.calls.find((c) => c.method === "messages/send");
+    expect(sendCall?.params).toEqual({
+      conversationId: "conv-alice",
+      parts: [{ type: "text", text: "reply text" }],
+      replyToId: "msg-123",
+    });
+  });
+
+  it("maintains separate cache entries per agent name", async () => {
+    service.responses.set("agents/lookupByName", {
+      agent: { id: "agent-alice-id" },
+    });
+    await service.sendToAgent("alice", "hello alice");
+
+    service.responses.set("agents/lookupByName", {
+      agent: { id: "agent-bob-id" },
+    });
+    service.responses.set("conversations/create", {
+      conversation: { id: "conv-bob" },
+    });
+    await service.sendToAgent("bob", "hello bob");
+
+    service.calls = [];
+    await service.sendToAgent("alice", "alice again");
+    await service.sendToAgent("bob", "bob again");
+
+    const sendCalls = service.calls.filter((c) => c.method === "messages/send");
+    expect(sendCalls).toHaveLength(2);
+    expect(
+      (sendCalls[0]!.params as { conversationId: string }).conversationId,
+    ).toBe("conv-alice");
+    expect(
+      (sendCalls[1]!.params as { conversationId: string }).conversationId,
+    ).toBe("conv-bob");
+  });
+
+  it("propagates errors from agents/lookupByName", async () => {
+    service.responses.delete("agents/lookupByName");
+
+    await expect(service.sendToAgent("alice", "hi")).rejects.toThrow(
+      /no canned response for agents\/lookupByName/,
+    );
+  });
+
+  it("propagates errors from conversations/create", async () => {
+    service.responses.delete("conversations/create");
+
+    await expect(service.sendToAgent("alice", "hi")).rejects.toThrow(
+      /no canned response for conversations\/create/,
+    );
+  });
+
+  it("propagates errors from messages/send", async () => {
+    service.responses.delete("messages/send");
+
+    await expect(service.sendToAgent("alice", "hi")).rejects.toThrow(
+      /no canned response for messages\/send/,
+    );
+  });
+});

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -68,6 +68,7 @@ export class MoltZapService {
   private conversations = new Map<string, ConversationMeta>();
   private messages = new Map<string, Message[]>();
   private agentNames = new Map<string, string>();
+  private agentConversationCache = new Map<string, string>();
   private lastNotified = new Map<string, Map<string, number>>();
   private lastRead = new Map<string, Map<string, number>>();
 
@@ -118,6 +119,7 @@ export class MoltZapService {
     this.conversations.clear();
     this.messages.clear();
     this.agentNames.clear();
+    this.agentConversationCache.clear();
     this.lastNotified.clear();
     this.lastRead.clear();
   }
@@ -397,6 +399,26 @@ export class MoltZapService {
       parts: [{ type: "text", text }],
       ...(opts?.replyTo ? { replyToId: opts.replyTo } : {}),
     });
+  }
+
+  async sendToAgent(
+    agentName: string,
+    text: string,
+    opts?: { replyTo?: string },
+  ): Promise<void> {
+    let conversationId = this.agentConversationCache.get(agentName);
+    if (!conversationId) {
+      const lookupResult = (await this.sendRpc("agents/lookupByName", {
+        name: agentName,
+      })) as { agent: { id: string } };
+      const createResult = (await this.sendRpc("conversations/create", {
+        type: "dm",
+        participants: [{ type: "agent", id: lookupResult.agent.id }],
+      })) as { conversation: { id: string } };
+      conversationId = createResult.conversation.id;
+      this.agentConversationCache.set(agentName, conversationId);
+    }
+    await this.send(conversationId, text, opts);
   }
 
   // --- Cross-Conversation Context ---

--- a/packages/openclaw-channel/src/openclaw-entry.delivery.test.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.delivery.test.ts
@@ -5,6 +5,7 @@ import type { Message } from "@moltzap/protocol";
 let capturedOnMessage: ((msg: Message) => void) | null = null;
 const mockSendRpc = vi.fn();
 const mockSend = vi.fn();
+const mockSendToAgent = vi.fn();
 const mockClose = vi.fn();
 
 vi.mock("@moltzap/client", () => ({
@@ -24,6 +25,7 @@ vi.mock("@moltzap/client", () => ({
     getContext: vi.fn().mockReturnValue(null),
     sendRpc: mockSendRpc,
     send: mockSend,
+    sendToAgent: mockSendToAgent,
     startSocketServer: vi.fn(),
     stopSocketServer: vi.fn(),
     on: vi.fn().mockImplementation((event: string, handler: Function) => {
@@ -33,10 +35,7 @@ vi.mock("@moltzap/client", () => ({
   })),
 }));
 
-import {
-  moltzapChannelPlugin,
-  agentConversationCache,
-} from "./openclaw-entry.js";
+import { moltzapChannelPlugin } from "./openclaw-entry.js";
 
 function makeMessage(overrides: Partial<Message> = {}): Message {
   return {
@@ -75,7 +74,6 @@ describe("Flow 6: Outbound delivery — deliver callback + sendText", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    agentConversationCache.clear();
     capturedOnMessage = null;
     abortController = new AbortController();
     mockDispatch = vi.fn().mockResolvedValue({ queuedFinal: true });
@@ -250,19 +248,8 @@ describe("Flow 6: Outbound delivery — deliver callback + sendText", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("sendText with agent: target auto-creates DM conversation", async () => {
-    mockSendRpc.mockImplementation(async (method: string) => {
-      if (method === "agents/lookupByName")
-        return { agent: { id: "agent-nova-id" } };
-      if (method === "conversations/create")
-        return { conversation: { id: "conv-auto-created" } };
-      if (method === "messages/send") return { message: { id: "sent-1" } };
-      if (method === "agents/lookup")
-        return { agents: [{ id: "agent-sender-1", name: "Atlas" }] };
-      if (method === "conversations/get")
-        return { conversation: { type: "dm" }, participants: [] };
-      return {};
-    });
+  it("sendText with agent: target delegates to service.sendToAgent", async () => {
+    mockSendToAgent.mockResolvedValue(undefined);
 
     const result = await moltzapChannelPlugin.outbound.sendText({
       cfg: makeCfg(),
@@ -272,69 +259,41 @@ describe("Flow 6: Outbound delivery — deliver callback + sendText", () => {
     });
 
     expect(result.ok).toBe(true);
-
-    const lookupCall = mockSendRpc.mock.calls.find(
-      (c) => c[0] === "agents/lookupByName",
-    );
-    expect(lookupCall![1]).toEqual({ name: "nova" });
-
-    const createCall = mockSendRpc.mock.calls.find(
-      (c) => c[0] === "conversations/create",
-    );
-    expect(createCall![1]).toEqual({
-      type: "dm",
-      participants: [{ type: "agent", id: "agent-nova-id" }],
-    });
-
-    expect(mockSend).toHaveBeenCalledWith("conv-auto-created", "Hello nova", {
+    expect(mockSendToAgent).toHaveBeenCalledWith("nova", "Hello nova", {
       replyTo: undefined,
     });
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
-  it("sendText with agent: target reuses cached conversation on second call", async () => {
-    mockSendRpc.mockImplementation(async (method: string) => {
-      if (method === "agents/lookupByName")
-        return { agent: { id: "agent-nova-id" } };
-      if (method === "conversations/create")
-        return { conversation: { id: "conv-cached" } };
-      if (method === "agents/lookup")
-        return { agents: [{ id: "agent-sender-1", name: "Atlas" }] };
-      if (method === "conversations/get")
-        return { conversation: { type: "dm" }, participants: [] };
-      return {};
-    });
-
-    await moltzapChannelPlugin.outbound.sendText({
-      cfg: makeCfg(),
-      to: "agent:nova",
-      text: "First message",
-      accountId: "delivery-test",
-    });
-
-    mockSendRpc.mockClear();
-    mockSend.mockClear();
-    mockSendRpc.mockImplementation(async (method: string) => {
-      if (method === "agents/lookupByName")
-        throw new Error("Should not call lookupByName on cached target");
-      if (method === "conversations/create")
-        throw new Error(
-          "Should not call conversations/create on cached target",
-        );
-      return {};
-    });
+  it("sendText with agent: target forwards replyToId to sendToAgent", async () => {
+    mockSendToAgent.mockResolvedValue(undefined);
 
     const result = await moltzapChannelPlugin.outbound.sendText({
       cfg: makeCfg(),
       to: "agent:nova",
-      text: "Second message",
+      text: "Reply text",
       accountId: "delivery-test",
+      replyToId: "msg-parent-1",
     });
 
     expect(result.ok).toBe(true);
-    expect(mockSend).toHaveBeenCalledOnce();
-    expect(mockSend).toHaveBeenCalledWith("conv-cached", "Second message", {
-      replyTo: undefined,
+    expect(mockSendToAgent).toHaveBeenCalledWith("nova", "Reply text", {
+      replyTo: "msg-parent-1",
     });
+  });
+
+  it("sendText with agent: target returns error when sendToAgent throws", async () => {
+    mockSendToAgent.mockRejectedValue(new Error("lookup failed"));
+
+    const result = await moltzapChannelPlugin.outbound.sendText({
+      cfg: makeCfg(),
+      to: "agent:nova",
+      text: "Hello nova",
+      accountId: "delivery-test",
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { error: Error }).error.message).toBe("lookup failed");
   });
 
   it("sendText returns error when client is not connected", async () => {

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -76,9 +76,6 @@ function resolveAccount(
 
 const activeClients = new Map<string, MoltZapService>();
 
-/** Cache: accountId → (agentName → conversationId) for auto-created DM conversations. */
-export const agentConversationCache = new Map<string, Map<string, string>>();
-
 export const moltzapChannelPlugin = {
   id: CHANNEL_ID,
 
@@ -575,7 +572,6 @@ export const moltzapChannelPlugin = {
         ctx.log?.info?.("MoltZap: stopping");
         service.close();
         activeClients.delete(ctx.accountId);
-        agentConversationCache.delete(ctx.accountId);
       }
     },
   },
@@ -621,40 +617,19 @@ export const moltzapChannelPlugin = {
       }
 
       try {
-        let conversationId: string | undefined;
-
         if (ctx.to.startsWith(TARGET_PREFIX_AGENT)) {
           const agentName = ctx.to.slice(TARGET_PREFIX_AGENT.length);
-          const accountCache =
-            agentConversationCache.get(accountId) ?? new Map<string, string>();
-          conversationId = accountCache.get(agentName);
-
-          if (!conversationId) {
-            const lookupResult = (await service.sendRpc("agents/lookupByName", {
-              name: agentName,
-            })) as { agent: { id: string } };
-
-            const createResult = (await service.sendRpc(
-              "conversations/create",
-              {
-                type: "dm",
-                participants: [{ type: "agent", id: lookupResult.agent.id }],
-              },
-            )) as { conversation: { id: string } };
-
-            conversationId = createResult.conversation.id;
-            accountCache.set(agentName, conversationId);
-            agentConversationCache.set(accountId, accountCache);
-          }
-        } else if (ctx.to.startsWith(TARGET_PREFIX_CONV)) {
-          conversationId = ctx.to.slice(TARGET_PREFIX_CONV.length);
+          await service.sendToAgent(agentName, ctx.text, {
+            replyTo: ctx.replyToId,
+          });
         } else {
-          conversationId = ctx.to;
+          const conversationId = ctx.to.startsWith(TARGET_PREFIX_CONV)
+            ? ctx.to.slice(TARGET_PREFIX_CONV.length)
+            : ctx.to;
+          await service.send(conversationId, ctx.text, {
+            replyTo: ctx.replyToId,
+          });
         }
-
-        await service.send(conversationId!, ctx.text, {
-          replyTo: ctx.replyToId,
-        });
         return { ok: true as const };
       } catch (err) {
         return {


### PR DESCRIPTION
## Summary

Adds \`MoltZapService.sendToAgent(agentName, text, opts?)\` and refactors \`@moltzap/openclaw-channel\`'s DM-target handling to delegate to it. The (agentName → conversationId) cache is now an instance field on \`MoltZapService\`, not a module-level export on openclaw-channel.


## What changed

**\`@moltzap/client\`:**
- \`service.ts\` — new \`sendToAgent\` method: resolves the target agent via \`agents/lookupByName\`, creates a DM via \`conversations/create\` if needed, caches the resulting conversation id on the service instance, then delegates to the existing \`send()\`. Cache cleared on \`close()\` alongside the other instance caches.
- \`service.test.ts\` (new) — 7 unit tests with a \`FakeMoltZapService\` that overrides \`sendRpc\` to return canned responses. Covers: first-call resolution sequence, cache-hit skip, \`replyTo\` forwarding, per-agent cache isolation, error propagation from each of the 3 RPC steps.

**\`@moltzap/openclaw-channel\`:**
- \`openclaw-entry.ts\` — \`outbound.sendText\`'s \`agent:\` branch now calls \`service.sendToAgent(name, text, {replyTo})\` instead of open-coding the 3-step RPC dance. The module-level \`agentConversationCache\` export and its cleanup in \`stopAccount\` are deleted.
- \`openclaw-entry.delivery.test.ts\` — the old tests that asserted on the \`agents/lookupByName\` + \`conversations/create\` + \`send\` call sequence are replaced with 3 tests that assert on the delegation: correct args passed to \`sendToAgent\`, \`replyToId\` forwarding, and error propagation. The separate cache-reuse test is dropped here because caching is now the client's concern and is covered in \`service.test.ts\`.

## Why



🤖 Generated with [Claude Code](https://claude.com/claude-code)