### PR TITLE
feat: bearer-token auth via UserService for app-minted sessions

### DIFF
--- a/docs/protocol/methods/auth-connect.mdx
+++ b/docs/protocol/methods/auth-connect.mdx
@@ -9,8 +9,12 @@ Authenticate a WebSocket connection. Must be the first message on a new connecti
 
 ## Parameters
 
-<ParamField path="agentKey" type="string" required>
+<ParamField path="agentKey" type="string">
   The agentKey field.
+</ParamField>
+
+<ParamField path="sessionToken" type="string">
+  The sessionToken field.
 </ParamField>
 
 <ParamField path="minProtocol" type="string" required>

--- a/packages/protocol/src/schema/methods/auth.ts
+++ b/packages/protocol/src/schema/methods/auth.ts
@@ -46,7 +46,13 @@ export const Connect = defineRpc({
   name: "auth/connect",
   params: Type.Object(
     {
-      agentKey: Type.String(),
+      /** Agent API key — `moltzap_agent_<keyId>_<secret>`. Exactly one of
+       * `agentKey` or `sessionToken` must be present. */
+      agentKey: Type.Optional(Type.String()),
+      /** App-minted bearer token. Resolved via `UserService.validateSession`
+       * during auth/connect. Exactly one of `agentKey` or `sessionToken`
+       * must be present. */
+      sessionToken: Type.Optional(Type.String()),
       minProtocol: Type.String(),
       maxProtocol: Type.String(),
     },

--- a/packages/server/src/app/handlers/auth.handlers.ts
+++ b/packages/server/src/app/handlers/auth.handlers.ts
@@ -1,9 +1,10 @@
 import type { AuthService } from "../../services/auth.service.js";
 import type { ConversationService } from "../../services/conversation.service.js";
 import type { PresenceService } from "../../services/presence.service.js";
+import type { UserService } from "../../services/user.service.js";
 import { defineMethod } from "../../rpc/context.js";
 import { sql } from "kysely";
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 import { ConnIdTag } from "../layers.js";
 import type {
   RpcMethodRegistry,
@@ -20,8 +21,11 @@ import {
   AgentsList,
 } from "@moltzap/protocol";
 import type { RpcFailure } from "../../runtime/index.js";
-import { unauthorized } from "../../runtime/index.js";
-import { catchSqlErrorAsDefect } from "../../db/effect-kysely-toolkit.js";
+import { invalidParams, unauthorized } from "../../runtime/index.js";
+import {
+  catchSqlErrorAsDefect,
+  takeFirstOption,
+} from "../../db/effect-kysely-toolkit.js";
 
 function toAgentCard(row: {
   id: string;
@@ -47,6 +51,9 @@ export function createCoreAuthHandlers(deps: {
   presenceService: PresenceService;
   connections: ConnectionManager;
   db: Db;
+  /** Optional app-minted session resolver. When null, auth/connect rejects
+   * `sessionToken` requests with Unauthorized. */
+  userService: UserService | null;
 }): RpcMethodRegistry {
   return {
     "auth/connect": defineMethod(Connect, {
@@ -64,18 +71,26 @@ export function createCoreAuthHandlers(deps: {
               return yield* buildHelloOk(conn.auth, deps);
             }
 
-            const agent = yield* deps.authService.authenticateAgent(
-              params.agentKey,
-            );
-            if (!agent) {
-              return yield* Effect.fail(unauthorized("Authentication failed"));
+            const hasAgentKey = typeof params.agentKey === "string";
+            const hasSessionToken = typeof params.sessionToken === "string";
+            if (hasAgentKey === hasSessionToken) {
+              return yield* Effect.fail(
+                invalidParams(
+                  "Exactly one of `agentKey` or `sessionToken` required",
+                ),
+              );
             }
 
-            const auth: AuthenticatedContext = {
-              agentId: agent.agentId,
-              agentStatus: agent.status,
-              ownerUserId: agent.ownerUserId,
-            };
+            const auth: AuthenticatedContext = hasSessionToken
+              ? yield* authenticateSession(
+                  params.sessionToken as string,
+                  deps.userService,
+                  deps.db,
+                )
+              : yield* authenticateAgentKey(
+                  params.agentKey as string,
+                  deps.authService,
+                );
 
             conn.auth = auth;
 
@@ -178,6 +193,65 @@ export function createCoreAuthHandlers(deps: {
         ),
     }),
   };
+}
+
+/** Agent API-key path — existing behavior, typed `never` from authService. */
+function authenticateAgentKey(
+  agentKey: string,
+  authService: AuthService,
+): Effect.Effect<AuthenticatedContext, RpcFailure> {
+  return Effect.gen(function* () {
+    const agent = yield* authService.authenticateAgent(agentKey);
+    if (!agent) {
+      return yield* Effect.fail(unauthorized("Authentication failed"));
+    }
+    return {
+      agentId: agent.agentId,
+      agentStatus: agent.status,
+      ownerUserId: agent.ownerUserId,
+    };
+  });
+}
+
+/**
+ * App-minted bearer-token path. Resolves the session via
+ * `UserService.validateSession`, then looks up the agent status so
+ * `requiresActive` gating still works for the bearer path.
+ */
+function authenticateSession(
+  token: string,
+  userService: UserService | null,
+  db: Db,
+): Effect.Effect<AuthenticatedContext, RpcFailure> {
+  return catchSqlErrorAsDefect(
+    Effect.gen(function* () {
+      if (!userService?.validateSession) {
+        return yield* Effect.fail(
+          unauthorized("Session tokens not supported by this server"),
+        );
+      }
+      const result = yield* userService.validateSession(token);
+      if (!result.valid) {
+        return yield* Effect.fail(unauthorized("Authentication failed"));
+      }
+      // `result` is now narrowed to the `valid: true` branch; agentId and
+      // ownerUserId are guaranteed present by the discriminated union.
+      const rowOpt = yield* takeFirstOption(
+        db
+          .selectFrom("agents")
+          .select("status")
+          .where("id", "=", result.agentId),
+      );
+      if (Option.isNone(rowOpt)) {
+        return yield* Effect.fail(unauthorized("Authentication failed"));
+      }
+      return {
+        agentId: result.agentId,
+        agentStatus: rowOpt.value.status,
+        ownerUserId: result.ownerUserId,
+      };
+    }),
+  );
 }
 
 function buildHelloOk(

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -134,6 +134,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       presenceService,
       connections,
       db,
+      userService: config.userService ?? null,
     }),
     ...createConversationHandlers({
       conversationService,

--- a/packages/server/src/services/user.service.ts
+++ b/packages/server/src/services/user.service.ts
@@ -2,8 +2,31 @@ import { Effect } from "effect";
 import type { WebhookClient } from "../adapters/webhook.js";
 import type { Logger } from "../logger.js";
 
+/**
+ * Result of resolving an app-minted bearer session token. Discriminated
+ * union: `valid: true` guarantees `agentId` and `ownerUserId` are present,
+ * `valid: false` carries no payload. Narrow on `.valid` at call sites.
+ *
+ * The wire shape from webhooks is looser (optional fields); the
+ * `WebhookUserService` normalizer rejects partial payloads so anything
+ * reaching a call site already satisfies this invariant.
+ */
+export type SessionValidation =
+  | { readonly valid: false }
+  | {
+      readonly valid: true;
+      readonly agentId: string;
+      readonly ownerUserId: string;
+    };
+
 export interface UserService {
   validateUser(userId: string): Effect.Effect<{ valid: boolean }, never>;
+  /**
+   * Validate an app-minted session token during auth/connect. Optional —
+   * cores that don't support bearer-token auth omit it entirely. Returns
+   * `{valid: false}` for unknown/expired/revoked tokens.
+   */
+  validateSession?(token: string): Effect.Effect<SessionValidation, never>;
 }
 
 export class InProcessUserService implements UserService {
@@ -38,6 +61,50 @@ export class WebhookUserService implements UserService {
           this.logger.error(
             { err: cause, userId, url: this.url },
             "User validation webhook failed, rejecting user",
+          );
+          return { valid: false };
+        }),
+      ),
+    );
+  }
+
+  validateSession(token: string): Effect.Effect<SessionValidation, never> {
+    // Wire shape is looser than the internal discriminated union; normalize
+    // here so nothing downstream needs to re-check for missing fields.
+    interface WireResponse {
+      valid?: unknown;
+      agentId?: unknown;
+      ownerUserId?: unknown;
+    }
+    return Effect.tryPromise({
+      try: () =>
+        this.client.callSync<WireResponse>({
+          url: this.url,
+          event: "sessions.validate",
+          body: { token },
+          timeoutMs: this.timeoutMs,
+        }),
+      catch: (err) => err,
+    }).pipe(
+      Effect.map((result): SessionValidation => {
+        if (result.valid !== true) return { valid: false };
+        if (
+          typeof result.agentId !== "string" ||
+          typeof result.ownerUserId !== "string"
+        ) {
+          return { valid: false };
+        }
+        return {
+          valid: true,
+          agentId: result.agentId,
+          ownerUserId: result.ownerUserId,
+        };
+      }),
+      Effect.catchAllCause((cause) =>
+        Effect.sync((): SessionValidation => {
+          this.logger.error(
+            { err: cause, url: this.url },
+            "Session validation webhook failed, rejecting",
           );
           return { valid: false };
         }),


### PR DESCRIPTION
## Summary

Adds a session-token path to \`auth/connect\` alongside the existing \`agentKey\` path, delegating resolution to \`UserService.validateSession(token)\`. Enables apps like moltzap-app to mint short-lived bearer tokens for browsers without giving them the agent's API key.

## Protocol change

\`ConnectParamsSchema\` was:
```ts
{ agentKey: string, minProtocol, maxProtocol }
```

Now:
```ts
{
  agentKey?: string,
  sessionToken?: string,  // exactly one required
  minProtocol,
  maxProtocol,
}
```

Server rejects with \`InvalidParams\` if both or neither are present.

## UserService extension

```ts
interface UserService {
  validateUser(userId: string): Promise<{ valid: boolean }>;
  validateSession?(token: string): Promise<{
    valid: boolean;
    agentId?: string;
    ownerUserId?: string;
  }>;
}
```

- \`InProcessUserService\` — no-op (session tokens require an external resolver anyway)
- \`WebhookUserService\` — implements \`validateSession\` via \`sessions.validate\` event

## auth/connect flow

1. Client sends \`{sessionToken: "app_session:..."}\`
2. Server delegates to \`userService.validateSession(token)\`
3. Resolver returns \`{valid, agentId, ownerUserId}\` or \`{valid: false}\`
4. Server looks up local \`agents.status\` for the resolved agentId (for \`requiresActive\` gating)
5. Auth context populated same as agent-key path

## Why

Prior art: \`moltzap-app\` wanted browsers to authenticate to core WS without holding agent API keys (security + revocation concerns). Options were:
- Proxy the WS through app (adds ops surface, stateful middleware)
- Escrow agent keys in app DB (new security surface)
- Let app mint bearer tokens and let core call back for validation ← this PR

## Test plan

- \`{agentKey}\` alone → existing behavior, all tests pass
- \`{sessionToken}\` when \`userService.validateSession\` is unset → \`Unauthorized: Session tokens not supported by this server\`
- \`{sessionToken}\` with valid response → auth context populated, RPCs work
- \`{sessionToken}\` with \`{valid: false}\` → \`Unauthorized: Authentication failed\`
- \`{sessionToken}\` with resolved agentId that doesn't exist in \`agents\` → \`Unauthorized\`
- Both \`agentKey\` and \`sessionToken\` → \`InvalidParams\`
- Neither → \`InvalidParams\`

## Relation to other PRs

Pairs with #78 (skipDefaultRegisterRoute), #79 (onDisconnection + ownerUserId), #80 (deliveryWebhook). Together these are the extension points moltzap-app needs for the "two-service split" pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)