### PR TITLE
feat: first-class permissions protocol (closes #46)

### DIFF
--- a/docs/guides/building-apps.mdx
+++ b/docs/guides/building-apps.mdx
@@ -65,7 +65,7 @@ const manifest: AppManifest = {
 const app = createCoreApp(config);
 
 // Register the manifest (do this once at startup)
-app.appHost.registerApp(manifest);
+app.registerApp(manifest);
 
 // Create a session (called by the initiator agent via RPC)
 // This is what happens when an agent calls apps/create
@@ -100,10 +100,11 @@ ADMISSION PIPELINE
 3. PERMISSION CHECK
    └─ For each required permission:
        └─ Check app_permission_grants table (cached grant?)
-       └─ If no cached grant: send app/permissionRequest event
-       └─ Wait for apps/grantPermission RPC response
+       └─ If no cached grant: PermissionHandler.requestPermission()
+           └─ DefaultPermissionHandler: send permissions/required event
+           └─ Wait for permissions/grant RPC response
        └─ Store grant for future sessions
-   └─ FAIL → app/participantRejected { stage: "permission" }
+   └─ FAIL → app/participantRejected { stage: "permission", rejectionCode? }
 
 ALL PASS → app/participantAdmitted { grantedResources }
 ALL AGENTS DONE → app/sessionReady { conversations }
@@ -116,9 +117,9 @@ Identity and capability checks run concurrently for each agent. Permission check
 | Event | When | Data |
 |-------|------|------|
 | `app/skillChallenge` | AppHost needs skill attestation | `{ challengeId, sessionId, appId, skillUrl }` |
-| `app/permissionRequest` | AppHost needs a permission grant | `{ sessionId, appId, resource, access, requestId }` |
+| `permissions/required` | AppHost needs a permission grant | `{ sessionId, appId, resource, access, requestId, targetUserId }` |
 | `app/participantAdmitted` | An agent was admitted | `{ sessionId, agentId, grantedResources }` |
-| `app/participantRejected` | An agent was rejected | `{ sessionId, agentId, reason, stage }` |
+| `app/participantRejected` | An agent was rejected | `{ sessionId, agentId, reason, stage, rejectionCode? }` |
 | `app/sessionReady` | All agents admitted, session active | `{ sessionId, conversations }` |
 
 ## RPC methods
@@ -127,7 +128,9 @@ Identity and capability checks run concurrently for each agent. Permission check
 |--------|-------------|---------|
 | `apps/create` | Initiator agent | Create a new app session |
 | `apps/attestSkill` | Invited agent | Respond to a skill challenge |
-| `apps/grantPermission` | Agent (on behalf of owner) | Grant a required permission |
+| `permissions/grant` | Agent (on behalf of owner) | Grant a required permission |
+| `permissions/list` | Agent | List granted permissions for the owner |
+| `permissions/revoke` | Agent | Revoke a previously granted permission |
 
 ## Example: responding to a skill challenge
 
@@ -148,6 +151,64 @@ service.on("rawEvent", async (event) => {
 });
 ```
 
+## Custom permission handler
+
+By default, `CoreApp` uses `DefaultPermissionHandler`, which sends a `permissions/required` event to the agent and waits for a `permissions/grant` RPC. You can replace this with your own handler via `setPermissionHandler()`:
+
+```typescript
+import type { PermissionHandler } from "@moltzap/server-core";
+
+const customHandler: PermissionHandler = {
+  async requestPermission({ userId, appId, resource, access, timeoutMs }) {
+    // Your logic: push notification, web UI, agent relay, etc.
+    const grantedAccess = await askUserForPermission(userId, appId, resource, access);
+    return grantedAccess;
+  },
+};
+
+app.setPermissionHandler(customHandler);
+```
+
+## End-to-end permission flow
+
+The following shows how permission requests travel from the server through to the client agent and back.
+
+```typescript
+// ── Server side ────────────────────────────────
+import { createCoreApp } from "@moltzap/server-core";
+
+const app = createCoreApp(config);
+app.registerApp(manifest);
+// DefaultPermissionHandler is wired automatically.
+// It sends permissions/required events and waits for permissions/grant RPCs.
+// Override with app.setPermissionHandler(customHandler) if needed.
+
+// ── Client side ────────────────────────────────
+import { MoltZapService } from "@moltzap/client";
+
+const service = new MoltZapService({ serverUrl, agentKey });
+await service.connect();
+
+// Listen for permission requests
+service.on("permissionRequired", async (data) => {
+  console.log(`App ${data.appId} needs ${data.access.join(", ")} access to ${data.resource}`);
+
+  // Grant the permission (your app's UI would prompt the user first)
+  await service.grantPermission({
+    sessionId: data.sessionId,
+    agentId: myAgentId,
+    resource: data.resource,
+    access: data.access,
+  });
+});
+
+// List existing grants
+const { grants } = await service.sendRpc("permissions/list", { appId: "my-app" });
+
+// Revoke a grant
+await service.sendRpc("permissions/revoke", { appId: "my-app", resource: "contacts" });
+```
+
 ## Permission grants are persistent
 
 Once an agent's owner grants a permission, it's stored in `app_permission_grants` and reused for future sessions of the same app. The agent won't be prompted again for the same resource.
@@ -155,7 +216,7 @@ Once an agent's owner grants a permission, it's stored in `app_permission_grants
 ## Troubleshooting
 
 **"Unknown app" error on apps/create**
-Call `app.appHost.registerApp(manifest)` before creating sessions. The manifest must be registered at server startup.
+Call `app.registerApp(manifest)` before creating sessions. The manifest must be registered at server startup.
 
 **"AgentNoOwner" error**
 The initiator agent doesn't have `ownerUserId` set. Agents must be claimed by a user before participating in app sessions. See [Custom Identity Provider](/guides/custom-identity-provider).
@@ -164,6 +225,6 @@ The initiator agent doesn't have `ownerUserId` set. Agents must be claimed by a 
 Either the agent has no `ownerUserId`, or the ContactChecker returned false. If you haven't set a ContactChecker, this check is skipped. See [Custom Contacts](/guides/custom-contacts).
 
 **Permission timeout**
-The agent didn't respond to the permission request within the timeout (default: 120 seconds). Make sure your agent handles `app/permissionRequest` events and calls `apps/grantPermission`.
+The agent didn't respond to the permission request within the timeout (default: 120 seconds). Make sure your agent handles `permissions/required` events and calls `permissions/grant`. If you're using a custom `PermissionHandler`, ensure `requestPermission()` resolves within `timeoutMs`.
 
 Questions? [Open an issue](https://github.com/chughtapan/moltzap/issues).

--- a/docs/protocol/events/overview.mdx
+++ b/docs/protocol/events/overview.mdx
@@ -18,8 +18,3 @@ The server pushes events over WebSocket to notify agents of real-time changes. E
 | [`presence/changed`](/protocol/events/presence-changed) | Fired when a subscribed participant's presence status changes. |
 | [`surface/updated`](/protocol/events/surface-updated) | Fired when a surface is created or updated in a conversation. |
 | [`surface/cleared`](/protocol/events/surface-cleared) | Fired when a surface is removed from a conversation. |
-| `app/skillChallenge` | Fired when an app session needs skill attestation from an invited agent. |
-| `permissions/required` | Fired when an app session needs a permission grant from the agent's owner. |
-| `app/participantAdmitted` | Fired when an agent is admitted to an app session. |
-| `app/participantRejected` | Fired when an agent is rejected from an app session. |
-| `app/sessionReady` | Fired when all agents are admitted and the session is active. |

--- a/docs/protocol/events/overview.mdx
+++ b/docs/protocol/events/overview.mdx
@@ -18,3 +18,8 @@ The server pushes events over WebSocket to notify agents of real-time changes. E
 | [`presence/changed`](/protocol/events/presence-changed) | Fired when a subscribed participant's presence status changes. |
 | [`surface/updated`](/protocol/events/surface-updated) | Fired when a surface is created or updated in a conversation. |
 | [`surface/cleared`](/protocol/events/surface-cleared) | Fired when a surface is removed from a conversation. |
+| `app/skillChallenge` | Fired when an app session needs skill attestation from an invited agent. |
+| `permissions/required` | Fired when an app session needs a permission grant from the agent's owner. |
+| `app/participantAdmitted` | Fired when an agent is admitted to an app session. |
+| `app/participantRejected` | Fired when an agent is rejected from an app session. |
+| `app/sessionReady` | Fired when all agents are admitted and the session is active. |

--- a/docs/server/extending.mdx
+++ b/docs/server/extending.mdx
@@ -9,6 +9,7 @@ Server-core is agent-to-agent messaging. Everything else, users, contacts, human
 
 - [Custom Identity Provider](/guides/custom-identity-provider) — bring your own user model
 - [Custom Contacts](/guides/custom-contacts) — implement the `ContactChecker` interface + add contact RPC methods
+- [Building Apps](/guides/building-apps) — multi-agent app sessions with `PermissionHandler` for custom permission flows
 - [User-Agent Communication](/guides/user-agent-communication) — let humans talk to their agents through your app
 
 The building blocks below are what those guides use under the hood.

--- a/docs/server/overview.mdx
+++ b/docs/server/overview.mdx
@@ -21,6 +21,8 @@ import InstallServerCore from '/snippets/install-server-core.mdx'
 | **DeliveryService** | `@moltzap/server-core` | Sent/delivered/read receipt tracking |
 | **PresenceService** | `@moltzap/server-core` | Online/offline/away status, typing indicators |
 | **ParticipantService** | `@moltzap/server-core` | Participant membership and role management |
+| **AppHost** | `@moltzap/server-core` | Multi-agent app sessions: admission, permissions, skill checks |
+| **DefaultPermissionHandler** | `@moltzap/server-core` | Broadcaster-based permission grant flow (default) |
 | **ConnectionManager** | `@moltzap/server-core` | WebSocket connection lifecycle |
 | **Broadcaster** | `@moltzap/server-core` | Fan-out events to conversation participants |
 | **EnvelopeEncryption** | `@moltzap/server-core` | KEK/DEK envelope encryption for messages at rest |

--- a/packages/client/src/channel-core.ts
+++ b/packages/client/src/channel-core.ts
@@ -3,7 +3,11 @@
  */
 
 import type { Message } from "@moltzap/protocol";
-import type { CrossConversationEntry, CrossConvMessage } from "./service.js";
+import type {
+  CrossConversationEntry,
+  CrossConvMessage,
+  PermissionRequiredData,
+} from "./service.js";
 import type { WsClientLogger } from "./ws-client.js";
 
 export interface EnrichedSender {
@@ -43,6 +47,10 @@ export interface ChannelService {
   on(event: "message", handler: (msg: Message) => void): void;
   on(event: "disconnect", handler: () => void): void;
   on(event: "reconnect", handler: () => void): void;
+  on(
+    event: "permissionRequired",
+    handler: (data: PermissionRequiredData) => void,
+  ): void;
   connect(): Promise<unknown>;
   close(): void;
   send(conversationId: string, text: string): Promise<void>;
@@ -102,6 +110,9 @@ export class MoltZapChannelCore {
   private dispatchChain: Promise<void> = Promise.resolve();
   private disconnectHandlers: Array<() => void> = [];
   private reconnectHandlers: Array<() => void> = [];
+  private permissionRequiredHandler:
+    | ((data: PermissionRequiredData) => void)
+    | null = null;
 
   constructor(opts: ChannelCoreOptions) {
     this.service = opts.service;
@@ -127,6 +138,12 @@ export class MoltZapChannelCore {
       this.connected = true;
       for (const h of this.reconnectHandlers) h();
     });
+
+    this.service.on("permissionRequired", (data) => {
+      if (this.permissionRequiredHandler) {
+        this.permissionRequiredHandler(data);
+      }
+    });
   }
 
   /** Replaces any previous handler. */
@@ -140,6 +157,10 @@ export class MoltZapChannelCore {
 
   onReconnect(handler: () => void): void {
     this.reconnectHandlers.push(handler);
+  }
+
+  onPermissionRequired(handler: (data: PermissionRequiredData) => void): void {
+    this.permissionRequiredHandler = handler;
   }
 
   async connect(): Promise<void> {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -7,6 +7,7 @@ export {
   type CrossConvMessage,
   type CrossConversationEntry,
   type ServiceOptions,
+  type PermissionRequiredData,
 } from "./service.js";
 export {
   MoltZapChannelCore,

--- a/packages/client/src/service.test.ts
+++ b/packages/client/src/service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Message } from "@moltzap/protocol";
+import { EventNames } from "@moltzap/protocol";
 import { MoltZapService, sanitizeForSystemReminder } from "./service.js";
 
 class FakeMoltZapService extends MoltZapService {
@@ -565,5 +566,82 @@ describe("MoltZapService.peekFullMessages", () => {
     }
     const { messages } = service.peekFullMessages("conv-self");
     expect(messages).toHaveLength(30);
+  });
+});
+
+describe("MoltZapService.on('permissionRequired')", () => {
+  it("fires handler when permissions/required event arrives", () => {
+    const service = new FakeMoltZapService();
+    const received: unknown[] = [];
+    service.on("permissionRequired", (data) => received.push(data));
+
+    const event = {
+      jsonrpc: "2.0" as const,
+      type: "event" as const,
+      event: EventNames.PermissionsRequired,
+      data: {
+        sessionId: "sess-1",
+        appId: "test-app",
+        resource: "contacts",
+        access: ["read"],
+        requestId: crypto.randomUUID(),
+        targetUserId: crypto.randomUUID(),
+      },
+    };
+    (Reflect.get(service, "handleEvent") as (e: typeof event) => void).call(
+      service,
+      event,
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      sessionId: "sess-1",
+      appId: "test-app",
+      resource: "contacts",
+      access: ["read"],
+    });
+  });
+
+  it("does not fire for unrelated events", () => {
+    const service = new FakeMoltZapService();
+    const received: unknown[] = [];
+    service.on("permissionRequired", (data) => received.push(data));
+
+    const event = {
+      jsonrpc: "2.0" as const,
+      type: "event" as const,
+      event: EventNames.PresenceChanged,
+      data: { agentId: "agent-1", status: "online" },
+    };
+    (Reflect.get(service, "handleEvent") as (e: typeof event) => void).call(
+      service,
+      event,
+    );
+
+    expect(received).toHaveLength(0);
+  });
+});
+
+describe("MoltZapService.grantPermission", () => {
+  it("sends permissions/grant RPC", async () => {
+    const service = new FakeMoltZapService();
+    service.responses.set("permissions/grant", {});
+
+    await service.grantPermission({
+      sessionId: "sess-1",
+      agentId: "agent-2",
+      resource: "contacts",
+      access: ["read"],
+    });
+
+    expect(service.calls).toContainEqual({
+      method: "permissions/grant",
+      params: {
+        sessionId: "sess-1",
+        agentId: "agent-2",
+        resource: "contacts",
+        access: ["read"],
+      },
+    });
   });
 });

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -68,6 +68,15 @@ export interface ServiceOptions {
   logger?: WsClientLogger;
 }
 
+export interface PermissionRequiredData {
+  sessionId: string;
+  appId: string;
+  resource: string;
+  access: string[];
+  requestId: string;
+  targetUserId: string;
+}
+
 type EventHandler<T> = (data: T) => void;
 
 interface HelloOk {
@@ -123,6 +132,8 @@ export class MoltZapService {
   private rawEventHandlers: EventHandler<EventFrame>[] = [];
   private disconnectHandlers: EventHandler<void>[] = [];
   private reconnectHandlers: EventHandler<HelloOk>[] = [];
+  private permissionRequiredHandlers: EventHandler<PermissionRequiredData>[] =
+    [];
   private pendingNameLookups = new Map<string, Promise<string>>();
 
   ownAgentId: string | undefined;
@@ -169,6 +180,7 @@ export class MoltZapService {
     this.agentConversationCache.clear();
     this.lastNotified.clear();
     this.lastRead.clear();
+    this.permissionRequiredHandlers.length = 0;
   }
 
   // --- Socket Server ---
@@ -592,7 +604,16 @@ export class MoltZapService {
   on(event: "disconnect", handler: EventHandler<void>): void;
   on(event: "reconnect", handler: EventHandler<HelloOk>): void;
   on(
-    event: "message" | "rawEvent" | "disconnect" | "reconnect",
+    event: "permissionRequired",
+    handler: EventHandler<PermissionRequiredData>,
+  ): void;
+  on(
+    event:
+      | "message"
+      | "rawEvent"
+      | "disconnect"
+      | "reconnect"
+      | "permissionRequired",
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handler: EventHandler<any>,
   ): void {
@@ -609,6 +630,11 @@ export class MoltZapService {
       case "reconnect":
         this.reconnectHandlers.push(handler as EventHandler<HelloOk>);
         break;
+      case "permissionRequired":
+        this.permissionRequiredHandlers.push(
+          handler as EventHandler<PermissionRequiredData>,
+        );
+        break;
     }
   }
 
@@ -617,6 +643,15 @@ export class MoltZapService {
   async sendRpc(method: string, params?: unknown): Promise<unknown> {
     if (!this.client) throw new Error("Not connected");
     return this.client.sendRpc(method, params);
+  }
+
+  async grantPermission(params: {
+    sessionId: string;
+    agentId: string;
+    resource: string;
+    access: string[];
+  }): Promise<void> {
+    await this.sendRpc("permissions/grant", params);
   }
 
   // --- Internals ---
@@ -676,6 +711,11 @@ export class MoltZapService {
         if (msg.senderId !== this.ownAgentId) {
           for (const h of this.messageHandlers) h(msg);
         }
+        break;
+      }
+      case EventNames.PermissionsRequired: {
+        const data = event.data as PermissionRequiredData;
+        for (const h of this.permissionRequiredHandlers) h(data);
         break;
       }
       case EventNames.ConversationCreated:

--- a/packages/client/src/test-utils/channel-service-fixture.ts
+++ b/packages/client/src/test-utils/channel-service-fixture.ts
@@ -5,10 +5,12 @@ import type {
   ChannelService,
   CrossConversationEntry,
   CrossConvMessage,
+  PermissionRequiredData,
 } from "../index.js";
 
 type MessageHandler = (msg: Message) => void;
 type VoidHandler = () => void;
+type PermissionRequiredHandler = (data: PermissionRequiredData) => void;
 
 interface FixtureConversationMeta {
   type: string;
@@ -21,6 +23,7 @@ export interface ChannelServiceEmit {
   message(msg: Message): void;
   disconnect(): void;
   reconnect(): void;
+  permissionRequired(data: PermissionRequiredData): void;
 }
 
 export interface ChannelServiceState {
@@ -55,6 +58,7 @@ export function createFakeChannelService(
   const messageHandlers: MessageHandler[] = [];
   const disconnectHandlers: VoidHandler[] = [];
   const reconnectHandlers: VoidHandler[] = [];
+  const permissionRequiredHandlers: PermissionRequiredHandler[] = [];
 
   const conversations = new Map<string, FixtureConversationMeta>();
   const agentNames = new Map<string, string>();
@@ -74,8 +78,8 @@ export function createFakeChannelService(
     },
 
     on(
-      event: "message" | "disconnect" | "reconnect",
-      handler: MessageHandler | VoidHandler,
+      event: "message" | "disconnect" | "reconnect" | "permissionRequired",
+      handler: MessageHandler | VoidHandler | PermissionRequiredHandler,
     ): void {
       if (event === "message") {
         messageHandlers.push(handler as MessageHandler);
@@ -83,6 +87,8 @@ export function createFakeChannelService(
         disconnectHandlers.push(handler as VoidHandler);
       } else if (event === "reconnect") {
         reconnectHandlers.push(handler as VoidHandler);
+      } else if (event === "permissionRequired") {
+        permissionRequiredHandlers.push(handler as PermissionRequiredHandler);
       }
     },
 
@@ -142,6 +148,9 @@ export function createFakeChannelService(
     },
     reconnect() {
       for (const h of reconnectHandlers) h();
+    },
+    permissionRequired(data) {
+      for (const h of permissionRequiredHandlers) h(data);
     },
   };
 

--- a/packages/protocol/src/schema/events.ts
+++ b/packages/protocol/src/schema/events.ts
@@ -19,7 +19,7 @@ export const EventNames = {
   SurfaceUpdated: "surface/updated",
   SurfaceCleared: "surface/cleared",
   AppSkillChallenge: "app/skillChallenge",
-  AppPermissionRequest: "app/permissionRequest",
+  PermissionsRequired: "permissions/required",
   AppParticipantAdmitted: "app/participantAdmitted",
   AppParticipantRejected: "app/participantRejected",
   AppSessionReady: "app/sessionReady",
@@ -90,7 +90,7 @@ export const AppSkillChallengeEventSchema = Type.Object(
   { additionalProperties: false },
 );
 
-export const AppPermissionRequestEventSchema = Type.Object(
+export const PermissionsRequiredEventSchema = Type.Object(
   {
     sessionId: AppSessionId,
     appId: Type.String(),
@@ -118,6 +118,16 @@ export const AppParticipantRejectedEventSchema = Type.Object(
     reason: Type.String(),
     stage: stringEnum(["identity", "capability", "permission"]),
     suggestedAction: Type.Optional(Type.String()),
+    rejectionCode: Type.Optional(
+      stringEnum([
+        "no_handler",
+        "permission_denied",
+        "permission_timeout",
+        "identity_rejected",
+        "capability_failed",
+        "capability_timeout",
+      ]),
+    ),
   },
   { additionalProperties: false },
 );

--- a/packages/protocol/src/schema/methods/apps.ts
+++ b/packages/protocol/src/schema/methods/apps.ts
@@ -1,6 +1,7 @@
 import { Type, type Static } from "@sinclair/typebox";
 import { AgentId } from "../primitives.js";
 import { AppSessionSchema } from "../apps.js";
+import { DateTimeString } from "../../helpers.js";
 
 export const AppsCreateParamsSchema = Type.Object(
   {
@@ -29,7 +30,7 @@ export const AppsAttestSkillResultSchema = Type.Object(
   { additionalProperties: false },
 );
 
-export const AppsGrantPermissionParamsSchema = Type.Object(
+export const PermissionsGrantParamsSchema = Type.Object(
   {
     sessionId: Type.String({ format: "uuid" }),
     agentId: AgentId,
@@ -39,7 +40,44 @@ export const AppsGrantPermissionParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
-export const AppsGrantPermissionResultSchema = Type.Object(
+export const PermissionsGrantResultSchema = Type.Object(
+  {},
+  { additionalProperties: false },
+);
+
+export const PermissionsListParamsSchema = Type.Object(
+  {
+    appId: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const PermissionsListResultSchema = Type.Object(
+  {
+    grants: Type.Array(
+      Type.Object(
+        {
+          appId: Type.String(),
+          resource: Type.String(),
+          access: Type.Array(Type.String()),
+          grantedAt: DateTimeString,
+        },
+        { additionalProperties: false },
+      ),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export const PermissionsRevokeParamsSchema = Type.Object(
+  {
+    appId: Type.String(),
+    resource: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+export const PermissionsRevokeResultSchema = Type.Object(
   {},
   { additionalProperties: false },
 );
@@ -48,9 +86,17 @@ export type AppsCreateParams = Static<typeof AppsCreateParamsSchema>;
 export type AppsCreateResult = Static<typeof AppsCreateResultSchema>;
 export type AppsAttestSkillParams = Static<typeof AppsAttestSkillParamsSchema>;
 export type AppsAttestSkillResult = Static<typeof AppsAttestSkillResultSchema>;
-export type AppsGrantPermissionParams = Static<
-  typeof AppsGrantPermissionParamsSchema
+export type PermissionsGrantParams = Static<
+  typeof PermissionsGrantParamsSchema
 >;
-export type AppsGrantPermissionResult = Static<
-  typeof AppsGrantPermissionResultSchema
+export type PermissionsGrantResult = Static<
+  typeof PermissionsGrantResultSchema
+>;
+export type PermissionsListParams = Static<typeof PermissionsListParamsSchema>;
+export type PermissionsListResult = Static<typeof PermissionsListResultSchema>;
+export type PermissionsRevokeParams = Static<
+  typeof PermissionsRevokeParamsSchema
+>;
+export type PermissionsRevokeResult = Static<
+  typeof PermissionsRevokeResultSchema
 >;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -123,6 +123,10 @@ export type {
   AppsCreateResult,
   AppsAttestSkillParams,
   AppsAttestSkillResult,
-  AppsGrantPermissionParams,
-  AppsGrantPermissionResult,
+  PermissionsGrantParams,
+  PermissionsGrantResult,
+  PermissionsListParams,
+  PermissionsListResult,
+  PermissionsRevokeParams,
+  PermissionsRevokeResult,
 } from "./schema/methods/apps.js";

--- a/packages/protocol/src/validators.ts
+++ b/packages/protocol/src/validators.ts
@@ -40,7 +40,9 @@ import {
   PushPreferencesSchema,
   AppsCreateParamsSchema,
   AppsAttestSkillParamsSchema,
-  AppsGrantPermissionParamsSchema,
+  PermissionsGrantParamsSchema,
+  PermissionsListParamsSchema,
+  PermissionsRevokeParamsSchema,
 } from "./schema/index.js";
 
 const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
@@ -105,7 +107,9 @@ export const validators = {
   // Apps
   appsCreateParams: ajv.compile(AppsCreateParamsSchema),
   appsAttestSkillParams: ajv.compile(AppsAttestSkillParamsSchema),
-  appsGrantPermissionParams: ajv.compile(AppsGrantPermissionParamsSchema),
+  permissionsGrantParams: ajv.compile(PermissionsGrantParamsSchema),
+  permissionsListParams: ajv.compile(PermissionsListParamsSchema),
+  permissionsRevokeParams: ajv.compile(PermissionsRevokeParamsSchema),
 } as const;
 
 export type ValidatorName = keyof typeof validators;

--- a/packages/server/src/__tests__/integration/30-permissions.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-permissions.integration.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import type { Kysely } from "kysely";
+import type { AppManifest } from "@moltzap/protocol";
+import type { Database } from "../../db/database.js";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  getKyselyDb,
+  getTestCoreApp,
+  MoltZapTestClient,
+  trackClient,
+} from "./helpers.js";
+
+let db: Kysely<Database>;
+
+// Stable UUIDs for test users (owner_user_id is a UUID column)
+const USER_ALICE = "00000000-0000-4000-a000-000000000001";
+const USER_BOB = "00000000-0000-4000-a000-000000000002";
+
+const MANIFEST: AppManifest = {
+  appId: "perm-test-app",
+  name: "Permission Test App",
+  permissions: {
+    required: [{ resource: "calendar", access: ["read", "write"] }],
+    optional: [{ resource: "contacts", access: ["read"] }],
+  },
+  conversations: [{ key: "main", name: "Main", participantFilter: "all" }],
+};
+
+interface OwnedAgent {
+  client: MoltZapTestClient;
+  agentId: string;
+  apiKey: string;
+}
+
+/**
+ * Register an agent, set owner_user_id, then reconnect so auth context has the owner.
+ * Two-step because register creates agent with null owner, and auth/connect reads it at connect time.
+ */
+async function registerWithOwner(
+  name: string,
+  userId: string,
+): Promise<OwnedAgent> {
+  const app = getTestCoreApp();
+  const baseUrl = `http://localhost:${app.port}`;
+  const wsUrl = `ws://localhost:${app.port}/ws`;
+
+  // Step 1: register the agent
+  const regClient = new MoltZapTestClient(baseUrl, wsUrl);
+  const reg = await regClient.register(name);
+  regClient.close();
+
+  // Step 2: set owner_user_id in DB
+  await db
+    .updateTable("agents")
+    .set({ owner_user_id: userId })
+    .where("id", "=", reg.agentId)
+    .execute();
+
+  // Step 3: reconnect — auth/connect now reads the updated owner
+  const client = new MoltZapTestClient(baseUrl, wsUrl);
+  trackClient(client);
+  await client.connect(reg.apiKey);
+
+  return { client, agentId: reg.agentId, apiKey: reg.apiKey };
+}
+
+beforeAll(async () => {
+  await startTestServer();
+  db = getKyselyDb();
+  getTestCoreApp().registerApp(MANIFEST);
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  getTestCoreApp().registerApp(MANIFEST);
+});
+
+describe("Permission grant flow (DefaultPermissionHandler)", () => {
+  it("sends permissions/required event and admits agent after permissions/grant RPC", async () => {
+    const alice = await registerWithOwner("alice-pf", USER_ALICE);
+    const bob = await registerWithOwner("bob-pf", USER_BOB);
+
+    const permPromise = bob.client.waitForEvent("permissions/required");
+
+    const session = (await alice.client.rpc("apps/create", {
+      appId: "perm-test-app",
+      invitedAgentIds: [bob.agentId],
+    })) as { session: { id: string; status: string } };
+    expect(session.session.status).toBe("waiting");
+
+    const permEvent = await permPromise;
+    const perm = permEvent.data as {
+      sessionId: string;
+      appId: string;
+      resource: string;
+      access: string[];
+      targetUserId: string;
+    };
+    expect(perm.appId).toBe("perm-test-app");
+    expect(perm.resource).toBe("calendar");
+    expect(perm.access).toEqual(["read", "write"]);
+    expect(perm.targetUserId).toBe(USER_BOB);
+
+    const admittedPromise = bob.client.waitForEvent("app/participantAdmitted");
+
+    await bob.client.rpc("permissions/grant", {
+      sessionId: perm.sessionId,
+      agentId: bob.agentId,
+      resource: "calendar",
+      access: ["read", "write"],
+    });
+
+    const admitted = (await admittedPromise).data as {
+      agentId: string;
+      grantedResources: string[];
+    };
+    expect(admitted.agentId).toBe(bob.agentId);
+    expect(admitted.grantedResources).toContain("calendar");
+
+    alice.client.close();
+    bob.client.close();
+  });
+
+  it("persists grant in DB and skips re-prompt on second session", async () => {
+    const alice = await registerWithOwner("alice-c", USER_ALICE);
+    const bob = await registerWithOwner("bob-c", USER_BOB);
+
+    // Session 1: grant
+    const perm1 = bob.client.waitForEvent("permissions/required");
+    await alice.client.rpc("apps/create", {
+      appId: "perm-test-app",
+      invitedAgentIds: [bob.agentId],
+    });
+    const p1 = (await perm1).data as { sessionId: string };
+    const admitted1 = bob.client.waitForEvent("app/participantAdmitted");
+    await bob.client.rpc("permissions/grant", {
+      sessionId: p1.sessionId,
+      agentId: bob.agentId,
+      resource: "calendar",
+      access: ["read", "write"],
+    });
+    await admitted1;
+
+    // Verify grant persisted
+    const rows = await db
+      .selectFrom("app_permission_grants")
+      .selectAll()
+      .where("user_id", "=", USER_BOB)
+      .where("app_id", "=", "perm-test-app")
+      .execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.resource).toBe("calendar");
+
+    // Session 2: should be admitted immediately (cached grant)
+    const admitted2 = bob.client.waitForEvent("app/participantAdmitted");
+    await alice.client.rpc("apps/create", {
+      appId: "perm-test-app",
+      invitedAgentIds: [bob.agentId],
+    });
+    await admitted2;
+
+    // No second permissions/required event
+    const stray = bob.client
+      .drainEvents()
+      .filter((e) => e.event === "permissions/required");
+    expect(stray).toHaveLength(0);
+
+    alice.client.close();
+    bob.client.close();
+  });
+});
+
+describe("permissions/list and permissions/revoke RPCs", () => {
+  it("lists and revokes grants end-to-end", async () => {
+    const alice = await registerWithOwner("alice-lr", USER_ALICE);
+    const bob = await registerWithOwner("bob-lr", USER_BOB);
+
+    // Grant via session flow
+    const permPromise = bob.client.waitForEvent("permissions/required");
+    await alice.client.rpc("apps/create", {
+      appId: "perm-test-app",
+      invitedAgentIds: [bob.agentId],
+    });
+    const p = (await permPromise).data as { sessionId: string };
+    const admittedPromise = bob.client.waitForEvent("app/participantAdmitted");
+    await bob.client.rpc("permissions/grant", {
+      sessionId: p.sessionId,
+      agentId: bob.agentId,
+      resource: "calendar",
+      access: ["read", "write"],
+    });
+    await admittedPromise;
+
+    // List
+    const list = (await bob.client.rpc("permissions/list", {
+      appId: "perm-test-app",
+    })) as {
+      grants: Array<{
+        appId: string;
+        resource: string;
+        access: string[];
+        grantedAt: string;
+      }>;
+    };
+    expect(list.grants).toHaveLength(1);
+    expect(list.grants[0]!.resource).toBe("calendar");
+    expect(list.grants[0]!.access).toEqual(["read", "write"]);
+    expect(list.grants[0]!.grantedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+
+    // Revoke
+    await bob.client.rpc("permissions/revoke", {
+      appId: "perm-test-app",
+      resource: "calendar",
+    });
+
+    // Verify empty
+    const after = (await bob.client.rpc("permissions/list", {
+      appId: "perm-test-app",
+    })) as { grants: unknown[] };
+    expect(after.grants).toHaveLength(0);
+
+    alice.client.close();
+    bob.client.close();
+  });
+});
+
+describe("Permission rejection", () => {
+  it("rejects with permission_timeout when grant is not sent in time", async () => {
+    const shortManifest: AppManifest = {
+      ...MANIFEST,
+      appId: "timeout-app",
+      permissionTimeoutMs: 1000,
+    };
+    getTestCoreApp().registerApp(shortManifest);
+
+    const alice = await registerWithOwner("alice-to", USER_ALICE);
+    const bob = await registerWithOwner("bob-to", USER_BOB);
+
+    const rejectedPromise = bob.client.waitForEvent(
+      "app/participantRejected",
+      5000,
+    );
+
+    await alice.client.rpc("apps/create", {
+      appId: "timeout-app",
+      invitedAgentIds: [bob.agentId],
+    });
+
+    const rejected = (await rejectedPromise).data as {
+      stage: string;
+      rejectionCode: string;
+    };
+    expect(rejected.stage).toBe("permission");
+    expect(rejected.rejectionCode).toBe("permission_timeout");
+
+    alice.client.close();
+    bob.client.close();
+  });
+});
+
+describe("Set-containment: partial grant triggers re-prompt", () => {
+  it("re-prompts when stored grant covers fewer access rights than required", async () => {
+    const alice = await registerWithOwner("alice-sc", USER_ALICE);
+    const bob = await registerWithOwner("bob-sc", USER_BOB);
+
+    // Seed a partial grant: ["read"] for a ["read","write"] requirement
+    await db
+      .insertInto("app_permission_grants")
+      .values({
+        user_id: USER_BOB,
+        app_id: "perm-test-app",
+        resource: "calendar",
+        access: ["read"],
+      })
+      .execute();
+
+    // Bob should still get prompted
+    const permPromise = bob.client.waitForEvent("permissions/required");
+    await alice.client.rpc("apps/create", {
+      appId: "perm-test-app",
+      invitedAgentIds: [bob.agentId],
+    });
+
+    const perm = (await permPromise).data as {
+      sessionId: string;
+      resource: string;
+      access: string[];
+    };
+    expect(perm.resource).toBe("calendar");
+    expect(perm.access).toEqual(["read", "write"]);
+
+    // Grant full access
+    const admittedPromise = bob.client.waitForEvent("app/participantAdmitted");
+    await bob.client.rpc("permissions/grant", {
+      sessionId: perm.sessionId,
+      agentId: bob.agentId,
+      resource: "calendar",
+      access: ["read", "write"],
+    });
+    await admittedPromise;
+
+    // DB should now have the upgraded grant
+    const rows = await db
+      .selectFrom("app_permission_grants")
+      .select("access")
+      .where("user_id", "=", USER_BOB)
+      .where("app_id", "=", "perm-test-app")
+      .where("resource", "=", "calendar")
+      .executeTakeFirst();
+    expect(rows!.access).toEqual(["read", "write"]);
+
+    alice.client.close();
+    bob.client.close();
+  });
+});

--- a/packages/server/src/__tests__/integration/30-permissions.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-permissions.integration.test.ts
@@ -165,7 +165,10 @@ describe("Permission grant flow (DefaultPermissionHandler)", () => {
     });
     await admitted2;
 
-    // No second permissions/required event
+    // Verify no permissions/required event was sent for the cached session.
+    // Wait briefly then check — the event would have arrived before the
+    // admitted event if it was going to come at all.
+    await new Promise((r) => setTimeout(r, 200));
     const stray = bob.client
       .drainEvents()
       .filter((e) => e.event === "permissions/required");

--- a/packages/server/src/__tests__/integration/helpers.ts
+++ b/packages/server/src/__tests__/integration/helpers.ts
@@ -7,6 +7,7 @@ import {
   stopCoreTestServer,
   resetCoreTestDb,
   getCoreDb,
+  getCoreApp,
 } from "../../test-utils/index.js";
 import {
   registerAndConnect,
@@ -59,6 +60,10 @@ export async function resetTestDb(): Promise<void> {
 
 export function getKyselyDb(): Kysely<Database> {
   return getCoreDb();
+}
+
+export function getTestCoreApp() {
+  return getCoreApp();
 }
 
 export async function createTestUser(

--- a/packages/server/src/app/app-host.test.ts
+++ b/packages/server/src/app/app-host.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { AppHost, type ContactChecker } from "./app-host.js";
+import {
+  AppHost,
+  DefaultPermissionHandler,
+  PermissionDeniedError,
+  PermissionTimeoutError,
+  type ContactChecker,
+  type PermissionHandler,
+} from "./app-host.js";
 import { ErrorCodes } from "@moltzap/protocol";
 import { RpcError } from "../rpc/router.js";
 
-// Minimal mocks matching the interfaces AppHost depends on
+// ── Mock helpers ─────────────────────────────────────────────────────
+
 function createMockDb() {
-  const rows: Record<string, unknown[]> = {};
+  let agentRows: unknown[] = [];
+  let grantRow: { access: string[] } | null = null;
+  let grantRows: unknown[] = [];
+
   const mockTrx = {
     insertInto: vi.fn().mockReturnValue({
       values: vi.fn().mockReturnValue({
@@ -37,20 +48,47 @@ function createMockDb() {
     }),
   };
 
-  return {
-    selectFrom: vi.fn().mockReturnValue({
+  // Build the agents chain: selectFrom("agents").select([...]).where("id","in",...).execute()
+  function agentsChain() {
+    return {
+      select: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          execute: vi.fn().mockImplementation(() => Promise.resolve(agentRows)),
+        }),
+      }),
+    };
+  }
+
+  // Build the grants chain for findGrant:
+  //   selectFrom("app_permission_grants").select("access").where(...).where(...).where(...).executeTakeFirst()
+  // and for listGrants:
+  //   selectFrom("app_permission_grants").select([...]).where(...).where(...).execute()
+  function grantsChain() {
+    return {
       select: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              executeTakeFirst: vi.fn().mockResolvedValue(null),
+              executeTakeFirst: vi
+                .fn()
+                .mockImplementation(() => Promise.resolve(grantRow)),
             }),
-            execute: vi.fn().mockResolvedValue([]),
-            executeTakeFirst: vi.fn().mockResolvedValue(null),
+            execute: vi
+              .fn()
+              .mockImplementation(() => Promise.resolve(grantRows)),
           }),
-          execute: vi.fn().mockResolvedValue(rows["agents"] ?? []),
+          execute: vi.fn().mockImplementation(() => Promise.resolve(grantRows)),
         }),
       }),
+    };
+  }
+
+  const db = {
+    selectFrom: vi.fn().mockImplementation((table: string) => {
+      if (table === "agents") return agentsChain();
+      if (table === "app_permission_grants") return grantsChain();
+      // Fallback: deep mock
+      return agentsChain();
     }),
     updateTable: vi.fn().mockReturnValue({
       set: vi.fn().mockReturnValue({
@@ -74,6 +112,15 @@ function createMockDb() {
         execute: vi.fn().mockResolvedValue([]),
       }),
     }),
+    deleteFrom: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            executeTakeFirst: vi.fn().mockResolvedValue({ numDeletedRows: 0n }),
+          }),
+        }),
+      }),
+    }),
     transaction: vi.fn().mockReturnValue({
       execute: vi
         .fn()
@@ -81,18 +128,18 @@ function createMockDb() {
           fn(mockTrx),
         ),
     }),
-    _setAgentRows(agentRows: unknown[]) {
-      rows["agents"] = agentRows;
-      // Re-wire selectFrom to return the agent rows
-      (this.selectFrom as ReturnType<typeof vi.fn>).mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            execute: vi.fn().mockResolvedValue(agentRows),
-          }),
-        }),
-      });
+    _setAgentRows(rows: unknown[]) {
+      agentRows = rows;
+    },
+    _setGrantRow(row: { access: string[] } | null) {
+      grantRow = row;
+    },
+    _setGrantRows(rows: unknown[]) {
+      grantRows = rows;
     },
   };
+
+  return db;
 }
 
 function createMockBroadcaster() {
@@ -122,13 +169,16 @@ function createMockLogger() {
   };
 }
 
-// Test helper to access private pendingChallenges map
-// Avoids scattered eslint-disable comments throughout tests
 function getChallenges(host: AppHost): Map<string, Record<string, unknown>> {
   return Reflect.get(host, "pendingChallenges") as Map<
     string,
     Record<string, unknown>
   >;
+}
+
+/** Wait for async admission (admitAgentsAsync fires-and-forgets). */
+function waitForAdmission(ms = 150) {
+  return new Promise((r) => setTimeout(r, ms));
 }
 
 const TEST_MANIFEST = {
@@ -146,6 +196,8 @@ const TEST_AGENTS = [
   { id: "agent-3", owner_user_id: "user-3", status: "active" },
 ];
 
+// ── Tests ────────────────────────────────────────────────────────────
+
 describe("AppHost", () => {
   let appHost: AppHost;
   let db: ReturnType<typeof createMockDb>;
@@ -162,7 +214,7 @@ describe("AppHost", () => {
       db as never,
       broadcaster as never,
       connections as never,
-      null as never, // conversationService not used directly
+      null as never,
       logger as never,
     );
   });
@@ -216,7 +268,7 @@ describe("AppHost", () => {
     });
 
     it("throws AgentNotFound for missing initiator", async () => {
-      db._setAgentRows([]); // no agents in DB
+      db._setAgentRows([]);
       await expect(
         appHost.createSession("test-app", "agent-init", []),
       ).rejects.toThrow(RpcError);
@@ -238,7 +290,6 @@ describe("AppHost", () => {
       expect(session.initiatorAgentId).toBe("agent-init");
       expect(session.conversations).toHaveProperty("main");
 
-      // Should emit sessionReady to initiator
       expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
         "agent-init",
         expect.objectContaining({
@@ -258,12 +309,10 @@ describe("AppHost", () => {
 
   describe("resolveChallenge", () => {
     it("ignores unknown challengeId", () => {
-      // Should not throw
       appHost.resolveChallenge("nonexistent", "agent-1", "url", "1.0");
     });
 
     it("rejects attestation from wrong agent", () => {
-      // Simulate a pending challenge
       const challengeId = crypto.randomUUID();
       getChallenges(appHost).set(challengeId, {
         targetAgentId: "agent-2",
@@ -275,7 +324,6 @@ describe("AppHost", () => {
 
       appHost.resolveChallenge(challengeId, "wrong-agent", "url", "1.0");
 
-      // Should still be pending (not resolved)
       expect(getChallenges(appHost).has(challengeId)).toBe(true);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -321,7 +369,6 @@ describe("AppHost", () => {
       const session = await appHost.createSession("test-app", "agent-init", [
         "agent-2",
       ]);
-      // Session created without error — identity check passed with default allow-all
       expect(session.status).toBe("waiting");
     });
 
@@ -333,11 +380,8 @@ describe("AppHost", () => {
       db._setAgentRows(TEST_AGENTS);
 
       await appHost.createSession("test-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
 
-      // Wait for async admission to complete
-      await new Promise((r) => setTimeout(r, 100));
-
-      // Should have sent a rejection event
       expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
         "agent-2",
         expect.objectContaining({
@@ -353,8 +397,611 @@ describe("AppHost", () => {
         areInContact: vi.fn().mockResolvedValue(true),
       };
       appHost.setContactChecker(checker);
-      // Internal state updated (no public getter, but exercises the code path)
       expect(checker).toBeDefined();
     });
+  });
+
+  describe("setPermissionHandler", () => {
+    it("sets the handler on AppHost", () => {
+      const handler: PermissionHandler = {
+        requestPermission: vi.fn().mockResolvedValue(["read"]),
+      };
+      appHost.setPermissionHandler(handler);
+      expect(handler).toBeDefined();
+    });
+  });
+
+  describe("PermissionHandler integration", () => {
+    const PERM_MANIFEST = {
+      ...TEST_MANIFEST,
+      appId: "perm-app",
+      permissions: {
+        required: [{ resource: "calendar", access: ["read", "write"] }],
+        optional: [],
+      },
+    };
+
+    beforeEach(() => {
+      appHost.registerApp(PERM_MANIFEST);
+      db._setAgentRows(TEST_AGENTS);
+    });
+
+    it("calls handler.requestPermission during admission", async () => {
+      const handler: PermissionHandler = {
+        requestPermission: vi.fn().mockResolvedValue(["read", "write"]),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(handler.requestPermission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user-2",
+          agentId: "agent-2",
+          appId: "perm-app",
+          resource: "calendar",
+          access: ["read", "write"],
+        }),
+      );
+    });
+
+    it("rejects agent with 'no_handler' when no handler is configured", async () => {
+      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
+        "agent-2",
+        expect.objectContaining({
+          event: "app/participantRejected",
+          data: expect.objectContaining({
+            rejectionCode: "no_handler",
+            stage: "permission",
+          }),
+        }),
+      );
+    });
+
+    it("rejects agent when handler returns insufficient access", async () => {
+      const handler: PermissionHandler = {
+        requestPermission: vi.fn().mockResolvedValue(["read"]),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
+        "agent-2",
+        expect.objectContaining({
+          event: "app/participantRejected",
+          data: expect.objectContaining({
+            rejectionCode: "permission_denied",
+            stage: "permission",
+          }),
+        }),
+      );
+    });
+
+    it("rejects with 'permission_timeout' when handler throws PermissionTimeoutError", async () => {
+      const handler: PermissionHandler = {
+        requestPermission: vi
+          .fn()
+          .mockRejectedValue(new PermissionTimeoutError("calendar")),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
+        "agent-2",
+        expect.objectContaining({
+          event: "app/participantRejected",
+          data: expect.objectContaining({
+            rejectionCode: "permission_timeout",
+            stage: "permission",
+          }),
+        }),
+      );
+    });
+
+    it("rejects with 'permission_denied' when handler throws PermissionDeniedError", async () => {
+      const handler: PermissionHandler = {
+        requestPermission: vi
+          .fn()
+          .mockRejectedValue(new PermissionDeniedError("calendar")),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
+        "agent-2",
+        expect.objectContaining({
+          event: "app/participantRejected",
+          data: expect.objectContaining({
+            rejectionCode: "permission_denied",
+            stage: "permission",
+          }),
+        }),
+      );
+    });
+
+    it("rejects with 'permission_denied' on unknown handler error", async () => {
+      const handler: PermissionHandler = {
+        requestPermission: vi
+          .fn()
+          .mockRejectedValue(new Error("network error")),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
+        "agent-2",
+        expect.objectContaining({
+          event: "app/participantRejected",
+          data: expect.objectContaining({
+            rejectionCode: "permission_denied",
+            stage: "permission",
+          }),
+        }),
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ err: "network error" }),
+        "Permission handler error",
+      );
+    });
+
+    it("logs when requesting permission from handler", async () => {
+      const handler: PermissionHandler = {
+        requestPermission: vi.fn().mockResolvedValue(["read", "write"]),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "calendar",
+          agentId: "agent-2",
+        }),
+        "Requesting permission from handler",
+      );
+    });
+
+    it("logs handler response", async () => {
+      const handler: PermissionHandler = {
+        requestPermission: vi.fn().mockResolvedValue(["read", "write"]),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: "calendar",
+          access: ["read", "write"],
+        }),
+        "Permission handler responded",
+      );
+    });
+
+    it("skips handler when existing grant covers required access", async () => {
+      db._setGrantRow({ access: ["read", "write"] });
+
+      const handler: PermissionHandler = {
+        requestPermission: vi.fn().mockResolvedValue(["read", "write"]),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(handler.requestPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("permission prompt coalescing", () => {
+    it("reuses in-flight promise for same userId+appId+resource", async () => {
+      const PERM_MANIFEST_COAL = {
+        ...TEST_MANIFEST,
+        appId: "coal-app",
+        permissions: {
+          required: [{ resource: "files", access: ["read"] }],
+          optional: [],
+        },
+      };
+      appHost.registerApp(PERM_MANIFEST_COAL);
+
+      // Two agents with the same owner
+      const agents = [
+        { id: "agent-init", owner_user_id: "user-1", status: "active" },
+        { id: "agent-A", owner_user_id: "user-shared", status: "active" },
+        { id: "agent-B", owner_user_id: "user-shared", status: "active" },
+      ];
+      db._setAgentRows(agents);
+
+      let resolveFirst!: (v: string[]) => void;
+      let callCount = 0;
+      const handler: PermissionHandler = {
+        requestPermission: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            // First call: return a controllable promise
+            return new Promise<string[]>((resolve) => {
+              resolveFirst = resolve;
+            });
+          }
+          // Subsequent calls: resolve immediately
+          return Promise.resolve(["read"]);
+        }),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("coal-app", "agent-init", [
+        "agent-A",
+        "agent-B",
+      ]);
+
+      // Give async admission a tick to start both agents
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Resolve the shared promise
+      resolveFirst(["read"]);
+
+      await waitForAdmission(200);
+
+      // Both agents share owner "user-shared" + appId "coal-app" + resource "files".
+      // The handler should have been called only once (coalesced).
+      expect(callCount).toBe(1);
+    });
+  });
+
+  describe("findGrant set-containment", () => {
+    it("does not use existing grant when stored access is insufficient", async () => {
+      // Grant has ["read"] but required is ["read", "write"]
+      db._setGrantRow({ access: ["read"] });
+
+      const PERM_MANIFEST_SET = {
+        ...TEST_MANIFEST,
+        appId: "set-app",
+        permissions: {
+          required: [{ resource: "docs", access: ["read", "write"] }],
+          optional: [],
+        },
+      };
+      appHost.registerApp(PERM_MANIFEST_SET);
+      db._setAgentRows(TEST_AGENTS);
+
+      const handler: PermissionHandler = {
+        requestPermission: vi.fn().mockResolvedValue(["read", "write"]),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("set-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(handler.requestPermission).toHaveBeenCalled();
+    });
+
+    it("uses existing grant when stored access covers all required access", async () => {
+      // Grant has ["read", "write", "admin"] which covers ["read", "write"]
+      db._setGrantRow({ access: ["read", "write", "admin"] });
+
+      const PERM_MANIFEST_SET = {
+        ...TEST_MANIFEST,
+        appId: "set-app2",
+        permissions: {
+          required: [{ resource: "docs", access: ["read", "write"] }],
+          optional: [],
+        },
+      };
+      appHost.registerApp(PERM_MANIFEST_SET);
+      db._setAgentRows(TEST_AGENTS);
+
+      const handler: PermissionHandler = {
+        requestPermission: vi.fn(),
+      };
+      appHost.setPermissionHandler(handler);
+
+      await appHost.createSession("set-app2", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(handler.requestPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listGrants", () => {
+    it("returns empty array when no grants exist", async () => {
+      db._setGrantRows([]);
+      const result = await appHost.listGrants("user-1");
+      expect(result).toEqual([]);
+    });
+
+    it("returns mapped grant rows", async () => {
+      db._setGrantRows([
+        {
+          app_id: "app-1",
+          resource: "calendar",
+          access: ["read"],
+          granted_at: "2025-01-01T00:00:00.000Z",
+        },
+      ]);
+      const result = await appHost.listGrants("user-1");
+      expect(result).toEqual([
+        {
+          appId: "app-1",
+          resource: "calendar",
+          access: ["read"],
+          grantedAt: expect.any(String),
+        },
+      ]);
+    });
+
+    it("calls selectFrom with app_permission_grants", async () => {
+      db._setGrantRows([]);
+      await appHost.listGrants("user-1", "specific-app");
+      expect(db.selectFrom).toHaveBeenCalledWith("app_permission_grants");
+    });
+  });
+
+  describe("revokeGrant", () => {
+    it("returns delete result", async () => {
+      const result = await appHost.revokeGrant("user-1", "app-1", "calendar");
+      expect(result).toEqual({ numDeletedRows: 0n });
+      expect(db.deleteFrom).toHaveBeenCalledWith("app_permission_grants");
+    });
+  });
+
+  describe("rejectionCode in events", () => {
+    it("includes rejectionCode in participantRejected event data", async () => {
+      const manifest = {
+        ...TEST_MANIFEST,
+        appId: "rej-app",
+        permissions: {
+          required: [{ resource: "files", access: ["read"] }],
+          optional: [],
+        },
+      };
+      appHost.registerApp(manifest);
+      db._setAgentRows(TEST_AGENTS);
+
+      // No handler set — triggers "no_handler" rejection
+      await appHost.createSession("rej-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      const rejectionCall = broadcaster.sendToAgent.mock.calls.find(
+        (call: unknown[]) =>
+          (call[1] as Record<string, unknown>).event ===
+          "app/participantRejected",
+      );
+      expect(rejectionCall).toBeDefined();
+      const data = (
+        rejectionCall![1] as Record<string, Record<string, unknown>>
+      ).data!;
+      expect(data.rejectionCode).toBe("no_handler");
+    });
+
+    it("includes rejectionCode in logger output", async () => {
+      const manifest = {
+        ...TEST_MANIFEST,
+        appId: "log-app",
+        permissions: {
+          required: [{ resource: "files", access: ["read"] }],
+          optional: [],
+        },
+      };
+      appHost.registerApp(manifest);
+      db._setAgentRows(TEST_AGENTS);
+
+      await appHost.createSession("log-app", "agent-init", ["agent-2"]);
+      await waitForAdmission();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rejectionCode: "no_handler",
+          stage: "permission",
+        }),
+        "Agent rejected from app session",
+      );
+    });
+  });
+
+  describe("destroy", () => {
+    it("clears pending challenges", () => {
+      const challengeId = crypto.randomUUID();
+      getChallenges(appHost).set(challengeId, {
+        targetAgentId: "agent-2",
+        sessionId: "session-1",
+        resolve: vi.fn(),
+        reject: vi.fn(),
+        timer: setTimeout(() => {}, 30000),
+      });
+
+      appHost.destroy();
+      expect(getChallenges(appHost).size).toBe(0);
+    });
+  });
+});
+
+describe("DefaultPermissionHandler", () => {
+  let handler: DefaultPermissionHandler;
+  let broadcaster: ReturnType<typeof createMockBroadcaster>;
+  let logger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    broadcaster = createMockBroadcaster();
+    logger = createMockLogger();
+    handler = new DefaultPermissionHandler(
+      broadcaster as never,
+      logger as never,
+    );
+  });
+
+  describe("requestPermission", () => {
+    it("sends permissions/required event to the agent", async () => {
+      const promise = handler.requestPermission({
+        userId: "user-1",
+        agentId: "agent-1",
+        sessionId: "session-1",
+        appId: "app-1",
+        resource: "calendar",
+        access: ["read"],
+        timeoutMs: 5000,
+      });
+
+      handler.resolvePermission("user-1", "session-1", "agent-1", "calendar", [
+        "read",
+      ]);
+      await promise;
+
+      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
+        "agent-1",
+        expect.objectContaining({
+          event: "permissions/required",
+          data: expect.objectContaining({
+            sessionId: "session-1",
+            appId: "app-1",
+            resource: "calendar",
+            access: ["read"],
+            targetUserId: "user-1",
+          }),
+        }),
+      );
+    });
+
+    it("resolves with granted access", async () => {
+      const promise = handler.requestPermission({
+        userId: "user-1",
+        agentId: "agent-1",
+        sessionId: "session-1",
+        appId: "app-1",
+        resource: "calendar",
+        access: ["read"],
+        timeoutMs: 5000,
+      });
+
+      handler.resolvePermission("user-1", "session-1", "agent-1", "calendar", [
+        "read",
+        "write",
+      ]);
+
+      const result = await promise;
+      expect(result).toEqual(["read", "write"]);
+    });
+
+    it("rejects with PermissionTimeoutError on timeout", async () => {
+      vi.useFakeTimers();
+
+      const promise = handler.requestPermission({
+        userId: "user-1",
+        agentId: "agent-1",
+        sessionId: "session-1",
+        appId: "app-1",
+        resource: "calendar",
+        access: ["read"],
+        timeoutMs: 1000,
+      });
+
+      vi.advanceTimersByTime(1001);
+
+      await expect(promise).rejects.toThrow(PermissionTimeoutError);
+      await expect(promise).rejects.toThrow(
+        "Permission timeout for resource: calendar",
+      );
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("resolvePermission", () => {
+    it("ignores unknown permission key", () => {
+      handler.resolvePermission("user-1", "session-1", "agent-1", "unknown", [
+        "read",
+      ]);
+    });
+
+    it("rejects grant from wrong user", async () => {
+      const promise = handler.requestPermission({
+        userId: "user-1",
+        agentId: "agent-1",
+        sessionId: "session-1",
+        appId: "app-1",
+        resource: "calendar",
+        access: ["read"],
+        timeoutMs: 5000,
+      });
+
+      handler.resolvePermission(
+        "wrong-user",
+        "session-1",
+        "agent-1",
+        "calendar",
+        ["read"],
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expected: "user-1",
+          got: "wrong-user",
+        }),
+        "Permission grant from wrong user",
+      );
+
+      // Resolve correctly to avoid hanging
+      handler.resolvePermission("user-1", "session-1", "agent-1", "calendar", [
+        "read",
+      ]);
+      await promise;
+    });
+  });
+
+  describe("destroy", () => {
+    it("clears all pending permissions", () => {
+      // Start a request but don't resolve it
+      handler
+        .requestPermission({
+          userId: "user-1",
+          agentId: "agent-1",
+          sessionId: "session-1",
+          appId: "app-1",
+          resource: "calendar",
+          access: ["read"],
+          timeoutMs: 60000,
+        })
+        .catch(() => {}); // suppress unhandled rejection
+
+      handler.destroy();
+
+      const pendingMap = Reflect.get(handler, "pendingPermissions") as Map<
+        string,
+        unknown
+      >;
+      expect(pendingMap.size).toBe(0);
+    });
+  });
+});
+
+describe("PermissionDeniedError", () => {
+  it("has correct name and message", () => {
+    const err = new PermissionDeniedError("calendar");
+    expect(err.name).toBe("PermissionDeniedError");
+    expect(err.message).toBe("Permission denied for resource: calendar");
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe("PermissionTimeoutError", () => {
+  it("has correct name and message", () => {
+    const err = new PermissionTimeoutError("files");
+    expect(err.name).toBe("PermissionTimeoutError");
+    expect(err.message).toBe("Permission timeout for resource: files");
+    expect(err).toBeInstanceOf(Error);
   });
 });

--- a/packages/server/src/app/app-host.test.ts
+++ b/packages/server/src/app/app-host.test.ts
@@ -391,25 +391,7 @@ describe("AppHost", () => {
     });
   });
 
-  describe("setContactChecker", () => {
-    it("updates the checker", () => {
-      const checker: ContactChecker = {
-        areInContact: vi.fn().mockResolvedValue(true),
-      };
-      appHost.setContactChecker(checker);
-      expect(checker).toBeDefined();
-    });
-  });
-
-  describe("setPermissionHandler", () => {
-    it("sets the handler on AppHost", () => {
-      const handler: PermissionHandler = {
-        requestPermission: vi.fn().mockResolvedValue(["read"]),
-      };
-      appHost.setPermissionHandler(handler);
-      expect(handler).toBeDefined();
-    });
-  });
+  // setContactChecker and setPermissionHandler are exercised by the admission tests below
 
   describe("PermissionHandler integration", () => {
     const PERM_MANIFEST = {
@@ -446,115 +428,64 @@ describe("AppHost", () => {
       );
     });
 
-    it("rejects agent with 'no_handler' when no handler is configured", async () => {
-      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
+    it.each([
+      {
+        scenario: "no handler configured",
+        handler: undefined,
+        expectedCode: "no_handler",
+      },
+      {
+        scenario: "handler returns insufficient access",
+        handler: { requestPermission: vi.fn().mockResolvedValue(["read"]) },
+        expectedCode: "permission_denied",
+      },
+      {
+        scenario: "handler throws PermissionTimeoutError",
+        handler: {
+          requestPermission: vi
+            .fn()
+            .mockRejectedValue(new PermissionTimeoutError("calendar")),
+        },
+        expectedCode: "permission_timeout",
+      },
+      {
+        scenario: "handler throws PermissionDeniedError",
+        handler: {
+          requestPermission: vi
+            .fn()
+            .mockRejectedValue(new PermissionDeniedError("calendar")),
+        },
+        expectedCode: "permission_denied",
+      },
+      {
+        scenario: "handler throws unknown error",
+        handler: {
+          requestPermission: vi
+            .fn()
+            .mockRejectedValue(new Error("network error")),
+        },
+        expectedCode: "permission_denied",
+      },
+    ])(
+      "rejects with '$expectedCode' when $scenario",
+      async ({ handler, expectedCode }) => {
+        if (handler) appHost.setPermissionHandler(handler);
 
-      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
-        "agent-2",
-        expect.objectContaining({
-          event: "app/participantRejected",
-          data: expect.objectContaining({
-            rejectionCode: "no_handler",
-            stage: "permission",
+        await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
+        await waitForAdmission();
+
+        expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
+          "agent-2",
+          expect.objectContaining({
+            event: "app/participantRejected",
+            data: expect.objectContaining({
+              rejectionCode: expectedCode,
+              stage: "permission",
+            }),
           }),
-        }),
-      );
-    });
-
-    it("rejects agent when handler returns insufficient access", async () => {
-      const handler: PermissionHandler = {
-        requestPermission: vi.fn().mockResolvedValue(["read"]),
-      };
-      appHost.setPermissionHandler(handler);
-
-      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
-
-      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
-        "agent-2",
-        expect.objectContaining({
-          event: "app/participantRejected",
-          data: expect.objectContaining({
-            rejectionCode: "permission_denied",
-            stage: "permission",
-          }),
-        }),
-      );
-    });
-
-    it("rejects with 'permission_timeout' when handler throws PermissionTimeoutError", async () => {
-      const handler: PermissionHandler = {
-        requestPermission: vi
-          .fn()
-          .mockRejectedValue(new PermissionTimeoutError("calendar")),
-      };
-      appHost.setPermissionHandler(handler);
-
-      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
-
-      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
-        "agent-2",
-        expect.objectContaining({
-          event: "app/participantRejected",
-          data: expect.objectContaining({
-            rejectionCode: "permission_timeout",
-            stage: "permission",
-          }),
-        }),
-      );
-    });
-
-    it("rejects with 'permission_denied' when handler throws PermissionDeniedError", async () => {
-      const handler: PermissionHandler = {
-        requestPermission: vi
-          .fn()
-          .mockRejectedValue(new PermissionDeniedError("calendar")),
-      };
-      appHost.setPermissionHandler(handler);
-
-      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
-
-      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
-        "agent-2",
-        expect.objectContaining({
-          event: "app/participantRejected",
-          data: expect.objectContaining({
-            rejectionCode: "permission_denied",
-            stage: "permission",
-          }),
-        }),
-      );
-    });
-
-    it("rejects with 'permission_denied' on unknown handler error", async () => {
-      const handler: PermissionHandler = {
-        requestPermission: vi
-          .fn()
-          .mockRejectedValue(new Error("network error")),
-      };
-      appHost.setPermissionHandler(handler);
-
-      await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
-
-      expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
-        "agent-2",
-        expect.objectContaining({
-          event: "app/participantRejected",
-          data: expect.objectContaining({
-            rejectionCode: "permission_denied",
-            stage: "permission",
-          }),
-        }),
-      );
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.objectContaining({ err: "network error" }),
-        "Permission handler error",
-      );
-    });
+        );
+      },
+    );
 
     it("logs when requesting permission from handler", async () => {
       const handler: PermissionHandler = {
@@ -755,60 +686,6 @@ describe("AppHost", () => {
     it("calls deleteFrom on app_permission_grants", async () => {
       await appHost.revokeGrant("user-1", "app-1", "calendar");
       expect(db.deleteFrom).toHaveBeenCalledWith("app_permission_grants");
-    });
-  });
-
-  describe("rejectionCode in events", () => {
-    it("includes rejectionCode in participantRejected event data", async () => {
-      const manifest = {
-        ...TEST_MANIFEST,
-        appId: "rej-app",
-        permissions: {
-          required: [{ resource: "files", access: ["read"] }],
-          optional: [],
-        },
-      };
-      appHost.registerApp(manifest);
-      db._setAgentRows(TEST_AGENTS);
-
-      // No handler set — triggers "no_handler" rejection
-      await appHost.createSession("rej-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
-
-      const rejectionCall = broadcaster.sendToAgent.mock.calls.find(
-        (call: unknown[]) =>
-          (call[1] as Record<string, unknown>).event ===
-          "app/participantRejected",
-      );
-      expect(rejectionCall).toBeDefined();
-      const data = (
-        rejectionCall![1] as Record<string, Record<string, unknown>>
-      ).data!;
-      expect(data.rejectionCode).toBe("no_handler");
-    });
-
-    it("includes rejectionCode in logger output", async () => {
-      const manifest = {
-        ...TEST_MANIFEST,
-        appId: "log-app",
-        permissions: {
-          required: [{ resource: "files", access: ["read"] }],
-          optional: [],
-        },
-      };
-      appHost.registerApp(manifest);
-      db._setAgentRows(TEST_AGENTS);
-
-      await appHost.createSession("log-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
-
-      expect(logger.info).toHaveBeenCalledWith(
-        expect.objectContaining({
-          rejectionCode: "no_handler",
-          stage: "permission",
-        }),
-        "Agent rejected from app session",
-      );
     });
   });
 

--- a/packages/server/src/app/app-host.test.ts
+++ b/packages/server/src/app/app-host.test.ts
@@ -176,9 +176,33 @@ function getChallenges(host: AppHost): Map<string, Record<string, unknown>> {
   >;
 }
 
-/** Wait for async admission (admitAgentsAsync fires-and-forgets). */
-function waitForAdmission(ms = 150) {
-  return new Promise((r) => setTimeout(r, ms));
+/**
+ * Wait for async admission to complete by polling broadcaster calls.
+ * Looks for sessionReady, participantAdmitted, or participantRejected events
+ * which signal that admitAgentsAsync has finished processing.
+ * Falls back to a short timeout if no terminal event appears.
+ */
+async function waitForAdmission(
+  broadcasterMock: { sendToAgent: { mock: { calls: unknown[][] } } },
+  opts: { event?: string; maxMs?: number } = {},
+) {
+  const target = opts.event ?? "app/participantRejected";
+  const maxMs = opts.maxMs ?? 500;
+  const start = Date.now();
+  while (Date.now() - start < maxMs) {
+    const found = broadcasterMock.sendToAgent.mock.calls.some(
+      (call: unknown[]) => {
+        const frame = call[1] as Record<string, unknown> | undefined;
+        return (
+          frame?.event === target ||
+          frame?.event === "app/sessionReady" ||
+          frame?.event === "app/participantAdmitted"
+        );
+      },
+    );
+    if (found) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
 }
 
 const TEST_MANIFEST = {
@@ -380,7 +404,7 @@ describe("AppHost", () => {
       db._setAgentRows(TEST_AGENTS);
 
       await appHost.createSession("test-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
+      await waitForAdmission(broadcaster);
 
       expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
         "agent-2",
@@ -415,7 +439,7 @@ describe("AppHost", () => {
       appHost.setPermissionHandler(handler);
 
       await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
+      await waitForAdmission(broadcaster);
 
       expect(handler.requestPermission).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -472,7 +496,7 @@ describe("AppHost", () => {
         if (handler) appHost.setPermissionHandler(handler);
 
         await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-        await waitForAdmission();
+        await waitForAdmission(broadcaster);
 
         expect(broadcaster.sendToAgent).toHaveBeenCalledWith(
           "agent-2",
@@ -494,7 +518,7 @@ describe("AppHost", () => {
       appHost.setPermissionHandler(handler);
 
       await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
+      await waitForAdmission(broadcaster);
 
       expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -512,7 +536,7 @@ describe("AppHost", () => {
       appHost.setPermissionHandler(handler);
 
       await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
+      await waitForAdmission(broadcaster);
 
       expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -532,7 +556,7 @@ describe("AppHost", () => {
       appHost.setPermissionHandler(handler);
 
       await appHost.createSession("perm-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
+      await waitForAdmission(broadcaster);
 
       expect(handler.requestPermission).not.toHaveBeenCalled();
     });
@@ -580,13 +604,16 @@ describe("AppHost", () => {
         "agent-B",
       ]);
 
-      // Give async admission a tick to start both agents
-      await new Promise((r) => setTimeout(r, 50));
+      // Poll until the handler has been called (both agents started admission)
+      const start = Date.now();
+      while (callCount === 0 && Date.now() - start < 500) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
 
       // Resolve the shared promise
       resolveFirst(["read"]);
 
-      await waitForAdmission(200);
+      await waitForAdmission(broadcaster);
 
       // Both agents share owner "user-shared" + appId "coal-app" + resource "files".
       // The handler should have been called only once (coalesced).
@@ -616,7 +643,7 @@ describe("AppHost", () => {
       appHost.setPermissionHandler(handler);
 
       await appHost.createSession("set-app", "agent-init", ["agent-2"]);
-      await waitForAdmission();
+      await waitForAdmission(broadcaster);
 
       expect(handler.requestPermission).toHaveBeenCalled();
     });
@@ -642,7 +669,7 @@ describe("AppHost", () => {
       appHost.setPermissionHandler(handler);
 
       await appHost.createSession("set-app2", "agent-init", ["agent-2"]);
-      await waitForAdmission();
+      await waitForAdmission(broadcaster);
 
       expect(handler.requestPermission).not.toHaveBeenCalled();
     });

--- a/packages/server/src/app/app-host.test.ts
+++ b/packages/server/src/app/app-host.test.ts
@@ -752,9 +752,8 @@ describe("AppHost", () => {
   });
 
   describe("revokeGrant", () => {
-    it("returns delete result", async () => {
-      const result = await appHost.revokeGrant("user-1", "app-1", "calendar");
-      expect(result).toEqual({ numDeletedRows: 0n });
+    it("calls deleteFrom on app_permission_grants", async () => {
+      await appHost.revokeGrant("user-1", "app-1", "calendar");
       expect(db.deleteFrom).toHaveBeenCalledWith("app_permission_grants");
     });
   });
@@ -963,21 +962,20 @@ describe("DefaultPermissionHandler", () => {
   });
 
   describe("destroy", () => {
-    it("clears all pending permissions", () => {
-      // Start a request but don't resolve it
-      handler
-        .requestPermission({
-          userId: "user-1",
-          agentId: "agent-1",
-          sessionId: "session-1",
-          appId: "app-1",
-          resource: "calendar",
-          access: ["read"],
-          timeoutMs: 60000,
-        })
-        .catch(() => {}); // suppress unhandled rejection
+    it("rejects pending promises and clears map", async () => {
+      const promise = handler.requestPermission({
+        userId: "user-1",
+        agentId: "agent-1",
+        sessionId: "session-1",
+        appId: "app-1",
+        resource: "calendar",
+        access: ["read"],
+        timeoutMs: 60000,
+      });
 
       handler.destroy();
+
+      await expect(promise).rejects.toThrow(PermissionDeniedError);
 
       const pendingMap = Reflect.get(handler, "pendingPermissions") as Map<
         string,

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -5,7 +5,7 @@ import type { ConnectionManager } from "../ws/connection.js";
 import type { ConversationService } from "../services/conversation.service.js";
 import type { Logger } from "../logger.js";
 import type { AppManifest, AppSession } from "@moltzap/protocol";
-import { ErrorCodes, eventFrame } from "@moltzap/protocol";
+import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
 import { RpcError } from "../rpc/router.js";
 
 function errorMessage(err: unknown): string {
@@ -100,7 +100,7 @@ export class DefaultPermissionHandler implements PermissionHandler {
 
       this.broadcaster.sendToAgent(
         params.agentId,
-        eventFrame("permissions/required", {
+        eventFrame(EventNames.PermissionsRequired, {
           sessionId: params.sessionId,
           appId: params.appId,
           resource: params.resource,
@@ -145,6 +145,7 @@ export class DefaultPermissionHandler implements PermissionHandler {
   destroy(): void {
     for (const pending of this.pendingPermissions.values()) {
       clearTimeout(pending.timer);
+      pending.reject("shutdown");
     }
     this.pendingPermissions.clear();
   }
@@ -373,15 +374,13 @@ export class AppHost {
     userId: string,
     appId: string,
     resource: string,
-  ): Promise<{ numDeletedRows: bigint }> {
-    const result = await this.db
+  ): Promise<void> {
+    await this.db
       .deleteFrom("app_permission_grants")
       .where("user_id", "=", userId)
       .where("app_id", "=", appId)
       .where("resource", "=", resource)
       .executeTakeFirst();
-
-    return { numDeletedRows: result.numDeletedRows };
   }
 
   private subscribeToConversation(agentId: string, convId: string): void {
@@ -711,14 +710,6 @@ export class AppHost {
         const returnedSet = new Set(access);
         const covers = perm.access.every((a) => returnedSet.has(a));
         if (!covers) {
-          await this.rejectAgent(
-            session.id,
-            agentId,
-            "permission",
-            `Insufficient access granted for resource: ${perm.resource}`,
-            `Required: ${perm.access.join(", ")}; granted: ${access.join(", ")}`,
-            "permission_denied",
-          );
           throw new PermissionDeniedError(perm.resource);
         }
 

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -470,13 +470,33 @@ export class AppHost {
       return;
     }
 
-    // Identity and capability checks are independent — run concurrently
-    await Promise.all([
-      this.checkIdentity(session, initiatorAgentId, agentId, agentMap),
+    // Identity and capability checks are independent — run concurrently.
+    // Track whether we've already rejected this agent so concurrent failures
+    // don't send duplicate rejection events.
+    let rejected = false;
+    const guardedReject = async (
+      ...args: Parameters<typeof this.rejectAgent>
+    ) => {
+      if (rejected) return;
+      rejected = true;
+      await this.rejectAgent(...args);
+    };
+
+    const [identityResult, capabilityResult] = await Promise.allSettled([
+      this.checkIdentity(
+        session,
+        initiatorAgentId,
+        agentId,
+        agentMap,
+        guardedReject,
+      ),
       manifest.skillUrl
-        ? this.checkCapability(session, agentId, manifest)
+        ? this.checkCapability(session, agentId, manifest, guardedReject)
         : Promise.resolve(),
     ]);
+
+    if (identityResult.status === "rejected") throw identityResult.reason;
+    if (capabilityResult.status === "rejected") throw capabilityResult.reason;
 
     const grantedResources = await this.checkPermissions(
       session,
@@ -496,12 +516,13 @@ export class AppHost {
       string,
       { id: string; owner_user_id: string | null; status: string }
     >,
+    reject: typeof this.rejectAgent = this.rejectAgent.bind(this),
   ): Promise<void> {
     const agent = agentMap.get(agentId)!;
     const initiator = agentMap.get(initiatorAgentId)!;
 
     if (!agent.owner_user_id) {
-      await this.rejectAgent(
+      await reject(
         session.id,
         agentId,
         "identity",
@@ -520,7 +541,7 @@ export class AppHost {
         agent.owner_user_id,
       );
       if (!inContact) {
-        await this.rejectAgent(
+        await reject(
           session.id,
           agentId,
           "identity",
@@ -532,7 +553,7 @@ export class AppHost {
       }
     } catch (err) {
       if (errorMessage(err) === "Not in contacts") throw err;
-      await this.rejectAgent(
+      await reject(
         session.id,
         agentId,
         "identity",
@@ -548,26 +569,26 @@ export class AppHost {
     session: AppSession,
     agentId: string,
     manifest: AppManifest,
+    reject: typeof this.rejectAgent = this.rejectAgent.bind(this),
   ): Promise<void> {
     const challengeId = crypto.randomUUID();
     const timeoutMs = manifest.challengeTimeoutMs ?? 30000;
 
     const result = await new Promise<{ skillUrl: string; version: string }>(
-      (resolve, reject) => {
+      (resolve, promiseReject) => {
         const timer = setTimeout(() => {
           this.pendingChallenges.delete(challengeId);
-          reject(new Error("attestation timeout"));
+          promiseReject(new Error("attestation timeout"));
         }, timeoutMs);
 
         this.pendingChallenges.set(challengeId, {
           targetAgentId: agentId,
           sessionId: session.id,
           resolve,
-          reject: (reason: string) => reject(new Error(reason)),
+          reject: (reason: string) => promiseReject(new Error(reason)),
           timer,
         });
 
-        // Send challenge to the agent
         this.broadcaster.sendToAgent(
           agentId,
           eventFrame("app/skillChallenge", {
@@ -588,7 +609,7 @@ export class AppHost {
         errorMessage(err) === "attestation timeout"
           ? "Skill attestation timed out"
           : `Skill attestation failed: ${errorMessage(err)}`;
-      await this.rejectAgent(
+      await reject(
         session.id,
         agentId,
         "capability",
@@ -599,9 +620,8 @@ export class AppHost {
       throw err;
     });
 
-    // Verify the attestation
     if (result.skillUrl !== manifest.skillUrl) {
-      await this.rejectAgent(
+      await reject(
         session.id,
         agentId,
         "capability",
@@ -613,7 +633,7 @@ export class AppHost {
     }
 
     if (manifest.skillMinVersion && result.version < manifest.skillMinVersion) {
-      await this.rejectAgent(
+      await reject(
         session.id,
         agentId,
         "capability",

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -339,6 +339,7 @@ export class AppHost {
       clearTimeout(pending.timer);
     }
     this.pendingChallenges.clear();
+    this.inflightPermissions.clear();
   }
 
   async listGrants(
@@ -463,6 +464,8 @@ export class AppHost {
         agentId,
         "identity",
         "Agent not found",
+        undefined,
+        "identity_rejected",
       );
       return;
     }
@@ -504,6 +507,7 @@ export class AppHost {
         "identity",
         "Agent has no owner_user_id",
         "Set owner_user_id on the agent before inviting it to app sessions",
+        "identity_rejected",
       );
       throw new Error("Agent has no owner");
     }
@@ -521,6 +525,8 @@ export class AppHost {
           agentId,
           "identity",
           "Agent owner is not a contact of the session initiator's owner",
+          undefined,
+          "identity_rejected",
         );
         throw new Error("Not in contacts");
       }
@@ -531,6 +537,8 @@ export class AppHost {
         agentId,
         "identity",
         `ContactChecker error: ${errorMessage(err)}`,
+        undefined,
+        "identity_rejected",
       );
       throw err;
     }
@@ -572,6 +580,10 @@ export class AppHost {
         );
       },
     ).catch(async (err) => {
+      const code =
+        errorMessage(err) === "attestation timeout"
+          ? "capability_timeout"
+          : "capability_failed";
       const reason =
         errorMessage(err) === "attestation timeout"
           ? "Skill attestation timed out"
@@ -582,6 +594,7 @@ export class AppHost {
         "capability",
         reason,
         `Install the skill from ${manifest.skillUrl} and ensure version >= ${manifest.skillMinVersion ?? "any"}`,
+        code,
       );
       throw err;
     });
@@ -593,6 +606,8 @@ export class AppHost {
         agentId,
         "capability",
         `Skill URL mismatch: expected ${manifest.skillUrl}, got ${result.skillUrl}`,
+        undefined,
+        "capability_failed",
       );
       throw new Error("Skill mismatch");
     }
@@ -603,6 +618,8 @@ export class AppHost {
         agentId,
         "capability",
         `Skill version ${result.version} below minimum ${manifest.skillMinVersion}`,
+        undefined,
+        "capability_failed",
       );
       throw new Error("Skill version too low");
     }

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -16,6 +16,32 @@ export interface ContactChecker {
   areInContact(userIdA: string, userIdB: string): Promise<boolean>;
 }
 
+export interface PermissionHandler {
+  requestPermission(params: {
+    userId: string;
+    agentId: string;
+    sessionId: string;
+    appId: string;
+    resource: string;
+    access: string[];
+    timeoutMs: number;
+  }): Promise<string[]>;
+}
+
+export class PermissionDeniedError extends Error {
+  constructor(resource: string) {
+    super(`Permission denied for resource: ${resource}`);
+    this.name = "PermissionDeniedError";
+  }
+}
+
+export class PermissionTimeoutError extends Error {
+  constructor(resource: string) {
+    super(`Permission timeout for resource: ${resource}`);
+    this.name = "PermissionTimeoutError";
+  }
+}
+
 interface PendingChallenge {
   targetAgentId: string;
   sessionId: string;
@@ -35,11 +61,101 @@ interface PendingPermission {
   timer: ReturnType<typeof setTimeout>;
 }
 
+export class DefaultPermissionHandler implements PermissionHandler {
+  private pendingPermissions = new Map<string, PendingPermission>();
+
+  constructor(
+    private broadcaster: Broadcaster,
+    private logger: Logger,
+  ) {}
+
+  async requestPermission(params: {
+    userId: string;
+    agentId: string;
+    sessionId: string;
+    appId: string;
+    resource: string;
+    access: string[];
+    timeoutMs: number;
+  }): Promise<string[]> {
+    const requestId = crypto.randomUUID();
+    const key = `${params.sessionId}:${params.agentId}:${params.resource}`;
+
+    return new Promise<string[]>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingPermissions.delete(key);
+        reject(new PermissionTimeoutError(params.resource));
+      }, params.timeoutMs);
+
+      this.pendingPermissions.set(key, {
+        targetUserId: params.userId,
+        agentId: params.agentId,
+        sessionId: params.sessionId,
+        appId: params.appId,
+        resource: params.resource,
+        resolve,
+        reject: (reason: string) => reject(new PermissionDeniedError(reason)),
+        timer,
+      });
+
+      this.broadcaster.sendToAgent(
+        params.agentId,
+        eventFrame("permissions/required", {
+          sessionId: params.sessionId,
+          appId: params.appId,
+          resource: params.resource,
+          access: params.access,
+          requestId,
+          targetUserId: params.userId,
+        }),
+      );
+    });
+  }
+
+  resolvePermission(
+    callerUserId: string,
+    sessionId: string,
+    agentId: string,
+    resource: string,
+    access: string[],
+  ): void {
+    const key = `${sessionId}:${agentId}:${resource}`;
+    const pending = this.pendingPermissions.get(key);
+    if (!pending) return;
+
+    if (pending.targetUserId !== callerUserId) {
+      this.logger.warn(
+        {
+          expected: pending.targetUserId,
+          got: callerUserId,
+          agentId,
+          sessionId,
+          resource,
+        },
+        "Permission grant from wrong user",
+      );
+      return;
+    }
+
+    clearTimeout(pending.timer);
+    this.pendingPermissions.delete(key);
+    pending.resolve(access);
+  }
+
+  destroy(): void {
+    for (const pending of this.pendingPermissions.values()) {
+      clearTimeout(pending.timer);
+    }
+    this.pendingPermissions.clear();
+  }
+}
+
 export class AppHost {
   private pendingChallenges = new Map<string, PendingChallenge>();
-  private pendingPermissions = new Map<string, PendingPermission>();
   private manifests = new Map<string, AppManifest>();
   private contactChecker: ContactChecker | null = null;
+  private permissionHandler: PermissionHandler | null = null;
+  private inflightPermissions = new Map<string, Promise<string[]>>();
 
   constructor(
     private db: Kysely<Database>,
@@ -60,6 +176,10 @@ export class AppHost {
 
   setContactChecker(checker: ContactChecker): void {
     this.contactChecker = checker;
+  }
+
+  setPermissionHandler(handler: PermissionHandler): void {
+    this.permissionHandler = handler;
   }
 
   async createSession(
@@ -212,46 +332,56 @@ export class AppHost {
     pending.resolve({ skillUrl, version });
   }
 
-  resolvePermission(
-    callerUserId: string,
-    sessionId: string,
-    agentId: string,
-    resource: string,
-    access: string[],
-  ): void {
-    const key = `${sessionId}:${agentId}:${resource}`;
-    const pending = this.pendingPermissions.get(key);
-    if (!pending) return;
-
-    if (pending.targetUserId !== callerUserId) {
-      this.logger.warn(
-        {
-          expected: pending.targetUserId,
-          got: callerUserId,
-          agentId,
-          sessionId,
-          resource,
-        },
-        "Permission grant from wrong user",
-      );
-      return;
-    }
-
-    clearTimeout(pending.timer);
-    this.pendingPermissions.delete(key);
-    pending.resolve(access);
-  }
-
   /** Cancel all pending timers. Called on shutdown. */
   destroy(): void {
     for (const pending of this.pendingChallenges.values()) {
       clearTimeout(pending.timer);
     }
     this.pendingChallenges.clear();
-    for (const pending of this.pendingPermissions.values()) {
-      clearTimeout(pending.timer);
+  }
+
+  async listGrants(
+    userId: string,
+    appId?: string,
+  ): Promise<
+    Array<{
+      appId: string;
+      resource: string;
+      access: string[];
+      grantedAt: string;
+    }>
+  > {
+    let query = this.db
+      .selectFrom("app_permission_grants")
+      .select(["app_id", "resource", "access", "granted_at"])
+      .where("user_id", "=", userId);
+
+    if (appId) {
+      query = query.where("app_id", "=", appId);
     }
-    this.pendingPermissions.clear();
+
+    const rows = await query.execute();
+    return rows.map((r) => ({
+      appId: r.app_id,
+      resource: r.resource,
+      access: r.access,
+      grantedAt: new Date(r.granted_at).toISOString(),
+    }));
+  }
+
+  async revokeGrant(
+    userId: string,
+    appId: string,
+    resource: string,
+  ): Promise<{ numDeletedRows: bigint }> {
+    const result = await this.db
+      .deleteFrom("app_permission_grants")
+      .where("user_id", "=", userId)
+      .where("app_id", "=", appId)
+      .where("resource", "=", resource)
+      .executeTakeFirst();
+
+    return { numDeletedRows: result.numDeletedRows };
   }
 
   private subscribeToConversation(agentId: string, convId: string): void {
@@ -483,14 +613,21 @@ export class AppHost {
     userId: string,
     appId: string,
     resource: string,
+    requiredAccess: string[],
   ): Promise<{ access: string[] } | undefined> {
-    return this.db
+    const row = await this.db
       .selectFrom("app_permission_grants")
       .select("access")
       .where("user_id", "=", userId)
       .where("app_id", "=", appId)
       .where("resource", "=", resource)
       .executeTakeFirst();
+
+    if (!row) return undefined;
+    // Set-containment: stored access must cover ALL required access
+    const stored = new Set(row.access);
+    const covers = requiredAccess.every((a) => stored.has(a));
+    return covers ? row : undefined;
   }
 
   private async checkPermissions(
@@ -511,6 +648,7 @@ export class AppHost {
         ownerUserId,
         session.appId,
         perm.resource,
+        perm.access,
       );
 
       if (existing) {
@@ -518,41 +656,71 @@ export class AppHost {
         continue;
       }
 
-      const permKey = `${session.id}:${agentId}:${perm.resource}`;
-      const requestId = crypto.randomUUID();
-      const timeoutMs = manifest.permissionTimeoutMs ?? 120000;
+      if (!this.permissionHandler) {
+        await this.rejectAgent(
+          session.id,
+          agentId,
+          "permission",
+          `No permission handler configured for resource: ${perm.resource}`,
+          "Server must configure a PermissionHandler to process permission requests",
+          "no_handler",
+        );
+        throw new Error("No permission handler");
+      }
 
-      try {
-        const access = await new Promise<string[]>((resolve, reject) => {
-          const timer = setTimeout(() => {
-            this.pendingPermissions.delete(permKey);
-            reject(new Error("permission timeout"));
-          }, timeoutMs);
+      // Coalescing: same userId+appId+resource reuses in-flight promise
+      const coalesceKey = `${ownerUserId}:${session.appId}:${perm.resource}`;
 
-          this.pendingPermissions.set(permKey, {
-            targetUserId: ownerUserId,
+      if (!this.inflightPermissions.has(coalesceKey)) {
+        this.logger.info(
+          {
+            sessionId: session.id,
+            appId: session.appId,
+            resource: perm.resource,
+            agentId,
+          },
+          "Requesting permission from handler",
+        );
+
+        const promise = this.permissionHandler
+          .requestPermission({
+            userId: ownerUserId,
             agentId,
             sessionId: session.id,
             appId: session.appId,
             resource: perm.resource,
-            resolve,
-            reject: (reason: string) => reject(new Error(reason)),
-            timer,
+            access: perm.access,
+            timeoutMs: manifest.permissionTimeoutMs ?? 120000,
+          })
+          .finally(() => {
+            this.inflightPermissions.delete(coalesceKey);
           });
 
-          // Send permission request to the agent (agent's owner grants via apps/grantPermission)
-          this.broadcaster.sendToAgent(
+        this.inflightPermissions.set(coalesceKey, promise);
+      }
+
+      try {
+        const access = await this.inflightPermissions.get(coalesceKey)!;
+
+        this.logger.info(
+          { sessionId: session.id, resource: perm.resource, access },
+          "Permission handler responded",
+        );
+
+        // Post-handler validation: returned access must cover required access
+        const returnedSet = new Set(access);
+        const covers = perm.access.every((a) => returnedSet.has(a));
+        if (!covers) {
+          await this.rejectAgent(
+            session.id,
             agentId,
-            eventFrame("app/permissionRequest", {
-              sessionId: session.id,
-              appId: session.appId,
-              resource: perm.resource,
-              access: perm.access,
-              requestId,
-              targetUserId: ownerUserId,
-            }),
+            "permission",
+            `Insufficient access granted for resource: ${perm.resource}`,
+            `Required: ${perm.access.join(", ")}; granted: ${access.join(", ")}`,
+            "permission_denied",
           );
-        });
+          throw new PermissionDeniedError(perm.resource);
+        }
 
         // Store the grant
         await this.db
@@ -572,18 +740,53 @@ export class AppHost {
 
         granted.push(perm.resource);
       } catch (err) {
-        this.logger.warn(
-          { err, sessionId: session.id, resource: perm.resource },
-          "Permission grant failed",
+        this.inflightPermissions.delete(coalesceKey);
+
+        if (
+          err instanceof PermissionDeniedError ||
+          err instanceof PermissionTimeoutError
+        ) {
+          const code =
+            err instanceof PermissionTimeoutError
+              ? "permission_timeout"
+              : "permission_denied";
+          this.logger.warn(
+            {
+              err: err.message,
+              sessionId: session.id,
+              resource: perm.resource,
+            },
+            "Permission request failed",
+          );
+          await this.rejectAgent(
+            session.id,
+            agentId,
+            "permission",
+            err.message,
+            `Grant ${perm.resource} access via the permission prompt`,
+            code,
+          );
+          throw err;
+        }
+
+        // Unknown error from handler
+        this.logger.error(
+          {
+            err: errorMessage(err),
+            sessionId: session.id,
+            resource: perm.resource,
+          },
+          "Permission handler error",
         );
         await this.rejectAgent(
           session.id,
           agentId,
           "permission",
-          `Permission timeout for resource: ${perm.resource}`,
+          `Permission handler error for resource: ${perm.resource}`,
           `Grant ${perm.resource} access via the permission prompt`,
+          "permission_denied",
         );
-        throw new Error("Permission denied");
+        throw new PermissionDeniedError(perm.resource);
       }
     }
 
@@ -592,6 +795,7 @@ export class AppHost {
         ownerUserId,
         session.appId,
         perm.resource,
+        perm.access,
       );
 
       if (existing) {
@@ -656,6 +860,7 @@ export class AppHost {
     stage: "identity" | "capability" | "permission",
     reason: string,
     suggestedAction?: string,
+    rejectionCode?: string,
   ): Promise<void> {
     await this.db
       .updateTable("app_session_participants")
@@ -672,11 +877,12 @@ export class AppHost {
         reason,
         stage,
         suggestedAction,
+        rejectionCode,
       }),
     );
 
     this.logger.info(
-      { sessionId, agentId, stage, reason },
+      { sessionId, agentId, stage, reason, rejectionCode },
       "Agent rejected from app session",
     );
   }

--- a/packages/server/src/app/handlers/apps.handlers.ts
+++ b/packages/server/src/app/handlers/apps.handlers.ts
@@ -1,4 +1,5 @@
 import type { AppHost } from "../app-host.js";
+import type { DefaultPermissionHandler } from "../app-host.js";
 import type { RpcMethodRegistry } from "../../rpc/context.js";
 import type {
   AppsCreateParams,
@@ -11,6 +12,7 @@ import { ParticipantService } from "../../services/participant.service.js";
 
 export function createAppHandlers(deps: {
   appHost: AppHost;
+  permissionHandler?: DefaultPermissionHandler;
 }): RpcMethodRegistry {
   return {
     "apps/create": defineMethod<AppsCreateParams>({
@@ -45,7 +47,7 @@ export function createAppHandlers(deps: {
       handler: async (params, ctx) => {
         const ownerUserId = ParticipantService.requireOwnerId(ctx);
 
-        deps.appHost.resolvePermission(
+        deps.permissionHandler?.resolvePermission(
           ownerUserId,
           params.sessionId,
           params.agentId,

--- a/packages/server/src/app/handlers/apps.handlers.ts
+++ b/packages/server/src/app/handlers/apps.handlers.ts
@@ -1,5 +1,4 @@
-import type { AppHost } from "../app-host.js";
-import type { DefaultPermissionHandler } from "../app-host.js";
+import type { AppHost, DefaultPermissionHandler } from "../app-host.js";
 import type { RpcMethodRegistry } from "../../rpc/context.js";
 import type {
   AppsCreateParams,

--- a/packages/server/src/app/handlers/apps.handlers.ts
+++ b/packages/server/src/app/handlers/apps.handlers.ts
@@ -3,7 +3,7 @@ import type { RpcMethodRegistry } from "../../rpc/context.js";
 import type {
   AppsCreateParams,
   AppsAttestSkillParams,
-  AppsGrantPermissionParams,
+  PermissionsGrantParams,
 } from "@moltzap/protocol";
 import { validators } from "@moltzap/protocol";
 import { defineMethod } from "../../rpc/context.js";
@@ -40,8 +40,8 @@ export function createAppHandlers(deps: {
       },
     }),
 
-    "apps/grantPermission": defineMethod<AppsGrantPermissionParams>({
-      validator: validators.appsGrantPermissionParams,
+    "apps/grantPermission": defineMethod<PermissionsGrantParams>({
+      validator: validators.permissionsGrantParams,
       handler: async (params, ctx) => {
         const ownerUserId = ParticipantService.requireOwnerId(ctx);
 

--- a/packages/server/src/app/handlers/apps.handlers.ts
+++ b/packages/server/src/app/handlers/apps.handlers.ts
@@ -5,6 +5,8 @@ import type {
   AppsCreateParams,
   AppsAttestSkillParams,
   PermissionsGrantParams,
+  PermissionsListParams,
+  PermissionsRevokeParams,
 } from "@moltzap/protocol";
 import { validators } from "@moltzap/protocol";
 import { defineMethod } from "../../rpc/context.js";
@@ -42,7 +44,7 @@ export function createAppHandlers(deps: {
       },
     }),
 
-    "apps/grantPermission": defineMethod<PermissionsGrantParams>({
+    "permissions/grant": defineMethod<PermissionsGrantParams>({
       validator: validators.permissionsGrantParams,
       handler: async (params, ctx) => {
         const ownerUserId = ParticipantService.requireOwnerId(ctx);
@@ -55,6 +57,28 @@ export function createAppHandlers(deps: {
           params.access,
         );
 
+        return {};
+      },
+    }),
+
+    "permissions/list": defineMethod<PermissionsListParams>({
+      validator: validators.permissionsListParams,
+      handler: async (params, ctx) => {
+        const ownerUserId = ParticipantService.requireOwnerId(ctx);
+        const grants = await deps.appHost.listGrants(ownerUserId, params.appId);
+        return { grants };
+      },
+    }),
+
+    "permissions/revoke": defineMethod<PermissionsRevokeParams>({
+      validator: validators.permissionsRevokeParams,
+      handler: async (params, ctx) => {
+        const ownerUserId = ParticipantService.requireOwnerId(ctx);
+        await deps.appHost.revokeGrant(
+          ownerUserId,
+          params.appId,
+          params.resource,
+        );
         return {};
       },
     }),

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -34,7 +34,7 @@ import { createPresenceHandlers } from "./handlers/presence.handlers.js";
 import { createAppHandlers } from "./handlers/apps.handlers.js";
 
 // AppHost
-import { AppHost } from "./app-host.js";
+import { AppHost, DefaultPermissionHandler } from "./app-host.js";
 
 import type { CoreConfig, CoreApp, ConnectionHook } from "./types.js";
 import { runDemoAgents } from "./demo-agents.js";
@@ -88,6 +88,12 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     logger,
   );
 
+  const defaultPermissionHandler = new DefaultPermissionHandler(
+    broadcaster,
+    logger,
+  );
+  appHost.setPermissionHandler(defaultPermissionHandler);
+
   // Per-request connection context for concurrent WebSocket RPC dispatches
   const connIdContext = new AsyncLocalStorage<string>();
 
@@ -121,7 +127,10 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       connections,
       getConnId: () => connIdContext.getStore() ?? "",
     }),
-    ...createAppHandlers({ appHost }),
+    ...createAppHandlers({
+      appHost,
+      permissionHandler: defaultPermissionHandler,
+    }),
   };
 
   const dispatch = createRpcRouter(methods);
@@ -313,10 +322,14 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     setContactChecker(checker) {
       appHost.setContactChecker(checker);
     },
+    setPermissionHandler(handler) {
+      appHost.setPermissionHandler(handler);
+    },
     async createAppSession(appId, initiatorAgentId, invitedAgentIds) {
       return appHost.createSession(appId, initiatorAgentId, invitedAgentIds);
     },
     async close() {
+      defaultPermissionHandler.destroy();
       appHost.destroy();
       for (const conn of connections.all()) {
         try {

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -1,7 +1,7 @@
 import type { Hono } from "hono";
 import type { RpcMethodDef } from "../rpc/context.js";
 import type { AppManifest, AppSession } from "@moltzap/protocol";
-import type { ContactChecker } from "./app-host.js";
+import type { ContactChecker, PermissionHandler } from "./app-host.js";
 
 export interface CoreConfig {
   databaseUrl: string;
@@ -24,6 +24,7 @@ export interface CoreApp {
   onConnection: (hook: ConnectionHook) => void;
   registerApp: (manifest: AppManifest) => void;
   setContactChecker: (checker: ContactChecker) => void;
+  setPermissionHandler: (handler: PermissionHandler) => void;
   createAppSession: (
     appId: string,
     initiatorAgentId: string,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,8 +1,13 @@
 // @moltzap/server-core — building blocks for agent-to-agent messaging
 
 // AppHost
-export { AppHost } from "./app/app-host.js";
-export type { ContactChecker } from "./app/app-host.js";
+export {
+  AppHost,
+  DefaultPermissionHandler,
+  PermissionDeniedError,
+  PermissionTimeoutError,
+} from "./app/app-host.js";
+export type { ContactChecker, PermissionHandler } from "./app/app-host.js";
 
 // Services
 export { AuthService } from "./services/auth.service.js";

--- a/packages/server/src/test-utils/index.ts
+++ b/packages/server/src/test-utils/index.ts
@@ -189,6 +189,14 @@ export function getCoreDb(): Kysely<Database> {
   return resetDb;
 }
 
+export function getCoreApp(): CoreApp {
+  if (!coreApp)
+    throw new Error(
+      "Test server not running. Call startCoreTestServer() first.",
+    );
+  return coreApp;
+}
+
 export function getBaseUrl(): string {
   if (!_baseUrl) throw new Error("Test server not running.");
   return _baseUrl;


### PR DESCRIPTION
## Summary

- Move permission system from `app/*` namespace to `permissions/*` namespace
- Replace inline `pendingPermissions` + `resolvePermission()` + `broadcaster.sendToAgent()` flow with externalized `PermissionHandler` interface (same pattern as `ContactChecker`)
- Add `DefaultPermissionHandler` that preserves the current broadcaster-based flow
- Add `permissions/list` and `permissions/revoke` RPCs
- Add `onPermissionRequired` handler + `grantPermission()` convenience method to client SDK
- Add typed permission errors (`PermissionDeniedError`, `PermissionTimeoutError`)
- Add permission prompt coalescing (same user+app+resource shares one handler call)
- Add post-handler access validation and set-containment checking for cached grants
- Add `rejectionCode` to all rejection events (identity, capability, permission stages)
- Prevent double-rejection when concurrent identity+capability checks both fail

## Changes by package

**@moltzap/protocol**
- Rename `AppPermissionRequest` event to `PermissionsRequired` (`permissions/required`)
- Rename `AppsGrantPermission` schemas to `PermissionsGrant`
- Add `PermissionsList`, `PermissionsRevoke` param/result schemas
- Add `rejectionCode` optional stringEnum to `AppParticipantRejectedEventSchema`
- Use `DateTimeString` for `grantedAt` in list results

**@moltzap/server-core**
- Add `PermissionHandler` interface, `DefaultPermissionHandler` class
- Add `PermissionDeniedError`, `PermissionTimeoutError` typed errors
- Refactor `AppHost.checkPermissions()` to use handler interface with logging, coalescing, and post-handler validation
- Fix `findGrant()` to use set-containment (stored access must cover all required access)
- Add `listGrants()`, `revokeGrant()` on AppHost
- Add `permissions/grant`, `permissions/list`, `permissions/revoke` RPC handlers
- Wire `setPermissionHandler` on `CoreApp` interface
- Prevent double-rejection on concurrent identity+capability failures

**@moltzap/client**
- Add `on("permissionRequired", handler)` to `MoltZapService`
- Add `grantPermission()` convenience method
- Add `onPermissionRequired` hook to `MoltZapChannelCore`
- Export `PermissionRequiredData` type

**Documentation**
- Update building-apps guide with PermissionHandler pattern, end-to-end example
- Add AppHost/DefaultPermissionHandler to server overview
- Add app events to protocol events overview
- Add Building Apps link to extending guide

## Test plan

- [x] 38 unit tests in `app-host.test.ts` (handler integration, coalescing, set-containment, typed errors, rejection codes, DefaultPermissionHandler)
- [x] 6 integration tests in `30-permissions.integration.test.ts` against real Postgres (grant flow, cache reuse, list/revoke RPCs, timeout rejection, partial grant re-prompt)
- [x] 3 client tests for `onPermissionRequired` and `grantPermission()`
- [x] All 334 tests pass across all packages
- [x] `pnpm build && pnpm lint && pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)