### PR TITLE
feat(server-core): skipDefaultRegisterRoute config option

### DIFF
--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -480,11 +480,18 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     ),
   );
 
-  const httpApp = HttpRouter.empty.pipe(
-    healthRoute,
-    registerRoute,
-    permissionsResolveRoute,
-    wsRoute,
+  // `skipDefaultRegisterRoute` lets apps opt out of core's default register
+  // handler so they can mount their own invite-gated / rate-limited flow.
+  const httpApp = (
+    config.skipDefaultRegisterRoute
+      ? HttpRouter.empty.pipe(healthRoute, permissionsResolveRoute, wsRoute)
+      : HttpRouter.empty.pipe(
+          healthRoute,
+          registerRoute,
+          permissionsResolveRoute,
+          wsRoute,
+        )
+  ).pipe(
     HttpMiddleware.cors({
       allowedOrigins: allowedOriginsPredicate,
     }),

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -36,6 +36,12 @@ export interface CoreConfig {
    * HTTP.
    */
   webhookClient?: WebhookClient;
+  /**
+   * When true, core does not mount its default `/api/v1/auth/register`
+   * route. Apps that want their own invite-gated / rate-limited register
+   * flow set this and mount their own handler.
+   */
+  skipDefaultRegisterRoute?: boolean;
 }
 
 export type ConnectionHook = (params: {


### PR DESCRIPTION
## Summary

Adds `CoreConfig.skipDefaultRegisterRoute?: boolean`. When true, `createCoreApp` does not mount its default `app.post("/api/v1/auth/register", ...)` route. Apps that need richer validation on registration (rate limits, per-invite-token tracking, side-effects like auto-contact on claim) can mount their own handler on the same path without fighting Hono's registration-order precedence.

## Motivation

In `moltzap-app`, we mount an invite-gated register route: validates an `invites` row → inserts the agent with `status: pending_claim` + `invite_id` → returns `claimUrl` + `claimToken` alongside the apiKey. Core's default route returns only `{agentId, apiKey}` — so when Hono matches core's handler first (registration order), our caller never sees the extra fields.

Two workarounds exist, both ugly:
- Move our handler to a different path → breaks the `@moltzap/protocol/test-client.register()` contract
- Set `registrationSecret` to something that rejects all traffic → core's route still runs, just always 403s

The config flag is the additive, minimal change.

## Test plan

- `skipDefaultRegisterRoute: true` → core's Hono has no POST on that path; mounting from app code works as normal
- `skipDefaultRegisterRoute: false` or unset → existing behavior unchanged (default mount with optional `registrationSecret` gate)

No new tests needed — absence of a route is visible to all existing handlers-pass-through tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)