### PR TITLE
docs: add Effect migration plans

### DIFF
--- a/docs/superpowers/plans/2026-04-16-effect-hard-parts.md
+++ b/docs/superpowers/plans/2026-04-16-effect-hard-parts.md
@@ -1,0 +1,541 @@
+# Effect Migration Hard Parts
+
+> **Purpose:** This document is for the agents implementing the migration. It focuses on the places where a naive “replace `Promise` with `Effect`” port will miss the real value or preserve existing bugs.
+
+**Scope:** `@moltzap/server-core` and `@moltzap/client` internals only. `@moltzap/protocol` remains TypeBox/AJV and framework-neutral.
+
+**Main point:** Effect should not just re-express the current runtime. It should deliberately fix the current weak spots:
+- hanging connection attempts
+- duplicate message sends after timeout retries
+- state machines encoded as mutable `Map`s plus timers
+- fire-and-forget session admission work
+- request-scoped context smuggled through `AsyncLocalStorage`
+- flaky sleep-based tests
+
+---
+
+## 1. What Must Improve
+
+The migration should force these outcomes:
+
+- No RPC request may be retried automatically if doing so can duplicate side effects.
+- Disconnecting a socket must interrupt or fail all pending work immediately.
+- Long-lived background tasks must be owned by a `Scope`, not leaked through timers.
+- Session admission must become structured concurrency, not detached async work.
+- Request-scoped data such as `connId` must be explicit in Effect context, not hidden global state.
+- Timeout-heavy tests must move toward `TestClock`, not `setTimeout` sleeps.
+
+If a migration slice does not improve one of those classes of behavior, it is probably only translating syntax.
+
+---
+
+## 2. Build Trap: Protocol `dist` Is A Real Dependency
+
+### What is happening
+
+`packages/server` imports `@moltzap/protocol`, and TypeScript resolves that package through the workspace package exports. In practice, this means individual `server` builds rely on `packages/protocol/dist`, not just `packages/protocol/src`.
+
+That caused a misleading failure in this checkout:
+- `packages/protocol/src` already contained app schemas and new error codes
+- `packages/protocol/dist` was stale and missing them
+- `pnpm --filter @moltzap/server-core build` then reported many fake “missing export” errors in `packages/server/src/app/*`
+
+After rebuilding protocol first:
+- `pnpm --filter @moltzap/protocol build`
+- `pnpm --filter @moltzap/server-core build`
+
+the server build passed.
+
+### Guidance
+
+- Always rebuild `@moltzap/protocol` before validating `server` or `client` after protocol changes.
+- Do not spend time “fixing” server compile errors that are really stale protocol artifacts.
+- Long-term, consider TS project references or a workspace dev setup that reduces this stale-`dist` trap.
+
+---
+
+## 3. RPC Boundary: The Type-Safety Hole Is In `defineMethod`
+
+**Primary file:** `packages/server/src/rpc/context.ts`
+
+### Current problem
+
+The current helper:
+
+```ts
+export function defineMethod<TParams>(def: {
+  validator: (data: unknown) => boolean
+  handler: (params: TParams, ctx: AuthenticatedContext) => Promise<unknown>
+  requiresActive?: boolean
+}): RpcMethodDef {
+  return def as unknown as RpcMethodDef
+}
+```
+
+erases the very type it claims to protect. It relies on:
+- the validator being correct
+- the handler author choosing the right `TParams`
+- no drift between protocol schema and handler assumptions
+
+### Why this matters
+
+This is the server’s main “typed” boundary, but the actual runtime contract is:
+- `unknown` payload
+- AJV boolean validator
+- cast
+- thrown error on mismatch later
+
+Effect should fix this by making validation and domain execution part of the same typed program.
+
+### Recommended pattern
+
+- Keep AJV as the wire validator.
+- Add a bridge that turns “AJV boolean + current input” into:
+  - `Effect.succeed(typedParams)` on success
+  - `Effect.fail(InvalidParamsError)` on failure
+- Make each RPC method explicitly typed as:
+
+```ts
+type RpcProgram<P, A, E, R> =
+  (params: P, ctx: AuthenticatedContext) => Effect.Effect<A, E, R>
+```
+
+- Route failures through a single error-translation layer at the router boundary.
+
+### Extra improvement to take
+
+The router should distinguish:
+- protocol decode failures
+- domain failures
+- defects / unexpected exceptions
+
+Those are currently collapsed too early into `RpcError` or `Internal error`.
+
+---
+
+## 4. Request Context: Replace `AsyncLocalStorage` With Explicit Effect Context
+
+**Primary file:** `packages/server/src/app/server.ts`
+
+### Current problem
+
+`connId` is carried through `AsyncLocalStorage` so handlers can call `getConnId()` without taking it as an explicit parameter.
+
+This works, but it is fragile:
+- hidden dependency
+- difficult to test in isolation
+- tied to Node async context semantics
+- awkward once logic starts forking work
+
+### Recommended pattern
+
+- Use an Effect service or `FiberRef` to represent request/session context.
+- Set the connection context at the WS edge just before executing the request program.
+- Read it where needed from the Effect environment.
+
+### What to avoid
+
+- Do not keep `getConnId: () => string` closures as the long-term solution.
+- Do not reintroduce ad hoc ambient globals inside the Effect runtime.
+
+### Benefit
+
+This makes per-request state explicit and safe across Effect fibers, and it removes one of the main reasons the current code needs transport-level wiring to leak into domain handlers.
+
+---
+
+## 5. Client WebSocket Runtime: This Is A Real Runtime, Not A Utility
+
+**Primary file:** `packages/client/src/ws-client.ts`
+
+### Current problems
+
+#### 5.1 `connect()` can hang
+
+`connect()` only resolves from the `open -> auth/connect` path. If the socket closes or errors before open, the returned Promise can remain unsettled while reconnect logic runs in the background.
+
+#### 5.2 Pending RPCs survive disconnect until timeout
+
+`pendingRequests` are only failed by timeout or response. A disconnect does not fail them immediately.
+
+#### 5.3 Timeout retry can duplicate side effects
+
+`sendRpc()` retries once on timeout for every method except `auth/connect`:
+
+```ts
+if (err.message.startsWith("RPC timeout:") && method !== "auth/connect") {
+  return attempt()
+}
+```
+
+This is unsafe for non-idempotent methods like:
+- `messages/send`
+- `conversations/create`
+- `apps/create`
+
+A slow response can become a duplicated action.
+
+#### 5.4 Inbound frames are parsed but not validated
+
+Inbound JSON is `JSON.parse(...) as Record<string, unknown>` and then branched by shape. Event payloads are trusted too early.
+
+### Recommended pattern
+
+- Treat the websocket client as a scoped runtime service.
+- Use one connection loop fiber that owns:
+  - open
+  - authenticate
+  - read
+  - write
+  - reconnect policy
+- Use:
+  - `Mailbox` or `Queue` for inbound frames
+  - `Deferred` per pending RPC
+  - `Ref` / `SynchronizedRef` for connection state
+  - `Schedule.exponential(...).pipe(Schedule.jittered)` for reconnect
+  - `Effect.async` / `Effect.tryPromise` at the `ws` edge
+
+### Mandatory behavioral fix
+
+- Remove automatic retry for non-idempotent RPCs.
+- If retry support is desired, it must be opt-in and limited to explicitly idempotent methods.
+
+### Public API guidance
+
+- The external API may stay Promise-based for now.
+- Internally, the client should be driven by `ManagedRuntime` or a scoped runtime helper.
+
+---
+
+## 6. `MoltZapService`: Contract Drift And Mixed Responsibilities
+
+**Primary file:** `packages/client/src/service.ts`
+
+### Current problem classes
+
+#### 6.1 Contract drift in `sendToAgent`
+
+`sendToAgent()` currently assumes:
+
+```ts
+await this.sendRpc("agents/lookupByName", { name: agentName })
+// result as { agent: { id: string } }
+```
+
+but the protocol and server define:
+- request: `{ names: string[] }`
+- result: `{ agents: AgentCard[] }`
+
+The unit tests in `packages/client/src/service.test.ts` are also written against the stale singular shape, so they currently reinforce the bug.
+
+#### 6.2 Lifecycle, caching, eventing, and local socket server all live together
+
+`MoltZapService` currently owns:
+- connection lifecycle
+- inbound event routing
+- message caches
+- agent-name lookup caching
+- cross-conversation context state
+- local socket server lifecycle
+
+This is too much for one imperative class and too much shared mutable state for a direct line-by-line port.
+
+#### 6.3 Event subscriptions are push-arrays with no unsubscription story
+
+The current `on(...)` API appends handlers to arrays and never returns an unsubscribe handle.
+
+### Recommended split
+
+- Keep `MoltZapWsClient` or its replacement focused on transport/runtime only.
+- Move higher-level client state into a separate Effect service layer.
+- Model event subscriptions with:
+  - `PubSub`
+  - `SubscriptionRef`
+  - or a small managed subscription abstraction
+
+### Specific migration opportunity
+
+The cross-conversation context markers currently depend on mutable commit semantics. That is fine, but it should be explicit immutable state transitions through `Ref.modify`, not incidental mutation across methods.
+
+---
+
+## 7. AppHost: This Is The Hardest Server Migration
+
+**Primary file:** `packages/server/src/app/app-host.ts`
+
+### Why it is hard
+
+`AppHost` is not just “a service”. It is a state machine with:
+- persistent DB state
+- in-memory reverse indexes
+- timed hook execution
+- pending challenge state
+- pending permission coalescing
+- background admission flows
+- event fanout
+
+A line-by-line port would keep all the real complexity and just hide it in `Effect.sync`.
+
+### Current structural issues
+
+#### 7.1 Session admission is detached async work
+
+`createSession()` persists data, returns, and then kicks off `admitAgentsAsync(...)` as background work. Final session status updates then happen later and out of band.
+
+That is why tests like `33-session-failure.integration.test.ts` need sleeps before reading final DB state.
+
+#### 7.2 Challenge and permission state use ad hoc `Map + setTimeout`
+
+This affects:
+- `pendingChallenges`
+- `inflightPermissions`
+- default permission callback state
+- hook timeout wrappers
+
+These all want interruption-aware resources, not raw timers.
+
+#### 7.3 Permission coalescing semantics are subtle
+
+`inflightPermissions` coalesces on:
+
+```ts
+${ownerUserId}:${session.appId}:${perm.resource}
+```
+
+but the default permission resolver keys pending permission prompts by:
+
+```ts
+${sessionId}:${agentId}:${resource}
+```
+
+That means a single live prompt can satisfy multiple concurrent requests across sessions for the same user/app/resource, but only one session/agent pair is represented in the prompt payload. That may be acceptable, but it must be an explicit design decision, not an accidental side effect of string keys.
+
+#### 7.4 Hook timeout is fail-open, but only informally
+
+`runHookWithTimeout()` currently:
+- races the hook against a timer
+- aborts via `AbortController`
+- logs and returns `null` on timeout or error
+
+The fail-open behavior is important, but it is not encoded as a first-class policy.
+
+### Recommended pattern
+
+- Represent in-memory AppHost state as an Effect-managed state record:
+  - manifests
+  - hooks
+  - session/conversation indexes
+  - pending challenges
+  - inflight permissions
+- Use:
+  - `Ref` / `SynchronizedRef` for state
+  - `Deferred` for pending challenge and permission completions
+  - `FiberMap` for admission/background fibers keyed by session or agent
+  - `Effect.timeout` for hook/challenge/permission time windows
+  - `Scope` so all background work is interrupted on server shutdown
+
+### Mandatory behavioral fix
+
+Do not preserve the current “return now, maybe finish later, tests sleep” model for critical session state changes unless the asynchronous boundary is intentionally part of the product behavior.
+
+If session readiness/failure is logically part of session creation, the migration should make that explicit and testable.
+
+---
+
+## 8. Presence Is Wrong For Multi-Connection Agents
+
+**Primary files:**
+- `packages/server/src/app/server.ts`
+- `packages/server/src/services/presence.service.ts`
+
+### Current problem
+
+On websocket close, the server does:
+
+```ts
+if (conn?.auth) {
+  presenceService.setOffline(conn.auth.agentId)
+}
+```
+
+This marks an agent offline whenever any authenticated connection closes, even if that agent still has other live connections.
+
+### Why this matters
+
+The migration is a chance to fix the semantic model, not just the implementation shape.
+
+### Recommended model
+
+- Track authenticated live connection count per agent.
+- Compute derived presence from connection count plus explicit away/offline state if needed.
+- Use `SubscriptionRef` or a dedicated presence state service to publish changes deterministically.
+
+### Non-goal
+
+- Do not preserve “offline on any close” just because tests currently don’t catch it.
+
+---
+
+## 9. Transport And Domain Need A Cleaner Split On The Server
+
+**Primary file:** `packages/server/src/app/server.ts`
+
+### Current problem
+
+The websocket route currently handles:
+- parse errors
+- auth gating
+- dispatch
+- request-scoped context plumbing
+- post-auth connection hooks
+- presence updates on close
+
+This is a lot of policy in one transport callback.
+
+### Recommended split
+
+- Keep the WS edge thin:
+  - decode raw bytes to frames
+  - pass frames to a session/runtime service
+  - encode responses back to bytes
+- Move:
+  - auth state transitions
+  - connection subscriptions
+  - connection hook execution
+  - close semantics
+  - request dispatch
+  into services/effects owned by Layers
+
+### Why Effect helps here
+
+The transport callback can become mostly `runPromise` over a typed session effect, rather than a place where business logic accumulates because it has convenient access to `ws`, `db`, and `connections`.
+
+---
+
+## 10. Testing: The Migration Should Pay Off Here Immediately
+
+**Primary files:**
+- `packages/server/src/__tests__/integration/*`
+- `packages/client/src/__tests__/*`
+- `packages/client/src/service.test.ts`
+
+### Current problems
+
+- Many tests rely on `await new Promise((r) => setTimeout(r, 200/500/2000))`.
+- Some correctness relies on eventual consistency from detached background work.
+- Client unit tests contain fake response shapes that already drift from the real protocol.
+
+### Recommended pattern
+
+- Migrate timeout/retry/hook flows to `@effect/vitest`.
+- Use `TestClock` for:
+  - reconnect backoff
+  - RPC timeout handling
+  - hook timeout
+  - permission timeout
+  - challenge timeout
+- Use shared Layers for test fixtures instead of repeated bespoke setup.
+
+### Minimum expected benefit
+
+If the client reconnect or AppHost timeout logic still requires real sleeps after the migration, the migration did not go deep enough.
+
+---
+
+## 11. Recommended Effect Building Blocks For This Repo
+
+These are the modules that best match the actual hard parts in this codebase.
+
+### For runtime and resource ownership
+
+- `Effect.async`
+- `Effect.tryPromise`
+- `Effect.acquireRelease`
+- `Effect.runFork`
+- `Scope`
+- `ManagedRuntime`
+
+### For state and concurrency
+
+- `Ref`
+- `SynchronizedRef`
+- `SubscriptionRef`
+- `Deferred`
+- `FiberMap`
+- `Mailbox` or `Queue`
+
+### For retries and time
+
+- `Schedule.exponential`
+- `Schedule.jittered`
+- `Effect.timeout`
+- `TestClock`
+
+### For wiring and tests
+
+- `Context.Tag`
+- `Layer`
+- `@effect/vitest`
+
+---
+
+## 12. Concrete Guidance By Migration Slice
+
+### Auth / router slice
+
+- Fix `defineMethod` first.
+- Introduce typed failures before touching all services.
+- Replace `AsyncLocalStorage` with explicit request context.
+
+### Client runtime slice
+
+- Fix hanging connect behavior and pending-request interruption first.
+- Remove duplicate timeout retry before doing cosmetic refactors.
+- Decode inbound frames centrally.
+
+### AppHost slice
+
+- Model pending challenge/permission waits with `Deferred`.
+- Move admission flows under structured concurrency.
+- Decide and document permission-coalescing semantics before rewriting them.
+
+### Presence slice
+
+- Fix multi-connection semantics as part of the refactor, not after.
+
+### Test slice
+
+- Replace sleep-based timeout tests as soon as the runtime uses Effect clocks.
+
+---
+
+## 13. Anti-Patterns To Avoid
+
+- Do not wrap existing `async` methods in `Effect.tryPromise` and call it done.
+- Do not keep mutable `Map`s as the hidden source of truth behind Effect façades.
+- Do not preserve raw timer orchestration if `Effect.timeout` or `Schedule` can own it.
+- Do not keep automatic retry for non-idempotent RPCs.
+- Do not introduce a second runtime tree that mirrors the old one.
+- Do not trust current unit-test fakes more than the protocol package.
+
+---
+
+## 14. References
+
+Official Effect docs used for the recommended patterns:
+
+- Effect docs index: `https://effect-ts.github.io/effect/`
+- `Effect.async`, `Effect.promise`, `Effect.tryPromise`, `Effect.runFork`:
+  `https://effect-ts.github.io/effect/effect/Effect.ts.html`
+- `ManagedRuntime.make`:
+  `https://effect-ts.github.io/effect/effect/ManagedRuntime.ts.html`
+- `FiberMap.make`, `FiberMap.run`, `FiberMap.awaitEmpty`:
+  `https://effect-ts.github.io/effect/effect/FiberMap.ts.html`
+- `SubscriptionRef.make` and change-stream semantics:
+  `https://effect-ts.github.io/effect/effect/SubscriptionRef.ts.html`
+- `ScopedRef`:
+  `https://effect-ts.github.io/effect/effect/ScopedRef.ts.html`
+- `Mailbox.make`:
+  `https://effect-ts.github.io/effect/effect/Mailbox.ts.html`
+- `@effect/vitest` methods `effect`, `layer`, `scoped`, `live`, `scopedLive`:
+  `https://effect-ts.github.io/effect/vitest/index.ts.html`

--- a/docs/superpowers/plans/2026-04-16-effect-hard-parts.md
+++ b/docs/superpowers/plans/2026-04-16-effect-hard-parts.md
@@ -4,6 +4,8 @@
 
 **Scope:** `@moltzap/server-core` and `@moltzap/client` internals only. `@moltzap/protocol` remains TypeBox/AJV and framework-neutral.
 
+**Companion POC:** See `docs/superpowers/plans/2026-04-16-effect-kysely-poc.md` for the copyable `@effect/sql-kysely` toolkit and query rewrite sample referenced in section 7.
+
 **Main point:** Effect should not just re-express the current runtime. It should deliberately fix the current weak spots:
 - hanging connection attempts
 - duplicate message sends after timeout retries
@@ -256,6 +258,93 @@ The current `on(...)` API appends handlers to arrays and never returns an unsubs
 ### Specific migration opportunity
 
 The cross-conversation context markers currently depend on mutable commit semantics. That is fine, but it should be explicit immutable state transitions through `Ref.modify`, not incidental mutation across methods.
+
+---
+
+## 7. Database Migration: `@effect/sql-kysely` Is Viable Only With A Local Toolkit
+
+**Primary files:**
+- `packages/server/src/services/conversation.service.ts`
+- `packages/server/src/services/message.service.ts`
+- `packages/server/src/app/app-host.ts`
+
+### Current reality
+
+A targeted proof-of-concept against the real `Database` types showed:
+- builder chains do become Effect-native
+- transactions change shape but remain workable
+- the hardest seams are terminal helpers and raw SQL, not joins or ordinary query builders
+
+### What works cleanly
+
+These patterns port well:
+
+```ts
+const rows = yield* db
+  .selectFrom("agents")
+  .select("id")
+  .where("id", "in", agentIds)
+
+const inserted = yield* db
+  .insertInto("conversation_participants")
+  .values(participant)
+```
+
+### What does not stay native by default
+
+These remain awkward if the code uses `@effect/sql-kysely` directly:
+- `executeTakeFirst()`
+- `executeTakeFirstOrThrow()`
+- raw `sql``.execute(db)`
+- `db.transaction().execute(async (trx) => ...)` on the `Pg` path
+
+The transaction change is structural:
+
+```ts
+db.withTransaction(
+  Effect.gen(function* () {
+    ...
+  })
+)
+```
+
+### Why this matters here
+
+Current server code has approximately:
+- `101` `.execute*()` call sites
+- `13` raw `sql`` call sites
+- `3` transaction blocks
+
+So the hard part is not “can Effect Kysely express joins?” It can. The hard part is normalizing these terminal APIs before the service rewrite fans out.
+
+### Recommended implementation pattern
+
+Do not port services directly against bare `EffectKysely<DB>`.
+
+Instead, create a local DB toolkit/service that captures:
+- the patched `EffectKysely<DB>`
+- the underlying `SqlClient`
+
+Recommended helpers:
+- `takeFirstOption(query)`
+- `takeFirstOrElse(query, orElse)`
+- `rawQuery(rawBuilder)`
+- `withTransaction(effect)` or direct exposure of `db.withTransaction`
+
+This closes the main gaps:
+- single-row query ergonomics
+- explicit missing-row error policy
+- raw SQL execution through `SqlClient.unsafe(...)`
+
+### Why capture `SqlClient`
+
+Raw Kysely `sql`` ` builders can be compiled, and the resulting SQL plus params can be executed through `SqlClient.unsafe(...)` as a normal Effect. That means raw SQL does not force Promise wrappers if the DB layer captures both objects.
+
+### Recommendation
+
+- If the team keeps Kysely during the first Effect migration wave, Plan C1 remains the default.
+- If the team tries Plan C2, require the local DB toolkit first.
+- Do not let implementers scatter one-off `Effect.tryPromise(...)` wrappers across every service method. Centralize the bridge in one DB module.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-16-effect-kysely-poc.md
+++ b/docs/superpowers/plans/2026-04-16-effect-kysely-poc.md
@@ -1,0 +1,296 @@
+# Effect Kysely POC
+
+> **Purpose:** This is a copyable reference for the implementer. It captures the targeted `@effect/sql-kysely` proof-of-concept shape without forcing the main migration branch to adopt the runtime experiment directly.
+
+**What this POC demonstrates:**
+- builder chains can be used directly as `Effect`s
+- `transaction().execute(...)` becomes `db.withTransaction(...)`
+- `executeTakeFirst*` can be replaced with small toolkit helpers
+- raw Kysely `sql`` ` can be compiled and executed via captured `SqlClient`
+
+---
+
+## `effect-kysely-toolkit.ts`
+
+```ts
+import type { SqlClient as EffectSqlClient } from "@effect/sql/SqlClient";
+import * as PgKysely from "@effect/sql-kysely/Pg";
+import type { EffectKysely } from "@effect/sql-kysely/Pg";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { SqlError } from "@effect/sql/SqlError";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import type { RawBuilder } from "kysely";
+
+export interface EffectKyselyToolkit<DB> {
+  readonly db: EffectKysely<DB>;
+  readonly takeFirstOption: <A, E, R>(
+    query: Effect.Effect<ReadonlyArray<A>, E, R>,
+  ) => Effect.Effect<Option.Option<A>, E, R>;
+  readonly takeFirstOrElse: <A, E, R, E2>(
+    query: Effect.Effect<ReadonlyArray<A>, E, R>,
+    orElse: () => E2,
+  ) => Effect.Effect<A, E | E2, R>;
+  readonly takeFirstOrFail: <A, E, R>(
+    query: Effect.Effect<ReadonlyArray<A>, E, R>,
+    message?: string,
+  ) => Effect.Effect<A, E | Cause.NoSuchElementException, R>;
+  readonly rawQuery: <A extends object>(
+    query: RawBuilder<A>,
+  ) => Effect.Effect<ReadonlyArray<A>, SqlError>;
+}
+
+export function makeEffectKyselyToolkit<DB>(
+  db: EffectKysely<DB>,
+  client: EffectSqlClient,
+): EffectKyselyToolkit<DB> {
+  return {
+    db,
+    takeFirstOption: <A, E, R>(
+      query: Effect.Effect<ReadonlyArray<A>, E, R>,
+    ): Effect.Effect<Option.Option<A>, E, R> =>
+      query.pipe(Effect.map((rows) => Option.fromNullable(rows[0]))),
+    takeFirstOrElse: <A, E, R, E2>(
+      query: Effect.Effect<ReadonlyArray<A>, E, R>,
+      orElse: () => E2,
+    ): Effect.Effect<A, E | E2, R> =>
+      query.pipe(
+        Effect.flatMap((rows) =>
+          rows.length > 0 ? Effect.succeed(rows[0] as A) : Effect.fail(orElse()),
+        ),
+      ),
+    takeFirstOrFail: <A, E, R>(
+      query: Effect.Effect<ReadonlyArray<A>, E, R>,
+      message = "Expected at least one row",
+    ): Effect.Effect<A, E | Cause.NoSuchElementException, R> =>
+      query.pipe(
+        Effect.flatMap((rows) =>
+          rows.length > 0
+            ? Effect.succeed(rows[0] as A)
+            : Effect.fail(new Cause.NoSuchElementException(message)),
+        ),
+      ),
+    rawQuery: <A extends object>(
+      query: RawBuilder<A>,
+    ): Effect.Effect<ReadonlyArray<A>, SqlError> => {
+      const compiled = query.compile(db);
+      return client.unsafe<A>(compiled.sql, compiled.parameters);
+    },
+  };
+}
+
+export function makePgEffectKyselyToolkit<DB>(): Effect.Effect<
+  EffectKyselyToolkit<DB>,
+  never,
+  SqlClient.SqlClient
+> {
+  return Effect.gen(function* () {
+    const client = yield* SqlClient.SqlClient;
+    const db = yield* PgKysely.make<DB>();
+    return makeEffectKyselyToolkit(db, client);
+  });
+}
+```
+
+---
+
+## `effect-kysely-conversation.ts`
+
+```ts
+import { SqlError } from "@effect/sql/SqlError";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import { sql } from "kysely";
+import type {
+  ConversationType,
+  Database,
+  NewConversation,
+  NewConversationParticipant,
+} from "../src/db/database.js";
+import type { EffectKyselyToolkit } from "./effect-kysely-toolkit.js";
+
+interface ListRow {
+  id: string;
+  type: ConversationType;
+  name: string | null;
+  updated_at: Date;
+  has_last_message: boolean;
+  last_message_at: Date | null;
+  unread_count: number;
+}
+
+interface CreateConversationInput {
+  type: "dm" | "group";
+  name?: string;
+  agentIds: string[];
+  creatorAgentId: string;
+}
+
+export function createConversationPoc(
+  toolkit: EffectKyselyToolkit<Database>,
+  input: CreateConversationInput,
+): Effect.Effect<
+  {
+    conversationId: string;
+    foundAgentCount: number;
+  },
+  SqlError
+> {
+  const db = toolkit.db;
+
+  return db.withTransaction(
+    Effect.gen(function* () {
+      const foundAgents = yield* db
+        .selectFrom("agents")
+        .select("id")
+        .where("id", "in", input.agentIds);
+
+      const conversation: NewConversation = {
+        type: input.type,
+        name: input.name ?? null,
+        created_by_id: input.creatorAgentId,
+      };
+
+      const created = yield* toolkit.takeFirstOrElse(
+        db.insertInto("conversations").values(conversation).returningAll(),
+        () => new SqlError({ message: "Expected inserted conversation row" }),
+      );
+
+      const ownerParticipant: NewConversationParticipant = {
+        conversation_id: created.id,
+        agent_id: input.creatorAgentId,
+        role: "owner",
+      };
+
+      yield* db
+        .insertInto("conversation_participants")
+        .values(ownerParticipant);
+
+      yield* Effect.forEach(
+        input.agentIds,
+        (agentId) => {
+          const participant: NewConversationParticipant = {
+            conversation_id: created.id,
+            agent_id: agentId,
+            role: "member",
+          };
+
+          return db
+            .insertInto("conversation_participants")
+            .values(participant)
+            .onConflict((oc) => oc.doNothing());
+        },
+        { discard: true },
+      );
+
+      return {
+        conversationId: created.id,
+        foundAgentCount: foundAgents.length,
+      };
+    }),
+  );
+}
+
+export function findConversationPoc(
+  toolkit: EffectKyselyToolkit<Database>,
+  conversationId: string,
+): Effect.Effect<
+  Option.Option<{
+    id: string;
+    type: ConversationType;
+    name: string | null;
+    created_by_id: string;
+    created_at: Date;
+    updated_at: Date;
+  }>,
+  SqlError
+> {
+  return toolkit.takeFirstOption(
+    toolkit.db
+      .selectFrom("conversations")
+      .select([
+        "id",
+        "type",
+        "name",
+        "created_by_id",
+        "created_at",
+        "updated_at",
+      ])
+      .where("id", "=", conversationId),
+  );
+}
+
+export function listConversationsPoc(
+  toolkit: EffectKyselyToolkit<Database>,
+  agentId: string,
+  limit = 50,
+  cursor?: string,
+): Effect.Effect<
+  {
+    rows: ReadonlyArray<ListRow>;
+    participantRows: Array<{
+      conversation_id: string;
+      agent_id: string;
+    }>;
+  },
+  SqlError
+> {
+  const db = toolkit.db;
+
+  return Effect.gen(function* () {
+    const cursorParam = cursor ?? null;
+
+    const rows = yield* toolkit.rawQuery(
+      sql<ListRow>`
+        SELECT c.id, c.type, c.name, c.updated_at,
+               m.parts_encrypted IS NOT NULL as has_last_message,
+               m.created_at as last_message_at,
+               COALESCE(
+                 (SELECT COUNT(*) FROM messages m2
+                  WHERE m2.conversation_id = c.id
+                  AND m2.seq > cp.last_read_seq
+                  AND m2.is_deleted = false), 0
+               )::int as unread_count
+        FROM conversation_participants cp
+        JOIN conversations c ON c.id = cp.conversation_id
+        LEFT JOIN LATERAL (
+          SELECT parts_encrypted, created_at, seq FROM messages
+          WHERE conversation_id = c.id AND is_deleted = false
+          ORDER BY seq DESC LIMIT 1
+        ) m ON true
+        WHERE cp.agent_id = ${agentId}
+          AND c.archived_at IS NULL
+          ${cursorParam ? sql`AND c.updated_at < ${cursorParam}` : sql``}
+        ORDER BY COALESCE(m.created_at, c.updated_at) DESC
+        LIMIT ${limit + 1}
+      `,
+    );
+
+    const participantRows =
+      rows.length === 0
+        ? []
+        : yield* db
+            .selectFrom("conversation_participants")
+            .select(["conversation_id", "agent_id"])
+            .where(
+              "conversation_id",
+              "in",
+              rows.map((row) => row.id),
+            );
+
+    return { rows, participantRows };
+  });
+}
+```
+
+---
+
+## Reading Notes
+
+- This is a migration aid, not the final architecture.
+- The important part is the pattern:
+  - capture `EffectKysely<DB>` and `SqlClient`
+  - centralize first-row and raw-query handling
+  - keep service code on a small Effect-native DB surface
+- If the implementation proceeds with Plan C2, this toolkit shape should be introduced before broad service rewrites.

--- a/docs/superpowers/plans/2026-04-16-effect-migration-plans.md
+++ b/docs/superpowers/plans/2026-04-16-effect-migration-plans.md
@@ -1,0 +1,623 @@
+# Effect Migration Plans
+
+> **For agentic workers:** This document is a planning artifact, not an implementation diff. Follow one track or combine compatible tracks, but do not create a long-lived dual architecture. Temporary compatibility wrappers are allowed only at package boundaries.
+
+**Goal:** Port the client and server runtimes to Effect for stronger type safety, explicit dependency wiring, typed failures, and safer long-lived state management, while keeping `@moltzap/protocol` as the canonical TypeBox/AJV wire contract.
+
+**Repository decisions already locked in:**
+- `@moltzap/protocol` stays TypeBox-first for now.
+- `packages/server/` is the canonical source path for `@moltzap/server-core`.
+- The end state must not keep both imperative and Effect runtime trees in parallel.
+- `@effect/vitest` is part of the migration foundation, not late cleanup.
+- `packages/app-sdk` is not in the current branch; that track applies when PR #72 or equivalent lands.
+
+**Current hotspots in this checkout:**
+- `packages/server/src`: about 220 `as` casts, 40 `throw new RpcError` sites, 6 `JSON.parse` sites.
+- `packages/client/src`: about 176 `as` casts, 5 `JSON.parse` sites.
+- Mutable state clusters are concentrated in:
+  - `packages/server/src/app/app-host.ts`
+  - `packages/server/src/ws/connection.ts`
+  - `packages/server/src/services/conversation.service.ts`
+  - `packages/client/src/service.ts`
+  - `packages/client/src/ws-client.ts`
+- The most important unsafe seam today is `packages/server/src/rpc/context.ts`, where `defineMethod<T>()` erases types with a cast and relies on runtime validators to save the contract later.
+
+---
+
+## Shared Constraints
+
+### Hard rules
+
+- [ ] Keep `@moltzap/protocol` neutral and publishable without Effect.
+- [ ] Do not introduce a permanent `src/effect/` shadow tree beside the existing runtime tree.
+- [ ] Preserve current package names and public entrypoints unless a separate package-identity change is approved.
+- [ ] Use Effect internally even if a temporary Promise API is preserved externally.
+- [ ] Migrate in vertical slices and delete replaced imperative code as each slice stabilizes.
+
+### Target runtime model
+
+- Boundary validation:
+  - TypeBox + AJV stays at the transport edge.
+  - Invalid wire data becomes typed Effect failures immediately after validation.
+- Service model:
+  - `Context.Tag` for service identities.
+  - `Layer` for construction and dependency graphs.
+  - `Effect` return types instead of `Promise + throw`.
+- Error model:
+  - Preserve protocol `ErrorCodes`.
+  - Replace thrown operational errors with tagged Effect error values.
+  - Convert Effect failures back to protocol frames only at the edge.
+- Stateful runtime:
+  - `Ref` / `SynchronizedRef` for mutable state.
+  - `Deferred` for pending RPC results and readiness gates.
+  - `Queue` and optionally `Stream` for inbound event pipelines.
+  - `Scope` for socket, timer, and server lifecycle.
+  - `Schedule` for reconnect and retry policies.
+
+### Migration policy
+
+- [ ] Each migrated module keeps the same responsibility as the current module.
+- [ ] Compatibility wrappers may exist at package boundaries only.
+- [ ] New migrated tests use `@effect/vitest`.
+- [ ] Existing non-Effect tests may remain until the touched area is fully migrated.
+- [ ] Strengthen TypeScript flags only when the migrated slice is ready to absorb them.
+
+---
+
+## Plan A: Core Runtime Migration
+
+**Scope:** `@moltzap/server-core` and `@moltzap/client` become Effect-native internally, while `@moltzap/protocol`, Hono, WebSocket transport wiring, and Kysely remain in place initially.
+
+**Outcome:** One canonical Effect runtime model without a framework rewrite at the edge.
+
+### Stage A0: Foundation And Guardrails
+
+**Files likely touched:**
+- `package.json`
+- `packages/server/package.json`
+- `packages/client/package.json`
+- `tsconfig.base.json`
+- `packages/server/vitest*.config.*`
+- `packages/client/vitest*.config.*`
+
+- [ ] Add foundational dependencies where needed:
+  - `effect`
+  - `@effect/platform`
+  - `@effect/platform-node`
+  - `@effect/vitest`
+- [ ] Decide whether to add a small shared internal runtime package or keep helpers local to `packages/server/src/runtime` and `packages/client/src/runtime`.
+- [ ] Add minimal Effect test harness examples in both `server` and `client`.
+- [ ] Tighten TypeScript in stages:
+  - stage 1: `useUnknownInCatchVariables`
+  - stage 2: `noImplicitOverride`
+  - stage 3: `exactOptionalPropertyTypes`
+- [ ] Document migration invariants in package READMEs or internal docs if needed.
+
+**Deliverables:**
+- New baseline dependencies.
+- A small set of Effect helpers for:
+  - tagged errors
+  - logging helpers
+  - Promise bridge helpers
+  - validator-to-Effect bridge helpers
+
+**Verification:**
+- `pnpm --filter @moltzap/server-core test`
+- `pnpm --filter @moltzap/client test`
+- At least one `@effect/vitest` test per package to prove runtime setup works.
+
+### Stage A1: Protocol Boundary Bridge
+
+**Files likely touched:**
+- `packages/server/src/rpc/context.ts`
+- `packages/server/src/rpc/router.ts`
+- `packages/client/src/ws-client.ts`
+- `packages/client/src/service.ts`
+- New local bridge modules in `packages/server/src/rpc/` and `packages/client/src/runtime/`
+
+- [ ] Add a boundary helper that turns an AJV validator into `Effect.Effect<T, InvalidParamsError>`.
+- [ ] Replace the cast-based `defineMethod<T>()` pattern with a typed method definition that keeps:
+  - validator
+  - typed params
+  - typed result
+  - typed failure channel
+- [ ] Normalize wire decode/encode logic so `JSON.parse`, validator failures, and protocol-frame mismatches are all surfaced as explicit typed errors.
+- [ ] Stop passing `unknown` into deep handler/service code once validation has already succeeded.
+
+**Target module shape:**
+
+```ts
+type RpcProgram<P, A, E, R> = (params: P, ctx: AuthenticatedContext) => Effect.Effect<A, E, R>
+
+interface RpcMethod<P, A, E, R> {
+  readonly validator: (input: unknown) => boolean
+  readonly run: RpcProgram<P, A, E, R>
+  readonly requiresActive?: boolean
+}
+```
+
+**Deliverables:**
+- A reusable validator bridge.
+- A typed RPC definition model.
+- Router error translation from Effect failures to `ResponseFrame.error`.
+
+**Verification:**
+- Rewrite `packages/server/src/rpc/router.test.ts` to cover:
+  - validation failure
+  - typed domain failure
+  - unexpected defect
+  - active-agent gating
+
+### Stage A2: Server Composition Skeleton
+
+**Files likely touched:**
+- `packages/server/src/app/server.ts`
+- `packages/server/src/app/types.ts`
+- `packages/server/src/logger.ts`
+- `packages/server/src/config/*`
+- `packages/server/src/db/client.ts`
+- New modules under `packages/server/src/runtime/`
+
+- [ ] Define server service tags for:
+  - config
+  - logger
+  - db
+  - connection registry
+  - broadcaster
+  - auth service
+  - conversation service
+  - message service
+  - delivery service
+  - presence service
+  - participant service
+  - app host
+- [ ] Replace constructor-assembled service graphs in `createCoreApp()` with Layers.
+- [ ] Keep Hono as the transport shell for now, but have handlers execute Effects.
+- [ ] Move config loading from throw-based functions toward Effect-native loading and validation.
+- [ ] Wrap Kysely and Node APIs with `Effect.tryPromise` or `Effect.sync` at the boundary.
+
+**Important boundary rule:**
+- Hono handlers may remain `async`, but they should only bridge into `Effect.runPromise` at the outermost edge.
+
+**Deliverables:**
+- A single composed server Layer tree.
+- A `runServerEffect()` helper for HTTP and WS edges.
+- Clear separation between environment construction and business logic.
+
+**Verification:**
+- Server smoke tests still pass.
+- Server integration helper can still boot the app with the new Layer-backed construction.
+
+### Stage A3: Server Vertical Slice 1 — Auth And Session Handshake
+
+**Files likely touched:**
+- `packages/server/src/app/handlers/auth.handlers.ts`
+- `packages/server/src/services/auth.service.ts`
+- `packages/server/src/app/server.ts`
+- `packages/server/src/rpc/context.ts`
+- `packages/server/src/ws/connection.ts`
+
+- [ ] Convert `auth/connect` to `Effect`.
+- [ ] Convert agent registration HTTP flow to `Effect`.
+- [ ] Replace thrown `RpcError` usage in the auth path with tagged errors.
+- [ ] Move connection authentication state writes behind a service interface.
+- [ ] Make `buildHelloOk()` an Effect program rather than a side-effecting helper.
+
+**Goals of this slice:**
+- Prove the router can execute typed programs.
+- Prove Hono HTTP and WS edges can run the same Effect-based services.
+- Prove connection state can be modeled without leaking mutation everywhere.
+
+**Verification:**
+- Registration integration test.
+- Authentication failure integration test.
+- Heartbeat / reconnect baseline still works.
+
+### Stage A4: Server Vertical Slice 2 — Conversations And Messages
+
+**Files likely touched:**
+- `packages/server/src/app/handlers/messages.handlers.ts`
+- `packages/server/src/app/handlers/conversations.handlers.ts`
+- `packages/server/src/services/conversation.service.ts`
+- `packages/server/src/services/message.service.ts`
+- `packages/server/src/services/delivery.service.ts`
+- `packages/server/src/ws/broadcaster.ts`
+
+- [ ] Convert conversation and message services to `Effect`.
+- [ ] Replace throw-based authorization and existence checks with typed failures.
+- [ ] Move preview cache and similar local mutable caches into `Ref`s or scoped service state.
+- [ ] Convert broadcast and delivery tracking to Effects, even if the underlying socket/db calls remain imperative internally for one stage.
+- [ ] Make `messages/send` and `messages/list` fully typed from validated params to typed result.
+
+**Why this slice matters:**
+- This is the highest-value path in the system.
+- It exercises DB, transport, domain validation, encryption, and event fanout in one place.
+
+**Verification:**
+- Messaging integration tests:
+  - DM flow
+  - group chat
+  - message history
+  - multipart
+  - concurrent messages
+  - archived conversation rejection
+
+### Stage A5: Server Vertical Slice 3 — Presence, Permissions, And AppHost
+
+**Files likely touched:**
+- `packages/server/src/app/app-host.ts`
+- `packages/server/src/app/handlers/apps.handlers.ts`
+- `packages/server/src/app/handlers/presence.handlers.ts`
+- `packages/server/src/services/presence.service.ts`
+- `packages/server/src/services/participant.service.ts`
+
+- [ ] Convert `AppHost` from a class with many `Map`s and timers into Effect-managed state and scoped resources.
+- [ ] Replace inflight permission and challenge tracking with `Ref` + `Deferred`.
+- [ ] Replace timeout handling with `Effect.timeout` / `Schedule`.
+- [ ] Convert presence and participant flows to typed programs.
+- [ ] Move session admission flow, hook execution, and close flow into explicit Effect programs.
+
+**Key note:**
+- `AppHost` is the most stateful server module and the closest preview of what `app-sdk` will need on the client side. This slice should set the runtime pattern rather than invent a one-off style.
+
+**Verification:**
+- Integration coverage for:
+  - permissions
+  - app hooks
+  - session close
+  - session failure
+
+### Stage A6: Client Runtime Skeleton
+
+**Files likely touched:**
+- `packages/client/src/ws-client.ts`
+- `packages/client/src/service.ts`
+- `packages/client/src/channel-core.ts`
+- New local modules under `packages/client/src/runtime/`
+
+- [ ] Replace the websocket client lifecycle with `Effect`, `Scope`, `Deferred`, `Queue`, `Ref`, and `Schedule`.
+- [ ] Model pending RPCs as typed deferred results rather than ad hoc `Map<string, { resolve, reject }>` state.
+- [ ] Move reconnect/backoff out of `setTimeout` recursion into a declarative retry policy.
+- [ ] Decode and classify inbound frames before they reach service logic.
+- [ ] Replace mutable event dispatch chains with an explicit queue-driven pipeline.
+
+**Concrete mapping from current implementation to Effect primitives:**
+- `pendingRequests` -> `Ref<HashMap<RequestId, Deferred<Response>>>`
+- `reconnectAttempt` + `setTimeout` -> `Schedule.exponential(...)`
+- `onDisconnect` / `onReconnect` callbacks -> pub/sub queue or managed subscriptions
+- raw websocket resource -> `Scope`
+
+**Verification:**
+- `packages/client/src/service.test.ts`
+- `packages/client/src/channel-core.test.ts`
+- `packages/client/src/__tests__/service.integration.test.ts`
+
+### Stage A7: Client Service And CLI Stabilization
+
+**Files likely touched:**
+- `packages/client/src/service.ts`
+- `packages/client/src/cli/socket-client.ts`
+- `packages/client/src/cli/http-client.ts`
+- `packages/client/src/cli/commands/*`
+- `packages/client/src/index.ts`
+
+- [ ] Keep the public client API Promise-compatible initially via `Effect.runPromise`.
+- [ ] Remove direct internal mutation wherever message caches, conversation caches, and name-resolution caches can become `Ref` state.
+- [ ] Decide whether the local socket server remains imperative or also becomes scoped Effect-managed I/O.
+- [ ] Ensure CLI callers do not need to know that internals migrated to Effect.
+- [ ] Expose typed service-level errors instead of generic `Error("RPC timeout: ...")`.
+
+**Deliverables:**
+- Stable external API.
+- Effect-native internals.
+- Cleaner failure surface for SDK and CLI consumers.
+
+**Verification:**
+- CLI command tests.
+- Existing integration flows that use `@moltzap/client`.
+
+### Stage A8: Test Infrastructure Migration
+
+**Files likely touched:**
+- `packages/server/src/__tests__/*`
+- `packages/client/src/__tests__/*`
+- `packages/server/src/test-utils/*`
+- `packages/client/src/test-utils/*`
+- `vitest` config files
+
+- [ ] Move migrated slices to `@effect/vitest`.
+- [ ] Introduce test Layers for:
+  - fake logger
+  - fake clock where useful
+  - fake or in-memory connection registries
+  - DB fixtures
+- [ ] Keep existing integration testcontainers flow, but bridge setup into Effect where it improves determinism.
+- [ ] Use `TestClock` where timeout-heavy logic is migrated.
+
+**Deliverables:**
+- Deterministic timeout and retry tests.
+- Lower reliance on real timers for client reconnect and app permission flows.
+
+### Stage A9: Hardening And Cleanup
+
+**Files likely touched:**
+- Entire migrated surface
+- `tsconfig.base.json`
+- Any package-specific tsconfig files
+
+- [ ] Turn on the next TypeScript strictness flags once migrated slices are ready.
+- [ ] Remove compatibility wrappers that only existed for migration.
+- [ ] Delete replaced imperative code paths.
+- [ ] Reduce remaining `as` casts to exceptional edge cases only.
+- [ ] Audit `JSON.parse` sites and centralize them behind safe decoders.
+
+**Exit criteria for Plan A:**
+- `server` and `client` runtimes are Effect-native internally.
+- No parallel old/new service trees remain.
+- Public protocol package remains TypeBox-based.
+- Public APIs are stable.
+
+---
+
+## Plan B: HTTP Transport Replacement
+
+**Scope:** Replace Hono for HTTP endpoints with `@effect/platform` / `@effect/platform-node`, while preserving the already-migrated domain/runtime layers from Plan A.
+
+**Important:** This plan is optional and should not be started before the core runtime migration is coherent. Rewriting the HTTP shell first would hide the real migration work behind framework churn.
+
+### Stage B0: Preconditions
+
+- [ ] Plan A Stage A2 is complete.
+- [ ] Domain services are already available as Layers.
+- [ ] HTTP edge handlers are already thin bridges into Effects.
+
+### Stage B1: Replace Simple HTTP Routes
+
+**Files likely touched:**
+- `packages/server/src/app/server.ts`
+- `packages/server/src/standalone.ts`
+- `packages/server/src/app/dev.ts`
+- New modules under `packages/server/src/http/`
+
+- [ ] Reimplement `/health` using `HttpRouter` or `HttpApi`.
+- [ ] Reimplement `/api/v1/auth/register` on top of the same Effect service used by the current Hono route.
+- [ ] Reimplement `/api/v1/permissions/resolve` only after the underlying permission flow is already Effect-native.
+
+**Verification:**
+- Existing HTTP-level tests and integration flows still pass.
+
+### Stage B2: Decide WebSocket Strategy
+
+**There are two viable subplans:**
+
+#### B2a: Keep current WebSocket edge, replace only HTTP
+
+- [ ] Keep Hono or raw `ws` only for `/ws`.
+- [ ] Run the already-migrated Effect domain inside that thin edge.
+
+#### B2b: Replace WebSocket edge with Effect Platform primitives
+
+- [ ] Evaluate `Socket` / `NodeSocket` for server-side websocket support.
+- [ ] Design a dedicated Effect-based WS session runtime rather than forcing the HTTP abstraction to own it.
+- [ ] Replace connection lifecycle, heartbeat handling, and frame dispatch at the transport edge.
+
+**Risks of B2b:**
+- Higher engineering cost than simple HTTP replacement.
+- Harder parity testing for current WS behavior.
+- Easy to over-couple transport and domain if the runtime boundaries are not already clean.
+
+### Stage B3: Remove Hono
+
+- [ ] Only remove Hono after all live routes are migrated and parity tested.
+- [ ] Keep any remaining dev-only helpers or middleware isolated until the last route leaves Hono.
+
+**Exit criteria for Plan B:**
+- No Hono dependency in the server runtime.
+- HTTP routes are served through Effect Platform.
+- WS strategy is explicit, not incidental.
+
+---
+
+## Plan C: Database Strategy Plans
+
+This area is intentionally split into alternatives. The repo can stop after Plan A and still be fully Effect-native at the service/runtime layer.
+
+### Plan C1: Keep Kysely Behind Effect Services
+
+**Scope:** No SQL framework rewrite. Keep Kysely as the query builder and database integration surface, but expose it only through Effect services.
+
+**When this plan is enough:**
+- Type safety goals are mainly about runtime control flow, state, and errors.
+- Existing Kysely queries are stable and readable.
+- The team wants the lowest-risk migration.
+
+**Stages:**
+- [ ] Wrap DB access behind a `DbService` tag.
+- [ ] Centralize transaction helpers as Effect combinators.
+- [ ] Remove direct Kysely construction from leaf services.
+- [ ] Ensure all DB interaction returns typed Effect failures, not thrown driver errors.
+
+**Exit criteria:**
+- Business logic is Effect-native.
+- Kysely remains an implementation detail.
+
+### Plan C2: Use `@effect/sql-kysely` As A Bridge
+
+**Scope:** Introduce the official bridge package if it materially improves Effect integration without rewriting SQL access patterns.
+
+**Prerequisite:** Prototype it against the real query shapes in:
+- `packages/server/src/services/conversation.service.ts`
+- `packages/server/src/services/message.service.ts`
+- `packages/server/src/app/app-host.ts`
+
+**Stages:**
+- [ ] Run a proof-of-concept on one service with joins, transactions, and returning clauses.
+- [ ] Evaluate type quality, transaction ergonomics, and operational complexity.
+- [ ] If satisfactory, roll it out service by service.
+
+**Reason this is separate:**
+- The published docs surface for `@effect/sql-kysely` is smaller than the core SQL packages.
+- This should be validated on real queries before it becomes architectural policy.
+
+### Plan C3: Full SQL Rewrite To `@effect/sql-pg`
+
+**Scope:** Replace Kysely with Effect SQL primitives and Postgres integration.
+
+**When this plan makes sense:**
+- The team wants a fully Effect-native DB abstraction.
+- Query composition, resolvers, and transaction policies should live inside the Effect ecosystem.
+- Rewriting query builders is acceptable cost.
+
+### Stage C3.0: DB Capability Audit
+
+- [ ] Inventory every Kysely usage pattern:
+  - joins
+  - returning clauses
+  - `sql`` fragments
+  - transactions
+  - pagination
+  - generated database types
+- [ ] Identify which queries map cleanly to `SqlClient`, `Statement`, and `SqlResolver`.
+
+### Stage C3.1: Infrastructure Replacement
+
+**Files likely touched:**
+- `packages/server/src/db/client.ts`
+- `packages/server/src/db/database.ts`
+- `packages/server/src/services/*`
+
+- [ ] Replace pool setup with `PgClient.layer` or equivalent Layer construction.
+- [ ] Rework transaction entrypoints to `SqlClient.withTransaction`.
+- [ ] Replace direct driver error exposure with tagged DB failures.
+
+### Stage C3.2: Query Rewrite By Vertical Slice
+
+- [ ] Rewrite auth service queries.
+- [ ] Rewrite conversation service queries.
+- [ ] Rewrite message and delivery queries.
+- [ ] Rewrite app host permission/session queries last.
+
+### Stage C3.3: Remove Kysely
+
+- [ ] Delete Kysely-specific types, codegen config, and dialect setup only after all query paths are migrated.
+
+**Exit criteria for Plan C3:**
+- No Kysely dependency remains.
+- SQL access is fully Effect-native.
+
+---
+
+## Plan D: App SDK Migration Plan
+
+**Scope:** Applies when `packages/app-sdk` exists in the branch. Build it on top of the Effect-native client runtime rather than directly on the current imperative websocket client.
+
+**Why this is its own plan:**
+- `app-sdk` is public API surface.
+- Its internal runtime wants Effect, but its external surface should not force downstream apps to adopt Effect.
+
+### Stage D0: Preconditions
+
+- [ ] Plan A Stage A6 is complete.
+- [ ] Client reconnect, pending RPC, and event dispatch are already Effect-native.
+
+### Stage D1: Internal Runtime Model
+
+**Likely modules when the package exists:**
+- `packages/app-sdk/src/app.ts`
+- session managers
+- heartbeat managers
+- callback registries
+
+- [ ] Replace session maps and reverse indexes with `Ref`.
+- [ ] Replace heartbeat `setInterval` logic with `Schedule`.
+- [ ] Replace readiness and challenge waits with `Deferred`.
+- [ ] Replace callback-driven inbound routing with `Queue` or managed subscriptions.
+
+### Stage D2: Public API Compatibility
+
+- [ ] Keep public Promise/callback APIs stable.
+- [ ] Hide Effect internals behind small wrapper methods.
+- [ ] Expose typed errors and structured events without requiring downstream code to know `Effect`.
+
+### Stage D3: Integration With Server AppHost Semantics
+
+- [ ] Align SDK session lifecycle with the server’s Effect-based `AppHost`.
+- [ ] Share vocabulary and failure semantics for:
+  - permission requests
+  - session close
+  - ping / heartbeat
+  - hook-driven flows
+
+**Exit criteria for Plan D:**
+- `app-sdk` is built on the canonical Effect client runtime.
+- No second client runtime emerges inside the SDK.
+
+---
+
+## Suggested PR Slicing Template
+
+This section is neutral about which plan to choose. It exists to keep any chosen plan shippable.
+
+### Small PR policy
+
+- [ ] One vertical slice per PR wherever possible.
+- [ ] Keep compatibility wrappers local and delete them quickly.
+- [ ] Do not mix runtime migration with framework replacement in the same PR.
+- [ ] Prefer tests in the same PR as the migrated slice.
+
+### Example PR sequence for Plan A
+
+1. Foundation dependencies, helpers, and `@effect/vitest` setup.
+2. RPC/validator bridge and typed router scaffolding.
+3. Server composition Layer skeleton without changing behavior.
+4. Auth/register/connect slice.
+5. Conversations/messages slice.
+6. Presence/app-host slice.
+7. Client WS runtime slice.
+8. Client service/channel-core slice.
+9. CLI stabilization and cleanup.
+10. Strictness hardening.
+
+### Example PR sequence for Plan B
+
+1. HTTP abstraction skeleton beside current Hono routes.
+2. `/health` and registration route parity.
+3. Permission callback parity.
+4. Hono removal.
+
+### Example PR sequence for Plan C3
+
+1. SQL infrastructure Layer setup.
+2. Auth queries.
+3. Conversation queries.
+4. Message and delivery queries.
+5. App host queries.
+6. Kysely removal.
+
+---
+
+## Definition Of Done
+
+- [ ] `@moltzap/protocol` is still the neutral client/server contract package.
+- [ ] `@moltzap/server-core` and `@moltzap/client` are Effect-native internally.
+- [ ] No permanent dual runtime architecture exists.
+- [ ] Timeout, retry, and long-lived session flows are no longer hand-rolled around raw timers and mutable maps.
+- [ ] Typed failures replace exception-heavy control flow in migrated slices.
+- [ ] `@effect/vitest` is used for migrated test areas.
+
+---
+
+## Reference Material
+
+- Effect docs index: `https://effect-ts.github.io/effect/`
+- `Effect`: `https://effect-ts.github.io/effect/effect/Effect.ts.html`
+- `Layer`: `https://effect-ts.github.io/effect/effect/Layer.ts.html`
+- `Context`: `https://effect-ts.github.io/effect/effect/Context.ts.html`
+- `Config`: `https://effect-ts.github.io/effect/effect/Config.ts.html`
+- `Data`: `https://effect-ts.github.io/effect/effect/Data.ts.html`
+- `@effect/vitest`: `https://effect-ts.github.io/effect/docs/vitest`
+- `@effect/platform`: `https://effect-ts.github.io/effect/docs/platform`
+- `@effect/platform-node`: `https://effect-ts.github.io/effect/docs/platform-node`
+- `@effect/sql`: `https://effect-ts.github.io/effect/docs/sql`
+- `@effect/sql-pg`: `https://effect-ts.github.io/effect/docs/sql-pg`
+- `@effect/sql-kysely`: `https://effect-ts.github.io/effect/docs/sql-kysely`

--- a/docs/superpowers/plans/2026-04-16-effect-migration-plans.md
+++ b/docs/superpowers/plans/2026-04-16-effect-migration-plans.md
@@ -24,6 +24,8 @@
 
 **Companion deep-dive:** See `docs/superpowers/plans/2026-04-16-effect-hard-parts.md` for the code-level traps, behavior bugs worth fixing during migration, and recommended Effect patterns for the hardest runtime seams.
 
+**Companion POC:** See `docs/superpowers/plans/2026-04-16-effect-kysely-poc.md` for the targeted `@effect/sql-kysely` toolkit and `conversation.service`-style rewrite sample.
+
 ---
 
 ## Shared Constraints
@@ -481,8 +483,40 @@ This area is intentionally split into alternatives. The repo can stop after Plan
 - It first requires a deliberate Kysely upgrade track.
 - Even after the upgrade, it should still be treated as a bridge with patch-based risk, not a zero-risk foundation.
 
+**Additional proof-of-concept findings from a targeted `conversation.service`-style spike:**
+- Straight builder chains do map cleanly:
+  - `yield* db.selectFrom(...).select(...).where(...)`
+  - `yield* db.insertInto(...).values(...).returningAll()`
+- The `Pg` path replaces `db.transaction().execute(async (trx) => ...)` with `db.withTransaction(effect)`.
+- The main non-native seams are terminal helpers and raw SQL:
+  - `executeTakeFirst()`
+  - `executeTakeFirstOrThrow()`
+  - raw `sql``.execute(db)`
+- Those seams are bridgeable with a small local toolkit that captures both:
+  - the patched `EffectKysely<DB>` instance
+  - the underlying `SqlClient`
+- That toolkit can provide:
+  - `takeFirstOption`
+  - `takeFirstOrElse`
+  - `rawQuery`
+  - `inTransaction` or direct `db.withTransaction(...)`
+
+**Implication for this repo:**
+- `@effect/sql-kysely` is not “install one package and keep the current call style”.
+- It is “introduce a DB toolkit/service, then port services onto that surface”.
+- That is still materially smaller than a full `@effect/sql-pg` rewrite, but it is a real migration track.
+
+**Current rewrite surface in `packages/server/src`:**
+- roughly `101` `.execute*()` call sites
+- roughly `13` raw `sql`` call sites
+- `3` `transaction().execute(...)` blocks
+
 **Stages:**
 - [ ] Upgrade Kysely to a version supported by the current `@effect/sql-kysely` release in a separate compatibility PR.
+- [ ] Introduce a local DB toolkit/service that captures both `EffectKysely<DB>` and `SqlClient`.
+- [ ] Replace `executeTakeFirst*` usage with toolkit helpers before broad service rewrites.
+- [ ] Replace raw `sql`` execution with toolkit-backed execution or direct `@effect/sql` where appropriate.
+- [ ] Convert transaction-heavy modules to `db.withTransaction(effect)`.
 - [ ] Run a proof-of-concept on one service with joins, transactions, and returning clauses.
 - [ ] Evaluate type quality, transaction ergonomics, and operational complexity.
 - [ ] If satisfactory, roll it out service by service.

--- a/docs/superpowers/plans/2026-04-16-effect-migration-plans.md
+++ b/docs/superpowers/plans/2026-04-16-effect-migration-plans.md
@@ -424,6 +424,20 @@ interface RpcMethod<P, A, E, R> {
 
 This area is intentionally split into alternatives. The repo can stop after Plan A and still be fully Effect-native at the service/runtime layer.
 
+**Current recommendation for this repo:** Treat **Plan C1** as the default migration path.
+- Keep Kysely for the first Effect migration wave.
+- Hide it behind an Effect `DbService` / Layer boundary.
+- Revisit `@effect/sql-kysely` only after a proof-of-concept on real query-heavy modules.
+- Treat a full move to `@effect/sql-pg` as a separate project, not part of the initial runtime migration.
+
+**Why this is the current recommendation:**
+- The server currently has roughly 100 query-builder call sites plus raw `sql`` fragments, with the densest concentration in:
+  - `packages/server/src/app/app-host.ts`
+  - `packages/server/src/services/conversation.service.ts`
+  - `packages/server/src/services/message.service.ts`
+- The current DB bootstrap in `packages/server/src/db/client.ts` is already centralized, which makes it straightforward to wrap with `Layer.scoped`.
+- Rewriting the runtime model and rewriting the SQL layer at the same time would create avoidable migration risk.
+
 ### Plan C1: Keep Kysely Behind Effect Services
 
 **Scope:** No SQL framework rewrite. Keep Kysely as the query builder and database integration surface, but expose it only through Effect services.
@@ -435,6 +449,7 @@ This area is intentionally split into alternatives. The repo can stop after Plan
 
 **Stages:**
 - [ ] Wrap DB access behind a `DbService` tag.
+- [ ] Move DB construction and teardown into `Layer.scoped` using the existing `createDb()` / `db.destroy()` lifecycle.
 - [ ] Centralize transaction helpers as Effect combinators.
 - [ ] Remove direct Kysely construction from leaf services.
 - [ ] Ensure all DB interaction returns typed Effect failures, not thrown driver errors.
@@ -452,7 +467,22 @@ This area is intentionally split into alternatives. The repo can stop after Plan
 - `packages/server/src/services/message.service.ts`
 - `packages/server/src/app/app-host.ts`
 
+**Important caveats verified against the current package:**
+- The package README explicitly says the integration is **not fully future-proof** because it depends on Kysely internals and builder patching.
+- The current npm package peer dependency requires `kysely ^0.28.2`.
+- This repo currently uses `kysely ^0.27.0` in `packages/server` and `packages/evals`.
+- A scratch install validated the current state:
+  - latest `@effect/sql-kysely` installs and typechecks cleanly with `kysely 0.28.x`
+  - latest `@effect/sql-kysely` does **not** install cleanly with `kysely 0.27.x`
+  - forcing the `0.27.x` install still failed typechecking in a minimal sample
+
+**Interpretation:**
+- Plan C2 is not a same-day enhancement on top of the current repo.
+- It first requires a deliberate Kysely upgrade track.
+- Even after the upgrade, it should still be treated as a bridge with patch-based risk, not a zero-risk foundation.
+
 **Stages:**
+- [ ] Upgrade Kysely to a version supported by the current `@effect/sql-kysely` release in a separate compatibility PR.
 - [ ] Run a proof-of-concept on one service with joins, transactions, and returning clauses.
 - [ ] Evaluate type quality, transaction ergonomics, and operational complexity.
 - [ ] If satisfactory, roll it out service by service.

--- a/docs/superpowers/plans/2026-04-16-effect-migration-plans.md
+++ b/docs/superpowers/plans/2026-04-16-effect-migration-plans.md
@@ -22,6 +22,8 @@
   - `packages/client/src/ws-client.ts`
 - The most important unsafe seam today is `packages/server/src/rpc/context.ts`, where `defineMethod<T>()` erases types with a cast and relies on runtime validators to save the contract later.
 
+**Companion deep-dive:** See `docs/superpowers/plans/2026-04-16-effect-hard-parts.md` for the code-level traps, behavior bugs worth fixing during migration, and recommended Effect patterns for the hardest runtime seams.
+
 ---
 
 ## Shared Constraints

--- a/docs/superpowers/plans/2026-04-16-effect-migration-progress.md
+++ b/docs/superpowers/plans/2026-04-16-effect-migration-progress.md
@@ -1,0 +1,100 @@
+# Effect Migration — Progress Log
+
+> **For downstream consumers.** This document tracks scope expansion and completion state for the Effect migration. Planning artifacts live in `2026-04-16-effect-migration-plans.md` (scope), `2026-04-16-effect-hard-parts.md` (constraints + mandatory fixes), and `2026-04-16-effect-kysely-poc.md` (SQL bridge reference).
+
+**Branch doing the work:** `worktree-bold-elm-c01i` (will land as a series of PRs as scopes converge).
+
+**Last updated:** 2026-04-16, mid-session — 7 parallel agents still running.
+
+---
+
+## What shipped (landed in the working tree, typecheck-clean, tests green)
+
+### Plan A — Core runtime migration
+
+- **A0** — Foundation deps + `runtime/` helpers. `effect`, `@effect/vitest` installed in `@moltzap/server-core` and `@moltzap/client`. Tagged errors (`RpcFailure`, `InvalidParamsError`, `ForbiddenError` server; `NotConnectedError`, `RpcTimeoutError`, `RpcServerError`, `MalformedFrameError` client). Validator bridge (`validateParams(v, input): Effect<T, InvalidParamsError>`). Example `@effect/vitest` tests per package.
+
+- **A1 + A3 + A4 + A5** — Full server Effect migration. **No throws of typed domain errors anywhere.** `defineMethod` now only accepts `Effect<T, RpcFailure>` handlers. Router classifies three failure classes distinctly (decode / typed domain / defect) and maps to wire `ResponseFrame.error`. Every service (`auth`, `participant`, `conversation`, `delivery`, `message`, `user`) is Effect-returning. AppHost public methods return Effects. `DefaultPermissionService` uses `Effect.async` with typed `PermissionDeniedError | PermissionTimeoutError` channels. `inflightPermissions` coalesces via `Deferred` instead of `Promise<string[]>`. `admitAgentsAsync` uses `Effect.forkDaemon`. `runHookWithTimeout` uses `Effect.timeout` + `Effect.catchTag("TimeoutException", ...)`. `Promise.allSettled` in admission → `Effect.all([...], { concurrency: "unbounded", mode: "either" })`. `ContactService.areInContact: Effect<boolean, never>`. All `RpcError` class uses gone. 70/70 unit + 79/79 integration tests pass.
+
+- **A6** — Client WS runtime Effect-native. `ws-client.ts` internals are `ManagedRuntime` + `Ref<HashMap<string, Deferred>>` + `Effect.timeout` + scope-managed socket. New `packages/client/src/runtime/frame.ts` decodes inbound frames via protocol's pre-compiled AJV validators. **§5 hard-parts behavioral fixes (all four):**
+  1. `connect()` no longer hangs on pre-open close/error — settles immediately via single-shot latch.
+  2. Pending RPCs fail fast with `NotConnectedError` on disconnect (previously waited 30s for timeout).
+  3. Automatic retry for non-idempotent RPCs **removed**. Silent retry of `messages/send` / `conversations/create` / `apps/create` was a correctness bug; now every method gets one attempt.
+  4. Central typed decode for inbound frames via `decodeFrame` — malformed frames logged and dropped, never resolve a pending Deferred.
+
+- **A7** — Client `MoltZapService` Ref migration + **protocol contract drift bug fix** (§6.1). `sendToAgent` was calling `agents/lookupByName` with `{ name }` but protocol requires `{ names: string[] }`; return shape was `{ agent: { id } }` but protocol returns `{ agents: AgentCard[] }`. Tests reinforced the bug. Both fixed. All 7 stateful Maps moved to `Ref<HashMap>` (conversations, messages, agentNames, agentConversationCache, lastNotified, lastRead, pendingNameLookups). `pendingNameLookups` uses `Deferred` for coalescing (matches server's `inflightPermissions` pattern). Ext public API unchanged: async methods stay async, sync getters stay sync via `Effect.runSync(Ref.get(...))`. 128/128 client tests pass.
+
+### Plan B — HTTP transport replacement
+
+- **Hono → `@effect/platform` / `@effect/platform-node`** landed. All HTTP routes (`/health`, `/api/v1/auth/register`, `/api/v1/permissions/resolve`) served via `HttpRouter` + `HttpMiddleware.cors`. WebSocket kept on `ws` package (POC-guided decision — `@effect/platform` WS is higher-risk per hard-parts §5). WS upgrade attached manually to the Node `http.Server` exposed from `NodeHttpServer.layerContext`. Zero `hono` imports remain in `packages/server/src`. 149/149 tests pass.
+
+### Layer wiring + dependency injection
+
+- **Task #6 A2** — Layer-based `createCoreApp` wiring. 13 `Context.Tag`s (Db, Logger, Encryption, ConnectionManager, Broadcaster, Auth/Participant/Conversation/Delivery/Presence/AppHost/DefaultPermission/MessageService). 5-tier Layer composition via `Layer.provideMerge`. Handler factories' `deps` API unchanged — `createCoreApp` destructures a `ResolvedServices` object from a single `Effect.runSync(resolveServices.pipe(Effect.provide(FullLive)))`. 90-line imperative constructor chain → ~25 lines of declarative wiring. `packages/server/src/app/layers.ts` holds all tag + layer definitions.
+
+### Config
+
+- **Task #8** — `Effect.Config` native config loader. `packages/server/src/config/effect-config.ts` defines the full YAML shape via `Config.all` / `Config.nested` / `Config.option`. `loadConfigFromFile(path)` now returns `Effect<MoltZapConfig, ConfigLoadError>`. `ConfigLoadError` is a `Data.TaggedError` with discriminated `kind: "read" | "yaml" | "env" | "validation"`. `${ENV_VAR}` interpolation preserved. Behavior-compatible for consumers — `standalone.ts` edit is 3 lines.
+
+### Docs
+
+- Migration plans, hard-parts guide, SQL-Kysely POC doc all in `docs/superpowers/plans/` (this PR).
+
+---
+
+## What's in flight (agents still running)
+
+These are being worked on in parallel. Each touches a disjoint file scope.
+
+| Scope | Status | Files |
+|---|---|---|
+| **C2 Kysely** — custom PGlite SqlClient so `@effect/sql-kysely/Pg` works against both pg and PGlite (maintains zero-Docker quickstart) | Agent running | `packages/server/src/db/pglite-sql-client.ts` (new), `db/client.ts`, `db/effect-kysely-toolkit.ts` |
+| **Task #13 Typed RPC manifest** — `defineRpc({ name, params, result })` factory in `@moltzap/protocol`; typed `sendRpc<M>` + `defineMethod(manifest, handler)` overloads on client/server. Would have caught the A7 `sendToAgent` drift at compile time | Agent running | `packages/protocol/src/rpc.ts` (new), `rpc-registry.ts` (new), every method file under `schema/methods/*.ts`, client `ws-client.ts` + server `rpc/context.ts` overloads, one handler as POC |
+| **Evals Effect migration** — 4-phase pipeline (`runner.ts`) via `Effect.forEach { concurrency }`; LLM-judge retry+timeout via `Schedule.exponential().jittered` + `Effect.retry`; container lifecycle via `Effect.acquireRelease`; `FiberMap` for agent fleet | Agent running | `packages/evals/src/e2e-infra/*.ts` |
+| **OpenClaw polish** — module-global `activeClients` Map → factory closure; `try/catch` ladders in `directory.listPeers` / `listGroups` / `deliver` → `Effect.catchAll`; `new Promise(r => abortSignal.addEventListener("abort", r))` → `Effect.async` | Agent running | `packages/openclaw-channel/src/openclaw-entry.ts` |
+| **Task #7 FiberRef for connId** — hard-parts §4. Replace `AsyncLocalStorage<string>` with a `ConnIdTag` Context.Tag provided at WS edge. Removes `getConnId: () => ...` from every handler factory's deps | Agent running | `rpc/context.ts`, `rpc/router.ts`, `app/server.ts`, `app/handlers/*.ts` |
+| **Task #9 Effect logging Layer** — replace Pino global + ctor-injected `logger: Logger` with Effect `Logger.make` backed by Pino. Services call `Effect.logInfo(...).pipe(Effect.annotateLogs({...}))` | Agent running | `logger.ts`, `services/*.ts`, `app-host.ts`, `layers.ts` |
+| **Task #11 Layer-based test fakes** — replace `vi.mock` / `vi.spyOn` of our own services with `Layer.succeed(XxxTag, fake)` or structurally-typed test doubles. Catches contract drift at compile time | Agent running | `adapters/webhook.test.ts`, `service.test.ts` (client), new `test-utils/fakes.ts` |
+| **Nanoclaw cosmetic polish** | ✅ Done (cosmetic, for consistency) | `nanoclaw-channel/src/channels/moltzap.ts` |
+
+---
+
+## What's queued (not yet started)
+
+| Scope | Gate |
+|---|---|
+| **Task #10 TestClock for timeout-heavy integration tests** — replace real `setTimeout` sleeps with `TestClock.adjust(Duration.seconds(N))`. Hot targets: `33-session-failure`, `30-permissions`, `30-app-hooks`, `31-session-close` | After pglite lands (integration suite must be green to verify the migration) |
+| **Tighten `sloppy-code-guard.sh`** — reject `Promise<` / `async ` outside documented boundary files (transport edges, user-facing hook callbacks, framework contracts) | After everything else |
+| **Test pyramid rebalance** (tracked as GitHub issue #77) — move ~50 integration tests to Layer-based unit tests. Expected 4x CI speedup | Separate follow-up; issue filed |
+
+---
+
+## Explicit non-goals for this migration
+
+- **Do not** introduce a parallel `src/effect/` tree. Every migration slice replaces its imperative counterpart in-place.
+- **Do not** force external consumers to adopt Effect. Client public API stays Promise-based. CoreApp public methods that are user-callbacks (`dbCleanup`, `ConnectionHook`, `AppHooks`) stay Promise-compatible — the contracts are imposed by downstream, not us.
+- **Do not** migrate WebSocket transport to `@effect/platform`'s Socket. Hard-parts §5 flags it as higher-risk and incidental to this migration. Keep `ws` package; just Effect-manage the lifecycle.
+- **Do not** drop PGlite. Zero-Docker quickstart is a product feature. The custom PGlite SqlClient (in flight) preserves it.
+
+---
+
+## Why this matters for downstream
+
+- **Typed errors:** every RPC failure has a discriminated tag. Adding a new error code is a one-line `Data.TaggedError` declaration; the router pattern-matches on `_tag`. No more "InternalError" as a catch-all for silent data corruption.
+- **Structured concurrency:** `Effect.forkDaemon` for background admission, `FiberMap` for fleet management (evals), `Scope`-managed WS sockets. No more orphaned Promises that outlive the request that started them.
+- **Layer-based DI:** tests swap services for fakes with one line. The `sendToAgent` contract drift that shipped as a bug (fixed in A7) becomes a compile error with Layer-typed fakes.
+- **Timer determinism:** with `TestClock` integration (queued), the 500ms-sleep patterns in integration tests disappear. CI speed + flake reduction.
+- **Single source of truth for RPC contracts:** typed `defineRpc` manifest (in flight) unifies schema + types + validator + name per method. Enables future SDK codegen.
+
+---
+
+## Rough landing order (live; updated as agents converge)
+
+1. Server migration (Plans A0–A5 + Plan B) — landed in working tree
+2. Client migration (A6 + A7) — landed in working tree
+3. Plan C2 (PGlite SqlClient) — in flight, gates integration test verification
+4. Task #6 Layers + #8 Config + #13 RPC manifest + #7 FiberRef + #9 Logging Layer + #11 Test fakes — in flight
+5. Task #10 TestClock — after #3
+6. sloppy-code-guard tightening — last
+
+Exit criteria: `grep -r "Promise<\|async " packages/*/src | grep -v /runtime/ | grep -v test` returns only framework-edge files (Hono routes, WS callbacks, `@effect/platform` handlers, user-hook contracts).


### PR DESCRIPTION
## Summary
- add a full staged migration plan for moving client and server internals to Effect while keeping `@moltzap/protocol` TypeBox-based
- split the work into separate tracks for core runtime migration, optional HTTP replacement, optional SQL replacement, and app-sdk migration
- clean up stale `packages/server-core/...` filesystem path references so `packages/server/` is the only canonical source path

## Notes
- the new plan lives at `docs/superpowers/plans/2026-04-16-effect-migration-plans.md`
- published package identity remains `@moltzap/server-core`; this PR only standardizes filesystem path references

## Verification
- `bash packages/server/scripts/test-pack.sh` ✅
- `pnpm --filter @moltzap/server-core build` ⚠️ currently fails on existing app/protocol mismatches in `packages/server/src/app/*` that are not introduced by this PR
