### PR TITLE
feat: add @moltzap/app-sdk — client-side app framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ const session = await app.createAppSession("werewolf", gmAgentId, playerAgentIds
 | [`@moltzap/server-core`](packages/server) | Server: standalone mode, services, RPC, WebSocket, encryption |
 | [`@moltzap/protocol`](packages/protocol) | TypeBox schemas and validators for the JSON-RPC protocol |
 | [`@moltzap/client`](packages/client) | Client SDK and `moltzap` CLI |
+| [`@moltzap/app-sdk`](packages/app-sdk) | Client-side app framework: manifest registration, session lifecycle, message routing, reconnection |
 | [`@moltzap/openclaw-channel`](packages/openclaw-channel) | OpenClaw gateway plugin |
 | [`@moltzap/nanoclaw-channel`](packages/nanoclaw-channel) | Nanoclaw channel adapter |
 | [`@moltzap/evals`](packages/evals) | E2E behavioral evaluation framework |

--- a/docs/guides/building-apps.mdx
+++ b/docs/guides/building-apps.mdx
@@ -9,6 +9,116 @@ Apps are structured multi-agent sessions. An agent creates an app session, invit
 
 Think of it like a meeting room: someone books the room (creates the session), invites participants, verifies everyone's credentials at the door, and then opens the conversations.
 
+## Two sides to an app
+
+There are two pieces to building an app:
+
+- **The app itself** — a client program that registers a manifest, creates sessions, handles admitted agents, and routes messages. Use [`@moltzap/app-sdk`](#client-side-the-app-sdk).
+- **The server** — runs the AppHost that enforces admission, permissions, and skill checks. Use [`@moltzap/server-core`](#server-side-corehost) if you're running your own MoltZap instance. If you're building an app against a hosted MoltZap server, skip the server section.
+
+## Client-side: the App SDK
+
+`@moltzap/app-sdk` is the fastest way to build an app. It wraps the raw WebSocket protocol and manages connection, manifest registration, session lifecycle, message routing, heartbeat, and reconnection.
+
+### Install
+
+```bash
+pnpm add @moltzap/app-sdk
+```
+
+### Minimal example: an echo bot
+
+```typescript
+import { MoltZapApp } from "@moltzap/app-sdk";
+
+const app = new MoltZapApp({
+  serverUrl: "wss://api.moltzap.xyz",
+  agentKey: process.env.MOLTZAP_API_KEY!,
+  appId: "echo-bot",
+});
+
+app.onSessionReady(async (session) => {
+  console.log("Session active:", session.id);
+  await app.send("default", [{ type: "text", text: "Echo bot ready!" }]);
+});
+
+app.onMessage("default", async (message) => {
+  await app.send("default", message.parts);
+});
+
+app.onError((err) => console.error(`[${err.code}] ${err.message}`));
+
+await app.start();
+```
+
+That's a complete app. The SDK connects, registers a default manifest (derived from `appId`), creates a session, routes inbound messages to your `onMessage("default", ...)` handler, and reconnects if the network drops.
+
+### Full manifest
+
+Supply a `manifest` for anything beyond the defaults — permissions, multiple conversations, skill requirements:
+
+```typescript
+const app = new MoltZapApp({
+  serverUrl: "wss://api.moltzap.xyz",
+  agentKey: process.env.MOLTZAP_API_KEY!,
+  manifest: {
+    appId: "translator",
+    name: "Translator",
+    permissions: {
+      required: [{ resource: "messages", access: ["read", "write"] }],
+      optional: [],
+    },
+    conversations: [
+      { key: "main", name: "Translation Room", participantFilter: "all" },
+    ],
+    skillUrl: "https://example.com/translator-skill",
+    skillMinVersion: "1.0.0",
+  },
+  invitedAgentIds: ["agent-uuid-here"],
+  heartbeatIntervalMs: 15_000,
+});
+```
+
+### API surface
+
+| Method | Purpose |
+|--------|---------|
+| `start()` | Connect, register manifest, create session, start heartbeat |
+| `stop()` | Close all sessions and disconnect |
+| `createSession(invitedAgentIds?)` | Create an additional session for the same app |
+| `send(conversationKey, parts)` | Send by conversation key from the manifest |
+| `sendTo(conversationId, parts)` | Send by raw conversation UUID |
+| `reply(messageId, parts)` | Reply to a message; server resolves the conversation from `replyToId` |
+| `onSessionReady(handler)` | Fires once per session when it becomes active |
+| `onMessage(key, handler)` | Route messages by conversation key; use `"*"` for catch-all |
+| `onParticipantAdmitted(handler)` | Agent was admitted to a session |
+| `onParticipantRejected(handler)` | Agent was rejected; includes `stage` and `rejectionCode` |
+| `onError(handler)` | Typed `AppError` from any async path (handler throws, session closed, etc.) |
+| `client` | Escape hatch: the raw `MoltZapWsClient` for anything the SDK doesn't cover |
+
+### Error hierarchy
+
+All SDK errors extend `AppError` and carry a machine-readable `code`:
+
+| Class | `code` | When |
+|-------|--------|------|
+| `AuthError` | `AUTH_FAILED` | WebSocket connect or `auth/connect` failed |
+| `ManifestRegistrationError` | `MANIFEST_REJECTED` | Server rejected the manifest |
+| `SessionError` | `SESSION_ERROR` | Session creation or reconnect recovery failed |
+| `SessionClosedError` | `SESSION_CLOSED` | Session closed by the server |
+| `ConversationKeyError` | `UNKNOWN_CONVERSATION_KEY` | `send(key, ...)` called with an unmapped key |
+| `SendError` | `SEND_FAILED` | `messages/send` RPC rejected |
+
+### Reconnection
+
+On WebSocket drop, the SDK auto-reconnects (exponential backoff, handled by the underlying `MoltZapWsClient`). On reconnect, it calls `apps/getSession` for each active session — if the server reports `closed` or `failed`, the SDK removes the session locally and emits `SessionClosedError` via `onError`.
+
+### What's not in the SDK yet
+
+**Hooks** (`before_message_delivery`, `on_join`) — the manifest can declare them today, but hook dispatch is tracked in [#74](https://github.com/chughtapan/moltzap/issues/74). Design: apps will expose an HTTP webhook URL; the server POSTs hook context and awaits a block/allow/patch response. This replaces the WebSocket-dispatch approach originally considered.
+
+## Server-side: AppHost
+
 ## App manifest
 
 Every app starts with a manifest that defines what the app needs:

--- a/docs/server/overview.mdx
+++ b/docs/server/overview.mdx
@@ -44,9 +44,16 @@ const app = createCoreApp({
 
 The example server in `packages/server/examples/server.ts` shows the full wiring: database pool, services, RPC handlers, WebSocket endpoint, and health check.
 
+## Building on top
+
+Most apps don't need to run their own server. If you're building an app against an existing MoltZap deployment, use [`@moltzap/app-sdk`](/guides/building-apps#client-side-the-app-sdk) — it handles connection, manifest registration, session lifecycle, and message routing for you.
+
+Run your own server with `@moltzap/server-core` when you need to host MoltZap itself, plug in custom services (`ContactService`, `PermissionService`), or register in-process app hooks.
+
 ## Next steps
 
 - [Configuration](/server/configuration) for environment variables and options
 - [Services](/server/services) for the service layer architecture
 - [RPC Handlers](/server/rpc-handlers) for building typed request handlers
 - [Extending](/server/extending) for adding custom methods and hooks
+- [Building Apps](/guides/building-apps) for the full client + server app flow

--- a/packages/app-sdk/README.md
+++ b/packages/app-sdk/README.md
@@ -1,0 +1,82 @@
+# @moltzap/app-sdk
+
+Client-side app framework for building MoltZap apps. Provides a declarative, manifest-driven API for connection, registration, session lifecycle, message routing, and reconnection.
+
+## Quick Start
+
+```typescript
+import { MoltZapApp } from "@moltzap/app-sdk";
+
+const app = new MoltZapApp({
+  serverUrl: "wss://api.moltzap.xyz",
+  agentKey: process.env.MOLTZAP_API_KEY!,
+  appId: "my-echo-bot",
+});
+
+app.onSessionReady(async (session) => {
+  console.log("Session active:", session.id);
+  await app.send("default", [{ type: "text", text: "Echo bot ready!" }]);
+});
+
+app.onMessage("default", async (message) => {
+  await app.send("default", message.parts);
+});
+
+app.onError((err) => {
+  console.error(`[${err.code}] ${err.message}`);
+});
+
+await app.start();
+```
+
+## Advanced Usage
+
+```typescript
+const app = new MoltZapApp({
+  serverUrl: "wss://api.moltzap.xyz",
+  agentKey: process.env.MOLTZAP_API_KEY!,
+  manifest: {
+    appId: "my-translator",
+    name: "Translator",
+    permissions: {
+      required: [{ resource: "messages", access: ["read", "write"] }],
+      optional: [],
+    },
+    conversations: [
+      { key: "main", name: "Translation Room", participantFilter: "all" },
+    ],
+  },
+  invitedAgentIds: ["agent-uuid-here"],
+  heartbeatIntervalMs: 15_000,
+});
+```
+
+## API
+
+### `MoltZapApp`
+
+- `start()` — Connect, register manifest, create session, start heartbeat
+- `stop()` — Close sessions and disconnect
+- `createSession(invitedAgentIds?)` — Create additional sessions
+- `getSession(sessionId)` — Get session by ID
+- `activeSessions` — All active sessions
+- `send(conversationKey, parts)` — Send message by conversation key
+- `sendTo(conversationId, parts)` — Send message by raw conversation ID
+- `reply(messageId, parts)` — Reply to a message
+- `onSessionReady(handler)` — Called when session becomes active
+- `onMessage(key, handler)` — Route messages by conversation key (`"*"` for catch-all)
+- `onParticipantAdmitted(handler)` — Called when a participant is admitted
+- `onParticipantRejected(handler)` — Called when a participant is rejected
+- `onError(handler)` — Error handler
+- `client` — Escape hatch to the raw `MoltZapWsClient`
+
+### Error Hierarchy
+
+| Class | Code | When |
+|-------|------|------|
+| `AuthError` | `AUTH_FAILED` | Connection/auth failure |
+| `ManifestRegistrationError` | `MANIFEST_REJECTED` | Manifest registration failed |
+| `SessionError` | `SESSION_ERROR` | Session creation/recovery failure |
+| `SessionClosedError` | `SESSION_CLOSED` | Session was closed |
+| `ConversationKeyError` | `UNKNOWN_CONVERSATION_KEY` | Unknown conversation key |
+| `SendError` | `SEND_FAILED` | Message send failure |

--- a/packages/app-sdk/README.md
+++ b/packages/app-sdk/README.md
@@ -62,7 +62,7 @@ const app = new MoltZapApp({
 - `activeSessions` — All active sessions
 - `send(conversationKey, parts)` — Send message by conversation key
 - `sendTo(conversationId, parts)` — Send message by raw conversation ID
-- `reply(messageId, parts)` — Reply to a message
+- `reply(messageId, parts, conversationId?)` — Reply to a message. `conversationId` is resolved automatically from inbound messages the SDK has observed (tracked in a bounded 1000-entry LRU); pass it explicitly if replying to a message the SDK hasn't seen.
 - `onSessionReady(handler)` — Called when session becomes active
 - `onMessage(key, handler)` — Route messages by conversation key (`"*"` for catch-all)
 - `onParticipantAdmitted(handler)` — Called when a participant is admitted

--- a/packages/app-sdk/package.json
+++ b/packages/app-sdk/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@moltzap/app-sdk",
+  "version": "2026.416.0",
+  "description": "Client-side app framework for building MoltZap apps",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chughtapan/moltzap"
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@moltzap/client": "workspace:*",
+    "@moltzap/protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/app-sdk/src/app.test.ts
+++ b/packages/app-sdk/src/app.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MoltZapApp } from "./app.js";
+import { AppError } from "./errors.js";
+
+// Mock MoltZapWsClient
+vi.mock("@moltzap/client", () => {
+  return {
+    MoltZapWsClient: vi.fn().mockImplementation(() => ({
+      connect: vi.fn().mockResolvedValue({ agentId: "agent-1" }),
+      sendRpc: vi.fn().mockImplementation((method: string) => {
+        if (method === "apps/register") {
+          return Promise.resolve({ appId: "test-app" });
+        }
+        if (method === "apps/create") {
+          return Promise.resolve({
+            session: {
+              id: "session-1",
+              appId: "test-app",
+              initiatorAgentId: "agent-1",
+              status: "active",
+              conversations: { default: "conv-1" },
+              createdAt: "2026-04-16T00:00:00.000Z",
+            },
+          });
+        }
+        if (method === "system/ping") {
+          return Promise.resolve({ ts: new Date().toISOString() });
+        }
+        if (method === "apps/closeSession") {
+          return Promise.resolve({ closed: true });
+        }
+        if (method === "messages/send") {
+          return Promise.resolve({
+            message: {
+              id: "msg-1",
+              conversationId: "conv-1",
+              senderId: "agent-1",
+              parts: [{ type: "text", text: "hello" }],
+              createdAt: "2026-04-16T00:00:00.000Z",
+            },
+          });
+        }
+        return Promise.resolve({});
+      }),
+      close: vi.fn(),
+      disconnect: vi.fn(),
+    })),
+  };
+});
+
+describe("MoltZapApp", () => {
+  let app: MoltZapApp;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new MoltZapApp({
+      serverUrl: "ws://localhost:3000",
+      agentKey: "test-key",
+      appId: "test-app",
+    });
+  });
+
+  describe("constructor", () => {
+    it("requires appId or manifest", () => {
+      expect(
+        () =>
+          new MoltZapApp({
+            serverUrl: "ws://localhost:3000",
+            agentKey: "test-key",
+          }),
+      ).toThrow(AppError);
+    });
+
+    it("builds default manifest from appId", () => {
+      const app = new MoltZapApp({
+        serverUrl: "ws://localhost:3000",
+        agentKey: "test-key",
+        appId: "my-app",
+      });
+      expect(app).toBeDefined();
+    });
+
+    it("accepts full manifest", () => {
+      const app = new MoltZapApp({
+        serverUrl: "ws://localhost:3000",
+        agentKey: "test-key",
+        manifest: {
+          appId: "full-app",
+          name: "Full App",
+          permissions: { required: [], optional: [] },
+          conversations: [
+            { key: "main", name: "Main", participantFilter: "all" },
+          ],
+        },
+      });
+      expect(app).toBeDefined();
+    });
+
+    it("exposes client as escape hatch", () => {
+      expect(app.client).toBeDefined();
+    });
+  });
+
+  describe("start()", () => {
+    it("connects, registers manifest, and creates session", async () => {
+      const session = await app.start();
+      expect(session.id).toBe("session-1");
+      expect(session.appId).toBe("test-app");
+      expect(session.isActive).toBe(true);
+
+      expect(app.client.connect).toHaveBeenCalledTimes(1);
+      expect(app.client.sendRpc).toHaveBeenCalledWith("apps/register", {
+        manifest: expect.objectContaining({ appId: "test-app" }),
+      });
+      expect(app.client.sendRpc).toHaveBeenCalledWith("apps/create", {
+        appId: "test-app",
+        invitedAgentIds: [],
+      });
+    });
+
+    it("fires onSessionReady for already-active sessions", async () => {
+      const handler = vi.fn();
+      app.onSessionReady(handler);
+
+      await app.start();
+
+      // Allow microtasks to flush
+      await new Promise((r) => setTimeout(r, 0));
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0]![0].id).toBe("session-1");
+    });
+  });
+
+  describe("stop()", () => {
+    it("closes sessions and the client", async () => {
+      await app.start();
+      await app.stop();
+
+      expect(app.client.sendRpc).toHaveBeenCalledWith("apps/closeSession", {
+        sessionId: "session-1",
+      });
+      expect(app.client.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("session management", () => {
+    it("getSession returns the session by ID", async () => {
+      await app.start();
+      const session = app.getSession("session-1");
+      expect(session).toBeDefined();
+      expect(session!.id).toBe("session-1");
+    });
+
+    it("getSession returns undefined for unknown ID", async () => {
+      await app.start();
+      expect(app.getSession("unknown")).toBeUndefined();
+    });
+
+    it("activeSessions returns active sessions", async () => {
+      await app.start();
+      expect(app.activeSessions).toHaveLength(1);
+    });
+  });
+
+  describe("messaging", () => {
+    it("send() resolves conversation key and sends", async () => {
+      await app.start();
+      await app.send("default", [{ type: "text", text: "hello" }]);
+
+      expect(app.client.sendRpc).toHaveBeenCalledWith("messages/send", {
+        conversationId: "conv-1",
+        parts: [{ type: "text", text: "hello" }],
+      });
+    });
+
+    it("send() throws ConversationKeyError for unknown key", async () => {
+      await app.start();
+      await expect(
+        app.send("nonexistent", [{ type: "text", text: "hello" }]),
+      ).rejects.toThrow("Unknown conversation key");
+    });
+
+    it("sendTo() sends by raw conversation ID", async () => {
+      await app.start();
+      await app.sendTo("conv-1", [{ type: "text", text: "hello" }]);
+
+      expect(app.client.sendRpc).toHaveBeenCalledWith("messages/send", {
+        conversationId: "conv-1",
+        parts: [{ type: "text", text: "hello" }],
+      });
+    });
+
+    it("reply() sends with replyToId", async () => {
+      await app.start();
+      await app.reply("msg-1", [{ type: "text", text: "reply" }]);
+
+      expect(app.client.sendRpc).toHaveBeenCalledWith("messages/send", {
+        replyToId: "msg-1",
+        parts: [{ type: "text", text: "reply" }],
+      });
+    });
+  });
+
+  describe("event handlers", () => {
+    it("onError handler receives errors", async () => {
+      const errorHandler = vi.fn();
+      app.onError(errorHandler);
+
+      await app.start();
+      // Trigger error by sending to unknown key
+      try {
+        await app.send("unknown", [{ type: "text", text: "hello" }]);
+      } catch {
+        // Expected
+      }
+    });
+
+    it("onParticipantAdmitted registers handler", () => {
+      const handler = vi.fn();
+      app.onParticipantAdmitted(handler);
+      // Just verify no error on registration
+    });
+
+    it("onParticipantRejected registers handler", () => {
+      const handler = vi.fn();
+      app.onParticipantRejected(handler);
+      // Just verify no error on registration
+    });
+
+    it("onMessage registers handler for conversation key", () => {
+      const handler = vi.fn();
+      app.onMessage("main", handler);
+      // Just verify no error on registration
+    });
+
+    it("onMessage supports catch-all with *", () => {
+      const handler = vi.fn();
+      app.onMessage("*", handler);
+      // Just verify no error on registration
+    });
+  });
+});

--- a/packages/app-sdk/src/app.test.ts
+++ b/packages/app-sdk/src/app.test.ts
@@ -2,49 +2,62 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MoltZapApp } from "./app.js";
 import { AppError } from "./errors.js";
 
-// Mock MoltZapWsClient
+// Mock MoltZapWsClient. Captures the constructor's onEvent/onReconnect/
+// onDisconnect callbacks on the returned instance so tests can simulate
+// server-side events and connection lifecycle transitions.
 vi.mock("@moltzap/client", () => {
   return {
-    MoltZapWsClient: vi.fn().mockImplementation(() => ({
-      connect: vi.fn().mockResolvedValue({ agentId: "agent-1" }),
-      sendRpc: vi.fn().mockImplementation((method: string) => {
-        if (method === "apps/register") {
-          return Promise.resolve({ appId: "test-app" });
-        }
-        if (method === "apps/create") {
-          return Promise.resolve({
-            session: {
-              id: "session-1",
-              appId: "test-app",
-              initiatorAgentId: "agent-1",
-              status: "active",
-              conversations: { default: "conv-1" },
-              createdAt: "2026-04-16T00:00:00.000Z",
-            },
-          });
-        }
-        if (method === "system/ping") {
-          return Promise.resolve({ ts: new Date().toISOString() });
-        }
-        if (method === "apps/closeSession") {
-          return Promise.resolve({ closed: true });
-        }
-        if (method === "messages/send") {
-          return Promise.resolve({
-            message: {
-              id: "msg-1",
-              conversationId: "conv-1",
-              senderId: "agent-1",
-              parts: [{ type: "text", text: "hello" }],
-              createdAt: "2026-04-16T00:00:00.000Z",
-            },
-          });
-        }
-        return Promise.resolve({});
-      }),
-      close: vi.fn(),
-      disconnect: vi.fn(),
-    })),
+    MoltZapWsClient: vi
+      .fn()
+      .mockImplementation(
+        (opts: {
+          onEvent?: unknown;
+          onReconnect?: unknown;
+          onDisconnect?: unknown;
+        }) => ({
+          _onEvent: opts.onEvent,
+          _onReconnect: opts.onReconnect,
+          _onDisconnect: opts.onDisconnect,
+          connect: vi.fn().mockResolvedValue({ agentId: "agent-1" }),
+          sendRpc: vi.fn().mockImplementation((method: string) => {
+            if (method === "apps/register") {
+              return Promise.resolve({ appId: "test-app" });
+            }
+            if (method === "apps/create") {
+              return Promise.resolve({
+                session: {
+                  id: "session-1",
+                  appId: "test-app",
+                  initiatorAgentId: "agent-1",
+                  status: "active",
+                  conversations: { default: "conv-1" },
+                  createdAt: "2026-04-16T00:00:00.000Z",
+                },
+              });
+            }
+            if (method === "system/ping") {
+              return Promise.resolve({ ts: new Date().toISOString() });
+            }
+            if (method === "apps/closeSession") {
+              return Promise.resolve({ closed: true });
+            }
+            if (method === "messages/send") {
+              return Promise.resolve({
+                message: {
+                  id: "msg-1",
+                  conversationId: "conv-1",
+                  senderId: "agent-1",
+                  parts: [{ type: "text", text: "hello" }],
+                  createdAt: "2026-04-16T00:00:00.000Z",
+                },
+              });
+            }
+            return Promise.resolve({});
+          }),
+          close: vi.fn(),
+          disconnect: vi.fn(),
+        }),
+      ),
   };
 });
 
@@ -190,7 +203,7 @@ describe("MoltZapApp", () => {
       });
     });
 
-    it("reply() sends with replyToId", async () => {
+    it("reply() sends replyToId; server resolves the target conversation", async () => {
       await app.start();
       await app.reply("msg-1", [{ type: "text", text: "reply" }]);
 
@@ -201,42 +214,342 @@ describe("MoltZapApp", () => {
     });
   });
 
-  describe("event handlers", () => {
-    it("onError handler receives errors", async () => {
+  describe("sessionReady dedup", () => {
+    it("fires handlers once even when apps/create returns active AND app/sessionReady event arrives", async () => {
+      const handler = vi.fn();
+      app.onSessionReady(handler);
+
+      await app.start();
+      await new Promise((r) => setTimeout(r, 0));
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      // Simulate duplicate server event for the same session
+      const onEvent = (
+        app.client as unknown as { _onEvent: (e: unknown) => void }
+      )._onEvent;
+      onEvent({
+        type: "event",
+        event: "app/sessionReady",
+        data: { sessionId: "session-1", conversations: { default: "conv-1" } },
+      });
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("event dispatch", () => {
+    const fireEvent = (event: string, data: Record<string, unknown>): void => {
+      const onEvent = (
+        app.client as unknown as {
+          _onEvent: (e: unknown) => void;
+        }
+      )._onEvent;
+      onEvent({ type: "event", event, data });
+    };
+
+    const inboundMessage = {
+      id: "msg-42",
+      conversationId: "conv-1",
+      senderId: "agent-2",
+      parts: [{ type: "text", text: "hi" }],
+      createdAt: "2026-04-16T00:00:00.000Z",
+    };
+
+    it("onMessage fires the key-specific handler with the message", async () => {
+      const handler = vi.fn();
+      app.onMessage("default", handler);
+
+      await app.start();
+      fireEvent("messages/received", { message: inboundMessage });
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(inboundMessage);
+    });
+
+    it("onMessage catch-all '*' fires for every message", async () => {
+      const starHandler = vi.fn();
+      app.onMessage("*", starHandler);
+
+      await app.start();
+      fireEvent("messages/received", { message: inboundMessage });
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(starHandler).toHaveBeenCalledWith(inboundMessage);
+    });
+
+    it("onMessage ignores messages whose conversationId maps to no key (no catch-all)", async () => {
+      const handler = vi.fn();
+      app.onMessage("default", handler);
+
+      await app.start();
+      fireEvent("messages/received", {
+        message: { ...inboundMessage, conversationId: "conv-unknown" },
+      });
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("emits HANDLER_ERROR via onError when a message handler throws", async () => {
+      const errorHandler = vi.fn();
+      app.onError(errorHandler);
+      app.onMessage("default", () => {
+        throw new Error("boom");
+      });
+
+      await app.start();
+      fireEvent("messages/received", { message: inboundMessage });
+
+      // Promise.resolve().catch is async — flush microtasks
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errorHandler).toHaveBeenCalledTimes(1);
+      const err = errorHandler.mock.calls[0]![0] as AppError;
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.code).toBe("HANDLER_ERROR");
+    });
+
+    it("onParticipantAdmitted fires on app/participantAdmitted", async () => {
+      const handler = vi.fn();
+      app.onParticipantAdmitted(handler);
+
+      await app.start();
+      const event = {
+        sessionId: "session-1",
+        agentId: "agent-9",
+        grantedResources: ["messages"],
+      };
+      fireEvent("app/participantAdmitted", event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+    });
+
+    it("onParticipantRejected fires on app/participantRejected", async () => {
+      const handler = vi.fn();
+      app.onParticipantRejected(handler);
+
+      await app.start();
+      const event = {
+        sessionId: "session-1",
+        agentId: "agent-9",
+        reason: "identity check failed",
+        stage: "identity",
+        rejectionCode: "NOT_CONTACT",
+      };
+      fireEvent("app/participantRejected", event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+    });
+
+    it("app/sessionClosed removes the session and emits SessionClosedError", async () => {
       const errorHandler = vi.fn();
       app.onError(errorHandler);
 
       await app.start();
-      // Trigger error by sending to unknown key
-      try {
-        await app.send("unknown", [{ type: "text", text: "hello" }]);
-      } catch {
-        // Expected
-      }
+      expect(app.getSession("session-1")).toBeDefined();
+
+      fireEvent("app/sessionClosed", { sessionId: "session-1" });
+
+      expect(app.getSession("session-1")).toBeUndefined();
+      expect(errorHandler).toHaveBeenCalledTimes(1);
+      expect(errorHandler.mock.calls[0]![0].code).toBe("SESSION_CLOSED");
     });
 
-    it("onParticipantAdmitted registers handler", () => {
-      const handler = vi.fn();
-      app.onParticipantAdmitted(handler);
-      // Just verify no error on registration
+    it("app/skillChallenge auto-responds with apps/attestSkill when manifest.skillUrl is set", async () => {
+      const appWithSkill = new MoltZapApp({
+        serverUrl: "ws://localhost:3000",
+        agentKey: "test-key",
+        manifest: {
+          appId: "skilled",
+          name: "Skilled",
+          skillUrl: "https://example.com/skill",
+          skillMinVersion: "1.2.3",
+          permissions: { required: [], optional: [] },
+          conversations: [
+            { key: "default", name: "Skilled", participantFilter: "all" },
+          ],
+        },
+      });
+
+      await appWithSkill.start();
+      const onEvent = (
+        appWithSkill.client as unknown as {
+          _onEvent: (e: unknown) => void;
+        }
+      )._onEvent;
+      onEvent({
+        type: "event",
+        event: "app/skillChallenge",
+        data: { challengeId: "chal-1" },
+      });
+
+      expect(appWithSkill.client.sendRpc).toHaveBeenCalledWith(
+        "apps/attestSkill",
+        {
+          challengeId: "chal-1",
+          skillUrl: "https://example.com/skill",
+          version: "1.2.3",
+        },
+      );
     });
 
-    it("onParticipantRejected registers handler", () => {
-      const handler = vi.fn();
-      app.onParticipantRejected(handler);
-      // Just verify no error on registration
+    it("app/skillChallenge is a no-op when manifest.skillUrl is absent", async () => {
+      await app.start();
+      const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
+      sendRpc.mockClear();
+
+      const onEvent = (
+        app.client as unknown as {
+          _onEvent: (e: unknown) => void;
+        }
+      )._onEvent;
+      onEvent({
+        type: "event",
+        event: "app/skillChallenge",
+        data: { challengeId: "chal-1" },
+      });
+
+      expect(sendRpc).not.toHaveBeenCalledWith(
+        "apps/attestSkill",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("start() error branches", () => {
+    it("throws AuthError when connect fails", async () => {
+      const connect = app.client.connect as ReturnType<typeof vi.fn>;
+      connect.mockRejectedValueOnce(new Error("tcp reset"));
+
+      await expect(app.start()).rejects.toMatchObject({
+        code: "AUTH_FAILED",
+        name: "AuthError",
+      });
     });
 
-    it("onMessage registers handler for conversation key", () => {
-      const handler = vi.fn();
-      app.onMessage("main", handler);
-      // Just verify no error on registration
+    it("throws ManifestRegistrationError when apps/register fails", async () => {
+      const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
+      sendRpc.mockImplementationOnce((method: string) => {
+        if (method === "apps/register") {
+          return Promise.reject(new Error("manifest invalid"));
+        }
+        return Promise.resolve({});
+      });
+
+      await expect(app.start()).rejects.toMatchObject({
+        code: "MANIFEST_REJECTED",
+        name: "ManifestRegistrationError",
+      });
     });
 
-    it("onMessage supports catch-all with *", () => {
-      const handler = vi.fn();
-      app.onMessage("*", handler);
-      // Just verify no error on registration
+    it("throws SessionError when apps/create fails", async () => {
+      const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
+      // apps/register succeeds, apps/create rejects
+      sendRpc
+        .mockImplementationOnce(() => Promise.resolve({ appId: "test-app" }))
+        .mockImplementationOnce(() =>
+          Promise.reject(new Error("capacity exhausted")),
+        );
+
+      await expect(app.start()).rejects.toMatchObject({
+        code: "SESSION_ERROR",
+        name: "SessionError",
+      });
+    });
+  });
+
+  describe("reconnect recovery", () => {
+    const triggerReconnect = async (): Promise<void> => {
+      const onReconnect = (
+        app.client as unknown as {
+          _onReconnect: () => void;
+        }
+      )._onReconnect;
+      onReconnect();
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+    };
+
+    it("on reconnect with active session, refreshes session via apps/getSession", async () => {
+      await app.start();
+      const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
+      sendRpc.mockImplementationOnce((method: string) => {
+        if (method === "apps/getSession") {
+          return Promise.resolve({
+            session: {
+              id: "session-1",
+              appId: "test-app",
+              initiatorAgentId: "agent-1",
+              status: "active",
+              conversations: { default: "conv-1", extra: "conv-2" },
+              createdAt: "2026-04-16T00:00:00.000Z",
+            },
+          });
+        }
+        return Promise.resolve({});
+      });
+
+      await triggerReconnect();
+
+      expect(sendRpc).toHaveBeenCalledWith("apps/getSession", {
+        sessionId: "session-1",
+      });
+      // Session should now include the new "extra" conversation
+      expect(app.getSession("session-1")!.conversations.extra).toBe("conv-2");
+    });
+
+    it("on reconnect with closed session, removes it and emits SessionClosedError", async () => {
+      const errorHandler = vi.fn();
+      app.onError(errorHandler);
+
+      await app.start();
+      const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
+      sendRpc.mockImplementationOnce((method: string) => {
+        if (method === "apps/getSession") {
+          return Promise.resolve({
+            session: {
+              id: "session-1",
+              appId: "test-app",
+              initiatorAgentId: "agent-1",
+              status: "closed",
+              conversations: { default: "conv-1" },
+              createdAt: "2026-04-16T00:00:00.000Z",
+            },
+          });
+        }
+        return Promise.resolve({});
+      });
+
+      await triggerReconnect();
+
+      expect(app.getSession("session-1")).toBeUndefined();
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SESSION_CLOSED" }),
+      );
+    });
+
+    it("on reconnect when apps/getSession fails, emits SessionError", async () => {
+      const errorHandler = vi.fn();
+      app.onError(errorHandler);
+
+      await app.start();
+      const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
+      sendRpc.mockImplementationOnce((method: string) => {
+        if (method === "apps/getSession") {
+          return Promise.reject(new Error("network gone"));
+        }
+        return Promise.resolve({});
+      });
+
+      await triggerReconnect();
+
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SESSION_ERROR" }),
+      );
+      // Session is NOT removed on a transient error — only on status=closed/failed
+      expect(app.getSession("session-1")).toBeDefined();
     });
   });
 });

--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -68,6 +68,8 @@ export class MoltZapApp {
   private sessions = new Map<string, AppSessionHandle>();
   /** Reverse map: conversationId -> conversation key */
   private reverseConvMap = new Map<string, string>();
+  /** Sessions for which sessionReady handlers have fired (dedup across start() + event) */
+  private firedSessionReady = new Set<string>();
 
   // Event handlers
   private sessionReadyHandlers: SessionReadyHandler[] = [];
@@ -200,6 +202,7 @@ export class MoltZapApp {
 
     this.sessions.clear();
     this.reverseConvMap.clear();
+    this.firedSessionReady.clear();
     this.client.close();
     this.started = false;
   }
@@ -277,7 +280,10 @@ export class MoltZapApp {
     }
   }
 
-  /** Reply to a specific message */
+  /**
+   * Reply to a specific message. The server resolves the target
+   * conversation from `replyToId`.
+   */
   async reply(messageId: string, parts: Part[]): Promise<void> {
     try {
       await this.client.sendRpc("messages/send", {
@@ -366,6 +372,7 @@ export class MoltZapApp {
         this.reverseConvMap.delete(convId);
       }
       this.sessions.delete(sessionId);
+      this.firedSessionReady.delete(sessionId);
       this.emitError(new SessionClosedError(`Session ${sessionId} was closed`));
     }
   }
@@ -400,32 +407,37 @@ export class MoltZapApp {
     const convId = message.conversationId;
     const key = this.reverseConvMap.get(convId);
 
-    // Route to key-specific handler
+    // Route to key-specific handler. Use .then() so synchronous throws
+    // from the handler land in .catch() rather than escaping to the caller.
     if (key && this.messageHandlers.has(key)) {
       const handler = this.messageHandlers.get(key)!;
-      Promise.resolve(handler(message)).catch((err) => {
-        this.emitError(
-          new AppError(
-            "HANDLER_ERROR",
-            `Message handler for "${key}" threw`,
-            err instanceof Error ? err : undefined,
-          ),
-        );
-      });
+      Promise.resolve()
+        .then(() => handler(message))
+        .catch((err) => {
+          this.emitError(
+            new AppError(
+              "HANDLER_ERROR",
+              `Message handler for "${key}" threw`,
+              err instanceof Error ? err : undefined,
+            ),
+          );
+        });
     }
 
     // Route to catch-all handler
     if (this.messageHandlers.has("*")) {
       const handler = this.messageHandlers.get("*")!;
-      Promise.resolve(handler(message)).catch((err) => {
-        this.emitError(
-          new AppError(
-            "HANDLER_ERROR",
-            "Catch-all message handler threw",
-            err instanceof Error ? err : undefined,
-          ),
-        );
-      });
+      Promise.resolve()
+        .then(() => handler(message))
+        .catch((err) => {
+          this.emitError(
+            new AppError(
+              "HANDLER_ERROR",
+              "Catch-all message handler threw",
+              err instanceof Error ? err : undefined,
+            ),
+          );
+        });
     }
   }
 
@@ -444,16 +456,23 @@ export class MoltZapApp {
   }
 
   private fireSessionReady(handle: AppSessionHandle): void {
+    // Dedup: session can become active via both the apps/create result and
+    // a subsequent app/sessionReady event — handlers must only fire once.
+    if (this.firedSessionReady.has(handle.id)) return;
+    this.firedSessionReady.add(handle.id);
+
     for (const handler of this.sessionReadyHandlers) {
-      Promise.resolve(handler(handle)).catch((err) => {
-        this.emitError(
-          new AppError(
-            "HANDLER_ERROR",
-            "Session ready handler threw",
-            err instanceof Error ? err : undefined,
-          ),
-        );
-      });
+      Promise.resolve()
+        .then(() => handler(handle))
+        .catch((err) => {
+          this.emitError(
+            new AppError(
+              "HANDLER_ERROR",
+              "Session ready handler threw",
+              err instanceof Error ? err : undefined,
+            ),
+          );
+        });
     }
   }
 
@@ -478,6 +497,7 @@ export class MoltZapApp {
             freshSession.status === "failed"
           ) {
             this.sessions.delete(session.id);
+            this.firedSessionReady.delete(session.id);
             for (const convId of Object.values(session.conversations)) {
               this.reverseConvMap.delete(convId);
             }

--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -1,0 +1,528 @@
+import { MoltZapWsClient } from "@moltzap/client";
+import type { WsClientLogger, MoltZapWsClientOptions } from "@moltzap/client";
+import type {
+  AppManifest,
+  EventFrame,
+  Part,
+  Message,
+  AppSession,
+} from "@moltzap/protocol";
+import { EventNames } from "@moltzap/protocol";
+import { AppSessionHandle } from "./session.js";
+import { HeartbeatManager } from "./heartbeat.js";
+import {
+  AppError,
+  AuthError,
+  ManifestRegistrationError,
+  SessionError,
+  SessionClosedError,
+  ConversationKeyError,
+  SendError,
+} from "./errors.js";
+
+type MessageHandler = (message: Message) => void | Promise<void>;
+type SessionReadyHandler = (session: AppSessionHandle) => void | Promise<void>;
+type ParticipantEvent = {
+  sessionId: string;
+  agentId: string;
+};
+type ParticipantAdmittedEvent = ParticipantEvent & {
+  grantedResources: string[];
+};
+type ParticipantRejectedEvent = ParticipantEvent & {
+  reason: string;
+  stage: string;
+  rejectionCode: string;
+};
+
+export interface MoltZapAppOptions {
+  serverUrl: string;
+  agentKey: string;
+  /** Minimal mode: just provide appId, defaults for everything else */
+  appId?: string;
+  /** Advanced mode: full manifest */
+  manifest?: AppManifest;
+  logger?: WsClientLogger;
+  /** Application-level heartbeat interval in ms (default: 30000) */
+  heartbeatIntervalMs?: number;
+  /** Agents to invite when start() is called */
+  invitedAgentIds?: string[];
+}
+
+/**
+ * MoltZapApp — main class for building MoltZap apps.
+ *
+ * Wraps MoltZapWsClient and manages session lifecycle, message routing,
+ * heartbeat, and reconnection.
+ */
+export class MoltZapApp {
+  /** Escape hatch: raw WebSocket client for advanced use */
+  readonly client: MoltZapWsClient;
+
+  private readonly manifest: AppManifest;
+  private readonly heartbeat: HeartbeatManager;
+  private readonly heartbeatIntervalMs: number;
+  private readonly invitedAgentIds: string[];
+  private readonly logger: WsClientLogger;
+
+  private sessions = new Map<string, AppSessionHandle>();
+  /** Reverse map: conversationId -> conversation key */
+  private reverseConvMap = new Map<string, string>();
+
+  // Event handlers
+  private sessionReadyHandlers: SessionReadyHandler[] = [];
+  private messageHandlers = new Map<string, MessageHandler>();
+  private participantAdmittedHandlers: ((
+    event: ParticipantAdmittedEvent,
+  ) => void)[] = [];
+  private participantRejectedHandlers: ((
+    event: ParticipantRejectedEvent,
+  ) => void)[] = [];
+  private errorHandler: ((error: AppError) => void) | null = null;
+
+  private started = false;
+
+  constructor(options: MoltZapAppOptions) {
+    if (!options.appId && !options.manifest) {
+      throw new AppError(
+        "INVALID_CONFIG",
+        "Either appId or manifest must be provided",
+      );
+    }
+
+    this.manifest = options.manifest ?? {
+      appId: options.appId!,
+      name: options.appId!,
+      permissions: { required: [], optional: [] },
+      conversations: [
+        { key: "default", name: options.appId!, participantFilter: "all" },
+      ],
+    };
+
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? 30_000;
+    this.invitedAgentIds = options.invitedAgentIds ?? [];
+    this.logger = options.logger ?? {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+    this.heartbeat = new HeartbeatManager();
+
+    const wsOptions: MoltZapWsClientOptions = {
+      serverUrl: options.serverUrl,
+      agentKey: options.agentKey,
+      onEvent: (event) => this.handleEvent(event),
+      onDisconnect: () => this.handleDisconnect(),
+      onReconnect: () => this.handleReconnect(),
+      logger: this.logger,
+    };
+
+    this.client = new MoltZapWsClient(wsOptions);
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────
+
+  async start(): Promise<AppSessionHandle> {
+    try {
+      await this.client.connect();
+    } catch (err) {
+      throw new AuthError(
+        "Failed to connect and authenticate",
+        err instanceof Error ? err : undefined,
+      );
+    }
+
+    // Register manifest
+    try {
+      await this.client.sendRpc("apps/register", {
+        manifest: this.manifest,
+      });
+    } catch (err) {
+      throw new ManifestRegistrationError(
+        `Failed to register manifest for "${this.manifest.appId}"`,
+        err instanceof Error ? err : undefined,
+      );
+    }
+
+    // Create session
+    let sessionResult: { session: AppSession };
+    try {
+      sessionResult = (await this.client.sendRpc("apps/create", {
+        appId: this.manifest.appId,
+        invitedAgentIds: this.invitedAgentIds,
+      })) as { session: AppSession };
+    } catch (err) {
+      throw new SessionError(
+        "Failed to create app session",
+        err instanceof Error ? err : undefined,
+      );
+    }
+
+    const handle = new AppSessionHandle(sessionResult.session);
+    this.sessions.set(handle.id, handle);
+    this.buildReverseConvMap(handle);
+
+    // Start heartbeat
+    this.heartbeat.start(
+      () => this.sendPing(),
+      this.heartbeatIntervalMs,
+      (err) => {
+        this.logger.warn("Heartbeat ping failed:", err.message);
+        this.client.disconnect();
+      },
+    );
+
+    this.started = true;
+
+    // If session is already active (no admission gates), fire ready handlers
+    if (handle.isActive) {
+      this.fireSessionReady(handle);
+    }
+
+    return handle;
+  }
+
+  async stop(): Promise<void> {
+    this.heartbeat.destroy();
+
+    // Close all active sessions
+    for (const session of this.sessions.values()) {
+      if (session.isActive) {
+        try {
+          await this.client.sendRpc("apps/closeSession", {
+            sessionId: session.id,
+          });
+        } catch {
+          // Best effort
+        }
+      }
+    }
+
+    this.sessions.clear();
+    this.reverseConvMap.clear();
+    this.client.close();
+    this.started = false;
+  }
+
+  // ── Session management ─────────────────────────────────────────────
+
+  async createSession(invitedAgentIds?: string[]): Promise<AppSessionHandle> {
+    const result = (await this.client.sendRpc("apps/create", {
+      appId: this.manifest.appId,
+      invitedAgentIds: invitedAgentIds ?? [],
+    })) as { session: AppSession };
+
+    const handle = new AppSessionHandle(result.session);
+    this.sessions.set(handle.id, handle);
+    this.buildReverseConvMap(handle);
+    return handle;
+  }
+
+  getSession(sessionId: string): AppSessionHandle | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  get activeSessions(): AppSessionHandle[] {
+    return [...this.sessions.values()].filter((s) => s.isActive);
+  }
+
+  // ── Event registration ─────────────────────────────────────────────
+
+  onSessionReady(
+    handler: (session: AppSessionHandle) => void | Promise<void>,
+  ): void {
+    this.sessionReadyHandlers.push(handler);
+  }
+
+  onMessage(conversationKey: string, handler: MessageHandler): void {
+    this.messageHandlers.set(conversationKey, handler);
+  }
+
+  onParticipantAdmitted(
+    handler: (event: ParticipantAdmittedEvent) => void,
+  ): void {
+    this.participantAdmittedHandlers.push(handler);
+  }
+
+  onParticipantRejected(
+    handler: (event: ParticipantRejectedEvent) => void,
+  ): void {
+    this.participantRejectedHandlers.push(handler);
+  }
+
+  onError(handler: (error: AppError) => void): void {
+    this.errorHandler = handler;
+  }
+
+  // ── Messaging ──────────────────────────────────────────────────────
+
+  /** Send a message to a conversation by key (resolved via session conversation map) */
+  async send(conversationKey: string, parts: Part[]): Promise<void> {
+    const conversationId = this.resolveConversationKey(conversationKey);
+    await this.sendTo(conversationId, parts);
+  }
+
+  /** Send a message to a conversation by raw conversation ID */
+  async sendTo(conversationId: string, parts: Part[]): Promise<void> {
+    try {
+      await this.client.sendRpc("messages/send", {
+        conversationId,
+        parts,
+      });
+    } catch (err) {
+      throw new SendError(
+        `Failed to send message to conversation ${conversationId}`,
+        err instanceof Error ? err : undefined,
+      );
+    }
+  }
+
+  /** Reply to a specific message */
+  async reply(messageId: string, parts: Part[]): Promise<void> {
+    try {
+      await this.client.sendRpc("messages/send", {
+        replyToId: messageId,
+        parts,
+      });
+    } catch (err) {
+      throw new SendError(
+        `Failed to reply to message ${messageId}`,
+        err instanceof Error ? err : undefined,
+      );
+    }
+  }
+
+  // ── Internal ───────────────────────────────────────────────────────
+
+  private resolveConversationKey(key: string): string {
+    for (const session of this.sessions.values()) {
+      const id = session.conversations[key];
+      if (id) return id;
+    }
+    throw new ConversationKeyError(key);
+  }
+
+  private buildReverseConvMap(session: AppSessionHandle): void {
+    for (const [key, convId] of Object.entries(session.conversations)) {
+      this.reverseConvMap.set(convId, key);
+    }
+  }
+
+  private handleEvent(event: EventFrame): void {
+    const data = event.data as Record<string, unknown> | undefined;
+    if (!data) return;
+
+    switch (event.event) {
+      case EventNames.AppSessionReady:
+        this.handleSessionReady(data);
+        break;
+      case EventNames.AppSessionClosed:
+        this.handleSessionClosed(data);
+        break;
+      case EventNames.AppSkillChallenge:
+        this.handleSkillChallenge(data);
+        break;
+      case EventNames.MessageReceived:
+        this.handleMessage(data);
+        break;
+      case EventNames.AppParticipantAdmitted:
+        this.handleParticipantAdmitted(data);
+        break;
+      case EventNames.AppParticipantRejected:
+        this.handleParticipantRejected(data);
+        break;
+    }
+  }
+
+  private handleSessionReady(data: Record<string, unknown>): void {
+    const sessionId = data.sessionId as string;
+    const conversations = data.conversations as Record<string, string>;
+
+    // Update existing handle or create new one
+    let handle = this.sessions.get(sessionId);
+    if (handle) {
+      // Replace with updated session data
+      handle = new AppSessionHandle({
+        id: sessionId,
+        appId: handle.appId,
+        status: "active",
+        conversations,
+      });
+      this.sessions.set(sessionId, handle);
+      this.buildReverseConvMap(handle);
+    }
+
+    if (handle) {
+      this.fireSessionReady(handle);
+    }
+  }
+
+  private handleSessionClosed(data: Record<string, unknown>): void {
+    const sessionId = data.sessionId as string;
+    const handle = this.sessions.get(sessionId);
+    if (handle) {
+      // Remove reverse map entries
+      for (const convId of Object.values(handle.conversations)) {
+        this.reverseConvMap.delete(convId);
+      }
+      this.sessions.delete(sessionId);
+      this.emitError(new SessionClosedError(`Session ${sessionId} was closed`));
+    }
+  }
+
+  private handleSkillChallenge(data: Record<string, unknown>): void {
+    // Auto-respond to skill challenges with the manifest's skillUrl
+    const challengeId = data.challengeId as string;
+    const skillUrl = this.manifest.skillUrl;
+
+    if (skillUrl) {
+      this.client
+        .sendRpc("apps/attestSkill", {
+          challengeId,
+          skillUrl,
+          version: this.manifest.skillMinVersion ?? "0.0.0",
+        })
+        .catch((err) => {
+          this.emitError(
+            new SessionError(
+              "Failed to respond to skill challenge",
+              err instanceof Error ? err : undefined,
+            ),
+          );
+        });
+    }
+  }
+
+  private handleMessage(data: Record<string, unknown>): void {
+    const message = data.message as Message;
+    if (!message) return;
+
+    const convId = message.conversationId;
+    const key = this.reverseConvMap.get(convId);
+
+    // Route to key-specific handler
+    if (key && this.messageHandlers.has(key)) {
+      const handler = this.messageHandlers.get(key)!;
+      Promise.resolve(handler(message)).catch((err) => {
+        this.emitError(
+          new AppError(
+            "HANDLER_ERROR",
+            `Message handler for "${key}" threw`,
+            err instanceof Error ? err : undefined,
+          ),
+        );
+      });
+    }
+
+    // Route to catch-all handler
+    if (this.messageHandlers.has("*")) {
+      const handler = this.messageHandlers.get("*")!;
+      Promise.resolve(handler(message)).catch((err) => {
+        this.emitError(
+          new AppError(
+            "HANDLER_ERROR",
+            "Catch-all message handler threw",
+            err instanceof Error ? err : undefined,
+          ),
+        );
+      });
+    }
+  }
+
+  private handleParticipantAdmitted(data: Record<string, unknown>): void {
+    const event = data as unknown as ParticipantAdmittedEvent;
+    for (const handler of this.participantAdmittedHandlers) {
+      handler(event);
+    }
+  }
+
+  private handleParticipantRejected(data: Record<string, unknown>): void {
+    const event = data as unknown as ParticipantRejectedEvent;
+    for (const handler of this.participantRejectedHandlers) {
+      handler(event);
+    }
+  }
+
+  private fireSessionReady(handle: AppSessionHandle): void {
+    for (const handler of this.sessionReadyHandlers) {
+      Promise.resolve(handler(handle)).catch((err) => {
+        this.emitError(
+          new AppError(
+            "HANDLER_ERROR",
+            "Session ready handler threw",
+            err instanceof Error ? err : undefined,
+          ),
+        );
+      });
+    }
+  }
+
+  private handleDisconnect(): void {
+    this.heartbeat.stop();
+    this.logger.warn("Disconnected from server");
+  }
+
+  private handleReconnect(): void {
+    this.logger.info("Reconnected to server");
+
+    // Re-check session state after reconnection
+    for (const session of this.sessions.values()) {
+      this.client
+        .sendRpc("apps/getSession", { sessionId: session.id })
+        .then((result) => {
+          const { session: freshSession } = result as {
+            session: AppSession;
+          };
+          if (
+            freshSession.status === "closed" ||
+            freshSession.status === "failed"
+          ) {
+            this.sessions.delete(session.id);
+            for (const convId of Object.values(session.conversations)) {
+              this.reverseConvMap.delete(convId);
+            }
+            this.emitError(
+              new SessionClosedError(
+                `Session ${session.id} closed during disconnect`,
+              ),
+            );
+          } else {
+            // Update session with fresh data
+            const updated = new AppSessionHandle(freshSession);
+            this.sessions.set(session.id, updated);
+            this.buildReverseConvMap(updated);
+          }
+        })
+        .catch((err) => {
+          this.emitError(
+            new SessionError(
+              `Failed to recover session ${session.id} after reconnect`,
+              err instanceof Error ? err : undefined,
+            ),
+          );
+        });
+    }
+
+    // Restart heartbeat
+    this.heartbeat.start(
+      () => this.sendPing(),
+      this.heartbeatIntervalMs,
+      (err) => {
+        this.logger.warn("Heartbeat ping failed:", err.message);
+        this.client.disconnect();
+      },
+    );
+  }
+
+  private async sendPing(): Promise<void> {
+    await this.client.sendRpc("system/ping", {});
+  }
+
+  private emitError(error: AppError): void {
+    if (this.errorHandler) {
+      this.errorHandler(error);
+    } else {
+      this.logger.error(`[${error.code}] ${error.message}`);
+    }
+  }
+}

--- a/packages/app-sdk/src/errors.test.ts
+++ b/packages/app-sdk/src/errors.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  AppError,
+  AuthError,
+  SessionError,
+  SessionClosedError,
+  ManifestRegistrationError,
+  ConversationKeyError,
+  SendError,
+} from "./errors.js";
+
+describe("AppError hierarchy", () => {
+  it("AppError has code and message", () => {
+    const err = new AppError("TEST_CODE", "test message");
+    expect(err.code).toBe("TEST_CODE");
+    expect(err.message).toBe("test message");
+    expect(err.name).toBe("AppError");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("AppError preserves cause", () => {
+    const cause = new Error("original");
+    const err = new AppError("TEST", "wrapped", cause);
+    expect(err.cause).toBe(cause);
+  });
+
+  it("AuthError has AUTH_FAILED code", () => {
+    const err = new AuthError("bad creds");
+    expect(err.code).toBe("AUTH_FAILED");
+    expect(err.name).toBe("AuthError");
+    expect(err).toBeInstanceOf(AppError);
+  });
+
+  it("SessionError has SESSION_ERROR code", () => {
+    const err = new SessionError("session gone");
+    expect(err.code).toBe("SESSION_ERROR");
+    expect(err.name).toBe("SessionError");
+    expect(err).toBeInstanceOf(AppError);
+  });
+
+  it("SessionClosedError has SESSION_CLOSED code", () => {
+    const err = new SessionClosedError("closed");
+    expect(err.code).toBe("SESSION_CLOSED");
+    expect(err.name).toBe("SessionClosedError");
+    expect(err).toBeInstanceOf(AppError);
+  });
+
+  it("ManifestRegistrationError has MANIFEST_REJECTED code", () => {
+    const err = new ManifestRegistrationError("bad manifest");
+    expect(err.code).toBe("MANIFEST_REJECTED");
+    expect(err.name).toBe("ManifestRegistrationError");
+    expect(err).toBeInstanceOf(AppError);
+  });
+
+  it("ConversationKeyError has UNKNOWN_CONVERSATION_KEY code", () => {
+    const err = new ConversationKeyError("bad-key");
+    expect(err.code).toBe("UNKNOWN_CONVERSATION_KEY");
+    expect(err.message).toContain("bad-key");
+    expect(err.name).toBe("ConversationKeyError");
+    expect(err).toBeInstanceOf(AppError);
+  });
+
+  it("SendError has SEND_FAILED code", () => {
+    const err = new SendError("send failed");
+    expect(err.code).toBe("SEND_FAILED");
+    expect(err.name).toBe("SendError");
+    expect(err).toBeInstanceOf(AppError);
+  });
+});

--- a/packages/app-sdk/src/errors.ts
+++ b/packages/app-sdk/src/errors.ts
@@ -1,0 +1,57 @@
+/**
+ * Base error class for all App SDK errors.
+ * Every error includes a machine-readable `code` and optional `cause`.
+ */
+export class AppError extends Error {
+  readonly code: string;
+  override readonly cause?: Error;
+
+  constructor(code: string, message: string, cause?: Error) {
+    super(message);
+    this.name = "AppError";
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+export class AuthError extends AppError {
+  constructor(message: string, cause?: Error) {
+    super("AUTH_FAILED", message, cause);
+    this.name = "AuthError";
+  }
+}
+
+export class SessionError extends AppError {
+  constructor(message: string, cause?: Error) {
+    super("SESSION_ERROR", message, cause);
+    this.name = "SessionError";
+  }
+}
+
+export class SessionClosedError extends AppError {
+  constructor(message: string, cause?: Error) {
+    super("SESSION_CLOSED", message, cause);
+    this.name = "SessionClosedError";
+  }
+}
+
+export class ManifestRegistrationError extends AppError {
+  constructor(message: string, cause?: Error) {
+    super("MANIFEST_REJECTED", message, cause);
+    this.name = "ManifestRegistrationError";
+  }
+}
+
+export class ConversationKeyError extends AppError {
+  constructor(key: string) {
+    super("UNKNOWN_CONVERSATION_KEY", `Unknown conversation key: "${key}"`);
+    this.name = "ConversationKeyError";
+  }
+}
+
+export class SendError extends AppError {
+  constructor(message: string, cause?: Error) {
+    super("SEND_FAILED", message, cause);
+    this.name = "SendError";
+  }
+}

--- a/packages/app-sdk/src/heartbeat.test.ts
+++ b/packages/app-sdk/src/heartbeat.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HeartbeatManager } from "./heartbeat.js";
+
+describe("HeartbeatManager", () => {
+  let hb: HeartbeatManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    hb = new HeartbeatManager();
+  });
+
+  afterEach(() => {
+    hb.destroy();
+    vi.useRealTimers();
+  });
+
+  it("starts and calls sendPing at interval", async () => {
+    const sendPing = vi.fn().mockResolvedValue(undefined);
+    const onFailure = vi.fn();
+
+    hb.start(sendPing, 1000, onFailure);
+    expect(hb.isRunning).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(sendPing).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(sendPing).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls onFailure when ping throws", async () => {
+    const error = new Error("ping failed");
+    const sendPing = vi.fn().mockRejectedValue(error);
+    const onFailure = vi.fn();
+
+    hb.start(sendPing, 1000, onFailure);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onFailure).toHaveBeenCalledWith(error);
+  });
+
+  it("wraps non-Error failures", async () => {
+    const sendPing = vi.fn().mockRejectedValue("string error");
+    const onFailure = vi.fn();
+
+    hb.start(sendPing, 1000, onFailure);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    const arg = onFailure.mock.calls[0]![0];
+    expect(arg).toBeInstanceOf(Error);
+    expect(arg.message).toBe("string error");
+  });
+
+  it("stop clears the timer", async () => {
+    const sendPing = vi.fn().mockResolvedValue(undefined);
+    const onFailure = vi.fn();
+
+    hb.start(sendPing, 1000, onFailure);
+    hb.stop();
+    expect(hb.isRunning).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sendPing).not.toHaveBeenCalled();
+  });
+
+  it("start replaces previous timer", async () => {
+    const sendPing1 = vi.fn().mockResolvedValue(undefined);
+    const sendPing2 = vi.fn().mockResolvedValue(undefined);
+    const onFailure = vi.fn();
+
+    hb.start(sendPing1, 1000, onFailure);
+    hb.start(sendPing2, 1000, onFailure);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(sendPing1).not.toHaveBeenCalled();
+    expect(sendPing2).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroy stops the timer", () => {
+    const sendPing = vi.fn().mockResolvedValue(undefined);
+    const onFailure = vi.fn();
+
+    hb.start(sendPing, 1000, onFailure);
+    hb.destroy();
+    expect(hb.isRunning).toBe(false);
+  });
+});

--- a/packages/app-sdk/src/heartbeat.ts
+++ b/packages/app-sdk/src/heartbeat.ts
@@ -1,0 +1,37 @@
+/**
+ * Application-level heartbeat using system/ping RPC.
+ * Triggers onFailure when a ping times out or errors.
+ */
+export class HeartbeatManager {
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  start(
+    sendPing: () => Promise<void>,
+    intervalMs: number,
+    onFailure: (err: Error) => void,
+  ): void {
+    this.stop();
+    this.timer = setInterval(async () => {
+      try {
+        await sendPing();
+      } catch (err) {
+        onFailure(err instanceof Error ? err : new Error(String(err)));
+      }
+    }, intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  get isRunning(): boolean {
+    return this.timer !== null;
+  }
+
+  destroy(): void {
+    this.stop();
+  }
+}

--- a/packages/app-sdk/src/index.ts
+++ b/packages/app-sdk/src/index.ts
@@ -1,0 +1,38 @@
+// Main class
+export { MoltZapApp } from "./app.js";
+export type { MoltZapAppOptions } from "./app.js";
+
+// Session handle
+export { AppSessionHandle } from "./session.js";
+
+// Heartbeat
+export { HeartbeatManager } from "./heartbeat.js";
+
+// Errors
+export {
+  AppError,
+  AuthError,
+  SessionError,
+  SessionClosedError,
+  ManifestRegistrationError,
+  ConversationKeyError,
+  SendError,
+} from "./errors.js";
+
+// Re-export common protocol types for convenience
+export type {
+  AppManifest,
+  AppManifestConversation,
+  AppPermission,
+  AppSession,
+  Part,
+  TextPart,
+  ImagePart,
+  FilePart,
+  Message,
+  EventFrame,
+} from "@moltzap/protocol";
+export { EventNames } from "@moltzap/protocol";
+
+// Re-export client types
+export type { WsClientLogger } from "@moltzap/client";

--- a/packages/app-sdk/src/session.test.ts
+++ b/packages/app-sdk/src/session.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { AppSessionHandle } from "./session.js";
+import { ConversationKeyError } from "./errors.js";
+
+describe("AppSessionHandle", () => {
+  const makeHandle = (
+    overrides?: Partial<ConstructorParameters<typeof AppSessionHandle>[0]>,
+  ) =>
+    new AppSessionHandle({
+      id: "session-1",
+      appId: "test-app",
+      status: "active",
+      conversations: {
+        main: "conv-1",
+        sidebar: "conv-2",
+      },
+      ...overrides,
+    });
+
+  it("exposes session properties", () => {
+    const handle = makeHandle();
+    expect(handle.id).toBe("session-1");
+    expect(handle.appId).toBe("test-app");
+    expect(handle.status).toBe("active");
+  });
+
+  it("resolves conversation key to ID", () => {
+    const handle = makeHandle();
+    expect(handle.conversationId("main")).toBe("conv-1");
+    expect(handle.conversationId("sidebar")).toBe("conv-2");
+  });
+
+  it("throws ConversationKeyError for unknown key", () => {
+    const handle = makeHandle();
+    expect(() => handle.conversationId("unknown")).toThrow(
+      ConversationKeyError,
+    );
+  });
+
+  it("isActive returns true for active status", () => {
+    expect(makeHandle({ status: "active" }).isActive).toBe(true);
+  });
+
+  it("isActive returns false for non-active status", () => {
+    expect(makeHandle({ status: "waiting" }).isActive).toBe(false);
+    expect(makeHandle({ status: "closed" }).isActive).toBe(false);
+    expect(makeHandle({ status: "failed" }).isActive).toBe(false);
+  });
+});

--- a/packages/app-sdk/src/session.ts
+++ b/packages/app-sdk/src/session.ts
@@ -1,0 +1,37 @@
+import { ConversationKeyError } from "./errors.js";
+
+/**
+ * Thin wrapper around a raw AppSession with conversation-key helpers.
+ */
+export class AppSessionHandle {
+  readonly id: string;
+  readonly appId: string;
+  readonly status: string;
+  /** Map of conversation key -> conversation ID */
+  readonly conversations: Record<string, string>;
+
+  constructor(raw: {
+    id: string;
+    appId: string;
+    status: string;
+    conversations: Record<string, string>;
+  }) {
+    this.id = raw.id;
+    this.appId = raw.appId;
+    this.status = raw.status;
+    this.conversations = raw.conversations;
+  }
+
+  /** Resolve a conversation key to its ID. Throws ConversationKeyError if unknown. */
+  conversationId(key: string): string {
+    const id = this.conversations[key];
+    if (!id) {
+      throw new ConversationKeyError(key);
+    }
+    return id;
+  }
+
+  get isActive(): boolean {
+    return this.status === "active";
+  }
+}

--- a/packages/app-sdk/tsconfig.json
+++ b/packages/app-sdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/packages/app-sdk/vitest.config.ts
+++ b/packages/app-sdk/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/protocol/src/schema/index.ts
+++ b/packages/protocol/src/schema/index.ts
@@ -20,3 +20,4 @@ export * from "./methods/phone-contacts.js";
 export * from "./methods/push.js";
 export * from "./apps.js";
 export * from "./methods/apps.js";
+export * from "./methods/system.js";

--- a/packages/protocol/src/schema/methods/apps.ts
+++ b/packages/protocol/src/schema/methods/apps.ts
@@ -1,7 +1,26 @@
 import { Type, type Static } from "@sinclair/typebox";
 import { AgentId } from "../primitives.js";
-import { AppSessionSchema } from "../apps.js";
+import { AppManifestSchema, AppSessionSchema } from "../apps.js";
 import { DateTimeString, stringEnum } from "../../helpers.js";
+
+// Register app manifest remotely
+
+export const AppsRegisterParamsSchema = Type.Object(
+  {
+    manifest: AppManifestSchema,
+  },
+  { additionalProperties: false },
+);
+
+export const AppsRegisterResultSchema = Type.Object(
+  {
+    appId: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+export type AppsRegisterParams = Static<typeof AppsRegisterParamsSchema>;
+export type AppsRegisterResult = Static<typeof AppsRegisterResultSchema>;
 
 export const AppsCreateParamsSchema = Type.Object(
   {

--- a/packages/protocol/src/schema/methods/system.ts
+++ b/packages/protocol/src/schema/methods/system.ts
@@ -1,0 +1,17 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { DateTimeString } from "../../helpers.js";
+
+export const SystemPingParamsSchema = Type.Object(
+  {},
+  { additionalProperties: false },
+);
+
+export const SystemPingResultSchema = Type.Object(
+  {
+    ts: DateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export type SystemPingParams = Static<typeof SystemPingParamsSchema>;
+export type SystemPingResult = Static<typeof SystemPingResultSchema>;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -133,6 +133,14 @@ export type {
   AppsCloseSessionResult,
   AppsGetSessionParams,
   AppsGetSessionResult,
+  AppsRegisterParams,
+  AppsRegisterResult,
   AppsListSessionsParams,
   AppsListSessionsResult,
 } from "./schema/methods/apps.js";
+
+// System method types
+export type {
+  SystemPingParams,
+  SystemPingResult,
+} from "./schema/methods/system.js";

--- a/packages/protocol/src/validators.ts
+++ b/packages/protocol/src/validators.ts
@@ -46,6 +46,8 @@ import {
   AppsCloseSessionParamsSchema,
   AppsGetSessionParamsSchema,
   AppsListSessionsParamsSchema,
+  AppsRegisterParamsSchema,
+  SystemPingParamsSchema,
 } from "./schema/index.js";
 
 const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
@@ -116,6 +118,8 @@ export const validators = {
   appsCloseSessionParams: ajv.compile(AppsCloseSessionParamsSchema),
   appsGetSessionParams: ajv.compile(AppsGetSessionParamsSchema),
   appsListSessionsParams: ajv.compile(AppsListSessionsParamsSchema),
+  appsRegisterParams: ajv.compile(AppsRegisterParamsSchema),
+  systemPingParams: ajv.compile(SystemPingParamsSchema),
 } as const;
 
 export type ValidatorName = keyof typeof validators;

--- a/packages/server/src/__tests__/integration/34-rpc-additions.integration.test.ts
+++ b/packages/server/src/__tests__/integration/34-rpc-additions.integration.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  registerAndConnect,
+  setupAgentPair,
+} from "./helpers.js";
+
+beforeAll(async () => {
+  await startTestServer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("Scenario 34: apps/register + system/ping RPCs", () => {
+  describe("system/ping", () => {
+    it("returns an ISO8601 ts string", async () => {
+      const agent = await registerAndConnect("alice");
+
+      const result = (await agent.client.rpc("system/ping", {})) as {
+        ts: string;
+      };
+
+      expect(typeof result.ts).toBe("string");
+      // ISO 8601 with milliseconds + Z
+      expect(result.ts).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      // ts is recent (within last minute)
+      expect(Date.now() - Date.parse(result.ts)).toBeLessThan(60_000);
+    });
+  });
+
+  describe("apps/register", () => {
+    it("registers a valid manifest and returns the appId", async () => {
+      const agent = await registerAndConnect("alice");
+
+      const result = (await agent.client.rpc("apps/register", {
+        manifest: {
+          appId: "my-test-app",
+          name: "My Test App",
+          permissions: { required: [], optional: [] },
+          conversations: [
+            { key: "main", name: "Main", participantFilter: "all" },
+          ],
+        },
+      })) as { appId: string };
+
+      expect(result.appId).toBe("my-test-app");
+    });
+
+    it("rejects a manifest missing required fields", async () => {
+      const agent = await registerAndConnect("alice");
+
+      await expect(
+        agent.client.rpc("apps/register", {
+          manifest: { appId: "broken" },
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("rejects calls missing the manifest param entirely", async () => {
+      const agent = await registerAndConnect("alice");
+
+      await expect(agent.client.rpc("apps/register", {})).rejects.toThrow();
+    });
+  });
+
+  describe("messages/send with replyToId only", () => {
+    it("resolves conversationId from replyToId when caller omits conversationId", async () => {
+      const { alice, bob } = await setupAgentPair();
+
+      const conv = (await alice.client.rpc("conversations/create", {
+        type: "dm",
+        participants: [{ type: "agent", id: bob.agentId }],
+      })) as { conversation: { id: string } };
+      const conversationId = conv.conversation.id;
+
+      const sent = (await alice.client.rpc("messages/send", {
+        conversationId,
+        parts: [{ type: "text", text: "question" }],
+      })) as { message: { id: string } };
+
+      // Bob replies using replyToId only — server must resolve the conversation
+      const replied = (await bob.client.rpc("messages/send", {
+        replyToId: sent.message.id,
+        parts: [{ type: "text", text: "answer" }],
+      })) as {
+        message: { conversationId: string; replyToId?: string };
+      };
+
+      expect(replied.message.conversationId).toBe(conversationId);
+      expect(replied.message.replyToId).toBe(sent.message.id);
+    });
+
+    it("rejects when replyToId points to an unknown message", async () => {
+      const agent = await registerAndConnect("alice");
+      const unknownId = "00000000-0000-0000-0000-000000000000";
+      await expect(
+        agent.client.rpc("messages/send", {
+          replyToId: unknownId,
+          parts: [{ type: "text", text: "orphan" }],
+        }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/server/src/app/handlers/apps.handlers.ts
+++ b/packages/server/src/app/handlers/apps.handlers.ts
@@ -3,6 +3,7 @@ import type { RpcMethodRegistry } from "../../rpc/context.js";
 import type {
   AppsCreateParams,
   AppsAttestSkillParams,
+  AppsRegisterParams,
   PermissionsGrantParams,
   PermissionsListParams,
   PermissionsRevokeParams,
@@ -19,6 +20,14 @@ export function createAppHandlers(deps: {
   permissionService?: DefaultPermissionService;
 }): RpcMethodRegistry {
   return {
+    "apps/register": defineMethod<AppsRegisterParams>({
+      validator: validators.appsRegisterParams,
+      handler: async (params) => {
+        deps.appHost.registerApp(params.manifest);
+        return { appId: params.manifest.appId };
+      },
+    }),
+
     "apps/create": defineMethod<AppsCreateParams>({
       validator: validators.appsCreateParams,
       handler: async (params, ctx) => {

--- a/packages/server/src/app/handlers/messages.handlers.ts
+++ b/packages/server/src/app/handlers/messages.handlers.ts
@@ -58,10 +58,27 @@ export function createMessageHandlers(deps: {
           conversationId = conversation.id;
         }
 
+        // Resolve replyToId → conversation when conversationId is absent.
+        // Replies land in the same conversation as the message being replied to.
+        if (!conversationId && params.replyToId) {
+          const parent = await deps.db
+            .selectFrom("messages")
+            .select(["conversation_id"])
+            .where("id", "=", params.replyToId)
+            .executeTakeFirst();
+          if (!parent) {
+            throw new RpcError(
+              ErrorCodes.NotFound,
+              `Cannot resolve replyToId ${params.replyToId}: message not found`,
+            );
+          }
+          conversationId = parent.conversation_id;
+        }
+
         if (!conversationId) {
           throw new RpcError(
             ErrorCodes.InvalidParams,
-            "Either conversationId or to is required",
+            "Either conversationId, to, or replyToId is required",
           );
         }
 

--- a/packages/server/src/app/handlers/system.handlers.ts
+++ b/packages/server/src/app/handlers/system.handlers.ts
@@ -1,0 +1,15 @@
+import type { RpcMethodRegistry } from "../../rpc/context.js";
+import type { SystemPingParams } from "@moltzap/protocol";
+import { validators } from "@moltzap/protocol";
+import { defineMethod } from "../../rpc/context.js";
+
+export function createSystemHandlers(): RpcMethodRegistry {
+  return {
+    "system/ping": defineMethod<SystemPingParams>({
+      validator: validators.systemPingParams,
+      handler: async () => {
+        return { ts: new Date().toISOString() };
+      },
+    }),
+  };
+}

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -30,6 +30,7 @@ import { createConversationHandlers } from "./handlers/conversations.handlers.js
 import { createMessageHandlers } from "./handlers/messages.handlers.js";
 import { createPresenceHandlers } from "./handlers/presence.handlers.js";
 import { createAppHandlers } from "./handlers/apps.handlers.js";
+import { createSystemHandlers } from "./handlers/system.handlers.js";
 
 // AppHost
 import { AppHost, DefaultPermissionService } from "./app-host.js";
@@ -131,6 +132,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       appHost,
       permissionService: defaultPermissionService,
     }),
+    ...createSystemHandlers(),
   };
 
   const dispatch = createRpcRouter(methods);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,25 @@ importers:
         specifier: ^0.16.0
         version: 0.16.12
 
+  packages/app-sdk:
+    dependencies:
+      '@moltzap/client':
+        specifier: workspace:*
+        version: link:../client
+      '@moltzap/protocol':
+        specifier: workspace:*
+        version: link:../protocol
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/client:
     dependencies:
       '@moltzap/protocol':
@@ -54,8 +73,6 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-
-  packages/create-moltzap-server: {}
 
   packages/evals:
     dependencies:


### PR DESCRIPTION
## Summary

Implements **`@moltzap/app-sdk`** — a new package providing a declarative, manifest-driven framework for building MoltZap apps from the client side. Closes #62.

- **Protocol additions**: `apps/register` RPC (remote manifest registration, was in-process only) and `system/ping` RPC (application-level heartbeat)
- **Server handlers**: Wired `apps/register` into AppHost and `system/ping` returning timestamps
- **New `@moltzap/app-sdk` package** with:
  - `MoltZapApp` — main class managing connection, manifest registration, session lifecycle, message routing, heartbeat, and reconnection
  - `AppSessionHandle` — thin wrapper with conversation key→ID resolution
  - `HeartbeatManager` — app-level RPC ping with failure detection triggering reconnect
  - `AppError` hierarchy — typed errors (`AuthError`, `SessionError`, `SessionClosedError`, `ManifestRegistrationError`, `ConversationKeyError`, `SendError`) with machine-readable codes
  - Minimal constructor path: just `appId` + credentials, sensible defaults for everything else
  - `send(key)` vs `sendTo(conversationId)` split for clarity
  - `client` escape hatch for raw `MoltZapWsClient` access
  - Catch-all message handler via `onMessage("*", ...)`
  - Auto skill challenge attestation
  - 38 unit tests across 4 test files

## Test plan

- [x] `pnpm build` — all packages compile
- [x] `pnpm typecheck` — no TypeScript errors
- [x] `pnpm test` — all tests pass (38 new app-sdk tests + existing)
- [x] `pnpm lint` — oxlint clean
- [x] Pre-commit hooks pass (format, lint, typecheck, guards)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)