### PR TITLE
feat(server-core): onDisconnection hook + ownerUserId on onConnection

### DIFF
--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -41,7 +41,12 @@ import {
   type AsyncWebhookAdapter,
 } from "../adapters/webhook.js";
 
-import type { CoreConfig, CoreApp, ConnectionHook } from "./types.js";
+import type {
+  CoreConfig,
+  CoreApp,
+  ConnectionHook,
+  DisconnectionHook,
+} from "./types.js";
 import {
   DbTag,
   LoggerTag,
@@ -121,6 +126,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
 
   // Connection hooks
   const connectionHooks: ConnectionHook[] = [];
+  const disconnectionHooks: DisconnectionHook[] = [];
 
   // Webhook permission callback state (set via setWebhookPermissionCallback)
   let _webhookPermAdapter: AsyncWebhookAdapter | null = null;
@@ -406,8 +412,9 @@ export function createCoreApp(config: CoreConfig): CoreApp {
             // Fire connection hooks after a successful auth/connect — auth was
             // populated by the dispatch handler if the credentials were valid.
             if (frame.method === "auth/connect") {
-              const agentId = connections.get(connId)?.auth?.agentId;
-              if (!agentId) return;
+              const authCtx = connections.get(connId)?.auth;
+              if (!authCtx) return;
+              const { agentId, ownerUserId } = authCtx;
               const agentRow = yield* Effect.tryPromise(() =>
                 db
                   .selectFrom("agents")
@@ -419,7 +426,9 @@ export function createCoreApp(config: CoreConfig): CoreApp {
               for (const hook of connectionHooks) {
                 yield* Effect.tryPromise({
                   try: () =>
-                    Promise.resolve(hook({ agentId, agentName, connId })),
+                    Promise.resolve(
+                      hook({ agentId, agentName, ownerUserId, connId }),
+                    ),
                   catch: (err) => err,
                 }).pipe(
                   Effect.catchAll((err) =>
@@ -447,9 +456,33 @@ export function createCoreApp(config: CoreConfig): CoreApp {
         // connection leaks in the manager.
         yield* Effect.raceFirst(reader, Deferred.await(closeRequested)).pipe(
           Effect.onExit((exit) =>
-            Effect.sync(() => {
+            Effect.gen(function* () {
               const conn = connections.get(connId);
-              if (conn?.auth) presenceService.setOffline(conn.auth.agentId);
+              const authCtx = conn?.auth ?? null;
+              if (authCtx) presenceService.setOffline(authCtx.agentId);
+              // Disconnection hooks fire for connections that successfully
+              // authenticated. They run sequentially so an earlier hook's
+              // cleanup (e.g. `last_seen_at` update) completes before the
+              // next one observes the post-close state.
+              if (authCtx) {
+                const { agentId, ownerUserId } = authCtx;
+                for (const hook of disconnectionHooks) {
+                  yield* Effect.tryPromise({
+                    try: () =>
+                      Promise.resolve(hook({ agentId, ownerUserId, connId })),
+                    catch: (err) => err,
+                  }).pipe(
+                    Effect.catchAll((err) =>
+                      Effect.sync(() =>
+                        logger.error(
+                          { err, agentId, connId },
+                          "Disconnection hook error",
+                        ),
+                      ),
+                    ),
+                  );
+                }
+              }
               presenceService.removeConnection(connId);
               connections.remove(connId);
               if (Exit.isFailure(exit)) {
@@ -530,6 +563,9 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     },
     onConnection(hook: ConnectionHook) {
       connectionHooks.push(hook);
+    },
+    onDisconnection(hook: DisconnectionHook) {
+      disconnectionHooks.push(hook);
     },
     registerApp(manifest) {
       appHost.registerApp(manifest);

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -47,6 +47,14 @@ export interface CoreConfig {
 export type ConnectionHook = (params: {
   agentId: string;
   agentName: string;
+  /** Owner user ID resolved at auth/connect time. Null for unclaimed agents. */
+  ownerUserId: string | null;
+  connId: string;
+}) => Promise<void> | void;
+
+export type DisconnectionHook = (params: {
+  agentId: string;
+  ownerUserId: string | null;
   connId: string;
 }) => Promise<void> | void;
 
@@ -54,6 +62,12 @@ export interface CoreApp {
   readonly port: number;
   registerRpcMethod: (name: string, def: RpcMethodDef) => void;
   onConnection: (hook: ConnectionHook) => void;
+  /**
+   * Fires when a WebSocket closes, after auth was established. Use for
+   * per-user cleanup (e.g., `last_seen_at` updates). Does not fire for
+   * connections that never authenticated.
+   */
+  onDisconnection: (hook: DisconnectionHook) => void;
   registerApp: (manifest: AppManifest) => void;
   setContactService: (checker: ContactService) => void;
   setPermissionService: (handler: PermissionService) => void;


### PR DESCRIPTION
## Summary

Two small additive extensions to `CoreApp`:

1. **New `onDisconnection(hook)`** — fires on WS close (after auth was established). Mirrors `onConnection` for cleanup concerns: `last_seen_at` updates, per-user cache flushes, presence events.

2. **`ownerUserId` on `ConnectionHook` args** — extends from `{agentId, agentName, connId}` to `{agentId, agentName, ownerUserId, connId}`. The value is already resolved in `AuthenticatedContext` at \`auth/connect\` time, so passing it through avoids a per-hook re-query of the agents table.

## Why

In moltzap-app we cancel pending push notifications when an agent's owner comes online. Today that's \`onConnection({agentId}) => db.selectFrom("agents").where("id","=",agentId).select("owner_user_id")\` on every connect. Adding \`ownerUserId\` to the hook args eliminates the round-trip.

For disconnect, we want to update a human user's \`last_seen_at\` when their last agent drops. Currently no hook fires at close-after-auth.

## Behavior

- \`ConnectionHook\` args: adds \`ownerUserId: string | null\`. Hooks that don't read it compile unchanged.
- \`DisconnectionHook\`: fires only when auth was established (matching onConnection's gate). Does not fire for unauthenticated-then-closed connections. Errors log but don't block cleanup.
- Hook execution is sequential (\`for...await\`) to match the existing connection hook pattern. Each hook is wrapped in try/catch.

## Test plan

- Existing \`onConnection\` tests unaffected (ownerUserId added, not removed)
- New \`onDisconnection\` test: register + connect + close → hook fires with correct agentId + ownerUserId

🤖 Generated with [Claude Code](https://claude.com/claude-code)