### PR TITLE
feat: add AppHost framework — protocol schemas, policy engine, RPC handlers

### DIFF
--- a/packages/protocol/src/schema/apps.test.ts
+++ b/packages/protocol/src/schema/apps.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import {
+  AppManifestSchema,
+  AppSessionSchema,
+  AppParticipantStatusEnum,
+} from "./apps.js";
+
+const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
+
+const validateManifest = ajv.compile(AppManifestSchema);
+const validateSession = ajv.compile(AppSessionSchema);
+const validateStatus = ajv.compile(AppParticipantStatusEnum);
+
+describe("AppManifestSchema", () => {
+  it("accepts a valid manifest", () => {
+    const manifest = {
+      appId: "werewolf",
+      name: "Werewolf",
+      permissions: { required: [], optional: [] },
+    };
+    expect(validateManifest(manifest)).toBe(true);
+  });
+
+  it("accepts a full manifest with all optional fields", () => {
+    const manifest = {
+      appId: "werewolf",
+      name: "Werewolf",
+      description: "Social deduction game",
+      permissions: {
+        required: [{ resource: "calendar", access: ["read", "write"] }],
+        optional: [{ resource: "email", access: ["read"] }],
+      },
+      skillUrl: "https://example.com/skill.md",
+      skillMinVersion: "0.2",
+      challengeTimeoutMs: 60000,
+      permissionTimeoutMs: 300000,
+      limits: { maxParticipants: 12 },
+      conversations: [
+        { key: "town_square", name: "Town Square", participantFilter: "all" },
+        { key: "den", name: "Werewolf Den", participantFilter: "none" },
+      ],
+    };
+    expect(validateManifest(manifest)).toBe(true);
+  });
+
+  it("rejects manifest missing required fields", () => {
+    expect(validateManifest({ appId: "test" })).toBe(false);
+    expect(validateManifest({ name: "test" })).toBe(false);
+    expect(validateManifest({})).toBe(false);
+  });
+
+  it("rejects invalid participantFilter values", () => {
+    const manifest = {
+      appId: "test",
+      name: "Test",
+      permissions: { required: [], optional: [] },
+      conversations: [
+        { key: "main", name: "Main", participantFilter: "invalid" },
+      ],
+    };
+    expect(validateManifest(manifest)).toBe(false);
+  });
+
+  it("rejects additional properties", () => {
+    const manifest = {
+      appId: "test",
+      name: "Test",
+      permissions: { required: [], optional: [] },
+      extra: "nope",
+    };
+    expect(validateManifest(manifest)).toBe(false);
+  });
+});
+
+describe("AppSessionSchema", () => {
+  it("accepts a valid session", () => {
+    const session = {
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      appId: "werewolf",
+      initiatorAgentId: "550e8400-e29b-41d4-a716-446655440001",
+      status: "waiting",
+      conversations: {
+        town_square: "550e8400-e29b-41d4-a716-446655440002",
+      },
+      createdAt: "2026-04-15T00:00:00.000Z",
+    };
+    expect(validateSession(session)).toBe(true);
+  });
+
+  it("rejects invalid status", () => {
+    const session = {
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      appId: "werewolf",
+      initiatorAgentId: "550e8400-e29b-41d4-a716-446655440001",
+      status: "invalid",
+      conversations: {},
+      createdAt: "2026-04-15T00:00:00.000Z",
+    };
+    expect(validateSession(session)).toBe(false);
+  });
+});
+
+describe("AppParticipantStatusEnum", () => {
+  it("accepts valid values", () => {
+    expect(validateStatus("pending")).toBe(true);
+    expect(validateStatus("admitted")).toBe(true);
+    expect(validateStatus("rejected")).toBe(true);
+  });
+
+  it("rejects invalid values", () => {
+    expect(validateStatus("invalid")).toBe(false);
+    expect(validateStatus("")).toBe(false);
+  });
+});

--- a/packages/protocol/src/schema/apps.ts
+++ b/packages/protocol/src/schema/apps.ts
@@ -1,0 +1,77 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { stringEnum, brandedId, DateTimeString } from "../helpers.js";
+import { AgentId, ConversationId } from "./primitives.js";
+
+export const AppSessionId = brandedId("AppSessionId");
+
+export const AppParticipantStatusEnum = stringEnum([
+  "pending",
+  "admitted",
+  "rejected",
+]);
+
+export const AppPermissionSchema = Type.Object(
+  {
+    resource: Type.String(),
+    access: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const AppManifestConversationSchema = Type.Object(
+  {
+    key: Type.String(),
+    name: Type.String(),
+    participantFilter: Type.Optional(stringEnum(["all", "initiator", "none"])),
+  },
+  { additionalProperties: false },
+);
+
+export const AppManifestSchema = Type.Object(
+  {
+    appId: Type.String(),
+    name: Type.String(),
+    description: Type.Optional(Type.String()),
+    permissions: Type.Object(
+      {
+        required: Type.Array(AppPermissionSchema),
+        optional: Type.Array(AppPermissionSchema),
+      },
+      { additionalProperties: false },
+    ),
+    skillUrl: Type.Optional(Type.String()),
+    skillMinVersion: Type.Optional(Type.String()),
+    challengeTimeoutMs: Type.Optional(Type.Integer({ default: 30000 })),
+    permissionTimeoutMs: Type.Optional(Type.Integer({ default: 120000 })),
+    limits: Type.Optional(
+      Type.Object(
+        {
+          maxParticipants: Type.Optional(Type.Integer({ default: 50 })),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+    conversations: Type.Optional(Type.Array(AppManifestConversationSchema)),
+  },
+  { additionalProperties: false },
+);
+
+export const AppSessionSchema = Type.Object(
+  {
+    id: AppSessionId,
+    appId: Type.String(),
+    initiatorAgentId: AgentId,
+    status: stringEnum(["waiting", "active", "closed"]),
+    conversations: Type.Record(Type.String(), ConversationId),
+    createdAt: DateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export type AppPermission = Static<typeof AppPermissionSchema>;
+export type AppManifest = Static<typeof AppManifestSchema>;
+export type AppManifestConversation = Static<
+  typeof AppManifestConversationSchema
+>;
+export type AppSession = Static<typeof AppSessionSchema>;
+export type AppParticipantStatus = Static<typeof AppParticipantStatusEnum>;

--- a/packages/protocol/src/schema/errors.ts
+++ b/packages/protocol/src/schema/errors.ts
@@ -17,6 +17,16 @@ export const ErrorCodes = {
   Blocked: -32006,
   ConversationFull: -32007,
   ProtocolMismatch: -32008,
+  // App codes (-32010 to -32019)
+  AppNotFound: -32010,
+  AgentNotFound: -32011,
+  SkillTimeout: -32012,
+  SkillMismatch: -32013,
+  PermissionTimeout: -32014,
+  PermissionDenied: -32015,
+  IdentityRejected: -32016,
+  MaxParticipants: -32017,
+  AgentNoOwner: -32018,
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/packages/protocol/src/schema/events.ts
+++ b/packages/protocol/src/schema/events.ts
@@ -5,6 +5,8 @@ import { ContactSchema } from "./contacts.js";
 import { ConversationId, MessageId, AgentId } from "./primitives.js";
 import { PresenceStatusEnum } from "./presence.js";
 import { SurfaceSchema } from "./surfaces.js";
+import { AppSessionId } from "./apps.js";
+import { stringEnum } from "../helpers.js";
 
 export const EventNames = {
   MessageReceived: "messages/received",
@@ -16,6 +18,11 @@ export const EventNames = {
   PresenceChanged: "presence/changed",
   SurfaceUpdated: "surface/updated",
   SurfaceCleared: "surface/cleared",
+  AppSkillChallenge: "app/skillChallenge",
+  AppPermissionRequest: "app/permissionRequest",
+  AppParticipantAdmitted: "app/participantAdmitted",
+  AppParticipantRejected: "app/participantRejected",
+  AppSessionReady: "app/sessionReady",
 } as const;
 
 export const MessageReceivedEventSchema = Type.Object(
@@ -67,5 +74,58 @@ export const SurfaceUpdatedEventSchema = Type.Object(
 
 export const SurfaceClearedEventSchema = Type.Object(
   { conversationId: ConversationId },
+  { additionalProperties: false },
+);
+
+// App events
+
+export const AppSkillChallengeEventSchema = Type.Object(
+  {
+    challengeId: Type.String({ format: "uuid" }),
+    sessionId: AppSessionId,
+    appId: Type.String(),
+    skillUrl: Type.String(),
+    minVersion: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const AppPermissionRequestEventSchema = Type.Object(
+  {
+    sessionId: AppSessionId,
+    appId: Type.String(),
+    resource: Type.String(),
+    access: Type.Array(Type.String()),
+    requestId: Type.String({ format: "uuid" }),
+    targetUserId: Type.String({ format: "uuid" }),
+  },
+  { additionalProperties: false },
+);
+
+export const AppParticipantAdmittedEventSchema = Type.Object(
+  {
+    sessionId: AppSessionId,
+    agentId: AgentId,
+    grantedResources: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const AppParticipantRejectedEventSchema = Type.Object(
+  {
+    sessionId: AppSessionId,
+    agentId: AgentId,
+    reason: Type.String(),
+    stage: stringEnum(["identity", "capability", "permission"]),
+    suggestedAction: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const AppSessionReadyEventSchema = Type.Object(
+  {
+    sessionId: AppSessionId,
+    conversations: Type.Record(Type.String(), ConversationId),
+  },
   { additionalProperties: false },
 );

--- a/packages/protocol/src/schema/index.ts
+++ b/packages/protocol/src/schema/index.ts
@@ -18,3 +18,5 @@ export * from "./methods/invites.js";
 export * from "./methods/presence.js";
 export * from "./methods/phone-contacts.js";
 export * from "./methods/push.js";
+export * from "./apps.js";
+export * from "./methods/apps.js";

--- a/packages/protocol/src/schema/methods/apps.ts
+++ b/packages/protocol/src/schema/methods/apps.ts
@@ -1,0 +1,56 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { AgentId } from "../primitives.js";
+import { AppSessionSchema } from "../apps.js";
+
+export const AppsCreateParamsSchema = Type.Object(
+  {
+    appId: Type.String(),
+    invitedAgentIds: Type.Array(AgentId),
+  },
+  { additionalProperties: false },
+);
+
+export const AppsCreateResultSchema = Type.Object(
+  { session: AppSessionSchema },
+  { additionalProperties: false },
+);
+
+export const AppsAttestSkillParamsSchema = Type.Object(
+  {
+    challengeId: Type.String({ format: "uuid" }),
+    skillUrl: Type.String(),
+    version: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+export const AppsAttestSkillResultSchema = Type.Object(
+  {},
+  { additionalProperties: false },
+);
+
+export const AppsGrantPermissionParamsSchema = Type.Object(
+  {
+    sessionId: Type.String({ format: "uuid" }),
+    agentId: AgentId,
+    resource: Type.String(),
+    access: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const AppsGrantPermissionResultSchema = Type.Object(
+  {},
+  { additionalProperties: false },
+);
+
+export type AppsCreateParams = Static<typeof AppsCreateParamsSchema>;
+export type AppsCreateResult = Static<typeof AppsCreateResultSchema>;
+export type AppsAttestSkillParams = Static<typeof AppsAttestSkillParamsSchema>;
+export type AppsAttestSkillResult = Static<typeof AppsAttestSkillResultSchema>;
+export type AppsGrantPermissionParams = Static<
+  typeof AppsGrantPermissionParamsSchema
+>;
+export type AppsGrantPermissionResult = Static<
+  typeof AppsGrantPermissionResultSchema
+>;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -116,3 +116,22 @@ export type {
   SurfaceClearParams,
   Surface,
 } from "./schema/surfaces.js";
+
+// App types
+export type {
+  AppPermission,
+  AppManifest,
+  AppManifestConversation,
+  AppSession,
+  AppParticipantStatus,
+} from "./schema/apps.js";
+
+// Apps method types
+export type {
+  AppsCreateParams,
+  AppsCreateResult,
+  AppsAttestSkillParams,
+  AppsAttestSkillResult,
+  AppsGrantPermissionParams,
+  AppsGrantPermissionResult,
+} from "./schema/methods/apps.js";

--- a/packages/protocol/src/validators.ts
+++ b/packages/protocol/src/validators.ts
@@ -40,6 +40,9 @@ import {
   SurfaceActionParamsSchema,
   SurfaceClearParamsSchema,
   PushPreferencesSchema,
+  AppsCreateParamsSchema,
+  AppsAttestSkillParamsSchema,
+  AppsGrantPermissionParamsSchema,
 } from "./schema/index.js";
 
 const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
@@ -102,6 +105,11 @@ export const validators = {
   surfaceActionParams: ajv.compile(SurfaceActionParamsSchema),
   surfaceClearParams: ajv.compile(SurfaceClearParamsSchema),
   pushPreferencesParams: ajv.compile(PushPreferencesSchema),
+
+  // Apps
+  appsCreateParams: ajv.compile(AppsCreateParamsSchema),
+  appsAttestSkillParams: ajv.compile(AppsAttestSkillParamsSchema),
+  appsGrantPermissionParams: ajv.compile(AppsGrantPermissionParamsSchema),
 } as const;
 
 export type ValidatorName = keyof typeof validators;

--- a/packages/server-core/src/app/app-host.test.ts
+++ b/packages/server-core/src/app/app-host.test.ts
@@ -123,6 +123,15 @@ function createMockLogger() {
   };
 }
 
+// Test helper to access private pendingChallenges map
+// Avoids scattered eslint-disable comments throughout tests
+function getChallenges(host: AppHost): Map<string, Record<string, unknown>> {
+  return Reflect.get(host, "pendingChallenges") as Map<
+    string,
+    Record<string, unknown>
+  >;
+}
+
 const TEST_MANIFEST = {
   appId: "test-app",
   name: "Test App",
@@ -258,8 +267,7 @@ describe("AppHost", () => {
     it("rejects attestation from wrong agent", () => {
       // Simulate a pending challenge
       const challengeId = crypto.randomUUID();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (appHost as any)["pendingChallenges"].set(challengeId, {
+      getChallenges(appHost).set(challengeId, {
         targetAgentId: "agent-2",
         sessionId: "session-1",
         resolve: vi.fn(),
@@ -270,10 +278,7 @@ describe("AppHost", () => {
       appHost.resolveChallenge(challengeId, "wrong-agent", "url", "1.0");
 
       // Should still be pending (not resolved)
-      expect(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (appHost as any)["pendingChallenges"].has(challengeId),
-      ).toBe(true);
+      expect(getChallenges(appHost).has(challengeId)).toBe(true);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
           expected: "agent-2",
@@ -282,11 +287,7 @@ describe("AppHost", () => {
         "Skill attestation from wrong agent",
       );
 
-      // cleanup
-      clearTimeout(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (appHost as any)["pendingChallenges"].get(challengeId)!.timer,
-      );
+      appHost.destroy();
     });
 
     it("resolves valid challenge", () => {
@@ -294,8 +295,7 @@ describe("AppHost", () => {
       const resolve = vi.fn();
       const timer = setTimeout(() => {}, 30000);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (appHost as any)["pendingChallenges"].set(challengeId, {
+      getChallenges(appHost).set(challengeId, {
         targetAgentId: "agent-2",
         sessionId: "session-1",
         resolve,
@@ -309,10 +309,7 @@ describe("AppHost", () => {
         skillUrl: "skill-url",
         version: "1.0",
       });
-      expect(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (appHost as any)["pendingChallenges"].has(challengeId),
-      ).toBe(false);
+      expect(getChallenges(appHost).has(challengeId)).toBe(false);
     });
   });
 

--- a/packages/server-core/src/app/app-host.test.ts
+++ b/packages/server-core/src/app/app-host.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AppHost, type ContactChecker } from "./app-host.js";
+import { ErrorCodes } from "@moltzap/protocol";
+import { RpcError } from "../rpc/router.js";
+
+// Minimal mocks matching the interfaces AppHost depends on
+function createMockDb() {
+  const rows: Record<string, unknown[]> = {};
+  const mockTrx = {
+    insertInto: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returningAll: vi.fn().mockReturnValue({
+          executeTakeFirstOrThrow: vi.fn().mockResolvedValue({
+            id: crypto.randomUUID(),
+            type: "group",
+            name: "test",
+            created_by_type: "agent",
+            created_by_id: "agent-1",
+            created_at: new Date(),
+            updated_at: new Date(),
+          }),
+        }),
+        execute: vi.fn().mockResolvedValue([]),
+        onConflict: vi.fn().mockReturnValue({
+          doNothing: vi.fn().mockReturnValue({
+            execute: vi.fn().mockResolvedValue([]),
+          }),
+          doUpdateSet: vi.fn().mockReturnValue({
+            execute: vi.fn().mockResolvedValue([]),
+          }),
+          columns: vi.fn().mockReturnValue({
+            doUpdateSet: vi.fn().mockReturnValue({
+              execute: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      }),
+    }),
+  };
+
+  return {
+    selectFrom: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              executeTakeFirst: vi.fn().mockResolvedValue(null),
+            }),
+            execute: vi.fn().mockResolvedValue([]),
+            executeTakeFirst: vi.fn().mockResolvedValue(null),
+          }),
+          execute: vi.fn().mockResolvedValue(rows["agents"] ?? []),
+        }),
+      }),
+    }),
+    updateTable: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            execute: vi.fn().mockResolvedValue([]),
+          }),
+          execute: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    }),
+    insertInto: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflict: vi.fn().mockReturnValue({
+          columns: vi.fn().mockReturnValue({
+            doUpdateSet: vi.fn().mockReturnValue({
+              execute: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+        execute: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+    transaction: vi.fn().mockReturnValue({
+      execute: vi
+        .fn()
+        .mockImplementation(async (fn: (trx: unknown) => Promise<void>) =>
+          fn(mockTrx),
+        ),
+    }),
+    _setAgentRows(agentRows: unknown[]) {
+      rows["agents"] = agentRows;
+      // Re-wire selectFrom to return the agent rows
+      (this.selectFrom as ReturnType<typeof vi.fn>).mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            execute: vi.fn().mockResolvedValue(agentRows),
+          }),
+        }),
+      });
+    },
+  };
+}
+
+function createMockBroadcaster() {
+  return {
+    sendToParticipant: vi.fn(),
+    broadcastToConversation: vi.fn().mockReturnValue([]),
+  };
+}
+
+function createMockConnections() {
+  return {
+    getByParticipant: vi.fn().mockReturnValue([]),
+  };
+}
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    level: "info",
+    silent: vi.fn(),
+  };
+}
+
+const TEST_MANIFEST = {
+  appId: "test-app",
+  name: "Test App",
+  permissions: { required: [], optional: [] },
+  conversations: [
+    { key: "main", name: "Main Channel", participantFilter: "all" as const },
+  ],
+};
+
+const TEST_AGENTS = [
+  { id: "agent-init", owner_user_id: "user-1", status: "active" },
+  { id: "agent-2", owner_user_id: "user-2", status: "active" },
+  { id: "agent-3", owner_user_id: "user-3", status: "active" },
+];
+
+describe("AppHost", () => {
+  let appHost: AppHost;
+  let db: ReturnType<typeof createMockDb>;
+  let broadcaster: ReturnType<typeof createMockBroadcaster>;
+  let connections: ReturnType<typeof createMockConnections>;
+  let logger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    broadcaster = createMockBroadcaster();
+    connections = createMockConnections();
+    logger = createMockLogger();
+    appHost = new AppHost(
+      db as never,
+      broadcaster as never,
+      connections as never,
+      null as never, // conversationService not used directly
+      logger as never,
+    );
+  });
+
+  describe("registerApp", () => {
+    it("stores manifest and logs", () => {
+      appHost.registerApp(TEST_MANIFEST);
+      expect(appHost.getManifest("test-app")).toEqual(TEST_MANIFEST);
+      expect(logger.info).toHaveBeenCalledWith(
+        { appId: "test-app" },
+        "App registered",
+      );
+    });
+
+    it("overwrites on duplicate appId", () => {
+      appHost.registerApp(TEST_MANIFEST);
+      const updated = { ...TEST_MANIFEST, name: "Updated" };
+      appHost.registerApp(updated);
+      expect(appHost.getManifest("test-app")?.name).toBe("Updated");
+    });
+  });
+
+  describe("createSession", () => {
+    beforeEach(() => {
+      appHost.registerApp(TEST_MANIFEST);
+      db._setAgentRows(TEST_AGENTS);
+    });
+
+    it("throws AppNotFound for unknown appId", async () => {
+      await expect(
+        appHost.createSession("unknown", "agent-init", []),
+      ).rejects.toThrow(RpcError);
+
+      try {
+        await appHost.createSession("unknown", "agent-init", []);
+      } catch (err) {
+        expect((err as RpcError).code).toBe(ErrorCodes.AppNotFound);
+      }
+    });
+
+    it("throws MaxParticipants when too many agents", async () => {
+      appHost.registerApp({
+        ...TEST_MANIFEST,
+        appId: "small",
+        limits: { maxParticipants: 2 },
+      });
+      const manyAgents = Array.from({ length: 3 }, (_, i) => `agent-${i}`);
+      await expect(
+        appHost.createSession("small", "agent-init", manyAgents),
+      ).rejects.toThrow(RpcError);
+    });
+
+    it("throws AgentNotFound for missing initiator", async () => {
+      db._setAgentRows([]); // no agents in DB
+      await expect(
+        appHost.createSession("test-app", "agent-init", []),
+      ).rejects.toThrow(RpcError);
+    });
+
+    it("throws AgentNoOwner for ownerless initiator", async () => {
+      db._setAgentRows([
+        { id: "agent-init", owner_user_id: null, status: "active" },
+      ]);
+      await expect(
+        appHost.createSession("test-app", "agent-init", []),
+      ).rejects.toThrow(RpcError);
+    });
+
+    it("creates session with empty invitedAgentIds and emits sessionReady", async () => {
+      const session = await appHost.createSession("test-app", "agent-init", []);
+      expect(session.appId).toBe("test-app");
+      expect(session.status).toBe("active");
+      expect(session.initiatorAgentId).toBe("agent-init");
+      expect(session.conversations).toHaveProperty("main");
+
+      // Should emit sessionReady to initiator
+      expect(broadcaster.sendToParticipant).toHaveBeenCalledWith(
+        "agent",
+        "agent-init",
+        expect.objectContaining({
+          event: "app/sessionReady",
+        }),
+      );
+    });
+
+    it("creates session with invited agents and starts admission", async () => {
+      const session = await appHost.createSession("test-app", "agent-init", [
+        "agent-2",
+      ]);
+      expect(session.status).toBe("waiting");
+      expect(session.conversations).toHaveProperty("main");
+    });
+  });
+
+  describe("resolveChallenge", () => {
+    it("ignores unknown challengeId", () => {
+      // Should not throw
+      appHost.resolveChallenge("nonexistent", "agent-1", "url", "1.0");
+    });
+
+    it("rejects attestation from wrong agent", () => {
+      // Simulate a pending challenge
+      const challengeId = crypto.randomUUID();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (appHost as any)["pendingChallenges"].set(challengeId, {
+        targetAgentId: "agent-2",
+        sessionId: "session-1",
+        resolve: vi.fn(),
+        reject: vi.fn(),
+        timer: setTimeout(() => {}, 30000),
+      });
+
+      appHost.resolveChallenge(challengeId, "wrong-agent", "url", "1.0");
+
+      // Should still be pending (not resolved)
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (appHost as any)["pendingChallenges"].has(challengeId),
+      ).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expected: "agent-2",
+          got: "wrong-agent",
+        }),
+        "Skill attestation from wrong agent",
+      );
+
+      // cleanup
+      clearTimeout(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (appHost as any)["pendingChallenges"].get(challengeId)!.timer,
+      );
+    });
+
+    it("resolves valid challenge", () => {
+      const challengeId = crypto.randomUUID();
+      const resolve = vi.fn();
+      const timer = setTimeout(() => {}, 30000);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (appHost as any)["pendingChallenges"].set(challengeId, {
+        targetAgentId: "agent-2",
+        sessionId: "session-1",
+        resolve,
+        reject: vi.fn(),
+        timer,
+      });
+
+      appHost.resolveChallenge(challengeId, "agent-2", "skill-url", "1.0");
+
+      expect(resolve).toHaveBeenCalledWith({
+        skillUrl: "skill-url",
+        version: "1.0",
+      });
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (appHost as any)["pendingChallenges"].has(challengeId),
+      ).toBe(false);
+    });
+  });
+
+  describe("identity check", () => {
+    beforeEach(() => {
+      appHost.registerApp(TEST_MANIFEST);
+    });
+
+    it("allows all agents when no ContactChecker is set", async () => {
+      db._setAgentRows(TEST_AGENTS);
+      const session = await appHost.createSession("test-app", "agent-init", [
+        "agent-2",
+      ]);
+      // Session created without error — identity check passed with default allow-all
+      expect(session.status).toBe("waiting");
+    });
+
+    it("rejects agents when ContactChecker returns false", async () => {
+      const checker: ContactChecker = {
+        areInContact: vi.fn().mockResolvedValue(false),
+      };
+      appHost.setContactChecker(checker);
+      db._setAgentRows(TEST_AGENTS);
+
+      await appHost.createSession("test-app", "agent-init", ["agent-2"]);
+
+      // Wait for async admission to complete
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Should have sent a rejection event
+      expect(broadcaster.sendToParticipant).toHaveBeenCalledWith(
+        "agent",
+        "agent-2",
+        expect.objectContaining({
+          event: "app/participantRejected",
+        }),
+      );
+    });
+  });
+
+  describe("setContactChecker", () => {
+    it("updates the checker", () => {
+      const checker: ContactChecker = {
+        areInContact: vi.fn().mockResolvedValue(true),
+      };
+      appHost.setContactChecker(checker);
+      // Internal state updated (no public getter, but exercises the code path)
+      expect(checker).toBeDefined();
+    });
+  });
+});

--- a/packages/server-core/src/app/app-host.ts
+++ b/packages/server-core/src/app/app-host.ts
@@ -8,6 +8,10 @@ import type { AppManifest, AppSession } from "@moltzap/protocol";
 import { ErrorCodes, eventFrame } from "@moltzap/protocol";
 import { RpcError } from "../rpc/router.js";
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export interface ContactChecker {
   areInContact(userIdA: string, userIdB: string): Promise<boolean>;
 }
@@ -79,7 +83,6 @@ export class AppHost {
       );
     }
 
-    // Batch-fetch all agents (initiator + invited) to validate and get owner IDs
     const allAgentIds = [initiatorAgentId, ...invitedAgentIds];
     const agentRows = await this.db
       .selectFrom("agents")
@@ -89,7 +92,6 @@ export class AppHost {
 
     const agentMap = new Map(agentRows.map((r) => [r.id, r]));
 
-    // Validate initiator
     const initiator = agentMap.get(initiatorAgentId);
     if (!initiator) {
       throw new RpcError(ErrorCodes.AgentNotFound, "Initiator agent not found");
@@ -101,12 +103,10 @@ export class AppHost {
       );
     }
 
-    // Create session and conversations in a transaction
     const sessionId = crypto.randomUUID();
     const conversationMap: Record<string, string> = {};
 
     await this.db.transaction().execute(async (trx) => {
-      // Create manifest-declared conversations with metadata tags
       for (const convDef of manifest.conversations ?? []) {
         const conv = await trx
           .insertInto("conversations")
@@ -121,7 +121,6 @@ export class AppHost {
 
         conversationMap[convDef.key] = conv.id;
 
-        // Add initiator as owner of every conversation
         await trx
           .insertInto("conversation_participants")
           .values({
@@ -132,27 +131,20 @@ export class AppHost {
           })
           .execute();
 
-        // Subscribe initiator's connection to the conversation
-        for (const conn of this.connections.getByParticipant(
-          "agent",
-          initiatorAgentId,
-        )) {
-          conn.conversationIds.add(conv.id);
-        }
+        this.subscribeToConversation(initiatorAgentId, conv.id);
       }
 
-      // Insert session row
+      const initialStatus = invitedAgentIds.length === 0 ? "active" : "waiting";
       await trx
         .insertInto("app_sessions")
         .values({
           id: sessionId,
           app_id: appId,
           initiator_agent_id: initiatorAgentId,
-          status: "waiting",
+          status: initialStatus,
         })
         .execute();
 
-      // Insert participant rows for all invited agents
       for (const agentId of invitedAgentIds) {
         await trx
           .insertInto("app_session_participants")
@@ -171,19 +163,12 @@ export class AppHost {
       id: sessionId,
       appId,
       initiatorAgentId,
-      status: "waiting",
+      status: invitedAgentIds.length === 0 ? "active" : "waiting",
       conversations: conversationMap,
       createdAt: new Date().toISOString(),
     };
 
-    // Start async admission for each invited agent (non-blocking)
     if (invitedAgentIds.length === 0) {
-      // No agents to admit, session is immediately ready
-      await this.db
-        .updateTable("app_sessions")
-        .set({ status: "active" })
-        .where("id", "=", sessionId)
-        .execute();
       session.status = "active";
       this.broadcaster.sendToParticipant(
         "agent",
@@ -235,32 +220,44 @@ export class AppHost {
     resource: string,
     access: string[],
   ): void {
-    // Find matching pending permission
-    for (const [key, pending] of this.pendingPermissions) {
-      if (
-        pending.agentId === agentId &&
-        pending.sessionId === sessionId &&
-        pending.resource === resource
-      ) {
-        if (pending.targetUserId !== callerUserId) {
-          this.logger.warn(
-            {
-              expected: pending.targetUserId,
-              got: callerUserId,
-              agentId,
-              sessionId,
-              resource,
-            },
-            "Permission grant from wrong user",
-          );
-          return;
-        }
+    const key = `${sessionId}:${agentId}:${resource}`;
+    const pending = this.pendingPermissions.get(key);
+    if (!pending) return;
 
-        clearTimeout(pending.timer);
-        this.pendingPermissions.delete(key);
-        pending.resolve(access);
-        return;
-      }
+    if (pending.targetUserId !== callerUserId) {
+      this.logger.warn(
+        {
+          expected: pending.targetUserId,
+          got: callerUserId,
+          agentId,
+          sessionId,
+          resource,
+        },
+        "Permission grant from wrong user",
+      );
+      return;
+    }
+
+    clearTimeout(pending.timer);
+    this.pendingPermissions.delete(key);
+    pending.resolve(access);
+  }
+
+  /** Cancel all pending timers. Called on shutdown. */
+  destroy(): void {
+    for (const pending of this.pendingChallenges.values()) {
+      clearTimeout(pending.timer);
+    }
+    this.pendingChallenges.clear();
+    for (const pending of this.pendingPermissions.values()) {
+      clearTimeout(pending.timer);
+    }
+    this.pendingPermissions.clear();
+  }
+
+  private subscribeToConversation(agentId: string, convId: string): void {
+    for (const conn of this.connections.getByParticipant("agent", agentId)) {
+      conn.conversationIds.add(convId);
     }
   }
 
@@ -343,15 +340,12 @@ export class AppHost {
       return;
     }
 
-    // 1. Identity check
     await this.checkIdentity(session, initiatorAgentId, agentId, agentMap);
 
-    // 2. Capability check
     if (manifest.skillUrl) {
       await this.checkCapability(session, agentId, manifest);
     }
 
-    // 3. Permission check
     const grantedResources = await this.checkPermissions(
       session,
       agentId,
@@ -359,7 +353,6 @@ export class AppHost {
       agentMap,
     );
 
-    // 4. Admit
     await this.admitAgentToSession(session, agentId, grantedResources);
   }
 
@@ -403,12 +396,12 @@ export class AppHost {
         throw new Error("Not in contacts");
       }
     } catch (err) {
-      if ((err as Error).message === "Not in contacts") throw err;
+      if (errorMessage(err) === "Not in contacts") throw err;
       await this.rejectAgent(
         session.id,
         agentId,
         "identity",
-        `ContactChecker error: ${(err as Error).message}`,
+        `ContactChecker error: ${errorMessage(err)}`,
       );
       throw err;
     }
@@ -452,9 +445,9 @@ export class AppHost {
       },
     ).catch(async (err) => {
       const reason =
-        (err as Error).message === "attestation timeout"
+        errorMessage(err) === "attestation timeout"
           ? "Skill attestation timed out"
-          : `Skill attestation failed: ${(err as Error).message}`;
+          : `Skill attestation failed: ${errorMessage(err)}`;
       await this.rejectAgent(
         session.id,
         agentId,
@@ -487,6 +480,20 @@ export class AppHost {
     }
   }
 
+  private async findGrant(
+    userId: string,
+    appId: string,
+    resource: string,
+  ): Promise<{ access: string[] } | undefined> {
+    return this.db
+      .selectFrom("app_permission_grants")
+      .select("access")
+      .where("user_id", "=", userId)
+      .where("app_id", "=", appId)
+      .where("resource", "=", resource)
+      .executeTakeFirst();
+  }
+
   private async checkPermissions(
     session: AppSession,
     agentId: string,
@@ -500,33 +507,30 @@ export class AppHost {
     const ownerUserId = agent.owner_user_id!;
     const granted: string[] = [];
 
-    // Check required permissions
     for (const perm of manifest.permissions.required) {
-      const existing = await this.db
-        .selectFrom("app_permission_grants")
-        .select("access")
-        .where("user_id", "=", ownerUserId)
-        .where("app_id", "=", session.appId)
-        .where("resource", "=", perm.resource)
-        .executeTakeFirst();
+      const existing = await this.findGrant(
+        ownerUserId,
+        session.appId,
+        perm.resource,
+      );
 
       if (existing) {
         granted.push(perm.resource);
         continue;
       }
 
-      // Request permission from owner user
+      const permKey = `${session.id}:${agentId}:${perm.resource}`;
       const requestId = crypto.randomUUID();
       const timeoutMs = manifest.permissionTimeoutMs ?? 120000;
 
       try {
         const access = await new Promise<string[]>((resolve, reject) => {
           const timer = setTimeout(() => {
-            this.pendingPermissions.delete(requestId);
+            this.pendingPermissions.delete(permKey);
             reject(new Error("permission timeout"));
           }, timeoutMs);
 
-          this.pendingPermissions.set(requestId, {
+          this.pendingPermissions.set(permKey, {
             targetUserId: ownerUserId,
             agentId,
             sessionId: session.id,
@@ -580,15 +584,12 @@ export class AppHost {
       }
     }
 
-    // Check optional permissions (non-blocking, just check existing grants)
     for (const perm of manifest.permissions.optional) {
-      const existing = await this.db
-        .selectFrom("app_permission_grants")
-        .select("access")
-        .where("user_id", "=", ownerUserId)
-        .where("app_id", "=", session.appId)
-        .where("resource", "=", perm.resource)
-        .executeTakeFirst();
+      const existing = await this.findGrant(
+        ownerUserId,
+        session.appId,
+        perm.resource,
+      );
 
       if (existing) {
         granted.push(perm.resource);
@@ -603,7 +604,6 @@ export class AppHost {
     agentId: string,
     grantedResources: string[],
   ): Promise<void> {
-    // Update participant status
     await this.db
       .updateTable("app_session_participants")
       .set({ status: "admitted", admitted_at: new Date() })
@@ -611,7 +611,6 @@ export class AppHost {
       .where("agent_id", "=", agentId)
       .execute();
 
-    // Add agent to session conversations based on participantFilter
     const manifest = this.manifests.get(session.appId)!;
     for (const convDef of manifest.conversations ?? []) {
       const filter = convDef.participantFilter ?? "all";
@@ -630,18 +629,11 @@ export class AppHost {
           .onConflict((oc) => oc.doNothing())
           .execute();
 
-        // Subscribe agent's connection
-        for (const conn of this.connections.getByParticipant(
-          "agent",
-          agentId,
-        )) {
-          conn.conversationIds.add(convId);
-        }
+        this.subscribeToConversation(agentId, convId);
       }
       // "initiator" and "none" don't add the invited agent
     }
 
-    // Broadcast admission event to both agent and initiator
     const admittedEvent = eventFrame("app/participantAdmitted", {
       sessionId: session.id,
       agentId,

--- a/packages/server-core/src/app/app-host.ts
+++ b/packages/server-core/src/app/app-host.ts
@@ -1,0 +1,694 @@
+import type { Kysely } from "kysely";
+import type { Database } from "../db/database.js";
+import type { Broadcaster } from "../ws/broadcaster.js";
+import type { ConnectionManager } from "../ws/connection.js";
+import type { ConversationService } from "../services/conversation.service.js";
+import type { Logger } from "../logger.js";
+import type { AppManifest, AppSession } from "@moltzap/protocol";
+import { ErrorCodes, eventFrame } from "@moltzap/protocol";
+import { RpcError } from "../rpc/router.js";
+
+export interface ContactChecker {
+  areInContact(userIdA: string, userIdB: string): Promise<boolean>;
+}
+
+interface PendingChallenge {
+  targetAgentId: string;
+  sessionId: string;
+  resolve: (result: { skillUrl: string; version: string }) => void;
+  reject: (reason: string) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface PendingPermission {
+  targetUserId: string;
+  agentId: string;
+  sessionId: string;
+  appId: string;
+  resource: string;
+  resolve: (access: string[]) => void;
+  reject: (reason: string) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class AppHost {
+  private pendingChallenges = new Map<string, PendingChallenge>();
+  private pendingPermissions = new Map<string, PendingPermission>();
+  private manifests = new Map<string, AppManifest>();
+  private contactChecker: ContactChecker | null = null;
+
+  constructor(
+    private db: Kysely<Database>,
+    private broadcaster: Broadcaster,
+    private connections: ConnectionManager,
+    private conversationService: ConversationService,
+    private logger: Logger,
+  ) {}
+
+  registerApp(manifest: AppManifest): void {
+    this.manifests.set(manifest.appId, manifest);
+    this.logger.info({ appId: manifest.appId }, "App registered");
+  }
+
+  getManifest(appId: string): AppManifest | undefined {
+    return this.manifests.get(appId);
+  }
+
+  setContactChecker(checker: ContactChecker): void {
+    this.contactChecker = checker;
+  }
+
+  async createSession(
+    appId: string,
+    initiatorAgentId: string,
+    invitedAgentIds: string[],
+  ): Promise<AppSession> {
+    const manifest = this.manifests.get(appId);
+    if (!manifest) {
+      throw new RpcError(
+        ErrorCodes.AppNotFound,
+        `Unknown app: ${appId}. Call registerApp({ appId: '${appId}', ... }) before creating sessions.`,
+      );
+    }
+
+    const maxParticipants = manifest.limits?.maxParticipants ?? 50;
+    if (invitedAgentIds.length > maxParticipants) {
+      throw new RpcError(
+        ErrorCodes.MaxParticipants,
+        `Invited ${invitedAgentIds.length} agents but app limit is ${maxParticipants}`,
+      );
+    }
+
+    // Batch-fetch all agents (initiator + invited) to validate and get owner IDs
+    const allAgentIds = [initiatorAgentId, ...invitedAgentIds];
+    const agentRows = await this.db
+      .selectFrom("agents")
+      .select(["id", "owner_user_id", "status"])
+      .where("id", "in", allAgentIds)
+      .execute();
+
+    const agentMap = new Map(agentRows.map((r) => [r.id, r]));
+
+    // Validate initiator
+    const initiator = agentMap.get(initiatorAgentId);
+    if (!initiator) {
+      throw new RpcError(ErrorCodes.AgentNotFound, "Initiator agent not found");
+    }
+    if (!initiator.owner_user_id) {
+      throw new RpcError(
+        ErrorCodes.AgentNoOwner,
+        "Initiator agent has no owner_user_id. Agents must have an owner to participate in app sessions. Set owner_user_id on the agent.",
+      );
+    }
+
+    // Create session and conversations in a transaction
+    const sessionId = crypto.randomUUID();
+    const conversationMap: Record<string, string> = {};
+
+    await this.db.transaction().execute(async (trx) => {
+      // Create manifest-declared conversations with metadata tags
+      for (const convDef of manifest.conversations ?? []) {
+        const conv = await trx
+          .insertInto("conversations")
+          .values({
+            type: "group",
+            name: convDef.name,
+            created_by_type: "agent",
+            created_by_id: initiatorAgentId,
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+
+        conversationMap[convDef.key] = conv.id;
+
+        // Add initiator as owner of every conversation
+        await trx
+          .insertInto("conversation_participants")
+          .values({
+            conversation_id: conv.id,
+            participant_type: "agent",
+            participant_id: initiatorAgentId,
+            role: "owner",
+          })
+          .execute();
+
+        // Subscribe initiator's connection to the conversation
+        for (const conn of this.connections.getByParticipant(
+          "agent",
+          initiatorAgentId,
+        )) {
+          conn.conversationIds.add(conv.id);
+        }
+      }
+
+      // Insert session row
+      await trx
+        .insertInto("app_sessions")
+        .values({
+          id: sessionId,
+          app_id: appId,
+          initiator_agent_id: initiatorAgentId,
+          status: "waiting",
+        })
+        .execute();
+
+      // Insert participant rows for all invited agents
+      for (const agentId of invitedAgentIds) {
+        await trx
+          .insertInto("app_session_participants")
+          .values({
+            session_id: sessionId,
+            agent_id: agentId,
+            status: "pending",
+            rejection_reason: null,
+            admitted_at: null,
+          })
+          .execute();
+      }
+    });
+
+    const session: AppSession = {
+      id: sessionId,
+      appId,
+      initiatorAgentId,
+      status: "waiting",
+      conversations: conversationMap,
+      createdAt: new Date().toISOString(),
+    };
+
+    // Start async admission for each invited agent (non-blocking)
+    if (invitedAgentIds.length === 0) {
+      // No agents to admit, session is immediately ready
+      await this.db
+        .updateTable("app_sessions")
+        .set({ status: "active" })
+        .where("id", "=", sessionId)
+        .execute();
+      session.status = "active";
+      this.broadcaster.sendToParticipant(
+        "agent",
+        initiatorAgentId,
+        eventFrame("app/sessionReady", {
+          sessionId,
+          conversations: conversationMap,
+        }),
+      );
+    } else {
+      this.admitAgentsAsync(
+        session,
+        manifest,
+        initiatorAgentId,
+        invitedAgentIds,
+        agentMap,
+      );
+    }
+
+    return session;
+  }
+
+  resolveChallenge(
+    challengeId: string,
+    callerAgentId: string,
+    skillUrl: string,
+    version: string,
+  ): void {
+    const pending = this.pendingChallenges.get(challengeId);
+    if (!pending) return; // expired or unknown
+
+    if (pending.targetAgentId !== callerAgentId) {
+      this.logger.warn(
+        { challengeId, expected: pending.targetAgentId, got: callerAgentId },
+        "Skill attestation from wrong agent",
+      );
+      return;
+    }
+
+    clearTimeout(pending.timer);
+    this.pendingChallenges.delete(challengeId);
+    pending.resolve({ skillUrl, version });
+  }
+
+  resolvePermission(
+    callerUserId: string,
+    sessionId: string,
+    agentId: string,
+    resource: string,
+    access: string[],
+  ): void {
+    // Find matching pending permission
+    for (const [key, pending] of this.pendingPermissions) {
+      if (
+        pending.agentId === agentId &&
+        pending.sessionId === sessionId &&
+        pending.resource === resource
+      ) {
+        if (pending.targetUserId !== callerUserId) {
+          this.logger.warn(
+            {
+              expected: pending.targetUserId,
+              got: callerUserId,
+              agentId,
+              sessionId,
+              resource,
+            },
+            "Permission grant from wrong user",
+          );
+          return;
+        }
+
+        clearTimeout(pending.timer);
+        this.pendingPermissions.delete(key);
+        pending.resolve(access);
+        return;
+      }
+    }
+  }
+
+  // ── Internal ───────────────────────────────────────────────────────
+
+  private admitAgentsAsync(
+    session: AppSession,
+    manifest: AppManifest,
+    initiatorAgentId: string,
+    invitedAgentIds: string[],
+    agentMap: Map<
+      string,
+      { id: string; owner_user_id: string | null; status: string }
+    >,
+  ): void {
+    const resolved = new Map<string, "admitted" | "rejected">();
+    const total = invitedAgentIds.length;
+
+    const checkDone = () => {
+      if (resolved.size < total) return;
+
+      // All agents resolved — mark session active and emit sessionReady
+      this.db
+        .updateTable("app_sessions")
+        .set({ status: "active" })
+        .where("id", "=", session.id)
+        .execute()
+        .catch((err) =>
+          this.logger.error(
+            { err, sessionId: session.id },
+            "Failed to update session status",
+          ),
+        );
+
+      this.broadcaster.sendToParticipant(
+        "agent",
+        initiatorAgentId,
+        eventFrame("app/sessionReady", {
+          sessionId: session.id,
+          conversations: session.conversations,
+        }),
+      );
+    };
+
+    for (const agentId of invitedAgentIds) {
+      this.admitAgent(session, manifest, initiatorAgentId, agentId, agentMap)
+        .then(() => {
+          resolved.set(agentId, "admitted");
+          checkDone();
+        })
+        .catch((err) => {
+          resolved.set(agentId, "rejected");
+          this.logger.warn(
+            { err, agentId, sessionId: session.id },
+            "Agent admission failed",
+          );
+          checkDone();
+        });
+    }
+  }
+
+  private async admitAgent(
+    session: AppSession,
+    manifest: AppManifest,
+    initiatorAgentId: string,
+    agentId: string,
+    agentMap: Map<
+      string,
+      { id: string; owner_user_id: string | null; status: string }
+    >,
+  ): Promise<void> {
+    const agent = agentMap.get(agentId);
+    if (!agent) {
+      await this.rejectAgent(
+        session.id,
+        agentId,
+        "identity",
+        "Agent not found",
+      );
+      return;
+    }
+
+    // 1. Identity check
+    await this.checkIdentity(session, initiatorAgentId, agentId, agentMap);
+
+    // 2. Capability check
+    if (manifest.skillUrl) {
+      await this.checkCapability(session, agentId, manifest);
+    }
+
+    // 3. Permission check
+    const grantedResources = await this.checkPermissions(
+      session,
+      agentId,
+      manifest,
+      agentMap,
+    );
+
+    // 4. Admit
+    await this.admitAgentToSession(session, agentId, grantedResources);
+  }
+
+  private async checkIdentity(
+    session: AppSession,
+    initiatorAgentId: string,
+    agentId: string,
+    agentMap: Map<
+      string,
+      { id: string; owner_user_id: string | null; status: string }
+    >,
+  ): Promise<void> {
+    const agent = agentMap.get(agentId)!;
+    const initiator = agentMap.get(initiatorAgentId)!;
+
+    if (!agent.owner_user_id) {
+      await this.rejectAgent(
+        session.id,
+        agentId,
+        "identity",
+        "Agent has no owner_user_id",
+        "Set owner_user_id on the agent before inviting it to app sessions",
+      );
+      throw new Error("Agent has no owner");
+    }
+
+    if (!this.contactChecker) return; // default: allow all
+
+    try {
+      const inContact = await this.contactChecker.areInContact(
+        initiator.owner_user_id!,
+        agent.owner_user_id,
+      );
+      if (!inContact) {
+        await this.rejectAgent(
+          session.id,
+          agentId,
+          "identity",
+          "Agent owner is not a contact of the session initiator's owner",
+        );
+        throw new Error("Not in contacts");
+      }
+    } catch (err) {
+      if ((err as Error).message === "Not in contacts") throw err;
+      await this.rejectAgent(
+        session.id,
+        agentId,
+        "identity",
+        `ContactChecker error: ${(err as Error).message}`,
+      );
+      throw err;
+    }
+  }
+
+  private async checkCapability(
+    session: AppSession,
+    agentId: string,
+    manifest: AppManifest,
+  ): Promise<void> {
+    const challengeId = crypto.randomUUID();
+    const timeoutMs = manifest.challengeTimeoutMs ?? 30000;
+
+    const result = await new Promise<{ skillUrl: string; version: string }>(
+      (resolve, reject) => {
+        const timer = setTimeout(() => {
+          this.pendingChallenges.delete(challengeId);
+          reject(new Error("attestation timeout"));
+        }, timeoutMs);
+
+        this.pendingChallenges.set(challengeId, {
+          targetAgentId: agentId,
+          sessionId: session.id,
+          resolve,
+          reject: (reason: string) => reject(new Error(reason)),
+          timer,
+        });
+
+        // Send challenge to the agent
+        this.broadcaster.sendToParticipant(
+          "agent",
+          agentId,
+          eventFrame("app/skillChallenge", {
+            challengeId,
+            sessionId: session.id,
+            appId: session.appId,
+            skillUrl: manifest.skillUrl!,
+            minVersion: manifest.skillMinVersion,
+          }),
+        );
+      },
+    ).catch(async (err) => {
+      const reason =
+        (err as Error).message === "attestation timeout"
+          ? "Skill attestation timed out"
+          : `Skill attestation failed: ${(err as Error).message}`;
+      await this.rejectAgent(
+        session.id,
+        agentId,
+        "capability",
+        reason,
+        `Install the skill from ${manifest.skillUrl} and ensure version >= ${manifest.skillMinVersion ?? "any"}`,
+      );
+      throw err;
+    });
+
+    // Verify the attestation
+    if (result.skillUrl !== manifest.skillUrl) {
+      await this.rejectAgent(
+        session.id,
+        agentId,
+        "capability",
+        `Skill URL mismatch: expected ${manifest.skillUrl}, got ${result.skillUrl}`,
+      );
+      throw new Error("Skill mismatch");
+    }
+
+    if (manifest.skillMinVersion && result.version < manifest.skillMinVersion) {
+      await this.rejectAgent(
+        session.id,
+        agentId,
+        "capability",
+        `Skill version ${result.version} below minimum ${manifest.skillMinVersion}`,
+      );
+      throw new Error("Skill version too low");
+    }
+  }
+
+  private async checkPermissions(
+    session: AppSession,
+    agentId: string,
+    manifest: AppManifest,
+    agentMap: Map<
+      string,
+      { id: string; owner_user_id: string | null; status: string }
+    >,
+  ): Promise<string[]> {
+    const agent = agentMap.get(agentId)!;
+    const ownerUserId = agent.owner_user_id!;
+    const granted: string[] = [];
+
+    // Check required permissions
+    for (const perm of manifest.permissions.required) {
+      const existing = await this.db
+        .selectFrom("app_permission_grants")
+        .select("access")
+        .where("user_id", "=", ownerUserId)
+        .where("app_id", "=", session.appId)
+        .where("resource", "=", perm.resource)
+        .executeTakeFirst();
+
+      if (existing) {
+        granted.push(perm.resource);
+        continue;
+      }
+
+      // Request permission from owner user
+      const requestId = crypto.randomUUID();
+      const timeoutMs = manifest.permissionTimeoutMs ?? 120000;
+
+      try {
+        const access = await new Promise<string[]>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            this.pendingPermissions.delete(requestId);
+            reject(new Error("permission timeout"));
+          }, timeoutMs);
+
+          this.pendingPermissions.set(requestId, {
+            targetUserId: ownerUserId,
+            agentId,
+            sessionId: session.id,
+            appId: session.appId,
+            resource: perm.resource,
+            resolve,
+            reject: (reason: string) => reject(new Error(reason)),
+            timer,
+          });
+
+          this.broadcaster.sendToParticipant(
+            "user",
+            ownerUserId,
+            eventFrame("app/permissionRequest", {
+              sessionId: session.id,
+              appId: session.appId,
+              resource: perm.resource,
+              access: perm.access,
+              requestId,
+              targetUserId: ownerUserId,
+            }),
+          );
+        });
+
+        // Store the grant
+        await this.db
+          .insertInto("app_permission_grants")
+          .values({
+            user_id: ownerUserId,
+            app_id: session.appId,
+            resource: perm.resource,
+            access,
+          })
+          .onConflict((oc) =>
+            oc
+              .columns(["user_id", "app_id", "resource"])
+              .doUpdateSet({ access }),
+          )
+          .execute();
+
+        granted.push(perm.resource);
+      } catch {
+        await this.rejectAgent(
+          session.id,
+          agentId,
+          "permission",
+          `Permission timeout for resource: ${perm.resource}`,
+          `Grant ${perm.resource} access via the permission prompt`,
+        );
+        throw new Error("Permission denied");
+      }
+    }
+
+    // Check optional permissions (non-blocking, just check existing grants)
+    for (const perm of manifest.permissions.optional) {
+      const existing = await this.db
+        .selectFrom("app_permission_grants")
+        .select("access")
+        .where("user_id", "=", ownerUserId)
+        .where("app_id", "=", session.appId)
+        .where("resource", "=", perm.resource)
+        .executeTakeFirst();
+
+      if (existing) {
+        granted.push(perm.resource);
+      }
+    }
+
+    return granted;
+  }
+
+  private async admitAgentToSession(
+    session: AppSession,
+    agentId: string,
+    grantedResources: string[],
+  ): Promise<void> {
+    // Update participant status
+    await this.db
+      .updateTable("app_session_participants")
+      .set({ status: "admitted", admitted_at: new Date() })
+      .where("session_id", "=", session.id)
+      .where("agent_id", "=", agentId)
+      .execute();
+
+    // Add agent to session conversations based on participantFilter
+    const manifest = this.manifests.get(session.appId)!;
+    for (const convDef of manifest.conversations ?? []) {
+      const filter = convDef.participantFilter ?? "all";
+      const convId = session.conversations[convDef.key];
+      if (!convId) continue;
+
+      if (filter === "all") {
+        await this.db
+          .insertInto("conversation_participants")
+          .values({
+            conversation_id: convId,
+            participant_type: "agent",
+            participant_id: agentId,
+            role: "member",
+          })
+          .onConflict((oc) => oc.doNothing())
+          .execute();
+
+        // Subscribe agent's connection
+        for (const conn of this.connections.getByParticipant(
+          "agent",
+          agentId,
+        )) {
+          conn.conversationIds.add(convId);
+        }
+      }
+      // "initiator" and "none" don't add the invited agent
+    }
+
+    // Broadcast admission event to both agent and initiator
+    const admittedEvent = eventFrame("app/participantAdmitted", {
+      sessionId: session.id,
+      agentId,
+      grantedResources,
+    });
+    this.broadcaster.sendToParticipant("agent", agentId, admittedEvent);
+    this.broadcaster.sendToParticipant(
+      "agent",
+      session.initiatorAgentId,
+      admittedEvent,
+    );
+
+    this.logger.info(
+      { sessionId: session.id, agentId, grantedResources },
+      "Agent admitted to app session",
+    );
+  }
+
+  private async rejectAgent(
+    sessionId: string,
+    agentId: string,
+    stage: "identity" | "capability" | "permission",
+    reason: string,
+    suggestedAction?: string,
+  ): Promise<void> {
+    await this.db
+      .updateTable("app_session_participants")
+      .set({ status: "rejected", rejection_reason: reason })
+      .where("session_id", "=", sessionId)
+      .where("agent_id", "=", agentId)
+      .execute();
+
+    this.broadcaster.sendToParticipant(
+      "agent",
+      agentId,
+      eventFrame("app/participantRejected", {
+        sessionId,
+        agentId,
+        reason,
+        stage,
+        suggestedAction,
+      }),
+    );
+
+    this.logger.info(
+      { sessionId, agentId, stage, reason },
+      "Agent rejected from app session",
+    );
+  }
+}

--- a/packages/server-core/src/app/app-host.ts
+++ b/packages/server-core/src/app/app-host.ts
@@ -145,16 +145,18 @@ export class AppHost {
         })
         .execute();
 
-      for (const agentId of invitedAgentIds) {
+      if (invitedAgentIds.length > 0) {
         await trx
           .insertInto("app_session_participants")
-          .values({
-            session_id: sessionId,
-            agent_id: agentId,
-            status: "pending",
-            rejection_reason: null,
-            admitted_at: null,
-          })
+          .values(
+            invitedAgentIds.map((agentId) => ({
+              session_id: sessionId,
+              agent_id: agentId,
+              status: "pending" as const,
+              rejection_reason: null,
+              admitted_at: null,
+            })),
+          )
           .execute();
       }
     });
@@ -340,11 +342,13 @@ export class AppHost {
       return;
     }
 
-    await this.checkIdentity(session, initiatorAgentId, agentId, agentMap);
-
-    if (manifest.skillUrl) {
-      await this.checkCapability(session, agentId, manifest);
-    }
+    // Identity and capability checks are independent — run concurrently
+    await Promise.all([
+      this.checkIdentity(session, initiatorAgentId, agentId, agentMap),
+      manifest.skillUrl
+        ? this.checkCapability(session, agentId, manifest)
+        : Promise.resolve(),
+    ]);
 
     const grantedResources = await this.checkPermissions(
       session,

--- a/packages/server-core/src/app/core-schema.sql
+++ b/packages/server-core/src/app/core-schema.sql
@@ -144,3 +144,37 @@ CREATE TABLE conversation_keys (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (conversation_id, dek_version)
 );
+
+-- App sessions (AppHost framework)
+CREATE TYPE app_session_status AS ENUM ('waiting', 'active', 'closed');
+CREATE TYPE app_participant_status AS ENUM ('pending', 'admitted', 'rejected');
+
+CREATE TABLE app_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_id TEXT NOT NULL,
+  initiator_agent_id UUID NOT NULL REFERENCES agents(id),
+  status app_session_status NOT NULL DEFAULT 'waiting',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE app_session_participants (
+  session_id UUID NOT NULL REFERENCES app_sessions(id) ON DELETE CASCADE,
+  agent_id UUID NOT NULL REFERENCES agents(id),
+  status app_participant_status NOT NULL DEFAULT 'pending',
+  rejection_reason TEXT,
+  admitted_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (session_id, agent_id)
+);
+CREATE TRIGGER app_session_participants_updated_at BEFORE UPDATE ON app_session_participants
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TABLE app_permission_grants (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id),
+  app_id TEXT NOT NULL,
+  resource TEXT NOT NULL,
+  access TEXT[] NOT NULL,
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, app_id, resource)
+);

--- a/packages/server-core/src/app/handlers/apps.handlers.ts
+++ b/packages/server-core/src/app/handlers/apps.handlers.ts
@@ -1,0 +1,79 @@
+import type { AppHost } from "../app-host.js";
+import type { RpcMethodRegistry } from "../../rpc/context.js";
+import type {
+  AppsCreateParams,
+  AppsAttestSkillParams,
+  AppsGrantPermissionParams,
+} from "@moltzap/protocol";
+import { validators, ErrorCodes } from "@moltzap/protocol";
+import { defineMethod } from "../../rpc/context.js";
+import { RpcError } from "../../rpc/router.js";
+
+export function createAppHandlers(deps: {
+  appHost: AppHost;
+}): RpcMethodRegistry {
+  return {
+    "apps/create": defineMethod<AppsCreateParams>({
+      validator: validators.appsCreateParams,
+      handler: async (params, ctx) => {
+        if (ctx.kind !== "agent") {
+          throw new RpcError(
+            ErrorCodes.Forbidden,
+            "Only agents can create app sessions",
+          );
+        }
+
+        const session = await deps.appHost.createSession(
+          params.appId,
+          ctx.agentId,
+          params.invitedAgentIds,
+        );
+
+        return { session };
+      },
+    }),
+
+    "apps/attestSkill": defineMethod<AppsAttestSkillParams>({
+      validator: validators.appsAttestSkillParams,
+      handler: async (params, ctx) => {
+        if (ctx.kind !== "agent") {
+          throw new RpcError(
+            ErrorCodes.Forbidden,
+            "Only agents can attest skills",
+          );
+        }
+
+        deps.appHost.resolveChallenge(
+          params.challengeId,
+          ctx.agentId,
+          params.skillUrl,
+          params.version,
+        );
+
+        return {};
+      },
+    }),
+
+    "apps/grantPermission": defineMethod<AppsGrantPermissionParams>({
+      validator: validators.appsGrantPermissionParams,
+      handler: async (params, ctx) => {
+        if (ctx.kind !== "user") {
+          throw new RpcError(
+            ErrorCodes.Forbidden,
+            "Only users can grant permissions",
+          );
+        }
+
+        deps.appHost.resolvePermission(
+          ctx.userId,
+          params.sessionId,
+          params.agentId,
+          params.resource,
+          params.access,
+        );
+
+        return {};
+      },
+    }),
+  };
+}

--- a/packages/server-core/src/app/server.ts
+++ b/packages/server-core/src/app/server.ts
@@ -327,7 +327,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       return appHost.createSession(appId, initiatorAgentId, invitedAgentIds);
     },
     async close() {
-      // Close all WebSocket connections first so in-flight RPCs finish
+      appHost.destroy();
       for (const conn of connections.all()) {
         try {
           conn.ws.close();

--- a/packages/server-core/src/app/server.ts
+++ b/packages/server-core/src/app/server.ts
@@ -31,6 +31,10 @@ import { createCoreAuthHandlers } from "./handlers/auth.handlers.js";
 import { createConversationHandlers } from "./handlers/conversations.handlers.js";
 import { createMessageHandlers } from "./handlers/messages.handlers.js";
 import { createPresenceHandlers } from "./handlers/presence.handlers.js";
+import { createAppHandlers } from "./handlers/apps.handlers.js";
+
+// AppHost
+import { AppHost } from "./app-host.js";
 
 import type { CoreConfig, CoreApp, ConnectionHook } from "./types.js";
 import { runDemoAgents } from "./demo-agents.js";
@@ -75,6 +79,15 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     deliveryService,
   );
 
+  // AppHost
+  const appHost = new AppHost(
+    db,
+    broadcaster,
+    connections,
+    conversationService,
+    logger,
+  );
+
   // Per-request connection context for concurrent WebSocket RPC dispatches
   const connIdContext = new AsyncLocalStorage<string>();
 
@@ -112,6 +125,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       connections,
       getConnId: () => connIdContext.getStore() ?? "",
     }),
+    ...createAppHandlers({ appHost }),
   };
 
   const dispatch = createRpcRouter(methods);
@@ -302,6 +316,15 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     },
     onConnection(hook: ConnectionHook) {
       connectionHooks.push(hook);
+    },
+    registerApp(manifest) {
+      appHost.registerApp(manifest);
+    },
+    setContactChecker(checker) {
+      appHost.setContactChecker(checker);
+    },
+    async createAppSession(appId, initiatorAgentId, invitedAgentIds) {
+      return appHost.createSession(appId, initiatorAgentId, invitedAgentIds);
     },
     async close() {
       // Close all WebSocket connections first so in-flight RPCs finish

--- a/packages/server-core/src/app/types.ts
+++ b/packages/server-core/src/app/types.ts
@@ -1,5 +1,7 @@
 import type { Hono } from "hono";
 import type { RpcMethodDef } from "../rpc/context.js";
+import type { AppManifest, AppSession } from "@moltzap/protocol";
+import type { ContactChecker } from "./app-host.js";
 
 export interface CoreConfig {
   databaseUrl: string;
@@ -20,5 +22,12 @@ export interface CoreApp {
   readonly port: number;
   registerRpcMethod: (name: string, def: RpcMethodDef) => void;
   onConnection: (hook: ConnectionHook) => void;
+  registerApp: (manifest: AppManifest) => void;
+  setContactChecker: (checker: ContactChecker) => void;
+  createAppSession: (
+    appId: string,
+    initiatorAgentId: string,
+    invitedAgentIds: string[],
+  ) => Promise<AppSession>;
   close: () => Promise<void>;
 }

--- a/packages/server-core/src/db/database.ts
+++ b/packages/server-core/src/db/database.ts
@@ -25,6 +25,38 @@ export type {
   UserStatus,
 } from "./database.generated.js";
 
+// App-specific types (hand-written — not in generated file until kysely-codegen runs)
+export type AppSessionStatus = "waiting" | "active" | "closed";
+export type AppParticipantDbStatus = "pending" | "admitted" | "rejected";
+
+import type { Generated, Timestamp } from "./database.generated.js";
+
+export interface AppSessions {
+  id: Generated<string>;
+  app_id: string;
+  initiator_agent_id: string;
+  status: Generated<AppSessionStatus>;
+  created_at: Generated<Timestamp>;
+}
+
+export interface AppSessionParticipants {
+  session_id: string;
+  agent_id: string;
+  status: Generated<AppParticipantDbStatus>;
+  rejection_reason: string | null;
+  admitted_at: Timestamp | null;
+  updated_at: Generated<Timestamp>;
+}
+
+export interface AppPermissionGrants {
+  id: Generated<string>;
+  user_id: string;
+  app_id: string;
+  resource: string;
+  access: string[];
+  granted_at: Generated<Timestamp>;
+}
+
 // Re-export table interfaces
 export type {
   Agents,
@@ -75,6 +107,15 @@ export type ConversationKeyRow = Selectable<ConversationKeys>;
 export type NewConversationKey = Insertable<ConversationKeys>;
 export type ConversationKeyUpdate = Updateable<ConversationKeys>;
 
+export type AppSessionRow = Selectable<AppSessions>;
+export type NewAppSession = Insertable<AppSessions>;
+
+export type AppSessionParticipantRow = Selectable<AppSessionParticipants>;
+export type NewAppSessionParticipant = Insertable<AppSessionParticipants>;
+
+export type AppPermissionGrantRow = Selectable<AppPermissionGrants>;
+export type NewAppPermissionGrant = Insertable<AppPermissionGrants>;
+
 // Database interface (core tables only — no contacts, invites, push, surfaces)
 export interface Database {
   users: Users;
@@ -86,4 +127,7 @@ export interface Database {
   reactions: Reactions;
   encryption_keys: EncryptionKeys;
   conversation_keys: ConversationKeys;
+  app_sessions: AppSessions;
+  app_session_participants: AppSessionParticipants;
+  app_permission_grants: AppPermissionGrants;
 }

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -1,5 +1,9 @@
 // @moltzap/server-core — building blocks for agent-to-agent messaging
 
+// AppHost
+export { AppHost } from "./app/app-host.js";
+export type { ContactChecker } from "./app/app-host.js";
+
 // Services
 export { AuthService } from "./services/auth.service.js";
 export { ConversationService } from "./services/conversation.service.js";
@@ -43,4 +47,9 @@ export type {
   RpcMethodRegistry,
 } from "./rpc/context.js";
 export type { MoltZapConnection } from "./ws/connection.js";
+export type {
+  AppSessionRow,
+  AppSessionParticipantRow,
+  AppPermissionGrantRow,
+} from "./db/database.js";
 export { defineMethod } from "./rpc/context.js";

--- a/packages/server-core/src/test-utils/index.ts
+++ b/packages/server-core/src/test-utils/index.ts
@@ -171,6 +171,7 @@ export async function resetCoreTestDb(): Promise<void> {
   }
   await resetPool.query(`
     TRUNCATE TABLE
+      app_permission_grants, app_session_participants, app_sessions,
       reactions, message_delivery, messages,
       conversation_participants, conversation_keys, conversations,
       agents, users, encryption_keys

--- a/plan.md
+++ b/plan.md
@@ -1,254 +1,320 @@
-# Data Model Refactor — `moltzap` (OSS Protocol)
+<!-- /autoplan restore point: /home/tapanc/.gstack/projects/chughtapan-moltzap/worktree-agile-wobbling-catmull-autoplan-restore-20260414-233139.md -->
+# AppHost — Standardized App Framework for MoltZap
 
 ## Problem
 
-The TypeBox schemas in `@moltzap/protocol` have drifted from the canonical data model spec. The wire types carry fields that belong only to the server's internal state (`seq`, `reactions`, `isDeleted`), use a heavyweight `ParticipantRef` object where a plain `AgentId` suffices, and lack fields the spec requires (`agentType`, `metadata`, `taggedEntities`, `email`, `lastMessageTimestamp`). The Contact model is bidirectional when the spec calls for unidirectional.
+MoltZap needs a standardized interface for building **Apps** — structured services that agents participate in (Scheduler, Werewolf, prediction markets, etc.). Today, downstream consumers like `moltzap-arena` build game infrastructure from scratch, tightly coupling game logic to MoltZap primitives (conversations, agents, messages) with no shared admission, policy, or lifecycle layer.
 
-This PR aligns the protocol schemas to the spec, fixes every downstream consumer (server-core, client, openclaw-channel, nanoclaw-channel, evals), and updates all tests and documentation.
+The architecture spec defines three policy gates (Identity, Capability, Permission) that every App must enforce before admitting agents. This work adds the `AppHost` framework to `@moltzap/server-core` — a standardized way to define, register, and host Apps with built-in policy enforcement.
 
----
+## Naming Decision
 
-## Changes by Entity
+**`AppHost`** — the server-core component that *hosts* developer-defined Apps. It handles admission, policy enforcement, sessions, and lifecycle. Developers register App manifests with the host.
 
-### 1. Message (`packages/protocol/src/schema/messages.ts`)
+- `AppHost` (the policy engine + session manager in server-core)
+- `AppManifest` (the JSON declaration of what an App needs)
+- `AppSession` (a running instance of an App, backed by a group conversation)
+- `ContactChecker` (injectable identity policy — contacts live outside server-core)
 
-**Current fields:** `id, conversationId, sender (ParticipantRef), seq, replyToId?, parts, reactions?, isDeleted?, createdAt`
-
-| Action | Field | Detail |
-|--------|-------|--------|
-| Remove | `seq` | Server-internal ordering; not a wire concern |
-| Remove | `reactions` | Reactions stay server-side; not embedded in Message wire type |
-| Remove | `isDeleted` | Soft-delete flag is server-internal |
-| Rename + retype | `sender: ParticipantRefSchema` → `createdBy: AgentId` | Messages are always from agents; simplify from `{type,id}` to UUID |
-| Add | `taggedEntities: Type.Optional(Type.Array(AgentId))` | Per spec |
-| Keep | `replyToId?: MessageId` | Already correct |
-
-**Downstream cascade:**
-
-- **`methods/messages.ts`**: 
-  - `MessagesListParamsSchema`: Replace `afterSeq`/`beforeSeq` with cursor-based `before?: MessageId` and `after?: MessageId`
-  - `MessagesReadParamsSchema`: Replace `seq` with `upToMessageId: MessageId`
-  - `MessagesReactParamsSchema`: Keep (react RPC still works, just not embedded in Message)
-  - `MessagesDeleteParamsSchema`: Keep (delete RPC still works, just not exposed on wire)
-  - `MessagesListResultSchema`: Uses `MessageSchema` — auto-updated
-
-- **`server-core/services/message.service.ts`**:
-  - `send()`: Map `sender_type`+`sender_id` DB columns → `createdBy: AgentId` (just the agent ID)
-  - `list()`: Change `afterSeq`/`beforeSeq` filtering to `after`/`before` MessageId-based cursor pagination
-  - `read()`: Accept `upToMessageId` instead of `seq`; server resolves to internal seq
-  - `toWireMessage()`: Remove `seq`, `reactions`, `isDeleted` from output; rename `sender` → `createdBy`
-  - Internal seq generation stays — it's the DB ordering mechanism, just not exposed on wire
-
-- **`server-core/services/delivery.service.ts`**: Internal `upToSeq` stays (server-internal); no wire change needed
-
-- **`server-core/services/conversation.service.ts`**: `lastReadSeq` on `ConversationParticipantSchema` needs update to `lastReadMessageId: Type.Optional(MessageId)` in wire type (server keeps internal seq)
-
-- **`client/service.ts`**:
-  - `fetchMessages()`: Use `after`/`before` MessageId params instead of `afterSeq`/`beforeSeq`
-  - `markRead()`: Send `upToMessageId` instead of `seq`
-  - Message handling: Access `msg.createdBy` (string) instead of `msg.sender.id`/`msg.sender.type`
-  - Remove seq-based new-message detection logic; use message ID or timestamp comparison
-
-- **`client/channel-core.ts`**:
-  - `EnrichedSender` interface: Keep but source from `createdBy` (AgentId) instead of `sender.id`
-  - `enrichMessage()`: Resolve agent name from `message.createdBy` instead of `message.sender.id`
-
-- **`openclaw-channel/openclaw-entry.ts`**: Update `sender.id`/`sender.type` → `createdBy`
-- **`openclaw-channel/mapping.ts`**: Update `seq` references in event extraction
-- **`nanoclaw-channel/moltzap.ts`**: Update `enriched.sender.id` → `enriched.createdBy` (or enriched sender)
-
-- **`evals/runner.ts`**: Update sender field access
-
-- **CLI commands**: `history` display, `react`, `delete` — update field references
-
-- **Tests**: ~30 test files with `sender`/`seq` fixtures need updating
+Rejected names: `BaseApp` (sounds like abstract class), `AgentApp` (ambiguous agent-vs-app), `AppRuntime` (too enterprise).
 
 ---
 
-### 2. Agent + AgentCard (`packages/protocol/src/schema/identity.ts`)
+## Downstream Customer: moltzap-arena
 
-**Current fields:** `id, ownerUserId?, name, displayName?, description?, status, createdAt`
+The Arena is the first real consumer. Today it builds:
+- `GameRoom` — maps Discord-style channels (town_square, werewolf_den, role_{id}) to MoltZap conversations
+- `GameMaster` — pure state machine returning `Instruction[]` arrays
+- `GameOrchestrator` — executes instructions, manages phase timers, wires betting/spectators
+- `AgentManager` — registers agents, creates conversations via `@moltzap/server-core`
 
-| Action | Field | Detail |
-|--------|-------|--------|
-| Add | `agentType: Type.Optional(stringEnum(["OpenClaw", "NanoClaw"]))` | Per spec |
-| Add | `metadata: Type.Optional(Type.Object({ purpose: Type.Optional(Type.Array(Type.String())), description: Type.Optional(Type.String()), tags: Type.Optional(Type.Record(Type.String(), Type.String())) }))` | Per spec |
+**What Arena needs from AppHost:**
+1. Register Werewolf as an App with a manifest (permissions, skill URL, participant limits)
+2. Standard session creation that sets up the conversation + channels
+3. Policy enforcement so rogue agents can't join game sessions
+4. Lifecycle hooks so the orchestrator knows when all agents are admitted and ready
 
-`AgentCardSchema` derives via `Type.Omit(AgentSchema, ["createdAt"])` — new fields inherited automatically.
+**What Arena does NOT need AppHost to do:**
+- Game logic (stays in `@moltzap/arena-engine`)
+- Instruction execution (stays in orchestrator)
+- Betting/spectator management (Arena-specific, not generic)
+- Phase timers (game-specific)
 
-**Downstream cascade:** Minimal. New optional fields don't break existing consumers. `RegisterParamsSchema` may accept `agentType` optionally. Server-core `AuthService` passes through.
-
----
-
-### 3. User (`packages/protocol/src/schema/identity.ts`)
-
-**Current fields:** `id, phone?, displayName, avatarUrl?, status, createdAt`
-
-| Action | Field | Detail |
-|--------|-------|--------|
-| Add | `email: Type.Optional(Type.String({ format: "email" }))` | Per spec |
-
-**Downstream cascade:** Minimal — optional field addition.
+This informs the boundary: AppHost handles **admission and sessions**, not game/app logic.
 
 ---
 
-### 4. Contact (`packages/protocol/src/schema/contacts.ts`)
+## Design Decisions
 
-**Current model:** Bidirectional — `requesterId, targetId, status, requesterName, requesterPhone, targetName, targetPhone, agents?, lastSeenAt?`
+1. **App Session = collection of tagged conversations**: A session is NOT a single conversation. It's a set of conversations linked via `metadata.tags: [{ appSessionId, channelKey }]`. The `app_sessions` table tracks session state; conversations are linked by metadata, not FK. Agents become `conversation_participants` only after passing all three policies.
 
-**New model:** Unidirectional per spec:
+2. **Identity Policy is injectable**: `server-core` has no contacts table. Define a `ContactChecker` interface (`areInContact(userIdA, userIdB) → boolean`); downstream (moltzap-app) supplies the implementation. Default passes all agents (for dev/testing). AppHost resolves agent IDs to owner user IDs via the batch-fetched agent map before calling `areInContact()` — the checker never sees agent IDs.
+
+3. **Capability: challenge/response**: Server emits `app/skillChallenge` event → agent calls `apps/attestSkill` → handler resolves pending promise. 30s timeout.
+
+4. **Permission: request/grant via control channel**: Server emits `app/permissionRequest` → user approves via `apps/grantPermission`. 120s timeout for required permissions.
+
+5. **`registerApp()` on CoreApp**: App developers register their manifest. AppHost looks up the manifest by `appId` at session creation time.
+
+6. **No separate "channel" concept**: Apps declare conversations to auto-create in the manifest. AppHost creates them as normal group conversations with `name` set and `metadata.tags: [{ appSessionId, channelKey }]` for discoverability. Apps find their conversations by querying metadata tags. No `app_session_channels` table, no `addChannel()` API. Conversations are conversations.
+
+---
+
+## App Manifest Schema
 
 ```typescript
-ContactSchema = Type.Object({
-  id: ContactId,
-  contactUserId: UserId,
-  source: stringEnum(["phone", "manual", "email"]),
-  relationship: Type.Optional(Type.String()),
-  metadata: Type.Optional(Type.Object({
-    tags: Type.Optional(Type.Array(
-      Type.Record(Type.String(), Type.String())
-    )),
-  }, { additionalProperties: false })),
+// packages/protocol/src/schema/apps.ts
+AppManifestSchema = Type.Object({
+  appId: Type.String(),
+  name: Type.String(),
+  description: Type.Optional(Type.String()),
+  permissions: Type.Object({
+    required: Type.Array(Type.Object({
+      resource: Type.String(),
+      access: Type.Array(Type.String()),
+    })),
+    optional: Type.Array(Type.Object({
+      resource: Type.String(),
+      access: Type.Array(Type.String()),
+    })),
+  }),
+  skillUrl: Type.Optional(Type.String()),        // omit → skip capability check
+  skillMinVersion: Type.Optional(Type.String()),
+  challengeTimeoutMs: Type.Optional(Type.Integer({ default: 30000 })),
+  permissionTimeoutMs: Type.Optional(Type.Integer({ default: 120000 })),
+  limits: Type.Optional(Type.Object({
+    maxParticipants: Type.Optional(Type.Integer({ default: 50 })),
+  })),
+  conversations: Type.Optional(Type.Array(Type.Object({
+    key: Type.String(),           // e.g. "town_square", "werewolf_den" — stored in metadata tag
+    name: Type.String(),          // set as conversation.name
+    participantFilter: Type.Optional(
+      stringEnum(["all", "initiator", "none"])  // "none" = empty, app manages membership
+    ),
+  }))),
 }, { additionalProperties: false })
 ```
 
-- **Remove** `ContactStatusEnum` from wire exports
-- **Add** `RelationshipType = Type.String()` as named export
+---
 
-**Downstream cascade:**
+## Files to Create / Modify
 
-- **`methods/contacts.ts`**:
-  - `ContactsListParamsSchema`: Remove `status` filter (no more `ContactStatusEnum` on wire)
-  - `ContactsAddParamsSchema`: Change to `{ contactUserId: UserId, source: stringEnum([...]), relationship?: string }`
-  - `ContactsAcceptParamsSchema` / `ContactsAcceptResultSchema`: Remove (no bidirectional accept flow)
-  - `ContactIdParamsSchema`: Keep (for remove/block by ID)
+### `@moltzap/protocol`
 
-- **`server-core`**: Contact service adapts internal bidirectional model to unidirectional wire type. Server can still track status internally.
+**1. `packages/protocol/src/schema/apps.ts`** — NEW
+- `AppPermissionSchema` — `{ resource: string, access: string[] }`
+- `AppManifestSchema` — full manifest as above
+- `AppSessionSchema` — `{ id, appId, initiatorAgentId, status, conversations: Record<string, ConversationId>, createdAt }`
+- `AppParticipantStatusEnum` — `"pending" | "admitted" | "rejected"`
+- Static type exports
 
-- **`client/cli/commands/contacts.ts`**: Update display logic — no more `requesterName`/`targetName` fallback chain
+**2. `packages/protocol/src/schema/methods/apps.ts`** — NEW
+- `AppsCreateParamsSchema` — `{ appId, invitedAgentIds: AgentId[] }`
+- `AppsCreateResultSchema` — `{ session: AppSession }`
+- `AppsAttestSkillParamsSchema` — `{ challengeId, skillUrl, version }`
+- `AppsAttestSkillResultSchema` — `{}`
+- `AppsGrantPermissionParamsSchema` — `{ sessionId, agentId, resource, access[] }`
+- `AppsGrantPermissionResultSchema` — `{}`
 
-- **`openclaw-channel/mapping.ts`**: Update `extractContactRequest`/`extractContactAccepted` — restructure for new Contact model
+**3. `packages/protocol/src/schema/events.ts`** — UPDATE
+Add events:
+- `app/skillChallenge` — `{ challengeId, sessionId, appId, skillUrl, minVersion? }`
+- `app/permissionRequest` — `{ sessionId, appId, resource, access[], requestId }`
+- `app/participantAdmitted` — `{ sessionId, agentId, grantedResources[] }`
+- `app/participantRejected` — `{ sessionId, agentId, reason, stage }`
+- `app/sessionReady` — `{ sessionId, conversations: Record<string, ConversationId> }`
 
-- **Tests**: Contact-related test fixtures in server-core integration tests, mapping tests
+**4. `packages/protocol/src/schema/index.ts`** — UPDATE
+Add exports.
+
+**5. `packages/protocol/src/validators.ts`** — UPDATE
+Add compiled validators.
+
+### `@moltzap/server-core`
+
+**6. `packages/server-core/src/app/core-schema.sql`** — UPDATE
+Add tables:
+- `app_sessions` — `{ id, app_id, initiator_agent_id, status, created_at }` (no conversation_id — conversations linked via metadata tags)
+- `app_session_participants` — `{ session_id, agent_id, status, rejection_reason, admitted_at }`
+- `app_permission_grants` — `{ id, user_id, app_id, resource, access[], granted_at }`
+
+**7. `packages/server-core/src/db/database.ts`** — UPDATE
+Add Kysely table interfaces for new tables.
+
+**8. `packages/server-core/src/services/app-session.service.ts`** — NEW
+CRUD for app sessions and participant status tracking.
+
+**9. `packages/server-core/src/services/app-permission.service.ts`** — NEW
+Permission grant CRUD (upsert, check, list).
+
+**10. `packages/server-core/src/app/app-host.ts`** — NEW
+Core policy engine:
+
+```typescript
+export interface ContactChecker {
+  areInContact(userIdA: string, userIdB: string): Promise<boolean>;
+}
+
+export class AppHost {
+  private pendingChallenges: Map<string, PendingChallenge>
+  private pendingPermissions: Map<string, PendingPermission>
+  private manifests: Map<string, AppManifest>
+
+  constructor(deps: {
+    db: Kysely<Database>,
+    broadcaster: Broadcaster,
+    connections: ConnectionManager,
+    appSessionService: AppSessionService,
+    appPermissionService: AppPermissionService,
+    conversationService: ConversationService,
+    contactChecker?: ContactChecker,
+    logger: Logger,
+  })
+
+  registerApp(manifest: AppManifest): void
+  setContactChecker(checker: ContactChecker): void
+
+  // Creates session + channels, starts async admission for each invited agent
+  createSession(appId: string, initiatorAgentId: string, invitedAgentIds: string[]): Promise<AppSession>
+
+  // Called by apps/attestSkill handler
+  resolveChallenge(challengeId: string, skillUrl: string, version: string): void
+
+  // Called by apps/grantPermission handler
+  resolvePermission(userId: string, appId: string, resource: string, access: string[]): void
+
+  // Internal policy chain (per agent, async)
+  private admitAgent(session, manifest, initiatorAgentId, agentId): Promise<void>
+  private checkIdentity(agentId, initiatorAgentId): Promise<void>
+  private checkCapability(session, agentId, manifest): Promise<void>
+  private checkPermission(session, agentId, manifest): Promise<string[]>
+}
+```
+
+**11. `packages/server-core/src/app/handlers/apps.handlers.ts`** — NEW
+RPC handlers:
+- `apps/create` — creates session via AppHost, returns session + channels
+- `apps/attestSkill` — resolves capability challenge
+- `apps/grantPermission` — grants permission, resolves pending request
+
+**12. `packages/server-core/src/app/types.ts`** — UPDATE
+Add to `CoreApp`:
+```typescript
+registerApp: (manifest: AppManifest) => void;
+setContactChecker: (checker: ContactChecker) => void;
+createAppSession: (appId: string, initiatorAgentId: string, invitedAgentIds: string[]) => Promise<AppSession>;
+```
+
+**13. `packages/server-core/src/app/server.ts`** — UPDATE
+- Instantiate AppHost with all deps
+- Register app handlers
+- Expose `registerApp()` and `setContactChecker()` on returned CoreApp
+
+**14. `packages/server-core/src/index.ts`** — UPDATE
+Export: `AppHost`, `AppSessionService`, `AppPermissionService`, `ContactChecker`, new DB types.
 
 ---
 
-### 5. Conversation (`packages/protocol/src/schema/conversations.ts`)
+## Policy Chain Flow
 
-**Current fields:** `id, type, name?, createdBy (ParticipantRef), createdAt, updatedAt`
-
-| Action | Field | Detail |
-|--------|-------|--------|
-| Add | `metadata: Type.Optional(Type.Object({ tags: Type.Optional(Type.Array(Type.Record(Type.String(), Type.String()))) }, { additionalProperties: false }))` | Per spec |
-| Add | `lastMessageTimestamp: Type.Optional(DateTimeString)` | Per spec |
-
-**ConversationSummarySchema** — add `lastMessageTimestamp` and `metadata` here too.
-
-**ConversationParticipantSchema** — change `lastReadSeq: Type.Integer` → `lastReadMessageId: Type.Optional(MessageId)`
-
-**Downstream cascade:**
-- `server-core/conversation.service.ts`: Map `last_message_at` → `lastMessageTimestamp`, pass through `metadata`
-- `ConversationSummarySchema` already has `lastMessageAt` — rename to `lastMessageTimestamp` for consistency with spec
-
----
-
-## Validators & Type Exports
-
-**`validators.ts`**: Recompile all affected validators. Remove `messagesReactParams` and `messagesDeleteParams` if those RPC methods are removed, or keep if methods stay.
-
-**`types.ts`**: Update re-exports — add `RelationshipType`, ensure `Contact` type reflects new shape.
-
-**`schema/index.ts`**: No structural changes needed (uses `export *`).
+```
+apps/create called by initiator agent A1
+  → Validate manifest exists for appId
+  → Validate initiator has owner_user_id (required for app participation)
+  → Create conversations from manifest.conversations[] with name + metadata tags
+  → Insert app_session row
+  → For each invited agentId (async, non-blocking):
+      1. Identity: contactChecker.areInContact(ownerA, ownerB)
+         Fail → rejected "not a contact"
+      2. Capability: emit app/skillChallenge, await apps/attestSkill (30s)
+         Fail → rejected "skill mismatch" or "attestation timeout"
+      3. Permission: for each required resource, check grant or emit app/permissionRequest (120s)
+         Fail → rejected "permission denied" or "permission timeout"
+      4. Admit: add to conversation participants, emit app/participantAdmitted
+  → When all agents admitted or rejected, emit app/sessionReady
+```
 
 ---
 
-## Test Updates
+## How moltzap-arena Would Adopt This
 
-### Protocol tests (`packages/protocol/src/schema/`)
-- `messages.test.ts`: Update fixtures — remove `seq`, `reactions`, `isDeleted`; rename `sender` → `createdBy` (now just AgentId string)
-- `contacts.test.ts`: New Contact shape fixtures
-- `conversations.test.ts`: Add `metadata`, `lastMessageTimestamp`
-- `identity.test.ts`: Add `agentType`, `metadata` to Agent fixtures; `email` to User fixtures
+```typescript
+// In arena's server setup
+import { createCoreApp } from "@moltzap/server-core";
 
-### Server-core integration tests (`packages/server-core/src/__tests__/integration/`)
-- `03-dm-messaging`: Update sender → createdBy assertions, remove seq assertions
-- `04-group-chat`: Same
-- `05-reactions-deletion`: Update for reactions not on wire Message, isDeleted removed
-- `12-send-existing-conv`: Update sender.id → createdBy
-- `13-message-history`: Replace afterSeq/beforeSeq pagination with cursor-based
-- `23-reactions`: Reactions still work via RPC but not embedded in Message
-- `24-read-receipts`: Update seq → upToMessageId
-- `27-message-deletion`: isDeleted not on wire
+const core = createCoreApp(config);
 
-### Client tests (`packages/client/src/`)
-- `service.test.ts`: Update all message fixtures
-- `service.integration.test.ts`: Update sender, seq, pagination references
-- `channel-core` tests if any
+// Register Werewolf as an App
+core.registerApp({
+  appId: "werewolf",
+  name: "Werewolf",
+  description: "Social deduction game",
+  permissions: { required: [], optional: [] },
+  skillUrl: "https://arena.moltzap.com/skills/werewolf.md",
+  limits: { maxParticipants: 12 },
+  conversations: [
+    { key: "town_square", name: "Town Square", participantFilter: "all" },
+    { key: "werewolf_den", name: "Werewolf Den", participantFilter: "none" },
+  ],
+});
 
-### Channel tests
-- `openclaw-channel/mapping.test.ts`: Update contact extraction, sender references
-- `openclaw-channel/openclaw-entry.inbound-contract.test.ts`: Update sender references
-- `nanoclaw-channel/moltzap.test.ts`: Update sender references
+// Create a game session
+const session = await core.createAppSession("werewolf", gmAgentId, playerAgentIds);
+// session.conversations = { town_square: "conv-123", werewolf_den: "conv-456" }
+// Each conversation has metadata.tags: [{ appSessionId: session.id, channelKey: "town_square" }]
 
-### Example handlers (`packages/server-core/examples/handlers/`)
-- `messages.handlers.ts`: Update afterSeq/beforeSeq → after/before, seq → upToMessageId
+// Add per-player role conversations at runtime (just create conversations with tags)
+for (const player of players) {
+  const conv = await conversationService.create("group", `${player.name} Private`, [], gmRef);
+  // Tag it with the session — AppHost helper or direct metadata update
+}
 
----
+// GameOrchestrator finds conversations by querying metadata tags
+```
 
-## Documentation Updates
-
-| File | Change |
-|------|--------|
-| `docs/concepts/messages.mdx` | Remove seq/reactions/isDeleted docs; rename sender→createdBy; add taggedEntities |
-| `docs/concepts/contacts.mdx` | Replace bidirectional model docs with unidirectional |
-| `docs/protocol/methods/messages-list.mdx` | afterSeq/beforeSeq → after/before cursor |
-| `docs/protocol/methods/messages-delete.mdx` | Remove isDeleted reference |
-| `docs/guides/message-reactions.mdx` | Note reactions not embedded in Message wire type |
-| `docs/protocol/transport.mdx` | Update reconnection afterSeq reference |
-| `docs/snippets/send-message-example.mdx` | Update sender → createdBy in example |
-
----
-
-## Implementation Order
-
-1. **Protocol schemas** — make all schema changes first (messages, identity, contacts, conversations)
-2. **Protocol methods** — update RPC param/result schemas
-3. **Protocol validators + types** — recompile, update exports
-4. **Protocol tests** — fix all schema test fixtures
-5. **Server-core services** — fix type errors in message, conversation, delivery services
-6. **Server-core example handlers** — update handler implementations
-7. **Server-core integration tests** — fix all test fixtures and assertions
-8. **Client service + channel-core** — fix type errors
-9. **Client CLI commands** — update field access
-10. **Client tests** — fix fixtures
-11. **OpenClaw channel** — update mapping, entry point, tests
-12. **Nanoclaw channel** — update adapter, tests
-13. **Evals** — update runner sender references
-14. **Build + typecheck + test** — full verification
-15. **Documentation** — update Mintlify docs
+This replaces the current `GameRoom.createGameRoomWithExistingAgents()` + manual `agentManager.createConversation()` calls.
 
 ---
 
 ## Verification
 
-```bash
-pnpm build          # Protocol must compile; all consumers re-type-check
-pnpm typecheck      # No TypeScript errors
-pnpm test           # Unit tests pass
-pnpm test:integration  # Integration tests pass
-pnpm lint           # oxlint clean
-```
+1. **Unit tests** — `packages/server-core/src/app/app-host.test.ts`:
+   - Identity fail → participant rejected
+   - Capability timeout → rejected
+   - Permission denied → rejected  
+   - Full happy path with mock deps
+
+2. **Integration test** — `packages/server-core/src/__tests__/integration/30-app-host.integration.test.ts`:
+   - Register app, create session, verify skill challenge sent
+   - Attest skill, verify permission request sent
+   - Grant permission, verify participant admitted to conversation
+   - Verify session ready event
+
+3. **Build + type check**: `pnpm -r build && pnpm -r typecheck`
+
+---
+
+## Implementation Order
+
+1. Protocol schemas (apps.ts, methods/apps.ts, events update)
+2. Protocol validators + type exports
+3. Server-core DB schema + Kysely types
+4. AppSessionService + AppPermissionService
+5. AppHost class
+6. App RPC handlers
+7. Wire into createCoreApp + CoreApp interface
+8. Unit tests
+9. Integration tests
+10. Export from index.ts
 
 ---
 
 ## Risk Assessment
 
-- **High-impact rename**: `sender` → `createdBy` touches 50+ locations. Systematic find-replace + type-checker catches misses.
-- **Pagination model change**: `afterSeq`/`beforeSeq` → cursor-based. Server already has message IDs; query changes are straightforward.
-- **Contact model replacement**: Most complex change. Server needs adapter layer between internal bidirectional model and unidirectional wire type.
-- **New optional fields**: `agentType`, `metadata`, `email`, `taggedEntities`, `lastMessageTimestamp` — additive, low risk.
-
-All changes are wire-type only. Database schema stays the same — the server maps between internal representation and wire types.
+- **Channel concept is new**: Manifest-declared channels add complexity. Could defer to V2 and let apps create conversations manually (like Arena does today). Decision: include channels — it's the key developer experience win.
+- **Async admission**: Policy chain runs asynchronously per agent. Need careful promise/timeout management. Mitigated by in-memory maps with TTL cleanup.
+- **No contacts in server-core**: Injectable ContactChecker means the default (allow-all) is insecure. Clear documentation needed that production deployments must inject a real checker.
+- **Arena migration**: Arena will need to refactor GameRoom to use AppHost sessions. Not blocking — Arena can adopt incrementally.
 
 ---
 
@@ -256,28 +322,93 @@ All changes are wire-type only. Database schema stays the same — the server ma
 
 ### Critical fixes incorporated after review:
 
-1. **createdBy naming collision (CRITICAL)**: `ConversationSchema` already has `createdBy: ParticipantRefSchema`. To avoid type inconsistency, also change `Conversation.createdBy` to `AgentId` (conversations are always created by agents). This cascades to `ConversationCreatedEventSchema` via auto-reference.
+1. **Broken adoption example (CRITICAL, DX):** Plan showed `appHost.createSession()` but `appHost` was not exposed from `createCoreApp()`. Fix: add `createAppSession()` and `addChannel()` directly to `CoreApp` interface. Developer uses `core.createAppSession(...)` — one object, one import.
 
-2. **Cursor pagination subquery (HIGH)**: `after`/`before` MessageId cursors require a subquery: `WHERE seq > (SELECT seq FROM messages WHERE id = :afterId)`. Not a simple `WHERE id > :messageId` since UUIDs are not ordered.
+2. **No auth on `apps/create` (CRITICAL, Eng):** Any authenticated agent could create sessions. Fix: validate initiator is a registered agent with active status. Consider `allowedCreators` manifest field for production.
 
-3. **Client watermark replacement (HIGH)**: Replace `lastNotified`/`lastRead` seq-based maps in `service.ts` with "latest seen message ID" tracking. Use `createdAt` timestamp comparison for ordering since message IDs are UUIDs.
+3. **Challenge replay attack (CRITICAL, Eng):** Stale `challengeId` could resolve after timeout if race condition exists. Fix: delete `challengeId` from pending map on timeout BEFORE the rejection event. Check map existence on resolve.
 
-4. **MessageReadEventSchema (HIGH)**: `events.ts:36` uses `seq` directly. Change to `upToMessageId: MessageId` to match the new `MessagesReadParamsSchema`.
+4. **`resolveChallenge` caller not validated (HIGH, Eng):** Any agent could attest for another agent. Fix: store `targetAgentId` in pending challenge map, assert `ctx.agentId === pendingChallenge.targetAgentId`.
 
-5. **ContactAccepted event (MEDIUM)**: Keep `ContactAcceptedEventSchema` — it auto-references `ContactSchema` which will update to the new shape. The accept flow can remain server-side with the new contact wire shape.
+5. **Permission request routing (HIGH, Eng):** `app/permissionRequest` must go to the **owner of the invited agent** (the human user), NOT the agent itself. Self-granting is an authorization bypass. Fix: add `targetUserId` to event, route via `sendToParticipant("user", ownerUserId, ...)`.
 
-6. **Semver major bump (CRITICAL)**: This is a breaking change for published `@moltzap/protocol`. All consumers must upgrade atomically. Add changelog entry.
+6. **No structured error codes (CRITICAL, DX):** Every rejection was a black hole. Fix: add `AppErrorCode` enum (`APP_NOT_FOUND`, `AGENT_NOT_FOUND`, `SKILL_TIMEOUT`, `SKILL_MISMATCH`, `PERMISSION_TIMEOUT`, `PERMISSION_DENIED`, `IDENTITY_REJECTED`, `MAX_PARTICIPANTS`). Every rejection event includes `{ reason, stage, suggestedAction }`.
 
-7. **CLI contacts displayName (HIGH)**: New Contact schema has no display name. CLI must resolve names via `agents/lookup` or `users/lookup` by `contactUserId`.
+7. **No backpressure (HIGH, Eng):** Unlimited concurrent admission chains. Fix: enforce hard cap (50) when `maxParticipants` omitted. Validate `invitedAgentIds.length <= limits.maxParticipants` in handler. Use concurrency limiter.
 
-### Taste decisions (auto-decided per spec):
-- `taggedEntities` naming (spec says `taggedEntities`, not `mentions`) — kept as spec
-- `createdBy` naming (spec says `createdBy`, not `sender`) — kept as spec
+8. **In-memory state loss on restart (HIGH, Eng):** Pending admissions lost on crash. Fix: add `updated_at` to `app_session_participants`. On startup, query `status = 'pending'` rows older than timeout and transition to `rejected`. Log WARN.
+
+9. **Channel concept eliminated (MEDIUM, Eng):** Channels were just conversations with labels. Fix: drop the "channel" abstraction entirely. Conversations are tagged with `metadata.tags: [{ appSessionId, channelKey }]` for discoverability. No `app_session_channels` table. `participantFilter: "none"` creates empty conversations the app manages.
+
+10. **Configurable timeouts (MEDIUM, DX):** 30s/120s were hardcoded. Fix: add `challengeTimeoutMs` and `permissionTimeoutMs` to manifest with defaults.
+
+11. **Default ContactChecker warning (MEDIUM, DX):** Allow-all default is insecure. Fix: log `logger.warn("AppHost using default allow-all ContactChecker — inject a real checker for production")` at startup.
+
+12. **Dynamic conversations at runtime (MEDIUM, CEO+DX):** Arena needs per-player role conversations that can't be declared statically. Fix: apps create additional conversations via existing `conversationService.create()` and tag them with session metadata. No new API needed.
+
+13. **owner_user_id required for app participation (HIGH, Eng):** Agents without `owner_user_id` break the permission flow (no user to route requests to). Fix: validate `owner_user_id` is set on all participating agents. Arena must create a system user as owner for its game agents.
+
+13. **Protocol convention compliance (MEDIUM, Eng):** Use `stringEnum()` for enums, `brandedId()` for UUIDs per protocol CLAUDE.md conventions.
+
+14. **owner_user_id required for app participation (HIGH, Eng):** Agents without `owner_user_id` break the permission flow. Fix: validate on admission, reject with clear error. Arena creates a system user as owner for game agents.
+
+15. **Extend ErrorCodes, not a new enum (MEDIUM, Eng):** App error codes go into the existing `ErrorCodes` object in `errors.ts` (-32010 through -32018), not a separate `AppErrorCode` enum.
+
+16. **Batch-fetch agent owners (MEDIUM, Eng):** One query to fetch all invited agents' `owner_user_id` upfront instead of N per-agent lookups.
+
+17. **Transaction boundary for createSession (HIGH, Eng):** Wrap conversation creation + session row + participant rows in a single `db.transaction().execute()`. If any conversation fails to create, everything rolls back. Test: force a conversation creation failure, verify no orphaned rows.
+
+18. **AppHost resolves agent→user IDs (MEDIUM, Eng):** `ContactChecker.areInContact()` takes user IDs, not agent IDs. AppHost uses the batch-fetched agent map to resolve before calling the checker.
+
+19. **Getting started flow (HIGH, DX):** No docker-compose, no demo script, MWE is incomplete. Fix: add docker-compose.yml (Postgres + server), update `create-moltzap-server` to use `createCoreApp()` + AppHost, add `demo-app.ts` that registers 2 agents + creates an echo session + logs messages. Target TTHW: 5-10 min. Also: move `launchFleet()` out of `@moltzap/evals` into a more accessible location (server-core or a new `@moltzap/agent-runner` package) so hackathon devs don't need to import from the evals package.
+
+20. **Expand MWE to full flow (HIGH, DX):** Current MWE shows 30% of the steps. Fix: show agent registration via HTTP, WebSocket connection, THEN `createAppSession()`. The developer needs to see the complete path.
+
+21. **Error suggestedAction (MEDIUM, DX):** Error codes exist but lack fix guidance. Fix: every app RPC error includes `data.suggestedAction` with a concrete code snippet (e.g., "Call core.registerApp({ appId: 'werewolf', ... }) before creating sessions").
+
+22. **server-core README (MEDIUM, DX):** No README for the package developers import. Fix: add `packages/server-core/README.md` with AppHost section + JSDoc on `registerApp()`, `createAppSession()`, `AppManifest`.
+
+23. **App test utility (MEDIUM, DX):** Developers building apps need test helpers. Fix: add `setupAppTestSession()` to `test-utils/` that registers a test app + creates session + returns handles, following the existing `setupAgentPair()` pattern.
 
 ### Deferred to TODOS.md:
-- Custom AJV error messages for renamed fields (medium, not blocking)
-- Codemod for external consumers (no known external consumers yet)
-- Versioned wire types / v1+v2 coexistence (over-engineered for current scale)
+- Session query API (`apps/listSessions`, `apps/getSession`)
+- Orphaned session cleanup (sessions where all agents rejected)
+- JSDoc on all public types and methods
+- Minimal working example / getting started guide
+- Rate limiting session creation per agent
+- Session teardown API (`apps/closeSession`) — archive/delete conversations on game end. Requires conversation archival support first (no soft-delete or archive exists in ConversationService today). Without this, every game creates conversations that persist forever in the DB. `apps/closeSession` would set session status to "closed" and archive all linked conversations (found via metadata tags). Blocked by: conversation archival feature in server-core.
+- Permission grant scoping — add `session_id` to `app_permission_grants` so grants expire with sessions
+- Multi-process constraint — document that in-memory pending Maps require single-process deployment; add Redis/DB-backed Maps for horizontal scaling
+
+---
+
+## Minimal Working Example (acceptance test for DX)
+
+```typescript
+import { createCoreApp } from "@moltzap/server-core";
+
+const core = createCoreApp({
+  databaseUrl: process.env.DATABASE_URL!,
+  encryptionMasterSecret: "dev-secret-32-chars-minimum-here",
+  port: 3000,
+  corsOrigins: ["*"],
+});
+
+// Register a simple app — no skill attestation, no permissions
+core.registerApp({
+  appId: "echo",
+  name: "Echo App",
+  permissions: { required: [], optional: [] },
+  conversations: [{ key: "main", name: "Main Channel", participantFilter: "all" }],
+});
+
+// Create a session (after agents are registered and connected)
+const session = await core.createAppSession("echo", agentA.id, [agentB.id]);
+console.log("Session:", session.id);
+console.log("Conversations:", session.conversations);
+// → { main: "conv-uuid-here" }
+// The conversation has name: "Main Channel" and metadata tags linking it to the session
+```
 
 ---
 
@@ -286,16 +417,32 @@ All changes are wire-type only. Database schema stays the same — the server ma
 
 | # | Phase | Decision | Classification | Principle | Rationale | Rejected |
 |---|-------|----------|---------------|-----------|-----------|----------|
-| 1 | CEO | Accept premise (spec alignment is valid) | Mechanical | P6 | User filed issue, spec exists | "Just housekeeping" framing |
-| 2 | CEO | Single PR (no split) | Mechanical | P6 | User explicitly said don't cut scope | Split into multiple PRs |
-| 3 | CEO+DX | Add semver major bump | Mechanical | P1 | Breaking changes require major bump | Ship without version bump |
-| 4 | Eng | Fix createdBy collision - unify to AgentId | Mechanical | P1+P5 | Same field name must have same type | Leave inconsistent |
-| 5 | Eng | Specify subquery for cursor pagination | Mechanical | P5 | UUIDs not ordered, explicit > clever | Naive WHERE id > :id |
-| 6 | Eng | Track latest message ID instead of seq | Mechanical | P3 | Pragmatic replacement for watermarks | Set-based tracking (memory cost) |
-| 7 | Eng | Update MessageReadEventSchema | Mechanical | P1 | Completeness - can't leave seq on events | Leave events unchanged |
-| 8 | DX | Keep taggedEntities naming per spec | Taste | P6 | Spec authority, user's issue says taggedEntities | Rename to mentions |
-| 9 | DX | Keep createdBy naming per spec | Taste | P6 | Spec authority, user's issue says createdBy | Keep sender |
-| 10 | DX | CLI resolves displayName via lookup | Mechanical | P1 | Users need readable output | Show raw UUIDs |
+| 1 | CEO | Accept premises with adjustments | Mechanical | P6 | User filed issue, architecture spec exists | Reject plan entirely |
+| 2 | CEO | SELECTIVE EXPANSION mode | Mechanical | P6 | Autoplan default | SCOPE EXPANSION |
+| 3 | CEO | Make capability attestation optional | Mechanical | P3+P5 | No current consumer needs it; skip when no skillUrl | Force mandatory attestation |
+| 4 | CEO | Accept dynamic channels expansion | Mechanical | P2 | In blast radius, Arena needs it | Defer to V2 |
+| 5 | CEO | Accept lifecycle hooks expansion | Mechanical | P1 | 20 LOC, makes API useful | Defer |
+| 6 | CEO | Defer session query API | Mechanical | P3 | Not needed for Arena game loop | Include in scope |
+| 7 | Eng | Add auth check on apps/create | Mechanical | P1 | Security gap, no valid reason to skip | Leave open |
+| 8 | Eng | Store targetAgentId in challenge map | Mechanical | P1+P5 | Prevents attestation by wrong agent | Trust agent identity |
+| 9 | Eng | Route permissionRequest to owner user | Mechanical | P1 | Self-granting is auth bypass | Route to agent |
+| 10 | Eng | Add backpressure (default 50 max) | Mechanical | P3 | Unbounded concurrency is a DoS vector | No limit |
+| 11 | Eng | Add restart recovery via DB query | Mechanical | P1 | Silent failure on restart | Accept data loss |
+| 12 | Eng | Add "none" participantFilter | Mechanical | P5 | Explicit > implicit empty behavior | Leave ambiguous |
+| 13 | Eng | Use stringEnum/brandedId per conventions | Mechanical | P4 | DRY with existing protocol patterns | Ad-hoc types |
+| 14 | DX | Fix CoreApp to expose createAppSession | Mechanical | P5 | Example didn't compile | Keep separate AppHost |
+| 15 | DX | Add AppErrorCode enum | Mechanical | P1 | Every error path needs structured output | Generic RpcError |
+| 16 | DX | Add configurable timeouts to manifest | Mechanical | P1 | Hardcoded limits are an escape hatch gap | Keep hardcoded |
+| 17 | DX | Log WARN for default ContactChecker | Mechanical | P5 | Insecure default should be visible | Silent default |
+| 18 | DX | Add addChannel() for dynamic channels | Mechanical | P1+P2 | Arena needs per-player channels | Static only |
+
+---
+
+## Cross-Phase Themes
+
+**Theme: API surface discoverability** — flagged in CEO (thin extraction concern), Eng (missing auth on create), and DX (broken example, missing JSDoc). High-confidence signal that the developer-facing API needs careful attention during implementation. The fix (expose everything on CoreApp, add JSDoc, write MWE) addresses all three.
+
+**Theme: In-memory state fragility** — flagged in CEO (6-month regret) and Eng (restart recovery). The pending maps are necessary for async admission but need DB backing for production reliability.
 
 ---
 
@@ -303,9 +450,10 @@ All changes are wire-type only. Database schema stays the same — the server ma
 
 | Review | Trigger | Why | Runs | Status | Findings |
 |--------|---------|-----|------|--------|----------|
-| CEO Review | `/plan-ceo-review` | Scope & strategy | 1 | clean | 6 findings, all auto-resolved |
-| Eng Review | `/plan-eng-review` | Architecture & tests | 1 | clean | 8 findings, 7 incorporated into plan |
-| Design Review | `/plan-design-review` | UI/UX gaps | 0 | skipped | No UI scope detected |
-| DX Review | `/plan-devex-review` | Developer experience gaps | 1 | clean | 7 findings, 5 incorporated into plan |
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 1 | clean (via /autoplan) | 5 findings, all auto-resolved |
+| Eng Review | `/plan-eng-review` | Architecture & tests | 2 | clean (PLAN) | Run 1: 8 via autoplan. Run 2: 6 new (owner_user_id, metadata tags, ErrorCodes, batch fetch, transaction, areInContact) |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | skipped | No UI scope |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 2 | clean (PLAN) | Run 1: 5 via autoplan (score 5→7). Run 2: 5 new (getting started flow, MWE expansion, error suggestedAction, README, test utility). Score 5→7 |
+| Outside Voice | Claude subagent | Independent challenge | 3 | issues_found | 3 runs across autoplan + eng + dx. Key: metadata accepted, transaction added, teardown deferred |
 
-**VERDICT:** APPROVED — 3 reviews complete, 0 unresolved critical issues. All findings incorporated or deferred with rationale.
+**VERDICT:** CEO + ENG + DX CLEARED — 5 reviews complete, 0 unresolved critical issues. 23 total findings incorporated. Target TTHW: 5-10 min. `launchFleet()` to be relocated for DX.


### PR DESCRIPTION
## Summary

Adds the AppHost framework to `@moltzap/server-core` (closes #37). A standardized way to define, register, and host Apps with built-in policy enforcement.

**Protocol:**
- `AppManifest`, `AppSession`, `AppParticipantStatus` schemas
- `apps/create`, `apps/attestSkill`, `apps/grantPermission` RPC methods
- 5 app events (`skillChallenge`, `permissionRequest`, `admitted`, `rejected`, `sessionReady`)
- 9 new `ErrorCodes` (`AppNotFound` through `AgentNoOwner`)

**Server-core:**
- `AppHost` class with 3-gate policy chain (identity, capability, permission)
- 3 new DB tables (`app_sessions`, `app_session_participants`, `app_permission_grants`)
- RPC handlers wired into `createCoreApp()`
- `CoreApp` extended with `registerApp()`, `setContactChecker()`, `createAppSession()`

**Key design decisions:**
- Sessions are collections of metadata-tagged conversations (no separate channel concept)
- Capability attestation optional (skipped when no `skillUrl` in manifest)
- Permission requests routed to agent's `owner_user_id` (not the agent itself)
- Batch-fetch agent owners upfront, transaction boundary for session creation
- Identity + capability checks run concurrently via `Promise.all`
- Composite key for pending permission lookups (O(1) vs O(n))
- `destroy()` for shutdown timer cleanup

## Test Coverage

- 14 AppHost unit tests (registerApp, createSession validation, resolveChallenge, identity check)
- 9 protocol schema tests (AppManifest, AppSession, AppParticipantStatus validation)
- All 89 tests pass (66 existing + 23 new), 0 regressions

## Pre-Landing Review

- 5 review passes: /autoplan (CEO + Eng + DX), standalone /plan-eng-review, standalone /plan-devex-review
- 23 findings incorporated, 0 unresolved

## Test plan
- [x] Protocol builds clean (`pnpm --filter @moltzap/protocol build`)
- [x] Server-core builds clean (`pnpm --filter @moltzap/server-core build`)
- [x] All packages build clean (`pnpm -r build`)
- [x] Protocol tests pass (54 tests)
- [x] Server-core tests pass (35 tests)
- [x] Lint clean (0 warnings, 0 errors)
- [x] Format clean
- [x] Typecheck clean

## Related
- Plan comment: #37 (comment)
- Arena porting: chughtapan/moltzap-arena#50

🤖 Generated with [Claude Code](https://claude.com/claude-code)