### PR TITLE
fix(evals): judge fails all non-passing verdicts with "Unknown type"

### DIFF
--- a/packages/evals/src/e2e-infra/__tests__/llm-judge.test.ts
+++ b/packages/evals/src/e2e-infra/__tests__/llm-judge.test.ts
@@ -40,6 +40,20 @@ const SUCCESS = {
   usage: { input_tokens: 100, output_tokens: 50 },
 };
 
+const FAIL_WITH_ISSUES = {
+  type: "result" as const,
+  subtype: "success" as const,
+  structured_output: {
+    pass: false,
+    reason: "Missing required command.",
+    issues: [
+      { issue: "Agent did not produce /vote", severity: "critical" as const },
+      { issue: "Response was wordy", severity: "minor" as const },
+    ],
+  },
+  usage: { input_tokens: 120, output_tokens: 80 },
+};
+
 const ERROR_RESULT = {
   type: "result" as const,
   subtype: "error_during_execution" as const,
@@ -71,6 +85,24 @@ describe("judgeAgentResponse", () => {
     expect(call.options.maxTurns).toBeGreaterThanOrEqual(2);
     // Persona must stay inline in user prompt, not lifted to systemPrompt.
     expect(call.prompt).toContain("You are an expert QA evaluator");
+  });
+
+  it("parses a fail verdict with populated issues (severity walk)", async () => {
+    mockQuery.mockReset();
+    mockQuery.mockReturnValueOnce(asyncIter([FAIL_WITH_ISSUES]));
+
+    const result = await judgeAgentResponse({
+      scenario: SCENARIO,
+      agentResponse: "hi",
+      conversationContext: "{}",
+      evalModel: "claude-opus-4-6",
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("Missing required command.");
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues?.[0]?.severity).toBe("critical");
+    expect(result.issues?.[1]?.severity).toBe("minor");
   });
 
   it("retries on transient SDK errors and eventually succeeds", async () => {

--- a/packages/evals/src/e2e-infra/llm-judge.ts
+++ b/packages/evals/src/e2e-infra/llm-judge.ts
@@ -1,7 +1,6 @@
 import { query, type Options } from "@anthropic-ai/claude-agent-sdk";
 import { Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
-import { stringEnum } from "@moltzap/protocol";
 import { DEFAULT_JUDGE_MODEL } from "./model-config.js";
 import { logger } from "./logger.js";
 import type { EvalScenario, JudgeResult, TranscriptEntry } from "./types.js";
@@ -14,7 +13,11 @@ const JudgeResultSchema = Type.Object(
       Type.Object(
         {
           issue: Type.String(),
-          severity: stringEnum(["minor", "significant", "critical"]),
+          severity: Type.Union([
+            Type.Literal("minor"),
+            Type.Literal("significant"),
+            Type.Literal("critical"),
+          ]),
         },
         { additionalProperties: false },
       ),


### PR DESCRIPTION
## Summary

- `JudgeResultSchema` used `stringEnum()` for the `issues[].severity` field. `stringEnum` wraps `Type.Unsafe`, which has no TypeBox `Kind`, so `Value.Parse` cannot walk into it and throws `Unknown type`.
- The bug only fires when the judge returns `pass: false` with a **non-empty** `issues` array. A passing verdict returns `issues: []` and never enters the array, so the existing unit test (which only uses a passing fixture) never caught it — but every real failure verdict gets corrupted into `Evaluation flow failed: Unknown type`.
- Switches `severity` to a literal union, adds a regression test with a fail-with-issues fixture.

## How this was found

Running the full scenario suite against the new Claude judge from a consumer repo. Out of 10 scenarios, 4 hit the judge and all 4 came back as `Unknown type` critical errors. Traced it through `callJudgeWithSdk` → `Value.Parse(JudgeResultSchema, structured_output)` → TypeBox's `ValueCheckUnknownTypeError` at `check.mjs:23`, fired when the walker hit a schema with no recognized `Kind`.

Repro snippet (before the fix):

```ts
import { Type } from "@sinclair/typebox";
import { Value } from "@sinclair/typebox/value";
import { stringEnum } from "@moltzap/protocol";

const Schema = Type.Object({
  pass: Type.Boolean(),
  reason: Type.String(),
  issues: Type.Array(Type.Object({
    issue: Type.String(),
    severity: stringEnum(["minor", "significant", "critical"]),
  }, { additionalProperties: false })),
}, { additionalProperties: false });

Value.Parse(Schema, { pass: true,  reason: "ok",  issues: [] });                               // ok
Value.Parse(Schema, { pass: false, reason: "bad", issues: [{ issue: "x", severity: "critical" }] }); // throws: Unknown type
```

## Why not `stringEnum`

The protocol package's convention is `stringEnum()` over `Type.Union([Type.Literal()])` because some wire-protocol AJV validators reject `anyOf`. The judge result schema is internal to the judge — it's only consumed by `Value.Parse` on the client side and serialized into Claude's `json_schema` output format, neither of which has the `anyOf` aversion. So `Type.Union` is safe here and has the advantage of actually working with `Value.Parse`.

## Test plan

- [x] New unit test `parses a fail verdict with populated issues (severity walk)` with a mock SDK response shaped like `{ pass: false, issues: [...] }`
- [x] `pnpm test` green (14/14, was 13/13)
- [x] `pnpm build` green
- [ ] Verified end-to-end against the full scenario suite from a consumer repo (pending submodule bump on that side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)