### PR TITLE
feat(evals): add launchFleet API + nanoclaw exports

### DIFF
--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -29,6 +29,10 @@
     "./docker-manager": {
       "import": "./dist/e2e-infra/docker-manager.js",
       "types": "./dist/e2e-infra/docker-manager.d.ts"
+    },
+    "./nanoclaw-smoke": {
+      "import": "./dist/e2e-infra/nanoclaw-smoke.js",
+      "types": "./dist/e2e-infra/nanoclaw-smoke.d.ts"
     }
   },
   "dependencies": {

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -33,6 +33,14 @@
     "./nanoclaw-smoke": {
       "import": "./dist/e2e-infra/nanoclaw-smoke.js",
       "types": "./dist/e2e-infra/nanoclaw-smoke.d.ts"
+    },
+    "./agent-fleet": {
+      "import": "./dist/e2e-infra/agent-fleet.js",
+      "types": "./dist/e2e-infra/agent-fleet.d.ts"
+    },
+    "./nanoclaw-manager": {
+      "import": "./dist/e2e-infra/nanoclaw-manager.js",
+      "types": "./dist/e2e-infra/nanoclaw-manager.d.ts"
     }
   },
   "dependencies": {

--- a/packages/evals/src/e2e-infra/agent-fleet.ts
+++ b/packages/evals/src/e2e-infra/agent-fleet.ts
@@ -1,0 +1,153 @@
+/**
+ * Unified agent fleet launcher for E2E evals.
+ *
+ * Dispatches to DockerManager (openclaw) or NanoclawManager (nanoclaw),
+ * blocking until all agents are connected. Returns a single AgentFleet
+ * handle for cleanup and log access.
+ */
+
+import { DockerManager, type AgentContainer } from "./docker-manager.js";
+import { NanoclawManager, type NanoclawAgent } from "./nanoclaw-manager.js";
+import { logger } from "./logger.js";
+
+export type AgentRuntime = "openclaw" | "nanoclaw";
+
+export interface FleetAgent {
+  name: string;
+}
+
+export interface AgentFleet {
+  agents: FleetAgent[];
+  stopAll(): Promise<void>;
+  getLogs(name: string): string;
+}
+
+export interface LaunchFleetOpts {
+  runtime: AgentRuntime;
+  agents: Array<{ name: string; apiKey: string }>;
+  serverUrl: string;
+  modelId?: string;
+  /** Only applies to openclaw runtime. Nanoclaw uses cached workspace from ensureNanoclawInstalled. */
+  workspaceFiles?: (name: string) => Array<{ relativePath: string; content: string }>;
+  /** Timeout for each agent to connect. Defaults to 180_000 (180s). */
+  connectTimeoutMs?: number;
+}
+
+const POST_CONNECT_SETTLE_MS = 2_000;
+
+export async function launchFleet(opts: LaunchFleetOpts): Promise<AgentFleet> {
+  if (opts.runtime === "openclaw") {
+    return launchOpenClawFleet(opts);
+  }
+  return launchNanoclawFleet(opts);
+}
+
+async function launchOpenClawFleet(opts: LaunchFleetOpts): Promise<AgentFleet> {
+  const dockerManager = new DockerManager();
+  await dockerManager.ensureImage();
+
+  let containers: AgentContainer[];
+  try {
+    containers = await Promise.all(
+      opts.agents.map((agent) =>
+        dockerManager.startAgentAndWait({
+          name: agent.name,
+          moltzapServerUrl: opts.serverUrl,
+          moltzapApiKey: agent.apiKey,
+          agentModelId: opts.modelId,
+          workspaceFiles: opts.workspaceFiles?.(agent.name),
+          connectTimeoutMs: opts.connectTimeoutMs ?? 180_000,
+        }),
+      ),
+    );
+  } catch (err) {
+    // Partial failure: stop already-started containers before rethrowing.
+    await dockerManager.stopAll();
+    throw err;
+  }
+
+  // Grace delay: let the server register all connections before callers proceed.
+  await new Promise((r) => setTimeout(r, POST_CONNECT_SETTLE_MS));
+
+  logger.info(`Fleet started: ${containers.length} openclaw agent(s)`);
+
+  const agentMap = new Map(containers.map((c) => [c.name, c]));
+
+  return {
+    agents: containers.map((c) => ({ name: c.name })),
+    async stopAll() {
+      // Capture logs before stopping for post-mortem access.
+      for (const c of containers) {
+        const logs = dockerManager.getContainerLogs(c);
+        if (logs && logs !== "(no logs available)") {
+          const last20 = logs.split("\n").slice(-20).join("\n");
+          logger.info(`Fleet agent "${c.name}" logs (last 20):\n${last20}`);
+        }
+      }
+      await dockerManager.stopAll();
+    },
+    getLogs(name: string): string {
+      const container = agentMap.get(name);
+      if (!container) {
+        throw new Error(
+          `Unknown fleet agent "${name}". Known agents: ${[...agentMap.keys()].join(", ")}`,
+        );
+      }
+      return dockerManager.getContainerLogs(container);
+    },
+  };
+}
+
+async function launchNanoclawFleet(opts: LaunchFleetOpts): Promise<AgentFleet> {
+  const nanoclawManager = new NanoclawManager();
+  await nanoclawManager.ensureInstalled();
+
+  const agents: NanoclawAgent[] = [];
+  try {
+    // Sequential to avoid overwhelming OneCLI/Docker.
+    for (const agentOpts of opts.agents) {
+      const agent = await nanoclawManager.startAgent({
+        name: agentOpts.name,
+        apiKey: agentOpts.apiKey,
+        serverUrl: opts.serverUrl,
+        workspaceFiles: opts.workspaceFiles?.(agentOpts.name),
+      });
+      agents.push(agent);
+    }
+  } catch (err) {
+    // Partial failure: stop already-started agents before rethrowing.
+    await nanoclawManager.stopAll();
+    throw err;
+  }
+
+  // Grace delay: let the server register all connections before callers proceed.
+  await new Promise((r) => setTimeout(r, POST_CONNECT_SETTLE_MS));
+
+  logger.info(`Fleet started: ${agents.length} nanoclaw agent(s)`);
+
+  const agentMap = new Map(agents.map((a) => [a.name, a]));
+
+  return {
+    agents: agents.map((a) => ({ name: a.name })),
+    async stopAll() {
+      // Capture logs before stopping for post-mortem access.
+      for (const a of agents) {
+        const logs = nanoclawManager.getAgentLogs(a);
+        if (logs) {
+          const last20 = logs.split("\n").slice(-20).join("\n");
+          logger.info(`Fleet agent "${a.name}" logs (last 20):\n${last20}`);
+        }
+      }
+      await nanoclawManager.stopAll();
+    },
+    getLogs(name: string): string {
+      const agent = agentMap.get(name);
+      if (!agent) {
+        throw new Error(
+          `Unknown fleet agent "${name}". Known agents: ${[...agentMap.keys()].join(", ")}`,
+        );
+      }
+      return nanoclawManager.getAgentLogs(agent);
+    },
+  };
+}

--- a/packages/evals/src/e2e-infra/agent-fleet.ts
+++ b/packages/evals/src/e2e-infra/agent-fleet.ts
@@ -28,7 +28,9 @@ export interface LaunchFleetOpts {
   serverUrl: string;
   modelId?: string;
   /** Only applies to openclaw runtime. Nanoclaw uses cached workspace from ensureNanoclawInstalled. */
-  workspaceFiles?: (name: string) => Array<{ relativePath: string; content: string }>;
+  workspaceFiles?: (
+    name: string,
+  ) => Array<{ relativePath: string; content: string }>;
   /** Timeout for each agent to connect. Defaults to 180_000 (180s). */
   connectTimeoutMs?: number;
 }

--- a/packages/evals/src/e2e-infra/docker-manager.ts
+++ b/packages/evals/src/e2e-infra/docker-manager.ts
@@ -180,7 +180,10 @@ export class DockerManager {
     connectTimeoutMs?: number;
   }): Promise<AgentContainer> {
     const container = await this.startAgent(opts);
-    await waitForChannel(container.containerId, opts.connectTimeoutMs ?? 180_000);
+    await waitForChannel(
+      container.containerId,
+      opts.connectTimeoutMs ?? 180_000,
+    );
     return container;
   }
 

--- a/packages/evals/src/e2e-infra/docker-manager.ts
+++ b/packages/evals/src/e2e-infra/docker-manager.ts
@@ -14,6 +14,7 @@ import {
   buildOpenClawConfig,
   startRawContainer,
   waitForGateway,
+  waitForChannel,
   getLogs,
   stopContainer as stopRawContainer,
   OPENCLAW_STATE_DIR,
@@ -167,6 +168,20 @@ export class DockerManager {
       `Agent "${opts.name}" started (container: ${raw.containerId.slice(0, 12)}, port: ${raw.controlPort})`,
     );
     return agent;
+  }
+
+  async startAgentAndWait(opts: {
+    name: string;
+    agentModelId?: string;
+    moltzapServerUrl?: string;
+    moltzapApiKey?: string;
+    extraEnv?: Record<string, string>;
+    workspaceFiles?: Array<{ relativePath: string; content: string }>;
+    connectTimeoutMs?: number;
+  }): Promise<AgentContainer> {
+    const container = await this.startAgent(opts);
+    await waitForChannel(container.containerId, opts.connectTimeoutMs ?? 180_000);
+    return container;
   }
 
   async stopAgent(agent: AgentContainer): Promise<void> {

--- a/packages/evals/src/e2e-infra/model-config.ts
+++ b/packages/evals/src/e2e-infra/model-config.ts
@@ -1,3 +1,4 @@
 /** Default models for E2E evals. */
 export const DEFAULT_JUDGE_MODEL = "claude-opus-4-6";
 export const DEFAULT_AGENT_MODEL_ID = "minimax/MiniMax-M2.7-highspeed";
+export const DEFAULT_NANOCLAW_MODEL_DISPLAY = "anthropic/claude-sonnet-4-6";

--- a/packages/evals/src/e2e-infra/nanoclaw-manager.ts
+++ b/packages/evals/src/e2e-infra/nanoclaw-manager.ts
@@ -1,0 +1,96 @@
+/**
+ * Manages nanoclaw processes for E2E evals.
+ *
+ * Each agent is a separate nanoclaw subprocess sharing a cached binary
+ * and OneCLI gateway. Mirrors DockerManager's API surface.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  ensureNanoclawInstalled,
+  startNanoclawSmoke,
+  stopNanoclawSmoke,
+  getNanoclawLogs,
+  NANOCLAW_CACHE,
+  type NanoclawSmokeHandle,
+} from "./nanoclaw-smoke.js";
+import { logger } from "./logger.js";
+
+export interface NanoclawAgent {
+  name: string;
+  handle: NanoclawSmokeHandle;
+}
+
+export class NanoclawManager {
+  private agents: NanoclawAgent[] = [];
+
+  async ensureInstalled(): Promise<void> {
+    await ensureNanoclawInstalled();
+  }
+
+  async startAgent(opts: {
+    name: string;
+    apiKey: string;
+    serverUrl: string;
+    workspaceFiles?: Array<{ relativePath: string; content: string }>;
+  }): Promise<NanoclawAgent> {
+    logger.info(`Starting nanoclaw agent "${opts.name}"`);
+
+    // Write workspace files into the nanoclaw cache's container tree.
+    // Skills are volume-mounted at runtime (not baked into the image),
+    // so changes here are visible to the next subcontainer launch.
+    if (opts.workspaceFiles) {
+      for (const file of opts.workspaceFiles) {
+        const destPath = path.join(
+          NANOCLAW_CACHE,
+          "container/skills",
+          file.relativePath,
+        );
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        fs.writeFileSync(destPath, file.content);
+      }
+    }
+
+    const handle = await startNanoclawSmoke({
+      apiKey: opts.apiKey,
+      serverUrl: opts.serverUrl,
+    });
+    const agent: NanoclawAgent = { name: opts.name, handle };
+    this.agents.push(agent);
+    logger.info(`Nanoclaw agent "${opts.name}" connected`);
+    return agent;
+  }
+
+  async stopAgent(agent: NanoclawAgent): Promise<void> {
+    try {
+      await stopNanoclawSmoke(agent.handle);
+    } catch (err) {
+      logger.warn(
+        `Failed to stop nanoclaw agent "${agent.name}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    this.agents = this.agents.filter((a) => a !== agent);
+  }
+
+  async stopAll(): Promise<void> {
+    logger.info(`Stopping ${this.agents.length} nanoclaw agent(s)`);
+    const agents = [...this.agents];
+    this.agents = [];
+    await Promise.allSettled(
+      agents.map(async (agent) => {
+        try {
+          await stopNanoclawSmoke(agent.handle);
+        } catch (err) {
+          logger.warn(
+            `Failed to stop nanoclaw agent "${agent.name}": ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }),
+    );
+  }
+
+  getAgentLogs(agent: NanoclawAgent): string {
+    return getNanoclawLogs(agent.handle);
+  }
+}

--- a/packages/evals/src/e2e-infra/nanoclaw-smoke.ts
+++ b/packages/evals/src/e2e-infra/nanoclaw-smoke.ts
@@ -37,7 +37,7 @@ const ONECLI_COMPOSE_PATH = path.join(
 const NANOCLAW_SHA = "934f063aff5c30e7b49ce58b53b41901d3472a3e";
 const NANOCLAW_URL = `https://github.com/qwibitai/nanoclaw/archive/${NANOCLAW_SHA}.tar.gz`;
 
-const NANOCLAW_CACHE = path.join(
+export const NANOCLAW_CACHE = path.join(
   os.homedir(),
   ".cache/moltzap-evals/nanoclaw",
   NANOCLAW_SHA.slice(0, 12),

--- a/packages/evals/src/e2e-infra/runner.ts
+++ b/packages/evals/src/e2e-infra/runner.ts
@@ -8,21 +8,13 @@
  *   4. Analysis  — aggregate failures, identify patterns
  */
 
-import { execSync } from "node:child_process";
 import {
   startCoreTestServer,
   stopCoreTestServer,
   resetCoreTestDb,
 } from "@moltzap/server-core/test-utils";
 import { MoltZapTestClient } from "@moltzap/protocol/test-client";
-import { DockerManager } from "./docker-manager.js";
-import {
-  ensureNanoclawInstalled,
-  startNanoclawSmoke,
-  stopNanoclawSmoke,
-  getNanoclawLogs,
-  type NanoclawSmokeHandle,
-} from "./nanoclaw-smoke.js";
+import { launchFleet, type AgentFleet, type AgentRuntime } from "./agent-fleet.js";
 import { TIER5_SCENARIOS } from "./scenarios.js";
 import { judgeAgentResponse, analyzeFailures } from "./llm-judge.js";
 import { generateReport, generateSummaryMarkdown } from "./report.js";
@@ -334,7 +326,7 @@ async function generateResult(opts: {
   }
 }
 
-export type AgentRuntime = "openclaw" | "nanoclaw";
+export { type AgentRuntime } from "./agent-fleet.js";
 
 export async function runE2EEvals(opts: {
   scenarios?: string[];
@@ -381,21 +373,12 @@ export async function runE2EEvals(opts: {
   }
 
   const runtime: AgentRuntime = opts.runtime ?? "openclaw";
-  const dockerManager = new DockerManager();
-  let nanoclawHandle: NanoclawSmokeHandle | null = null;
+  let fleet: AgentFleet | null = null;
   let testServerBaseUrl = "";
   let testServerWsUrl = "";
   const clientsToClose: MoltZapTestClient[] = [];
 
   try {
-    if (runtime === "openclaw") {
-      // Verify Docker image exists
-      await dockerManager.ensureImage();
-    } else {
-      // Nanoclaw smoke test: vendor upstream source, inject channel, build.
-      await ensureNanoclawInstalled();
-    }
-
     // Phase 0: Start test infrastructure
     logger.info("Starting MoltZap core test server (testcontainers)...");
     const server = await startCoreTestServer();
@@ -448,65 +431,14 @@ export async function runE2EEvals(opts: {
       }),
     );
 
-    // Start the agent runtime (openclaw container OR nanoclaw subprocess).
-    if (runtime === "openclaw") {
-      logger.info("Starting OpenClaw agent container...");
-      const agentContainer = await dockerManager.startAgent({
-        name: "openclaw-eval-agent",
-        moltzapServerUrl: testServerWsUrl,
-        moltzapApiKey: agentReg.apiKey,
-        agentModelId: opts.agentModelId,
-      });
-
-      // Wait for the agent's channel plugin to actually connect via WebSocket.
-      // Poll container logs for "[moltzap] connected as" which confirms the plugin's
-      // auth/connect RPC succeeded.
-      logger.info("Waiting for agent to connect via MoltZap channel...");
-      const connectDeadline = Date.now() + 90_000;
-      let agentConnected = false;
-      while (Date.now() < connectDeadline) {
-        await new Promise((r) => setTimeout(r, 2000));
-        // Check container is still running
-        try {
-          const status = execSync(
-            `docker inspect ${agentContainer.containerId} --format='{{.State.Status}}'`,
-            { encoding: "utf-8" },
-          ).trim();
-          if (status !== "running") {
-            const logs = dockerManager.getContainerLogs(agentContainer);
-            throw new Error(`Agent container exited. Logs:\n${logs}`);
-          }
-        } catch (err) {
-          if (err instanceof Error && err.message.includes("container exited"))
-            throw err;
-        }
-        // Check container logs for successful MoltZap connection
-        const logs = dockerManager.getContainerLogs(agentContainer);
-        if (logs.includes("[moltzap] connected as")) {
-          agentConnected = true;
-          // Give the server a moment to register the connection
-          await new Promise((r) => setTimeout(r, 2000));
-          break;
-        }
-      }
-      if (!agentConnected) {
-        const logs = dockerManager.getContainerLogs(agentContainer);
-        throw new Error(
-          `Agent channel plugin did not connect within 90s. Container logs:\n${logs}`,
-        );
-      }
-      logger.info("Agent channel plugin connected. Starting eval scenarios...");
-    } else {
-      // Nanoclaw smoke: spawn the host subprocess, wait for connected marker.
-      logger.info("Starting nanoclaw subprocess...");
-      nanoclawHandle = await startNanoclawSmoke({
-        apiKey: agentReg.apiKey,
-        serverUrl: testServerWsUrl,
-      });
-      // Give the server a moment to register the connection
-      await new Promise((r) => setTimeout(r, 2000));
-      logger.info("Nanoclaw connected. Starting eval scenarios...");
-    }
+    // Start the agent runtime via fleet API (blocks until connected).
+    fleet = await launchFleet({
+      runtime,
+      agents: [{ name: "openclaw-eval-agent", apiKey: agentReg.apiKey }],
+      serverUrl: testServerWsUrl,
+      modelId: opts.agentModelId,
+    });
+    logger.info("Agent connected. Starting eval scenarios...");
 
     const allResults: EvaluatedResult[] = [];
     const totalJobs = selectedScenarios.length * runsPerScenario;
@@ -705,24 +637,7 @@ export async function runE2EEvals(opts: {
       },
     };
   } finally {
-    if (runtime === "openclaw") {
-      // Capture container logs before stopping (helps debug failures)
-      for (const c of dockerManager["containers"]) {
-        const logs = dockerManager.getContainerLogs(c);
-        if (logs && logs !== "(no logs available)") {
-          logger.info(`Container "${c.name}" logs:\n${logs}`);
-        }
-      }
-      await dockerManager.stopAll();
-    } else if (nanoclawHandle) {
-      const logs = getNanoclawLogs(nanoclawHandle);
-      if (logs) {
-        logger.info(
-          `Nanoclaw logs (last 20 lines):\n${logs.split("\n").slice(-20).join("\n")}`,
-        );
-      }
-      await stopNanoclawSmoke(nanoclawHandle);
-    }
+    if (fleet) await fleet.stopAll();
     for (const c of clientsToClose) c.close();
     await stopCoreTestServer().catch(() => {});
   }

--- a/packages/evals/src/e2e-infra/runner.ts
+++ b/packages/evals/src/e2e-infra/runner.ts
@@ -14,7 +14,11 @@ import {
   resetCoreTestDb,
 } from "@moltzap/server-core/test-utils";
 import { MoltZapTestClient } from "@moltzap/protocol/test-client";
-import { launchFleet, type AgentFleet, type AgentRuntime } from "./agent-fleet.js";
+import {
+  launchFleet,
+  type AgentFleet,
+  type AgentRuntime,
+} from "./agent-fleet.js";
 import { TIER5_SCENARIOS } from "./scenarios.js";
 import { judgeAgentResponse, analyzeFailures } from "./llm-judge.js";
 import { generateReport, generateSummaryMarkdown } from "./report.js";


### PR DESCRIPTION
## Summary
- Export nanoclaw-smoke utilities and model constant for downstream consumers
- Add `launchFleet()` API in `agent-fleet.ts` for unified agent runtime dispatch
- Add `NanoclawManager` (moved from Arena) with `workspaceFiles` support
- Add `startAgentAndWait()` to `DockerManager`
- Refactor `runner.ts` to use `launchFleet`
- Apply oxfmt formatting

Consumed by moltzap-arena#43.

## Test plan
- [x] `pnpm --filter @moltzap/evals build` passes
- [x] `pnpm --filter @moltzap/evals test` passes (14/14)