### PR TITLE
feat(server-core): expose Broadcaster + ConnectionManager on CoreApp

### DIFF
--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -569,6 +569,8 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     onDisconnection(hook: DisconnectionHook) {
       disconnectionHooks.push(hook);
     },
+    broadcaster,
+    connections,
     registerApp(manifest) {
       appHost.registerApp(manifest);
     },

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -10,6 +10,8 @@ import type {
   AsyncWebhookAdapter,
   WebhookClient,
 } from "../adapters/webhook.js";
+import type { Broadcaster } from "../ws/broadcaster.js";
+import type { ConnectionManager } from "../ws/connection.js";
 import type {
   BeforeMessageDeliveryHook,
   OnCloseHook,
@@ -80,6 +82,19 @@ export interface CoreApp {
    * connections that never authenticated.
    */
   onDisconnection: (hook: DisconnectionHook) => void;
+  /**
+   * Live Broadcaster instance. Apps that register custom RPCs and want to
+   * emit events out-of-band (not via `broadcastToConversation`) use this to
+   * `sendToAgent(agentId, event)`. Stable identity — same ref across the
+   * server lifetime.
+   */
+  readonly broadcaster: Broadcaster;
+  /**
+   * Live ConnectionManager instance. Apps can query `getByParticipant` to
+   * check whether an agent has any live connections (for presence-gated
+   * push decisions, etc.). Stable identity.
+   */
+  readonly connections: ConnectionManager;
   registerApp: (manifest: AppManifest) => void;
   setContactService: (checker: ContactService) => void;
   setPermissionService: (handler: PermissionService) => void;


### PR DESCRIPTION
## Summary

Adds \`broadcaster\` and \`connections\` as stable properties on the \`CoreApp\` return value. Apps that register custom RPCs via \`registerRpcMethod\` often need to fan events out to specific agents — e.g., notifying every active agent of a user when a contact request is accepted.

## Why

Without this, apps have two bad options:
1. Fork the server and re-inject their own Broadcaster
2. Stand up a parallel event bus that doesn't share connection state

The Broadcaster already knows every connection. Exposing the reference is additive and costs nothing.

## Use case

From \`moltzap-app\`'s contacts handlers (layered atop upstream's agent-only model):

\`\`\`ts
async function sendToOwnerAgents(db, broadcaster, userId, event) {
  const rows = await db.selectFrom("agents")
    .select("id")
    .where("owner_user_id", "=", userId)
    .where("status", "=", "active")
    .execute();
  for (const row of rows) {
    broadcaster.sendToAgent(row.id, event);
  }
}
\`\`\`

Replaces the \`Broadcaster.sendToUserAndAgents\` helper that was dropped when upstream went agent-only at the WS edge.

## Test plan

No new tests — \`broadcaster\` and \`connections\` are existing instances now reachable from the \`CoreApp\` return value. Stable identity is guaranteed by JavaScript reference semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)