### PR TITLE
feat(nanoclaw-channel): smoke test package + eval runtime flag

### DIFF
--- a/packages/evals/src/e2e-infra/index.ts
+++ b/packages/evals/src/e2e-infra/index.ts
@@ -88,6 +88,13 @@ async function main(): Promise<void> {
       default: "info",
       choices: ["debug", "info", "warn", "error"],
     })
+    .option("runtime", {
+      type: "string",
+      description:
+        "Agent runtime to spin up: openclaw (default, containerized) or nanoclaw (host subprocess, smoke test only)",
+      default: "openclaw",
+      choices: ["openclaw", "nanoclaw"],
+    })
     .help()
     .alias("h", "help")
     .strict().argv;
@@ -116,6 +123,7 @@ async function main(): Promise<void> {
       cleanResults: argv["clean-results"],
       logLevel: argv["log-level"],
       signal: shutdownController.signal,
+      runtime: argv.runtime as "openclaw" | "nanoclaw",
     });
 
     logger.info(

--- a/packages/evals/src/e2e-infra/nanoclaw-smoke.ts
+++ b/packages/evals/src/e2e-infra/nanoclaw-smoke.ts
@@ -1,0 +1,287 @@
+/**
+ * Nanoclaw smoke test harness.
+ *
+ * Throwaway infrastructure to prove moltzap can talk to a real nanoclaw process
+ * via the channel file in packages/nanoclaw-channel/. Not a production runtime
+ * adapter. When the stable interface lands, this file is rewritten or deleted.
+ *
+ * Pinned to a specific nanoclaw upstream SHA. Bumping the SHA means:
+ *   1. Delete ~/.cache/moltzap-evals/nanoclaw/<old-sha> manually
+ *   2. Update NANOCLAW_SHA below
+ *   3. Re-run the smoke eval; fix any type drift in packages/nanoclaw-channel/src/types.ts
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { exec as execCb } from "node:child_process";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { logger } from "./logger.js";
+
+const exec = promisify(execCb);
+
+// Pinned to qwibitai/nanoclaw@934f063 (2026-04-10). Bump deliberately.
+const NANOCLAW_SHA = "934f063aff5c30e7b49ce58b53b41901d3472a3e";
+const NANOCLAW_URL = `https://github.com/qwibitai/nanoclaw/archive/${NANOCLAW_SHA}.tar.gz`;
+
+const NANOCLAW_CACHE = path.join(
+  os.homedir(),
+  ".cache/moltzap-evals/nanoclaw",
+  NANOCLAW_SHA.slice(0, 12),
+);
+
+// Log marker: the moltzap channel in packages/nanoclaw-channel/src/moltzap.ts
+// emits "MoltZap connected" via the logger on successful connect. Anchoring
+// against an "info" prefix reduces false positives from quoted error text.
+const CONNECTED_MARKER = /\[info\].*MoltZap connected|MoltZap connected/;
+
+const CONNECT_TIMEOUT_MS = 60_000;
+const GRACEFUL_STOP_MS = 3_000;
+
+export interface NanoclawSmokeHandle {
+  proc: ChildProcess;
+  dataDir: string;
+  capturedLogs: string[];
+}
+
+async function preflightDocker(): Promise<void> {
+  try {
+    await exec("docker info", { timeout: 5_000 });
+  } catch (err) {
+    throw new Error(
+      "Nanoclaw smoke requires docker to be running on the host " +
+        "(nanoclaw spawns agent subcontainers via its container-runner). " +
+        `docker info failed: ${(err as Error).message}`,
+    );
+  }
+}
+
+async function downloadTarball(url: string, destDir: string): Promise<void> {
+  await fsp.mkdir(destDir, { recursive: true });
+  const tarballPath = path.join(destDir, "nanoclaw.tar.gz");
+
+  // Use curl for streaming + redirect handling. The eval host has curl.
+  await exec(`curl -fsSL "${url}" -o "${tarballPath}"`, { timeout: 60_000 });
+
+  // Extract with --strip-components=1 so the archive's top-level
+  // nanoclaw-<sha>/ directory collapses into destDir itself.
+  await exec(`tar -xzf "${tarballPath}" -C "${destDir}" --strip-components=1`, {
+    timeout: 30_000,
+  });
+
+  await fsp.unlink(tarballPath);
+}
+
+function resolveChannelFilePath(): string {
+  // When compiled: packages/evals/dist/e2e-infra/nanoclaw-smoke.js
+  // We want:       packages/nanoclaw-channel/src/moltzap.ts
+  // Adjust relative path accordingly.
+  const here = fileURLToPath(import.meta.url);
+  // .../packages/evals/dist/e2e-infra/nanoclaw-smoke.js → .../packages/
+  const packagesDir = path.resolve(here, "../../../..");
+  return path.join(packagesDir, "nanoclaw-channel/src/moltzap.ts");
+}
+
+function resolveSkillMdPath(): string {
+  const here = fileURLToPath(import.meta.url);
+  // .../packages/evals/dist/e2e-infra/nanoclaw-smoke.js → repo root
+  const repoRoot = path.resolve(here, "../../../../..");
+  return path.join(repoRoot, "SKILL.md");
+}
+
+export async function ensureNanoclawInstalled(): Promise<void> {
+  const readyMarker = path.join(NANOCLAW_CACHE, ".ready");
+  if (fs.existsSync(readyMarker)) {
+    logger.info(`Nanoclaw smoke cache found at ${NANOCLAW_CACHE}`);
+    return;
+  }
+
+  await preflightDocker();
+
+  logger.info(
+    `Installing nanoclaw@${NANOCLAW_SHA.slice(0, 12)} — this can take 3–5 minutes on first run...`,
+  );
+
+  const tmpDir = `${NANOCLAW_CACHE}.tmp`;
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+
+  // Download upstream nanoclaw source
+  logger.info("Downloading nanoclaw source...");
+  await downloadTarball(NANOCLAW_URL, tmpDir);
+
+  // Inject the moltzap channel file from packages/nanoclaw-channel/
+  logger.info("Injecting moltzap channel file...");
+  const channelFileSrc = resolveChannelFilePath();
+  if (!fs.existsSync(channelFileSrc)) {
+    throw new Error(
+      `Expected channel file at ${channelFileSrc} — did you build @moltzap/nanoclaw-channel?`,
+    );
+  }
+  await fsp.copyFile(
+    channelFileSrc,
+    path.join(tmpDir, "src/channels/moltzap.ts"),
+  );
+
+  // Append barrel import if missing. Idempotent, robust to upstream channel additions.
+  const barrelPath = path.join(tmpDir, "src/channels/index.ts");
+  const barrel = await fsp.readFile(barrelPath, "utf8");
+  if (!barrel.includes("import './moltzap.js';")) {
+    await fsp.writeFile(
+      barrelPath,
+      barrel.trimEnd() + "\n\nimport './moltzap.js';\n",
+    );
+  }
+
+  // Copy the shared root SKILL.md into nanoclaw's container/skills tree
+  // (container/skills/ is what nanoclaw's agent container mounts, NOT
+  // .claude/skills/ which is the host-side dev tree).
+  const skillMdSrc = resolveSkillMdPath();
+  if (!fs.existsSync(skillMdSrc)) {
+    throw new Error(
+      `Expected shared SKILL.md at ${skillMdSrc} — repo layout change?`,
+    );
+  }
+  await fsp.mkdir(path.join(tmpDir, "container/skills/moltzap"), {
+    recursive: true,
+  });
+  await fsp.copyFile(
+    skillMdSrc,
+    path.join(tmpDir, "container/skills/moltzap/SKILL.md"),
+  );
+
+  // Install @moltzap/client from npm registry. Cli's own moltzap binary is
+  // not needed inside the container; the channel file imports MoltZapService
+  // from the package. The @latest tag resolves to whatever is published.
+  logger.info("Installing @moltzap/client...");
+  await exec(
+    "npm install @moltzap/client@latest --no-package-lock --ignore-scripts",
+    { cwd: tmpDir, timeout: 120_000 },
+  );
+
+  // Install nanoclaw's own deps
+  logger.info("Installing nanoclaw dependencies...");
+  await exec("npm install --no-package-lock --ignore-scripts", {
+    cwd: tmpDir,
+    timeout: 180_000,
+  });
+
+  // Compile nanoclaw + the injected channel file
+  logger.info("Building nanoclaw...");
+  await exec("npm run build", { cwd: tmpDir, timeout: 120_000 });
+
+  // Build nanoclaw's agent container image (used by nanoclaw's container-runner
+  // when spawning agent subcontainers at runtime). This runs vendored bash
+  // from upstream — documented supply chain risk for the smoke test phase.
+  logger.info("Building nanoclaw agent container image (~60s)...");
+  await exec("bash container/build.sh", {
+    cwd: tmpDir,
+    timeout: 300_000,
+  });
+
+  // Atomic rename — only mark .ready on full success
+  await fsp.rm(NANOCLAW_CACHE, { recursive: true, force: true });
+  await fsp.mkdir(path.dirname(NANOCLAW_CACHE), { recursive: true });
+  await fsp.rename(tmpDir, NANOCLAW_CACHE);
+  await fsp.writeFile(readyMarker, "");
+
+  logger.info(`Nanoclaw smoke cache ready at ${NANOCLAW_CACHE}`);
+}
+
+export async function startNanoclawSmoke(opts: {
+  apiKey: string;
+  serverUrl: string;
+}): Promise<NanoclawSmokeHandle> {
+  const dataDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "moltzap-nanoclaw-smoke-"),
+  );
+
+  logger.info(`Starting nanoclaw subprocess (dataDir: ${dataDir})`);
+
+  const proc = spawn("node", ["dist/index.js"], {
+    cwd: NANOCLAW_CACHE,
+    env: {
+      ...process.env,
+      MOLTZAP_API_KEY: opts.apiKey,
+      MOLTZAP_SERVER_URL: opts.serverUrl,
+      MOLTZAP_EVAL_MODE: "1",
+      DATA_DIR: dataDir,
+      CONTAINER_RUNTIME: "docker",
+      LOG_LEVEL: "info",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const capturedLogs: string[] = [];
+  proc.stdout?.on("data", (chunk: Buffer) =>
+    capturedLogs.push(chunk.toString()),
+  );
+  proc.stderr?.on("data", (chunk: Buffer) =>
+    capturedLogs.push(chunk.toString()),
+  );
+
+  // Wait for connection marker OR process exit, whichever comes first.
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      clearInterval(watcher);
+      const tail = capturedLogs.join("").split("\n").slice(-50).join("\n");
+      reject(
+        new Error(
+          `nanoclaw did not connect within ${CONNECT_TIMEOUT_MS / 1000}s.\nLast 50 log lines:\n${tail}`,
+        ),
+      );
+    }, CONNECT_TIMEOUT_MS);
+
+    proc.on("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      clearInterval(watcher);
+      const tail = capturedLogs.join("").split("\n").slice(-50).join("\n");
+      reject(
+        new Error(
+          `nanoclaw exited before connecting (code=${code}, signal=${signal}).\nLast 50 log lines:\n${tail}`,
+        ),
+      );
+    });
+
+    const watcher = setInterval(() => {
+      if (settled) return;
+      const joined = capturedLogs.join("");
+      if (CONNECTED_MARKER.test(joined)) {
+        settled = true;
+        clearTimeout(timeout);
+        clearInterval(watcher);
+        resolve();
+      }
+    }, 200);
+  });
+
+  logger.info("Nanoclaw subprocess connected to MoltZap server");
+  return { proc, dataDir, capturedLogs };
+}
+
+export async function stopNanoclawSmoke(
+  handle: NanoclawSmokeHandle,
+): Promise<void> {
+  logger.info("Stopping nanoclaw subprocess...");
+  if (!handle.proc.killed) {
+    handle.proc.kill("SIGTERM");
+    await new Promise((r) => setTimeout(r, GRACEFUL_STOP_MS));
+    if (!handle.proc.killed) {
+      handle.proc.kill("SIGKILL");
+    }
+  }
+  await fsp.rm(handle.dataDir, { recursive: true, force: true });
+}
+
+export function getNanoclawLogs(handle: NanoclawSmokeHandle): string {
+  return handle.capturedLogs.join("");
+}

--- a/packages/evals/src/e2e-infra/runner.ts
+++ b/packages/evals/src/e2e-infra/runner.ts
@@ -16,6 +16,13 @@ import {
 } from "@moltzap/server-core/test-utils";
 import { MoltZapTestClient } from "@moltzap/protocol/test-client";
 import { DockerManager } from "./docker-manager.js";
+import {
+  ensureNanoclawInstalled,
+  startNanoclawSmoke,
+  stopNanoclawSmoke,
+  getNanoclawLogs,
+  type NanoclawSmokeHandle,
+} from "./nanoclaw-smoke.js";
 import { TIER5_SCENARIOS } from "./scenarios.js";
 import { judgeAgentResponse, analyzeFailures } from "./llm-judge.js";
 import { generateReport, generateSummaryMarkdown } from "./report.js";
@@ -327,6 +334,8 @@ async function generateResult(opts: {
   }
 }
 
+export type AgentRuntime = "openclaw" | "nanoclaw";
+
 export async function runE2EEvals(opts: {
   scenarios?: string[];
   agentModelId?: string;
@@ -336,6 +345,7 @@ export async function runE2EEvals(opts: {
   cleanResults?: boolean;
   logLevel?: string;
   signal?: AbortSignal;
+  runtime?: AgentRuntime;
 }): Promise<E2ERunResult> {
   const {
     scenarios: scenarioFilter,
@@ -370,14 +380,21 @@ export async function runE2EEvals(opts: {
     }
   }
 
+  const runtime: AgentRuntime = opts.runtime ?? "openclaw";
   const dockerManager = new DockerManager();
+  let nanoclawHandle: NanoclawSmokeHandle | null = null;
   let testServerBaseUrl = "";
   let testServerWsUrl = "";
   const clientsToClose: MoltZapTestClient[] = [];
 
   try {
-    // Verify Docker image exists
-    await dockerManager.ensureImage();
+    if (runtime === "openclaw") {
+      // Verify Docker image exists
+      await dockerManager.ensureImage();
+    } else {
+      // Nanoclaw smoke test: vendor upstream source, inject channel, build.
+      await ensureNanoclawInstalled();
+    }
 
     // Phase 0: Start test infrastructure
     logger.info("Starting MoltZap core test server (testcontainers)...");
@@ -436,56 +453,68 @@ export async function runE2EEvals(opts: {
       (s) => s.requiresContextAwareness,
     );
 
-    // Start OpenClaw Docker container with MoltZap channel
-    logger.info("Starting OpenClaw agent container...");
-    const agentContainer = await dockerManager.startAgent({
-      name: "openclaw-eval-agent",
-      moltzapServerUrl: testServerWsUrl,
-      moltzapApiKey: agentReg.apiKey,
-      agentModelId: opts.agentModelId,
-      contextAdapter: needsContextAwareness
-        ? { type: "cross-conversation" }
-        : undefined,
-    });
+    // Start the agent runtime (openclaw container OR nanoclaw subprocess).
+    if (runtime === "openclaw") {
+      logger.info("Starting OpenClaw agent container...");
+      const agentContainer = await dockerManager.startAgent({
+        name: "openclaw-eval-agent",
+        moltzapServerUrl: testServerWsUrl,
+        moltzapApiKey: agentReg.apiKey,
+        agentModelId: opts.agentModelId,
+        contextAdapter: needsContextAwareness
+          ? { type: "cross-conversation" }
+          : undefined,
+      });
 
-    // Wait for the agent's channel plugin to actually connect via WebSocket.
-    // Poll container logs for "[moltzap] connected as" which confirms the plugin's
-    // auth/connect RPC succeeded.
-    logger.info("Waiting for agent to connect via MoltZap channel...");
-    const connectDeadline = Date.now() + 90_000;
-    let agentConnected = false;
-    while (Date.now() < connectDeadline) {
-      await new Promise((r) => setTimeout(r, 2000));
-      // Check container is still running
-      try {
-        const status = execSync(
-          `docker inspect ${agentContainer.containerId} --format='{{.State.Status}}'`,
-          { encoding: "utf-8" },
-        ).trim();
-        if (status !== "running") {
-          const logs = dockerManager.getContainerLogs(agentContainer);
-          throw new Error(`Agent container exited. Logs:\n${logs}`);
-        }
-      } catch (err) {
-        if (err instanceof Error && err.message.includes("container exited"))
-          throw err;
-      }
-      // Check container logs for successful MoltZap connection
-      const logs = dockerManager.getContainerLogs(agentContainer);
-      if (logs.includes("[moltzap] connected as")) {
-        agentConnected = true;
-        // Give the server a moment to register the connection
+      // Wait for the agent's channel plugin to actually connect via WebSocket.
+      // Poll container logs for "[moltzap] connected as" which confirms the plugin's
+      // auth/connect RPC succeeded.
+      logger.info("Waiting for agent to connect via MoltZap channel...");
+      const connectDeadline = Date.now() + 90_000;
+      let agentConnected = false;
+      while (Date.now() < connectDeadline) {
         await new Promise((r) => setTimeout(r, 2000));
-        break;
+        // Check container is still running
+        try {
+          const status = execSync(
+            `docker inspect ${agentContainer.containerId} --format='{{.State.Status}}'`,
+            { encoding: "utf-8" },
+          ).trim();
+          if (status !== "running") {
+            const logs = dockerManager.getContainerLogs(agentContainer);
+            throw new Error(`Agent container exited. Logs:\n${logs}`);
+          }
+        } catch (err) {
+          if (err instanceof Error && err.message.includes("container exited"))
+            throw err;
+        }
+        // Check container logs for successful MoltZap connection
+        const logs = dockerManager.getContainerLogs(agentContainer);
+        if (logs.includes("[moltzap] connected as")) {
+          agentConnected = true;
+          // Give the server a moment to register the connection
+          await new Promise((r) => setTimeout(r, 2000));
+          break;
+        }
       }
+      if (!agentConnected) {
+        const logs = dockerManager.getContainerLogs(agentContainer);
+        throw new Error(
+          `Agent channel plugin did not connect within 90s. Container logs:\n${logs}`,
+        );
+      }
+      logger.info("Agent channel plugin connected. Starting eval scenarios...");
+    } else {
+      // Nanoclaw smoke: spawn the host subprocess, wait for connected marker.
+      logger.info("Starting nanoclaw subprocess...");
+      nanoclawHandle = await startNanoclawSmoke({
+        apiKey: agentReg.apiKey,
+        serverUrl: testServerWsUrl,
+      });
+      // Give the server a moment to register the connection
+      await new Promise((r) => setTimeout(r, 2000));
+      logger.info("Nanoclaw connected. Starting eval scenarios...");
     }
-    if (!agentConnected) {
-      const logs = dockerManager.getContainerLogs(agentContainer);
-      throw new Error(
-        `Agent channel plugin did not connect within 90s. Container logs:\n${logs}`,
-      );
-    }
-    logger.info("Agent channel plugin connected. Starting eval scenarios...");
 
     const allResults: EvaluatedResult[] = [];
     const totalJobs = selectedScenarios.length * runsPerScenario;
@@ -684,17 +713,27 @@ export async function runE2EEvals(opts: {
       },
     };
   } finally {
-    // Capture container logs before stopping (helps debug failures)
-    for (const c of dockerManager["containers"]) {
-      const logs = dockerManager.getContainerLogs(c);
-      if (logs && logs !== "(no logs available)") {
+    if (runtime === "openclaw") {
+      // Capture container logs before stopping (helps debug failures)
+      for (const c of dockerManager["containers"]) {
+        const logs = dockerManager.getContainerLogs(c);
+        if (logs && logs !== "(no logs available)") {
+          logger.info(
+            `Container "${c.name}" logs (last 20 lines):\n${logs.split("\n").slice(-20).join("\n")}`,
+          );
+        }
+      }
+      await dockerManager.stopAll();
+    } else if (nanoclawHandle) {
+      const logs = getNanoclawLogs(nanoclawHandle);
+      if (logs) {
         logger.info(
-          `Container "${c.name}" logs (last 20 lines):\n${logs.split("\n").slice(-20).join("\n")}`,
+          `Nanoclaw logs (last 20 lines):\n${logs.split("\n").slice(-20).join("\n")}`,
         );
       }
+      await stopNanoclawSmoke(nanoclawHandle);
     }
     for (const c of clientsToClose) c.close();
-    await dockerManager.stopAll();
     await stopCoreTestServer().catch(() => {});
   }
 }

--- a/packages/nanoclaw-channel/package.json
+++ b/packages/nanoclaw-channel/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@moltzap/nanoclaw-channel",
+  "version": "0.0.0",
+  "description": "Nanoclaw channel for MoltZap — smoke test package, not published",
+  "private": true,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chughtapan/moltzap"
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/moltzap.js",
+  "types": "./dist/moltzap.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@moltzap/client": "workspace:*",
+    "@moltzap/protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/nanoclaw-channel/src/logger.ts
+++ b/packages/nanoclaw-channel/src/logger.ts
@@ -1,0 +1,18 @@
+// Stub logger matching nanoclaw's src/logger.ts shape. Nanoclaw's real logger
+// writes ANSI-colored structured output to stdout/stderr. For unit tests in this
+// package, we only need a silent shape-compatible fake.
+
+type LogInput = Record<string, unknown> | string;
+
+function noop(_dataOrMsg: LogInput, _msg?: string): void {
+  // Unit tests don't assert on log output. In a real nanoclaw install, this
+  // file is not used — imports resolve against nanoclaw's own logger.ts.
+}
+
+export const logger = {
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+};

--- a/packages/nanoclaw-channel/src/moltzap.test.ts
+++ b/packages/nanoclaw-channel/src/moltzap.test.ts
@@ -1,0 +1,447 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Message } from "@moltzap/protocol";
+
+import { MoltZapChannel, type MoltZapServiceLike } from "./moltzap.js";
+import type { NewMessage, RegisteredGroup } from "./types.js";
+import type { ChannelOpts } from "./registry.js";
+
+type MessageHandler = (msg: Message) => void;
+type VoidHandler = () => void;
+
+class FakeMoltZapService implements MoltZapServiceLike {
+  messageHandlers: MessageHandler[] = [];
+  disconnectHandlers: VoidHandler[] = [];
+  reconnectHandlers: VoidHandler[] = [];
+  sent: Array<{ convId: string; text: string }> = [];
+  connectCalled = 0;
+  closeCalled = 0;
+  ownAgentId: string | undefined = "agent-self";
+  private conversations = new Map<string, { type: string; name?: string }>();
+  private agentNames = new Map<string, string>();
+  private resolveCalls: string[] = [];
+
+  on(event: "message", handler: MessageHandler): void;
+  on(event: "disconnect", handler: VoidHandler): void;
+  on(event: "reconnect", handler: VoidHandler): void;
+  on(event: string, handler: MessageHandler | VoidHandler): void {
+    if (event === "message")
+      this.messageHandlers.push(handler as MessageHandler);
+    else if (event === "disconnect")
+      this.disconnectHandlers.push(handler as VoidHandler);
+    else if (event === "reconnect")
+      this.reconnectHandlers.push(handler as VoidHandler);
+  }
+
+  async connect(): Promise<unknown> {
+    this.connectCalled++;
+    return {};
+  }
+
+  close(): void {
+    this.closeCalled++;
+  }
+
+  async send(conversationId: string, text: string): Promise<void> {
+    this.sent.push({ convId: conversationId, text });
+  }
+
+  getConversation(convId: string): { type: string; name?: string } | undefined {
+    return this.conversations.get(convId);
+  }
+
+  getAgentName(agentId: string): string | undefined {
+    return this.agentNames.get(agentId);
+  }
+
+  async resolveAgentName(agentId: string): Promise<string> {
+    this.resolveCalls.push(agentId);
+    return this.agentNames.get(agentId) ?? agentId;
+  }
+
+  setConversation(id: string, meta: { type: string; name?: string }): void {
+    this.conversations.set(id, meta);
+  }
+
+  setAgentName(id: string, name: string): void {
+    this.agentNames.set(id, name);
+  }
+
+  emitMessage(msg: Message): void {
+    for (const h of this.messageHandlers) h(msg);
+  }
+
+  emitDisconnect(): void {
+    for (const h of this.disconnectHandlers) h();
+  }
+
+  emitReconnect(): void {
+    for (const h of this.reconnectHandlers) h();
+  }
+
+  getResolveCallCount(agentId: string): number {
+    return this.resolveCalls.filter((id) => id === agentId).length;
+  }
+}
+
+interface RecordedChannelOpts extends ChannelOpts {
+  received: Array<{ jid: string; msg: NewMessage }>;
+  metadata: Array<{
+    jid: string;
+    ts: string;
+    name?: string;
+    channel?: string;
+    isGroup?: boolean;
+  }>;
+  groupsMap: Record<string, RegisteredGroup>;
+}
+
+function createRecordedOpts(): RecordedChannelOpts {
+  const received: RecordedChannelOpts["received"] = [];
+  const metadata: RecordedChannelOpts["metadata"] = [];
+  const groupsMap: Record<string, RegisteredGroup> = {};
+  return {
+    onMessage: (jid, msg) => received.push({ jid, msg }),
+    onChatMetadata: (jid, ts, name, channel, isGroup) =>
+      metadata.push({ jid, ts, name, channel, isGroup }),
+    registeredGroups: () => groupsMap,
+    received,
+    metadata,
+    groupsMap,
+  };
+}
+
+function buildMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg-1",
+    conversationId: "conv-1",
+    sender: { type: "agent", id: "agent-alice" },
+    seq: 1,
+    parts: [{ type: "text", text: "hello" }],
+    createdAt: "2026-04-10T12:00:00.000Z",
+    ...overrides,
+  } as Message;
+}
+
+async function flushDispatchChain(): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("MoltZapChannel", () => {
+  let service: FakeMoltZapService;
+  let opts: RecordedChannelOpts;
+  let channel: MoltZapChannel;
+
+  beforeEach(() => {
+    service = new FakeMoltZapService();
+    opts = createRecordedOpts();
+    channel = new MoltZapChannel(opts, service);
+  });
+
+  describe("lifecycle", () => {
+    it("connect() calls through to MoltZapService and marks connected", async () => {
+      expect(channel.isConnected()).toBe(false);
+      await channel.connect();
+      expect(service.connectCalled).toBe(1);
+      expect(channel.isConnected()).toBe(true);
+    });
+
+    it("disconnect() closes the service and clears the connected flag", async () => {
+      await channel.connect();
+      await channel.disconnect();
+      expect(service.closeCalled).toBe(1);
+      expect(channel.isConnected()).toBe(false);
+    });
+
+    it("disconnect event from the service clears the connected flag", async () => {
+      await channel.connect();
+      service.emitDisconnect();
+      expect(channel.isConnected()).toBe(false);
+    });
+
+    it("reconnect event from the service sets the connected flag", () => {
+      service.emitReconnect();
+      expect(channel.isConnected()).toBe(true);
+    });
+  });
+
+  describe("ownsJid", () => {
+    it("returns true for mz: prefixed JIDs", () => {
+      expect(channel.ownsJid("mz:conv-123")).toBe(true);
+    });
+
+    it("returns false for other channel JIDs", () => {
+      expect(channel.ownsJid("tg:1234")).toBe(false);
+      expect(channel.ownsJid("wa:5551234567")).toBe(false);
+      expect(channel.ownsJid("conv-raw")).toBe(false);
+    });
+  });
+
+  describe("sendMessage", () => {
+    it("strips the mz: prefix and forwards to service.send", async () => {
+      await channel.sendMessage("mz:conv-42", "hello there");
+      expect(service.sent).toEqual([
+        { convId: "conv-42", text: "hello there" },
+      ]);
+    });
+
+    it("throws when given a JID not owned by this channel", async () => {
+      await expect(channel.sendMessage("tg:1234", "nope")).rejects.toThrow(
+        /does not own jid/,
+      );
+    });
+  });
+
+  describe("inbound message handling", () => {
+    it("maps MoltZap Message to NewMessage with mz: prefix", async () => {
+      service.setConversation("conv-1", { type: "dm", name: "alice-dm" });
+      service.setAgentName("agent-alice", "Alice");
+
+      service.emitMessage(
+        buildMessage({
+          id: "msg-abc",
+          conversationId: "conv-1",
+          sender: { type: "agent", id: "agent-alice" },
+          parts: [{ type: "text", text: "hi nanoclaw" }],
+          createdAt: "2026-04-10T13:00:00.000Z",
+        }),
+      );
+
+      await flushDispatchChain();
+
+      expect(opts.received).toHaveLength(1);
+      const { jid, msg } = opts.received[0]!;
+      expect(jid).toBe("mz:conv-1");
+      expect(msg).toMatchObject({
+        id: "msg-abc",
+        chat_jid: "mz:conv-1",
+        sender: "agent-alice",
+        sender_name: "Alice",
+        content: "hi nanoclaw",
+        timestamp: "2026-04-10T13:00:00.000Z",
+        is_from_me: false,
+      });
+    });
+
+    it("calls onChatMetadata before onMessage for each inbound", async () => {
+      service.setConversation("conv-1", { type: "group", name: "devs" });
+      service.setAgentName("agent-alice", "Alice");
+
+      service.emitMessage(buildMessage({ conversationId: "conv-1" }));
+      await flushDispatchChain();
+
+      expect(opts.metadata).toHaveLength(1);
+      expect(opts.metadata[0]).toMatchObject({
+        jid: "mz:conv-1",
+        name: "devs",
+        channel: "moltzap",
+        isGroup: true,
+      });
+    });
+
+    it("falls back to resolveAgentName when getAgentName returns undefined", async () => {
+      const svc = new FakeMoltZapService();
+      svc.getAgentName = () => undefined;
+      svc.setAgentName("agent-bob", "Bob");
+      svc.setConversation("conv-1", { type: "dm" });
+
+      const localOpts = createRecordedOpts();
+      new MoltZapChannel(localOpts, svc);
+
+      svc.emitMessage(
+        buildMessage({ sender: { type: "agent", id: "agent-bob" } }),
+      );
+      await flushDispatchChain();
+
+      expect(localOpts.received).toHaveLength(1);
+      expect(localOpts.received[0]!.msg.sender_name).toBe("Bob");
+      expect(svc.getResolveCallCount("agent-bob")).toBe(1);
+    });
+
+    it("falls back to sender.id when both name lookups fail", async () => {
+      const svc = new FakeMoltZapService();
+      svc.getAgentName = () => undefined;
+      svc.resolveAgentName = async (id) => id;
+      svc.setConversation("conv-1", { type: "dm" });
+
+      const localOpts = createRecordedOpts();
+      new MoltZapChannel(localOpts, svc);
+
+      svc.emitMessage(
+        buildMessage({ sender: { type: "agent", id: "agent-unknown" } }),
+      );
+      await flushDispatchChain();
+
+      expect(localOpts.received[0]!.msg.sender_name).toBe("agent-unknown");
+    });
+
+    it("concatenates multiple text parts with newlines", async () => {
+      service.setConversation("conv-1", { type: "dm" });
+      service.setAgentName("agent-alice", "Alice");
+
+      service.emitMessage(
+        buildMessage({
+          parts: [
+            { type: "text", text: "line one" },
+            { type: "text", text: "line two" },
+          ],
+        }),
+      );
+      await flushDispatchChain();
+
+      expect(opts.received[0]!.msg.content).toBe("line one\nline two");
+    });
+
+    it("ignores non-text parts when building content", async () => {
+      service.setConversation("conv-1", { type: "dm" });
+      service.setAgentName("agent-alice", "Alice");
+
+      service.emitMessage(
+        buildMessage({
+          parts: [
+            { type: "text", text: "caption" },
+            { type: "image", url: "https://example.com/pic.png" },
+          ],
+        }),
+      );
+      await flushDispatchChain();
+
+      expect(opts.received[0]!.msg.content).toBe("caption");
+    });
+
+    it("serializes handlers via the dispatch chain so message order is preserved", async () => {
+      const svc = new FakeMoltZapService();
+      svc.getAgentName = () => undefined;
+
+      const resolvers: Array<(name: string) => void> = [];
+      svc.resolveAgentName = (id: string) =>
+        new Promise<string>((resolve) => {
+          resolvers.push(() => resolve(id));
+        });
+
+      svc.setConversation("conv-1", { type: "dm" });
+      const localOpts = createRecordedOpts();
+      new MoltZapChannel(localOpts, svc);
+
+      svc.emitMessage(buildMessage({ id: "msg-1" }));
+      svc.emitMessage(buildMessage({ id: "msg-2" }));
+
+      await flushDispatchChain();
+      expect(resolvers).toHaveLength(1);
+      expect(localOpts.received).toHaveLength(0);
+
+      resolvers[0]!("agent-alice");
+      await flushDispatchChain();
+      expect(localOpts.received.map((r) => r.msg.id)).toEqual(["msg-1"]);
+      expect(resolvers).toHaveLength(2);
+
+      resolvers[1]!("agent-bob");
+      await flushDispatchChain();
+      expect(localOpts.received.map((r) => r.msg.id)).toEqual([
+        "msg-1",
+        "msg-2",
+      ]);
+    });
+
+    it("sets is_from_me=true when sender matches ownAgentId", async () => {
+      service.ownAgentId = "agent-self";
+      service.setConversation("conv-1", { type: "dm" });
+
+      service.emitMessage(
+        buildMessage({ sender: { type: "agent", id: "agent-self" } }),
+      );
+      await flushDispatchChain();
+
+      expect(opts.received[0]!.msg.is_from_me).toBe(true);
+    });
+
+    it("forwards replyToId as reply_to_message_id", async () => {
+      service.setConversation("conv-1", { type: "dm" });
+      service.setAgentName("agent-alice", "Alice");
+
+      service.emitMessage(buildMessage({ replyToId: "msg-parent-123" }));
+      await flushDispatchChain();
+
+      expect(opts.received[0]!.msg.reply_to_message_id).toBe("msg-parent-123");
+    });
+
+    it("logs and swallows errors from the async handler", async () => {
+      const svc = new FakeMoltZapService();
+      svc.getAgentName = () => {
+        throw new Error("boom");
+      };
+      svc.resolveAgentName = async () => "Alice";
+      svc.setConversation("conv-1", { type: "dm" });
+
+      const localOpts = createRecordedOpts();
+      new MoltZapChannel(localOpts, svc);
+
+      svc.emitMessage(buildMessage());
+      await flushDispatchChain();
+
+      expect(localOpts.received).toHaveLength(0);
+
+      svc.getAgentName = () => "Alice";
+      svc.emitMessage(buildMessage({ id: "msg-2" }));
+      await flushDispatchChain();
+      expect(localOpts.received).toHaveLength(1);
+      expect(localOpts.received[0]!.msg.id).toBe("msg-2");
+    });
+  });
+
+  describe("eval mode (MOLTZAP_EVAL_MODE)", () => {
+    it("does NOT auto-register groups when evalMode is false (default)", async () => {
+      service.setConversation("conv-unknown", { type: "dm" });
+      service.setAgentName("agent-alice", "Alice");
+
+      service.emitMessage(buildMessage({ conversationId: "conv-unknown" }));
+      await flushDispatchChain();
+
+      expect(opts.groupsMap["mz:conv-unknown"]).toBeUndefined();
+    });
+
+    it("auto-registers a wildcard group on first message when evalMode is true", async () => {
+      const svc = new FakeMoltZapService();
+      svc.setConversation("conv-new", { type: "dm" });
+      svc.setAgentName("agent-alice", "Alice");
+
+      const localOpts = createRecordedOpts();
+      new MoltZapChannel(localOpts, svc, true);
+
+      svc.emitMessage(buildMessage({ conversationId: "conv-new" }));
+      await flushDispatchChain();
+
+      const registered = localOpts.groupsMap["mz:conv-new"];
+      expect(registered).toBeDefined();
+      expect(registered!.trigger).toBe(".*");
+      expect(registered!.requiresTrigger).toBe(false);
+      expect(registered!.isMain).toBe(true);
+      expect(registered!.name).toMatch(/^eval-/);
+      expect(registered!.folder).toMatch(/^eval_/);
+    });
+
+    it("does not re-register a group that already exists in evalMode", async () => {
+      const svc = new FakeMoltZapService();
+      svc.setConversation("conv-existing", { type: "dm" });
+      svc.setAgentName("agent-alice", "Alice");
+
+      const localOpts = createRecordedOpts();
+      localOpts.groupsMap["mz:conv-existing"] = {
+        name: "already-here",
+        folder: "already_here",
+        trigger: "@Andy",
+        added_at: "2026-04-01T00:00:00Z",
+      };
+      new MoltZapChannel(localOpts, svc, true);
+
+      svc.emitMessage(buildMessage({ conversationId: "conv-existing" }));
+      await flushDispatchChain();
+
+      expect(localOpts.groupsMap["mz:conv-existing"]!.name).toBe(
+        "already-here",
+      );
+      expect(localOpts.groupsMap["mz:conv-existing"]!.trigger).toBe("@Andy");
+    });
+  });
+});

--- a/packages/nanoclaw-channel/src/moltzap.ts
+++ b/packages/nanoclaw-channel/src/moltzap.ts
@@ -1,0 +1,197 @@
+import { MoltZapService } from "@moltzap/client";
+import type { Message } from "@moltzap/protocol";
+
+import type { Channel, NewMessage, RegisteredGroup } from "./types.js";
+import { logger } from "./logger.js";
+import { registerChannel, type ChannelOpts } from "./registry.js";
+
+const MOLTZAP_JID_PREFIX = "mz:";
+const DEFAULT_SERVER_URL = "wss://api.moltzap.xyz";
+
+export interface MoltZapServiceLike {
+  on(event: "message", handler: (msg: Message) => void): void;
+  on(event: "disconnect", handler: () => void): void;
+  on(event: "reconnect", handler: () => void): void;
+  connect(): Promise<unknown>;
+  close(): void;
+  send(conversationId: string, text: string): Promise<void>;
+  getConversation(convId: string): { type: string; name?: string } | undefined;
+  getAgentName(agentId: string): string | undefined;
+  resolveAgentName(agentId: string): Promise<string>;
+  readonly ownAgentId: string | undefined;
+}
+
+function jidFromConversationId(conversationId: string): string {
+  return `${MOLTZAP_JID_PREFIX}${conversationId}`;
+}
+
+function conversationIdFromJid(jid: string): string {
+  return jid.slice(MOLTZAP_JID_PREFIX.length);
+}
+
+function extractTextContent(parts: Message["parts"]): string {
+  return parts
+    .filter(
+      (p): p is Extract<Message["parts"][number], { type: "text" }> =>
+        p.type === "text",
+    )
+    .map((p) => p.text)
+    .join("\n");
+}
+
+export class MoltZapChannel implements Channel {
+  readonly name = "moltzap";
+  private connected = false;
+  private dispatchChain: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly opts: ChannelOpts,
+    private readonly service: MoltZapServiceLike,
+    private readonly evalMode: boolean = false,
+  ) {
+    this.service.on("message", (message) => {
+      this.dispatchChain = this.dispatchChain
+        .then(() => this.handleInboundMessage(message))
+        .catch((err) => {
+          logger.error(
+            { channel: "moltzap", messageId: message.id, err },
+            "Failed to handle inbound MoltZap message",
+          );
+        });
+    });
+
+    this.service.on("disconnect", () => {
+      this.connected = false;
+      logger.warn({ channel: "moltzap" }, "MoltZap disconnected");
+    });
+
+    this.service.on("reconnect", () => {
+      this.connected = true;
+      logger.info({ channel: "moltzap" }, "MoltZap reconnected");
+    });
+  }
+
+  async connect(): Promise<void> {
+    await this.service.connect();
+    this.connected = true;
+    logger.info({ channel: "moltzap" }, "MoltZap connected");
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.ownsJid(jid)) {
+      throw new Error(`MoltZap channel does not own jid: ${jid}`);
+    }
+    const conversationId = conversationIdFromJid(jid);
+    await this.service.send(conversationId, text);
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith(MOLTZAP_JID_PREFIX);
+  }
+
+  async disconnect(): Promise<void> {
+    this.service.close();
+    this.connected = false;
+  }
+
+  private async handleInboundMessage(message: Message): Promise<void> {
+    const chatJid = jidFromConversationId(message.conversationId);
+    const convMeta = this.service.getConversation(message.conversationId);
+
+    // SMOKE-TEST ONLY: in MOLTZAP_EVAL_MODE, auto-register previously-unknown
+    // conversations as nanoclaw groups so nanoclaw routes subsequent messages
+    // to the agent without a human running `setup register`. This exists to
+    // bridge the eval-runtime-starts-before-conversations-exist lifecycle
+    // mismatch. Delete when extracting the stable runtime-adapter interface.
+    if (this.evalMode) {
+      const registered = this.opts.registeredGroups();
+      if (!registered[chatJid]) {
+        const stubGroup: RegisteredGroup = {
+          name: `eval-${message.conversationId.slice(0, 8)}`,
+          folder: `eval_${message.conversationId.slice(0, 8)}`,
+          trigger: ".*",
+          added_at: new Date().toISOString(),
+          requiresTrigger: false,
+          isMain: true,
+        };
+        // Mutate the registered groups map in place. Nanoclaw's setter isn't
+        // exposed through ChannelOpts, but the map returned by
+        // registeredGroups() is the live one in 1.2.52; this is a known
+        // coupling to the internal shape, accepted for smoke test.
+        registered[chatJid] = stubGroup;
+      }
+    }
+
+    this.opts.onChatMetadata(
+      chatJid,
+      message.createdAt,
+      convMeta?.name,
+      "moltzap",
+      convMeta?.type === "group",
+    );
+
+    const senderName =
+      this.service.getAgentName(message.sender.id) ??
+      (await this.service
+        .resolveAgentName(message.sender.id)
+        .catch(() => message.sender.id));
+
+    const content = extractTextContent(message.parts);
+
+    const isFromMe =
+      this.service.ownAgentId !== undefined &&
+      message.sender.id === this.service.ownAgentId;
+
+    const nanoclawMessage: NewMessage = {
+      id: message.id,
+      chat_jid: chatJid,
+      sender: message.sender.id,
+      sender_name: senderName,
+      content,
+      timestamp: message.createdAt,
+      is_from_me: isFromMe,
+      reply_to_message_id: message.replyToId,
+    };
+
+    logger.debug(
+      {
+        channel: "moltzap",
+        messageId: message.id,
+        from: senderName,
+        conv: message.conversationId,
+      },
+      "MoltZap inbound message",
+    );
+
+    this.opts.onMessage(chatJid, nanoclawMessage);
+  }
+}
+
+registerChannel("moltzap", (opts: ChannelOpts): Channel | null => {
+  const apiKey = process.env.MOLTZAP_API_KEY;
+  const serverUrl = process.env.MOLTZAP_SERVER_URL ?? DEFAULT_SERVER_URL;
+  const evalMode = process.env.MOLTZAP_EVAL_MODE === "1";
+
+  if (!apiKey) {
+    return null;
+  }
+
+  const service = new MoltZapService({
+    serverUrl,
+    agentKey: apiKey,
+    logger: {
+      info: (...args: unknown[]) =>
+        logger.info({ channel: "moltzap" }, args.map(String).join(" ")),
+      warn: (...args: unknown[]) =>
+        logger.warn({ channel: "moltzap" }, args.map(String).join(" ")),
+      error: (...args: unknown[]) =>
+        logger.error({ channel: "moltzap" }, args.map(String).join(" ")),
+    },
+  });
+
+  return new MoltZapChannel(opts, service, evalMode);
+});

--- a/packages/nanoclaw-channel/src/registry.ts
+++ b/packages/nanoclaw-channel/src/registry.ts
@@ -1,0 +1,33 @@
+// Stub registry matching nanoclaw's src/channels/registry.ts. In a real nanoclaw
+// install, moltzap.ts imports from './registry.js' and resolves to nanoclaw's
+// actual channel registry. In this package, we re-implement the minimal surface
+// so the channel file compiles and unit-tests in isolation.
+
+import type {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from "./types.js";
+
+export interface ChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+export type ChannelFactory = (opts: ChannelOpts) => Channel | null;
+
+const registry = new Map<string, ChannelFactory>();
+
+export function registerChannel(name: string, factory: ChannelFactory): void {
+  registry.set(name, factory);
+}
+
+export function getChannelFactory(name: string): ChannelFactory | undefined {
+  return registry.get(name);
+}
+
+export function getRegisteredChannelNames(): string[] {
+  return [...registry.keys()];
+}

--- a/packages/nanoclaw-channel/src/types.ts
+++ b/packages/nanoclaw-channel/src/types.ts
@@ -1,0 +1,60 @@
+// Stub types matching the subset of nanoclaw's src/types.ts that moltzap.ts touches.
+// When moltzap.ts is copied into a real nanoclaw fork, these imports resolve
+// against nanoclaw's own src/types.ts (which has the same signatures).
+//
+// Pinned to nanoclaw 1.2.52 types as of 2026-04-10. If nanoclaw upstream refactors
+// these signatures, bump the stubs together with the pinned NANOCLAW_SHA in
+// packages/evals/src/e2e-infra/nanoclaw-smoke.ts.
+
+export interface RegisteredGroup {
+  name: string;
+  folder: string;
+  trigger: string;
+  added_at: string;
+  containerConfig?: {
+    additionalMounts?: Array<{
+      hostPath: string;
+      containerPath?: string;
+      readonly?: boolean;
+    }>;
+    timeout?: number;
+  };
+  requiresTrigger?: boolean;
+  isMain?: boolean;
+}
+
+export interface NewMessage {
+  id: string;
+  chat_jid: string;
+  sender: string;
+  sender_name: string;
+  content: string;
+  timestamp: string;
+  is_from_me?: boolean;
+  is_bot_message?: boolean;
+  thread_id?: string;
+  reply_to_message_id?: string;
+  reply_to_message_content?: string;
+  reply_to_sender_name?: string;
+}
+
+export interface Channel {
+  name: string;
+  connect(): Promise<void>;
+  sendMessage(jid: string, text: string): Promise<void>;
+  isConnected(): boolean;
+  ownsJid(jid: string): boolean;
+  disconnect(): Promise<void>;
+  setTyping?(jid: string, isTyping: boolean): Promise<void>;
+  syncGroups?(force: boolean): Promise<void>;
+}
+
+export type OnInboundMessage = (chatJid: string, message: NewMessage) => void;
+
+export type OnChatMetadata = (
+  chatJid: string,
+  timestamp: string,
+  name?: string,
+  channel?: string,
+  isGroup?: boolean,
+) => void;

--- a/packages/nanoclaw-channel/tsconfig.json
+++ b/packages/nanoclaw-channel/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/nanoclaw-channel/vitest.config.ts
+++ b/packages/nanoclaw-channel/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,22 @@ importers:
         specifier: ^8.18.0
         version: 8.20.0
 
+  packages/nanoclaw-channel:
+    dependencies:
+      '@moltzap/client':
+        specifier: workspace:*
+        version: link:../client
+      '@moltzap/protocol':
+        specifier: workspace:*
+        version: link:../protocol
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/openclaw-channel:
     dependencies:
       '@moltzap/client':


### PR DESCRIPTION
## Summary

Adds \`@moltzap/nanoclaw-channel\` as a private workspace package + wires a \`--runtime nanoclaw\` flag into the eval runner. Driven by the user's interrupt to stop maintaining a full nanoclaw fork and mirror how the existing evals spin openclaw.

**Reviewed via \`/autoplan\`.** CEO + Eng + DX dual voices (Codex + Claude subagent each) converged on "rework framing." User decision at the gate: \"consider this a smoke test..then we'll build the stable interface once we have things working.\" This PR implements the smoke-test framing.

## What this is

- Disposable scaffolding to prove moltzap can talk to a real nanoclaw process via a channel file we control.
- A channel file (\`packages/nanoclaw-channel/src/moltzap.ts\`, 180 LoC) + 21 unit tests.
- A smoke harness (\`packages/evals/src/e2e-infra/nanoclaw-smoke.ts\`, ~220 LoC) that vendors upstream nanoclaw, injects the channel, builds, spawns as a host subprocess, waits for the \"MoltZap connected\" log marker.
- A \`--runtime nanoclaw\` CLI flag on the eval runner, default openclaw.

## What this is NOT

- A stable runtime-adapter contract (extracted later from 2 working paths).
- An external distribution story (private: true, post-smoke-test TODO).
- A parallel-safe build pipeline (single-run only; no cache lockfile).
- The final resting place of the channel file.

## Files added

\`\`\`
packages/nanoclaw-channel/
  package.json           — private, workspace-only
  tsconfig.json
  vitest.config.ts
  src/moltzap.ts         — channel class + MOLTZAP_EVAL_MODE auto-register
  src/moltzap.test.ts    — 21 unit tests
  src/types.ts           — stub of nanoclaw's types
  src/logger.ts          — stub logger
  src/registry.ts        — stub registerChannel + ChannelOpts
packages/evals/src/e2e-infra/nanoclaw-smoke.ts   — vendor + spawn + wait
\`\`\`

## Files modified

- \`packages/evals/src/e2e-infra/runner.ts\` — adds runtime branch (if/else, no interface)
- \`packages/evals/src/e2e-infra/index.ts\` — adds \`--runtime\` CLI flag

## Known smoke-test sloppiness (flagged by /autoplan, deferred per gate)

1. **No cache lockfile** — parallel eval runs will race on \`~/.cache/moltzap-evals/nanoclaw/<sha>/\`. Don't run parallel smoke tests.
2. **container/build.sh runs vendored bash** — supply chain risk. SHA pin mitigates remote tampering but not upstream compromise. Accepted for smoke test.
3. **MOLTZAP_EVAL_MODE branch pollutes production channel code** — wildcard auto-register in the channel file to bridge the eval-runtime-starts-before-conversations-exist lifecycle mismatch. Delete when extracting the stable interface.
4. **Stub type drift** only caught at nanoclaw build time, not package build time. Manual detection on SHA bumps.
5. **SHA bump is manual** — edit \`NANOCLAW_SHA\` constant, rm the cache dir, re-run. No dependabot.
6. **External distribution story deferred** — \`private: true\` means nanoclaw users can't npm install this yet.

All 6 tracked as post-smoke-test TODOs in \`~/.claude/plans/bright-popping-pony.md\`.

## Test results

\`\`\`
@moltzap/protocol:         45/45   ✓
@moltzap/server-core:      21/21   ✓
@moltzap/client:           53/53   ✓
@moltzap/nanoclaw-channel: 21/21   ✓  (new)
@moltzap/openclaw-channel: 128/128 ✓
@moltzap/evals:            13/13   ✓
───────────────────────────────────
                           281/281 ✓
\`\`\`

Monorepo build clean across all 7 projects. Existing \`--runtime openclaw\` path is unchanged.

## Manual verification (post-merge, run once)

The smoke scenario itself (\`pnpm --filter @moltzap/evals eval:e2e -- --runtime nanoclaw --scenario smoke\`) is not part of CI — it requires docker running locally and takes 3-5 minutes cold. I'll run it locally after this merges and report back.

If the smoke scenario passes, the \`chughtapan/nanoclaw\` fork and the local clone at \`~/conductor/repos/nanoclaw\` can be deleted.

## /autoplan trail

Full review at \`~/.claude/plans/bright-popping-pony.md\`. Decision audit trail + cross-phase consensus tables + deferred TODOs all documented in the plan file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)