### PR TITLE
docs: add root CLAUDE.md and per-package CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# MoltZap
+
+Agent-to-agent messaging protocol and server. Monorepo managed with pnpm workspaces.
+
+## Monorepo Structure
+
+```
+packages/
+  protocol/        — TypeBox schemas, AJV validators, protocol source of truth (leaf dependency)
+  server/          — Server-core: services, RPC router, WebSocket, encryption, database
+  client/          — Client SDK: MoltZapService, MoltZapChannelCore, CLI (`moltzap`)
+  openclaw-channel/ — OpenClaw gateway plugin (bridges MoltZap into OpenClaw agents)
+  nanoclaw-channel/ — Nanoclaw lightweight adapter (smoke test package, not published)
+  evals/           — E2E evaluation framework with LLM judges and Docker-managed agent fleets
+  create-moltzap-server/ — Scaffolding CLI (private)
+docs/              — Mintlify documentation site (75+ MDX pages)
+scripts/           — CI/pre-commit guards (sloppy-code-guard.sh, version computation)
+```
+
+## Build Order
+
+`protocol` must build first — every other package depends on it.
+
+```
+pnpm install        # install all workspace dependencies
+pnpm build          # build all packages (protocol first via dependency graph)
+```
+
+## Common Commands
+
+```
+pnpm test           # unit tests (all packages, vitest)
+pnpm typecheck      # tsc --noEmit (all packages except create-moltzap-server)
+pnpm lint           # oxlint
+pnpm format         # oxfmt (auto-fix)
+pnpm format:check   # oxfmt (check only)
+pnpm check          # lint + format:check
+pnpm docs           # start Mintlify dev server at localhost:3333
+pnpm docs:generate  # regenerate protocol reference docs from TypeBox schemas
+pnpm docs:check:drift  # verify protocol docs match current schemas (CI check)
+```
+
+## Test Infrastructure
+
+- **Runner:** vitest v3
+- **Unit tests:** `pnpm test` in each package (or `pnpm -r test` from root)
+- **Integration tests:** `pnpm test:integration` in server, client, openclaw-channel, evals
+- **Integration test DB:** PGlite/testcontainers spin up real PostgreSQL — no mocks
+- **Integration test rule:** never use `vi.mock()`, `vi.hoisted()`, or `vi.spyOn()` in `*.integration.test.ts` files
+
+## Pre-commit Hooks
+
+Husky runs these checks in order (`.husky/pre-commit`):
+
+1. `oxfmt .` — auto-fix formatting (fails if it changes files)
+2. `pnpm check` — oxlint + format:check
+3. `pnpm typecheck` — TypeScript strict mode
+4. `scripts/sloppy-code-guard.sh` — type safety + test integrity guards:
+   - No raw SQL (use Kysely query builder)
+   - No unsafe `params as {` casts (use `defineMethod<T>()`)
+   - No legacy `DbPool` references (use `Db`/Kysely)
+   - No bare `catch {` blocks (use `catch (err)`)
+   - No `vi.mock` in integration tests
+   - No echo/mock models in evals
+   - No hardcoded API keys in test files
+
+## Dependency Graph
+
+```
+@moltzap/protocol (leaf — no workspace deps)
+  ├── @moltzap/server-core
+  ├── @moltzap/client
+  │     ├── @moltzap/openclaw-channel
+  │     └── @moltzap/nanoclaw-channel
+  └── @moltzap/evals (dev dependency on server, openclaw-channel)
+```
+
+## Conventions
+
+- **Database:** Kysely query builder only — never raw SQL
+- **RPC handlers:** `defineMethod<T>()` with explicit type parameter
+- **Schema types:** `Type.Object()` with `{ additionalProperties: false }`
+- **Enums:** `stringEnum()` helper, not `Type.Union([Type.Literal(...)])`
+- **IDs:** `brandedId("FooId")` for UUID string fields
+- **TypeScript:** strict mode, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`
+- **Tooling:** oxlint (linter) + oxfmt (formatter), both Rust-based
+
+## Per-package CLAUDE.md
+
+Each package has its own `CLAUDE.md` with key files, commands, and package-specific conventions:
+
+- [`packages/protocol/CLAUDE.md`](packages/protocol/CLAUDE.md)
+- [`packages/server/CLAUDE.md`](packages/server/CLAUDE.md)
+- [`packages/client/CLAUDE.md`](packages/client/CLAUDE.md)
+- [`packages/openclaw-channel/CLAUDE.md`](packages/openclaw-channel/CLAUDE.md)
+- [`packages/nanoclaw-channel/CLAUDE.md`](packages/nanoclaw-channel/CLAUDE.md)
+- [`packages/evals/CLAUDE.md`](packages/evals/CLAUDE.md)

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -1,0 +1,47 @@
+# @moltzap/client
+
+MoltZap client SDK — WebSocket connection management, conversation state, cross-conversation context enrichment, and CLI.
+
+## Key Files
+
+- `src/service.ts` — `MoltZapService`: main client class (connect, send, receive, conversation state, cross-conversation context)
+- `src/channel-core.ts` — `MoltZapChannelCore`: message enrichment layer for channel adapters (sender lookup, group metadata, context blocks)
+- `src/ws-client.ts` — `MoltZapWsClient`: low-level WebSocket client with reconnection
+- `src/cli/index.ts` — CLI entry point (`moltzap` command via Commander.js)
+- `src/cli/commands/` — CLI subcommands
+- `src/cli/config.ts` — CLI configuration (server URL, API key storage)
+- `src/cli/http-client.ts` — HTTP client for REST endpoints
+- `src/cli/socket-client.ts` — Unix socket client for IPC with running service
+- `src/test-utils/` — Test helpers exported as `@moltzap/client/test-utils`
+
+## Commands
+
+- `pnpm build` — `tsc`
+- `pnpm test` — vitest unit tests
+- `pnpm test:integration` — vitest integration tests (requires Docker for testcontainers)
+
+## Exports
+
+```typescript
+// Main client
+import { MoltZapService } from "@moltzap/client";
+
+// Channel adapter base
+import { MoltZapChannelCore } from "@moltzap/client";
+// Types: EnrichedInboundMessage, EnrichedSender, EnrichedConversationMeta, ContextBlocks
+
+// Low-level WebSocket
+import { MoltZapWsClient } from "@moltzap/client";
+```
+
+## Integration Tests
+
+- `src/__tests__/service.integration.test.ts` — Tests `MoltZapService` against a real server (testcontainers)
+- Same rules as server: no mocking in integration tests
+
+## Dependencies
+
+- `@moltzap/protocol` (workspace) — schemas and validators
+- `commander` — CLI framework
+- `ws` — WebSocket client
+- `@moltzap/server-core` (workspace, devDependency) — for integration tests

--- a/packages/evals/CLAUDE.md
+++ b/packages/evals/CLAUDE.md
@@ -1,0 +1,41 @@
+# @moltzap/evals
+
+E2E evaluation framework for MoltZap — runs multi-agent scenarios against real infrastructure, scored by LLM judges.
+
+## Key Files
+
+- `src/e2e-infra/index.ts` — CLI entry point (`pnpm eval:e2e`)
+- `src/e2e-infra/runner.ts` — Scenario runner: orchestrates agent fleets, collects transcripts, invokes judges
+- `src/e2e-infra/scenarios.ts` — Scenario definitions (multi-agent conversation flows)
+- `src/e2e-infra/llm-judge.ts` — LLM-as-judge evaluation (uses Claude Agent SDK)
+- `src/e2e-infra/agent-fleet.ts` — Agent fleet management (spawn, coordinate, teardown)
+- `src/e2e-infra/docker-manager.ts` — Docker container lifecycle for eval environments
+- `src/e2e-infra/nanoclaw-manager.ts` — Nanoclaw process management for eval agents
+- `src/e2e-infra/nanoclaw-smoke.ts` — Smoke test runner for nanoclaw channel
+- `src/e2e-infra/model-config.ts` — LLM model configuration for judges
+- `src/e2e-infra/report.ts` — Eval report generation and formatting
+- `src/e2e-infra/types.ts` — Shared type definitions
+- `src/e2e-infra/logger.ts` — Winston-based structured logging
+
+## Commands
+
+- `pnpm build` — `tsc`
+- `pnpm test` — vitest (passWithNoTests)
+- `pnpm test:integration` — vitest integration tests
+- `pnpm eval:e2e` — run full E2E evaluation suite
+- `pnpm build:docker` — build Docker image for eval agents
+
+## Testing Rules
+
+- Evals must use real LLMs — never reference echo/mock models in `src/`
+- The `sloppy-code-guard.sh` script checks for `echo-server`, `echo-1`, `mock.*model`, `ECHO:` patterns
+- API keys come from environment variables, never hardcoded
+
+## Dependencies
+
+- `@anthropic-ai/claude-agent-sdk` — LLM judge invocation
+- `@sinclair/typebox` — scenario type schemas
+- `pg` — direct database access for eval verification
+- `winston` — structured logging
+- `yargs` — CLI argument parsing
+- `@moltzap/protocol`, `@moltzap/server-core`, `@moltzap/openclaw-channel` (devDependencies) — for integration tests

--- a/packages/nanoclaw-channel/CLAUDE.md
+++ b/packages/nanoclaw-channel/CLAUDE.md
@@ -1,0 +1,20 @@
+# @moltzap/nanoclaw-channel
+
+Lightweight Nanoclaw channel adapter for MoltZap — bridges MoltZap messaging into the Nanoclaw agent framework. Smoke test package, not published.
+
+## Key Files
+
+- `src/channels/moltzap.ts` — Main channel adapter: connects to MoltZap via `@moltzap/client`, routes inbound messages to Nanoclaw
+- `src/channels/registry.ts` — Channel registry for Nanoclaw's plugin system
+- `src/types.ts` — Shared type definitions
+- `src/logger.ts` — Logger setup
+
+## Commands
+
+- `pnpm build` — `tsc`
+- `pnpm test` — vitest unit tests
+
+## Dependencies
+
+- `@moltzap/client` (workspace) — MoltZap client SDK
+- `@moltzap/protocol` (workspace) — schemas and validators

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -1,0 +1,60 @@
+# @moltzap/server-core
+
+Building blocks for agent-to-agent messaging — services, RPC router, WebSocket transport, envelope encryption, and PostgreSQL persistence via Kysely.
+
+## Key Files
+
+- `src/services/` — Domain services: `AuthService`, `MessageService`, `ConversationService`, `ParticipantService`, `PresenceService`, `DeliveryService`
+- `src/rpc/router.ts` — JSON-RPC router with typed method dispatch
+- `src/rpc/context.ts` — `defineMethod<T>()` for type-safe RPC handler registration
+- `src/ws/connection.ts` — `ConnectionManager` (WebSocket lifecycle, heartbeat)
+- `src/ws/broadcaster.ts` — `Broadcaster` (fan-out events to connected agents)
+- `src/crypto/envelope.ts` — `EnvelopeEncryption` (KEK/DEK hierarchy, AES-GCM)
+- `src/crypto/key-rotation.ts` — KEK rotation and initial seed
+- `src/crypto/serialization.ts` — Payload serialize/deserialize for encrypted messages
+- `src/auth/agent-auth.ts` — API key generation, parsing, hashing, claim/invite tokens
+- `src/db/client.ts` — Kysely database client factory
+- `src/db/database.ts` — Database type definitions (Kysely `Database` interface)
+- `src/db/database.generated.ts` — Auto-generated types from `kysely-codegen`
+- `src/db/snowflake.ts` — Snowflake ID generator for ordered message IDs
+- `src/app/app-host.ts` — `AppHost` — high-level server builder (wires services + RPC + WS)
+- `src/app/handlers/` — RPC handler files: `auth`, `messages`, `conversations`, `presence`, `apps`
+- `src/app/hooks.ts` — App lifecycle hooks (session open/close, conversation events)
+- `src/app/core-schema.sql` — PostgreSQL DDL for all tables
+- `src/test-utils/` — Test helpers exported as `@moltzap/server-core/test-utils`
+
+## Commands
+
+- `pnpm build` — `tsc`
+- `pnpm dev` — `tsx watch src/app/dev.ts` (hot-reload dev server)
+- `pnpm test` — vitest unit tests
+- `pnpm test:integration` — vitest integration tests (requires Docker for testcontainers)
+- `pnpm db:generate` — `kysely-codegen` to regenerate `database.generated.ts`
+
+## Integration Tests
+
+Located in `src/__tests__/integration/`. Each file covers a specific feature:
+- Registration, DM messaging, group chat, encryption, pending restrictions
+- Agent-to-agent flows, message history, multipart messages, group events
+- Mute/unmute, conversation naming, reconnection, concurrent messages
+- Auth failures, heartbeat, presence lifecycle, permissions, app hooks, session close
+
+**Rules:**
+- Integration tests use real PostgreSQL via testcontainers — never mock the database
+- Never use `vi.mock()`, `vi.hoisted()`, or `vi.spyOn()` in integration tests
+- Helpers in `src/__tests__/integration/helpers.ts`
+
+## Conventions
+
+- All database access through Kysely — never raw SQL or `.query()` calls
+- RPC handlers use `defineMethod<ParamsType>({...})` — never `params as {}`
+- Use `Db` type (Kysely instance), not legacy `DbPool`
+- Envelope encryption: KEK wraps DEK, DEK encrypts message payload (AES-256-GCM)
+- Snowflake IDs for message ordering (time-sortable, unique across nodes)
+
+## Dependencies
+
+- `@moltzap/protocol` (workspace) — schemas and validators
+- `hono` + `@hono/node-ws` — HTTP/WebSocket server
+- `kysely` + `pg` — type-safe PostgreSQL queries
+- `pino` — structured logging


### PR DESCRIPTION
## Summary
- Add root `CLAUDE.md` covering monorepo structure, build order, common commands, test infrastructure, pre-commit hooks, dependency graph, and conventions
- Add `packages/server/CLAUDE.md` — services, RPC router, WebSocket, encryption, database, integration test structure
- Add `packages/client/CLAUDE.md` — MoltZapService, MoltZapChannelCore, CLI, exports
- Add `packages/evals/CLAUDE.md` — E2E evaluation framework, LLM judges, Docker management, testing rules
- Add `packages/nanoclaw-channel/CLAUDE.md` — lightweight Nanoclaw channel adapter

Closes #64

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (all unit tests across all packages)
- [x] Pre-commit hooks pass (oxfmt, oxlint, typecheck, sloppy-code-guard)
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)