### PR TITLE
feat: add app hooks — before_message_delivery and on_join

### DIFF
--- a/packages/protocol/src/schema/apps.ts
+++ b/packages/protocol/src/schema/apps.ts
@@ -52,6 +52,26 @@ export const AppManifestSchema = Type.Object(
       ),
     ),
     conversations: Type.Optional(Type.Array(AppManifestConversationSchema)),
+    hooks: Type.Optional(
+      Type.Object(
+        {
+          before_message_delivery: Type.Optional(
+            Type.Object(
+              {
+                timeout_ms: Type.Optional(
+                  Type.Integer({ default: 5000, minimum: 100, maximum: 30000 }),
+                ),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+          on_join: Type.Optional(
+            Type.Object({}, { additionalProperties: false }),
+          ),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   },
   { additionalProperties: false },
 );

--- a/packages/protocol/src/schema/errors.ts
+++ b/packages/protocol/src/schema/errors.ts
@@ -27,6 +27,7 @@ export const ErrorCodes = {
   IdentityRejected: -32016,
   MaxParticipants: -32017,
   AgentNoOwner: -32018,
+  HookBlocked: -32019,
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/packages/protocol/src/schema/messages.ts
+++ b/packages/protocol/src/schema/messages.ts
@@ -44,6 +44,7 @@ export const MessageSchema = Type.Object(
     replyToId: Type.Optional(MessageId),
     parts: Type.Array(PartSchema, { minItems: 1, maxItems: 10 }),
     taggedEntities: Type.Optional(Type.Array(AgentId)),
+    patchedBy: Type.Optional(Type.String()),
     createdAt: DateTimeString,
   },
   { additionalProperties: false },

--- a/packages/protocol/src/test-client.ts
+++ b/packages/protocol/src/test-client.ts
@@ -162,8 +162,10 @@ export class MoltZapTestClient {
           if (resp.error) {
             const err = new Error(resp.error.message) as Error & {
               code: number;
+              data?: unknown;
             };
             err.code = resp.error.code;
+            if (resp.error.data !== undefined) err.data = resp.error.data;
             reject(err);
           } else {
             resolve(resp.result);

--- a/packages/server/src/__tests__/integration/30-app-hooks.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-app-hooks.integration.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  registerAndConnect,
+  getKyselyDb,
+} from "./helpers.js";
+import type { CoreApp } from "../../app/types.js";
+import { ErrorCodes } from "@moltzap/protocol";
+import type { ConnectedAgent } from "../../test-utils/helpers.js";
+
+let coreApp: CoreApp;
+
+beforeAll(async () => {
+  const server = await startTestServer();
+  coreApp = server.coreApp;
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+/** Register, connect, and assign an owner_user_id (required for app sessions). */
+async function registerAppAgent(name: string): Promise<ConnectedAgent> {
+  const agent = await registerAndConnect(name);
+  const db = getKyselyDb();
+  await db
+    .updateTable("agents")
+    .set({ owner_user_id: crypto.randomUUID() })
+    .where("id", "=", agent.agentId)
+    .execute();
+  return agent;
+}
+
+function registerTestApp(
+  app: CoreApp,
+  appId: string,
+  opts?: { hookTimeoutMs?: number },
+) {
+  app.registerApp({
+    appId,
+    name: `Test App ${appId}`,
+    permissions: { required: [], optional: [] },
+    conversations: [
+      { key: "main", name: "Main Channel", participantFilter: "all" },
+    ],
+    hooks: {
+      before_message_delivery: {
+        timeout_ms: opts?.hookTimeoutMs ?? 5000,
+      },
+      on_join: {},
+    },
+  });
+}
+
+describe("Scenario 30: App Hooks", () => {
+  describe("before_message_delivery", () => {
+    it("blocks a message and returns structured feedback", async () => {
+      const orchestrator = await registerAppAgent("orchestrator");
+
+      registerTestApp(coreApp, "test-blocker");
+
+      coreApp.onBeforeMessageDelivery("test-blocker", (ctx) => ({
+        block: true,
+        reason: "Invalid command format",
+        feedback: {
+          type: "error",
+          content: {
+            expected: "/kill target:AgentName",
+            got: ctx.message.parts,
+          },
+          retry: true,
+        },
+      }));
+
+      const session = (await orchestrator.client.rpc("apps/create", {
+        appId: "test-blocker",
+        invitedAgentIds: [],
+      })) as {
+        session: { id: string; conversations: Record<string, string> };
+      };
+
+      const convId = session.session.conversations["main"]!;
+
+      try {
+        await orchestrator.client.rpc("messages/send", {
+          conversationId: convId,
+          parts: [{ type: "text", text: "bad command" }],
+        });
+        expect.unreachable("Should have thrown");
+      } catch (err: unknown) {
+        const rpcErr = err as {
+          code: number;
+          message: string;
+          data?: unknown;
+        };
+        expect(rpcErr.code).toBe(ErrorCodes.HookBlocked);
+        expect(rpcErr.message).toContain("Invalid command format");
+        expect(rpcErr.data).toHaveProperty("feedback");
+        const feedback = (
+          rpcErr.data as {
+            feedback: { type: string; retry: boolean };
+          }
+        ).feedback;
+        expect(feedback.type).toBe("error");
+        expect(feedback.retry).toBe(true);
+      }
+    });
+
+    it("patches message parts before delivery", async () => {
+      const alice = await registerAppAgent("alice-hook");
+
+      registerTestApp(coreApp, "test-patcher");
+
+      coreApp.onBeforeMessageDelivery("test-patcher", (ctx) => ({
+        block: false,
+        patch: {
+          parts: [
+            {
+              type: "text" as const,
+              text:
+                "[REDACTED] " + (ctx.message.parts[0] as { text: string }).text,
+            },
+          ],
+        },
+      }));
+
+      const session = (await alice.client.rpc("apps/create", {
+        appId: "test-patcher",
+        invitedAgentIds: [],
+      })) as {
+        session: { id: string; conversations: Record<string, string> };
+      };
+
+      const convId = session.session.conversations["main"]!;
+
+      const result = (await alice.client.rpc("messages/send", {
+        conversationId: convId,
+        parts: [{ type: "text", text: "secret info" }],
+      })) as {
+        message: {
+          parts: Array<{ type: string; text: string }>;
+          patchedBy?: string;
+        };
+      };
+
+      expect(result.message.parts[0]!.text).toBe("[REDACTED] secret info");
+      expect(result.message.patchedBy).toBe("test-patcher");
+    });
+
+    it("passes through when hook allows", async () => {
+      const agent = await registerAppAgent("passthrough-agent");
+
+      registerTestApp(coreApp, "test-passthrough");
+
+      coreApp.onBeforeMessageDelivery("test-passthrough", () => ({
+        block: false,
+      }));
+
+      const session = (await agent.client.rpc("apps/create", {
+        appId: "test-passthrough",
+        invitedAgentIds: [],
+      })) as {
+        session: { id: string; conversations: Record<string, string> };
+      };
+
+      const convId = session.session.conversations["main"]!;
+
+      const result = (await agent.client.rpc("messages/send", {
+        conversationId: convId,
+        parts: [{ type: "text", text: "hello" }],
+      })) as {
+        message: { parts: Array<{ type: string; text: string }> };
+      };
+
+      expect(result.message.parts[0]!.text).toBe("hello");
+    });
+
+    it("times out and passes through on slow hook", async () => {
+      const agent = await registerAppAgent("timeout-agent");
+
+      registerTestApp(coreApp, "test-timeout", { hookTimeoutMs: 200 });
+
+      coreApp.onBeforeMessageDelivery("test-timeout", async () => {
+        await new Promise((r) => setTimeout(r, 1000));
+        return { block: true, reason: "Should never reach" };
+      });
+
+      const session = (await agent.client.rpc("apps/create", {
+        appId: "test-timeout",
+        invitedAgentIds: [],
+      })) as {
+        session: { id: string; conversations: Record<string, string> };
+      };
+
+      const convId = session.session.conversations["main"]!;
+
+      const result = (await agent.client.rpc("messages/send", {
+        conversationId: convId,
+        parts: [{ type: "text", text: "should pass" }],
+      })) as {
+        message: { parts: Array<{ type: string; text: string }> };
+      };
+
+      expect(result.message.parts[0]!.text).toBe("should pass");
+    });
+
+    it("passes through for non-app conversations", async () => {
+      const alice = await registerAppAgent("alice-noapp");
+      const bob = await registerAppAgent("bob-noapp");
+
+      const conv = (await alice.client.rpc("conversations/create", {
+        type: "dm",
+        participants: [{ type: "agent", id: bob.agentId }],
+      })) as { conversation: { id: string } };
+
+      const result = (await alice.client.rpc("messages/send", {
+        conversationId: conv.conversation.id,
+        parts: [{ type: "text", text: "normal DM" }],
+      })) as {
+        message: { parts: Array<{ type: string; text: string }> };
+      };
+
+      expect(result.message.parts[0]!.text).toBe("normal DM");
+    });
+
+    it("fails open when hook throws", async () => {
+      const agent = await registerAppAgent("error-agent");
+
+      registerTestApp(coreApp, "test-error");
+
+      coreApp.onBeforeMessageDelivery("test-error", () => {
+        throw new Error("Hook crashed!");
+      });
+
+      const session = (await agent.client.rpc("apps/create", {
+        appId: "test-error",
+        invitedAgentIds: [],
+      })) as {
+        session: { id: string; conversations: Record<string, string> };
+      };
+
+      const convId = session.session.conversations["main"]!;
+
+      const result = (await agent.client.rpc("messages/send", {
+        conversationId: convId,
+        parts: [{ type: "text", text: "should still send" }],
+      })) as {
+        message: { parts: Array<{ type: string; text: string }> };
+      };
+
+      expect(result.message.parts[0]!.text).toBe("should still send");
+    });
+  });
+
+  describe("on_join", () => {
+    it("fires on_join when agent is admitted to session", async () => {
+      const initiator = await registerAppAgent("init-join");
+      const invitee = await registerAppAgent("invitee-join");
+
+      let joinFired = false;
+      let joinCtx: {
+        agent: { agentId: string };
+        conversations: Record<string, string>;
+      } | null = null;
+
+      registerTestApp(coreApp, "test-join");
+
+      coreApp.onAppJoin("test-join", (ctx) => {
+        joinFired = true;
+        joinCtx = ctx;
+      });
+
+      await initiator.client.rpc("apps/create", {
+        appId: "test-join",
+        invitedAgentIds: [invitee.agentId],
+      });
+
+      // Wait for async admission to complete
+      await new Promise((r) => setTimeout(r, 500));
+
+      expect(joinFired).toBe(true);
+      expect(joinCtx!.agent.agentId).toBe(invitee.agentId);
+      expect(joinCtx!.conversations).toHaveProperty("main");
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration/helpers.ts
+++ b/packages/server/src/__tests__/integration/helpers.ts
@@ -20,6 +20,7 @@ import {
 import { MoltZapTestClient } from "@moltzap/protocol/test-client";
 import type { Database } from "../../db/database.js";
 import type { Kysely } from "kysely";
+import type { CoreApp } from "../../app/types.js";
 
 export type { ConnectedAgent } from "../../test-utils/helpers.js";
 export { MoltZapTestClient } from "@moltzap/protocol/test-client";
@@ -31,12 +32,15 @@ export {
   trackClient,
 };
 
+let _coreApp: CoreApp | null = null;
+
 /**
  * Start the core test server using the shared Postgres from globalSetup.
  */
 export async function startTestServer(_opts?: { devMode?: boolean }): Promise<{
   baseUrl: string;
   wsUrl: string;
+  coreApp: CoreApp;
 }> {
   // Get pgHost/pgPort from vitest's globalSetup via inject()
   const { inject } = await import("vitest");
@@ -44,11 +48,22 @@ export async function startTestServer(_opts?: { devMode?: boolean }): Promise<{
   const pgPort = inject("testPgPort");
 
   const server = await startCoreTestServer({ pgHost, pgPort });
-  return { baseUrl: server.baseUrl, wsUrl: server.wsUrl };
+  _coreApp = server.coreApp;
+  return {
+    baseUrl: server.baseUrl,
+    wsUrl: server.wsUrl,
+    coreApp: server.coreApp,
+  };
+}
+
+export function getCoreApp(): CoreApp {
+  if (!_coreApp) throw new Error("Test server not running.");
+  return _coreApp;
 }
 
 export async function stopTestServer(): Promise<void> {
   closeAllClients();
+  _coreApp = null;
   await stopCoreTestServer();
 }
 

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -315,7 +315,7 @@ export class AppHost {
     pending.resolve(access);
   }
 
-  /** Cancel all pending timers. Called on shutdown. */
+  /** Cancel all pending timers and clear state. Called on shutdown. */
   destroy(): void {
     for (const pending of this.pendingChallenges.values()) {
       clearTimeout(pending.timer);
@@ -325,6 +325,8 @@ export class AppHost {
       clearTimeout(pending.timer);
     }
     this.pendingPermissions.clear();
+    this.hooks.clear();
+    this.conversationToSession.clear();
   }
 
   private subscribeToConversation(agentId: string, convId: string): void {
@@ -344,21 +346,24 @@ export class AppHost {
       signal: controller.signal,
     };
 
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const result = await Promise.race([
         Promise.resolve(fn(ctxWithSignal)),
-        new Promise<null>((resolve) =>
-          setTimeout(() => {
+        new Promise<null>((resolve) => {
+          timer = setTimeout(() => {
             controller.abort();
             resolve(null);
-          }, timeoutMs),
-        ),
+          }, timeoutMs);
+        }),
       ]);
       return result;
     } catch (err) {
       controller.abort();
       this.logger.error({ err }, "Hook execution error");
       return null;
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -455,7 +460,12 @@ export class AppHost {
       agentMap,
     );
 
-    await this.admitAgentToSession(session, agentId, grantedResources);
+    await this.admitAgentToSession(
+      session,
+      agentId,
+      grantedResources,
+      agent.owner_user_id ?? "",
+    );
   }
 
   private async checkIdentity(
@@ -708,6 +718,7 @@ export class AppHost {
     session: AppSession,
     agentId: string,
     grantedResources: string[],
+    ownerId: string,
   ): Promise<void> {
     await this.db
       .updateTable("app_session_participants")
@@ -735,7 +746,6 @@ export class AppHost {
 
         this.subscribeToConversation(agentId, convId);
       }
-      // "initiator" and "none" don't add the invited agent
     }
 
     const admittedEvent = eventFrame("app/participantAdmitted", {
@@ -753,19 +763,10 @@ export class AppHost {
 
     const appHooks = this.hooks.get(session.appId);
     if (appHooks?.onJoin) {
-      const admittedAgent = await this.db
-        .selectFrom("agents")
-        .select("owner_user_id")
-        .where("id", "=", agentId)
-        .executeTakeFirst();
-
       try {
         await appHooks.onJoin({
           conversations: session.conversations,
-          agent: {
-            agentId,
-            ownerId: admittedAgent?.owner_user_id ?? "",
-          },
+          agent: { agentId, ownerId },
           sessionId: session.id,
           appId: session.appId,
         });

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -4,8 +4,15 @@ import type { Broadcaster } from "../ws/broadcaster.js";
 import type { ConnectionManager } from "../ws/connection.js";
 import type { ConversationService } from "../services/conversation.service.js";
 import type { Logger } from "../logger.js";
-import type { AppManifest, AppSession } from "@moltzap/protocol";
+import type { AppManifest, AppSession, Part } from "@moltzap/protocol";
 import { ErrorCodes, eventFrame } from "@moltzap/protocol";
+import type {
+  AppHooks,
+  BeforeMessageDeliveryContext,
+  BeforeMessageDeliveryHook,
+  HookResult,
+  OnJoinHook,
+} from "./hooks.js";
 import { RpcError } from "../rpc/router.js";
 
 function errorMessage(err: unknown): string {
@@ -40,6 +47,11 @@ export class AppHost {
   private pendingPermissions = new Map<string, PendingPermission>();
   private manifests = new Map<string, AppManifest>();
   private contactChecker: ContactChecker | null = null;
+  private hooks = new Map<string, AppHooks>();
+  private conversationToSession = new Map<
+    string,
+    { id: string; appId: string }
+  >();
 
   constructor(
     private db: Kysely<Database>,
@@ -60,6 +72,63 @@ export class AppHost {
 
   setContactChecker(checker: ContactChecker): void {
     this.contactChecker = checker;
+  }
+
+  onBeforeMessageDelivery(
+    appId: string,
+    handler: BeforeMessageDeliveryHook,
+  ): void {
+    const existing = this.hooks.get(appId) ?? {};
+    existing.beforeMessageDelivery = handler;
+    this.hooks.set(appId, existing);
+  }
+
+  onAppJoin(appId: string, handler: OnJoinHook): void {
+    const existing = this.hooks.get(appId) ?? {};
+    existing.onJoin = handler;
+    this.hooks.set(appId, existing);
+  }
+
+  async runBeforeMessageDelivery(
+    conversationId: string,
+    senderAgentId: string,
+    parts: Part[],
+    replyToId?: string,
+  ): Promise<{ result: HookResult; appId: string } | null> {
+    const session = this.conversationToSession.get(conversationId);
+    if (!session) return null;
+
+    const appHooks = this.hooks.get(session.appId);
+    if (!appHooks?.beforeMessageDelivery) return null;
+
+    const agent = await this.db
+      .selectFrom("agents")
+      .select("owner_user_id")
+      .where("id", "=", senderAgentId)
+      .executeTakeFirst();
+
+    const ctx = {
+      conversationId,
+      sender: {
+        agentId: senderAgentId,
+        ownerId: agent?.owner_user_id ?? "",
+      },
+      message: { parts, replyToId },
+      sessionId: session.id,
+      appId: session.appId,
+    };
+
+    const manifest = this.manifests.get(session.appId);
+    const timeoutMs =
+      manifest?.hooks?.before_message_delivery?.timeout_ms ?? 5000;
+
+    const result = await this.runWithTimeout(
+      appHooks.beforeMessageDelivery,
+      ctx,
+      timeoutMs,
+    );
+    if (!result) return null;
+    return { result, appId: session.appId };
   }
 
   async createSession(
@@ -159,6 +228,10 @@ export class AppHost {
       }
     });
 
+    for (const convId of Object.values(conversationMap)) {
+      this.conversationToSession.set(convId, { id: sessionId, appId });
+    }
+
     const session: AppSession = {
       id: sessionId,
       appId,
@@ -257,6 +330,35 @@ export class AppHost {
   private subscribeToConversation(agentId: string, convId: string): void {
     for (const conn of this.connections.getByAgent(agentId)) {
       conn.conversationIds.add(convId);
+    }
+  }
+
+  private async runWithTimeout(
+    fn: (ctx: BeforeMessageDeliveryContext) => HookResult | Promise<HookResult>,
+    ctx: Omit<BeforeMessageDeliveryContext, "signal">,
+    timeoutMs: number,
+  ): Promise<HookResult | null> {
+    const controller = new AbortController();
+    const ctxWithSignal: BeforeMessageDeliveryContext = {
+      ...ctx,
+      signal: controller.signal,
+    };
+
+    try {
+      const result = await Promise.race([
+        Promise.resolve(fn(ctxWithSignal)),
+        new Promise<null>((resolve) =>
+          setTimeout(() => {
+            controller.abort();
+            resolve(null);
+          }, timeoutMs),
+        ),
+      ]);
+      return result;
+    } catch (err) {
+      controller.abort();
+      this.logger.error({ err }, "Hook execution error");
+      return null;
     }
   }
 
@@ -648,6 +750,32 @@ export class AppHost {
       { sessionId: session.id, agentId, grantedResources },
       "Agent admitted to app session",
     );
+
+    const appHooks = this.hooks.get(session.appId);
+    if (appHooks?.onJoin) {
+      const admittedAgent = await this.db
+        .selectFrom("agents")
+        .select("owner_user_id")
+        .where("id", "=", agentId)
+        .executeTakeFirst();
+
+      try {
+        await appHooks.onJoin({
+          conversations: session.conversations,
+          agent: {
+            agentId,
+            ownerId: admittedAgent?.owner_user_id ?? "",
+          },
+          sessionId: session.id,
+          appId: session.appId,
+        });
+      } catch (err) {
+        this.logger.error(
+          { err, sessionId: session.id, agentId },
+          "on_join hook error",
+        );
+      }
+    }
   }
 
   private async rejectAgent(

--- a/packages/server/src/app/hooks.ts
+++ b/packages/server/src/app/hooks.ts
@@ -1,0 +1,39 @@
+import type { Part } from "@moltzap/protocol";
+
+export interface BeforeMessageDeliveryContext {
+  conversationId: string;
+  sender: { agentId: string; ownerId: string };
+  message: { parts: Part[]; replyToId?: string };
+  sessionId: string;
+  appId: string;
+  signal: AbortSignal;
+}
+
+export interface HookResult {
+  block: boolean;
+  reason?: string;
+  patch?: { parts: Part[] };
+  feedback?: {
+    type: "error" | "warning" | "info";
+    content: Record<string, unknown>;
+    retry?: boolean;
+  };
+}
+
+export type BeforeMessageDeliveryHook = (
+  ctx: BeforeMessageDeliveryContext,
+) => HookResult | Promise<HookResult>;
+
+export interface OnJoinContext {
+  conversations: Record<string, string>;
+  agent: { agentId: string; ownerId: string };
+  sessionId: string;
+  appId: string;
+}
+
+export type OnJoinHook = (ctx: OnJoinContext) => void | Promise<void>;
+
+export interface AppHooks {
+  beforeMessageDelivery?: BeforeMessageDeliveryHook;
+  onJoin?: OnJoinHook;
+}

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -318,6 +318,12 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     async createAppSession(appId, initiatorAgentId, invitedAgentIds) {
       return appHost.createSession(appId, initiatorAgentId, invitedAgentIds);
     },
+    onBeforeMessageDelivery(appId, handler) {
+      appHost.onBeforeMessageDelivery(appId, handler);
+    },
+    onAppJoin(appId, handler) {
+      appHost.onAppJoin(appId, handler);
+    },
     async close() {
       appHost.destroy();
       for (const conn of connections.all()) {

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -70,6 +70,16 @@ export function createCoreApp(config: CoreConfig): CoreApp {
   );
   const deliveryService = new DeliveryService(db);
   const presenceService = new PresenceService();
+
+  // AppHost (before MessageService — it needs the hook call)
+  const appHost = new AppHost(
+    db,
+    broadcaster,
+    connections,
+    conversationService,
+    logger,
+  );
+
   const messageService = new MessageService(
     db,
     logger,
@@ -77,15 +87,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     broadcaster,
     envelope,
     deliveryService,
-  );
-
-  // AppHost
-  const appHost = new AppHost(
-    db,
-    broadcaster,
-    connections,
-    conversationService,
-    logger,
+    appHost,
   );
 
   // Per-request connection context for concurrent WebSocket RPC dispatches

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -2,6 +2,7 @@ import type { Hono } from "hono";
 import type { RpcMethodDef } from "../rpc/context.js";
 import type { AppManifest, AppSession } from "@moltzap/protocol";
 import type { ContactChecker } from "./app-host.js";
+import type { BeforeMessageDeliveryHook, OnJoinHook } from "./hooks.js";
 
 export interface CoreConfig {
   databaseUrl: string;
@@ -29,5 +30,10 @@ export interface CoreApp {
     initiatorAgentId: string,
     invitedAgentIds: string[],
   ) => Promise<AppSession>;
+  onBeforeMessageDelivery: (
+    appId: string,
+    handler: BeforeMessageDeliveryHook,
+  ) => void;
+  onAppJoin: (appId: string, handler: OnJoinHook) => void;
   close: () => Promise<void>;
 }

--- a/packages/server/src/rpc/router.ts
+++ b/packages/server/src/rpc/router.ts
@@ -54,7 +54,7 @@ export function createRpcRouter(methods: RpcMethodRegistry) {
           { requestId, method: methodName, errorCode: err.code, durationMs },
           err.message,
         );
-        return errorResponse(requestId, err.code, err.message);
+        return errorResponse(requestId, err.code, err.message, err.data);
       }
       logger.error(
         { requestId, method: methodName, err, durationMs },
@@ -66,12 +66,15 @@ export function createRpcRouter(methods: RpcMethodRegistry) {
 }
 
 export class RpcError extends Error {
+  public readonly data?: unknown;
   constructor(
     public readonly code: number,
     message: string,
+    data?: unknown,
   ) {
     super(message);
     this.name = "RpcError";
+    this.data = data;
   }
 }
 
@@ -83,6 +86,12 @@ function errorResponse(
   id: string,
   code: number,
   message: string,
+  data?: unknown,
 ): ResponseFrame {
-  return { jsonrpc: "2.0", type: "response", id, error: { code, message } };
+  const error: { code: number; message: string; data?: unknown } = {
+    code,
+    message,
+  };
+  if (data !== undefined) error.data = data;
+  return { jsonrpc: "2.0", type: "response", id, error };
 }

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -72,8 +72,16 @@ export class MessageService {
         );
       }
       if (hookResponse?.result.patch?.parts) {
-        parts = hookResponse.result.patch.parts;
-        patchedBy = hookResponse.appId;
+        const patched = hookResponse.result.patch.parts;
+        if (patched.length >= 1 && patched.length <= 10) {
+          parts = patched;
+          patchedBy = hookResponse.appId;
+        } else {
+          this.logger.warn(
+            { appId: hookResponse.appId, patchLength: patched.length },
+            "Hook returned invalid patch (must be 1-10 parts), ignoring patch",
+          );
+        }
       }
     }
 

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -19,6 +19,7 @@ import {
 } from "../crypto/serialization.js";
 import { sql } from "kysely";
 import type { MessageRow } from "../db/database.js";
+import type { AppHost } from "../app/app-host.js";
 
 export class MessageService {
   constructor(
@@ -28,15 +29,17 @@ export class MessageService {
     private broadcaster: Broadcaster,
     private encryption: EnvelopeEncryption | null,
     private delivery: DeliveryService,
+    private appHost: AppHost | null = null,
   ) {}
 
   async send(
     conversationId: string,
-    parts: Part[],
+    inputParts: Part[],
     senderAgentId: string,
     replyToId?: string,
     excludeConnectionId?: string,
   ): Promise<Message> {
+    let parts = inputParts;
     await this.conversations.requireParticipant(conversationId, senderAgentId);
 
     if (replyToId) {
@@ -48,6 +51,29 @@ export class MessageService {
         .executeTakeFirst();
       if (!replyExists) {
         throw new RpcError(ErrorCodes.NotFound, "Reply target not found");
+      }
+    }
+
+    let patchedBy: string | undefined;
+    if (this.appHost) {
+      const hookResponse = await this.appHost.runBeforeMessageDelivery(
+        conversationId,
+        senderAgentId,
+        parts,
+        replyToId,
+      );
+      if (hookResponse?.result.block) {
+        throw new RpcError(
+          ErrorCodes.HookBlocked,
+          hookResponse.result.reason ?? "Blocked by app",
+          hookResponse.result.feedback
+            ? { feedback: hookResponse.result.feedback }
+            : undefined,
+        );
+      }
+      if (hookResponse?.result.patch?.parts) {
+        parts = hookResponse.result.patch.parts;
+        patchedBy = hookResponse.appId;
       }
     }
 
@@ -71,7 +97,7 @@ export class MessageService {
       .returningAll()
       .executeTakeFirstOrThrow();
 
-    const message = this.mapMessage(row, parts);
+    const message = this.mapMessage(row, parts, patchedBy);
 
     const firstTextPart = parts.find((p) => p.type === "text");
 
@@ -293,13 +319,18 @@ export class MessageService {
     ) as Part[];
   }
 
-  private mapMessage(row: MessageRow, parts: Part[]): Message {
+  private mapMessage(
+    row: MessageRow,
+    parts: Part[],
+    patchedBy?: string,
+  ): Message {
     return {
       id: row.id,
       conversationId: row.conversation_id,
       senderId: row.sender_id,
       replyToId: row.reply_to_id ?? undefined,
       parts,
+      ...(patchedBy && { patchedBy }),
       createdAt: row.created_at.toISOString(),
     };
   }


### PR DESCRIPTION
## Summary

Apps can now intercept message delivery and react to agents joining sessions, without building custom orchestration from scratch. This formalizes what moltzap-arena does ad-hoc into a reusable framework.

**Hook Registry on AppHost (Approach C)**
- `onBeforeMessageDelivery(appId, handler)` — block, patch, or pass messages with structured feedback
- `onAppJoin(appId, handler)` — react when agents are admitted to a session
- In-memory `conversationToSession` reverse index for O(1) conversation-to-session lookup
- `runWithTimeout()` with fail-open behavior (default 5000ms, LLM-compatible)

**Protocol Changes**
- `HookBlocked` error code (`-32019`) with structured `data.feedback` payload
- `hooks` field on `AppManifestSchema` (before_message_delivery timeout config, on_join declaration)
- Optional `patchedBy` field on `MessageSchema` to stamp transformed messages
- `RpcError` extended with optional `data` field for structured error payloads

**Integration Points**
- `MessageService.send()` calls `appHost.runBeforeMessageDelivery()` before encryption
- `admitAgentToSession()` fires on_join hook after admission
- `CoreApp` interface exposes `onBeforeMessageDelivery` and `onAppJoin`

Design doc: https://github.com/chughtapan/moltzap/issues/53

## Test Coverage

7 new integration tests covering all hook codepaths:
- Block message with structured feedback (error code, data.feedback)
- Patch message parts before delivery (patchedBy stamped)
- Passthrough when hook allows
- Timeout → fail-open (200ms timeout, 1s hook)
- Non-app conversation passthrough
- Fail-open when hook throws
- on_join fires on agent admission

Test Coverage Audit: 11/13 code paths tested (85%). 2 uncovered: destroy() cleanup (unit test territory), no-hook-registered explicit path (implicitly tested).

## Pre-Landing Review

Pre-Landing Review: No issues found. All SQL uses Kysely type-safe builder, no injection vectors, no trust boundary violations.

## Adversarial Review

Claude adversarial subagent found 6 items. 1 fixed (patch validation), 5 by-design or not-blocking-for-V1:
- [FIXED] Hook patches now validated (1-10 parts) before applying
- [BY DESIGN] Fail-open on timeout/crash (documented design decision)
- [BY DESIGN] on_join errors swallowed (observational hook)
- [V2] conversationToSession not rebuilt on restart (server is stateless across restarts today)
- [V2] No hook deregistration (handler replacement is expected behavior)
- [NOT AN ISSUE] patchedBy comes from trusted server-registered appId

## Plan Completion

Plan: `docs/superpowers/plans/2026-04-15-app-hooks.md`
All 10 implementation tasks DONE. Task 11 (arena /kill sketch) validated design but produced no code.

## Test plan
- [x] All unit tests pass (35 tests)
- [x] All integration tests pass (50 tests, 7 new)
- [x] Build clean, lint clean, typecheck clean
- [x] Pre-commit hooks pass on all commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)