### PR TITLE
feat(server-core): re-export runtime + effect-kysely toolkit

### DIFF
--- a/packages/server/src/__tests__/smoke.test.ts
+++ b/packages/server/src/__tests__/smoke.test.ts
@@ -27,5 +27,29 @@ describe("@moltzap/server-core", () => {
     expect(mod.createDb).toBeDefined();
     expect(mod.defineMethod).toBeDefined();
     expect(mod.nextSnowflakeId).toBeDefined();
+
+    // Runtime toolkit — error factories
+    expect(mod.notFound).toBeDefined();
+    expect(mod.forbidden).toBeDefined();
+    expect(mod.unauthorized).toBeDefined();
+    expect(mod.invalidParams).toBeDefined();
+    expect(mod.conflict).toBeDefined();
+    expect(mod.internalError).toBeDefined();
+    expect(mod.blocked).toBeDefined();
+    expect(mod.rateLimited).toBeDefined();
+
+    // Runtime toolkit — coalescing
+    expect(mod.coalesce).toBeDefined();
+    expect(mod.drainCoalesceMap).toBeDefined();
+
+    // Effect-Kysely toolkit
+    expect(mod.makeEffectKysely).toBeDefined();
+    expect(mod.takeFirstOption).toBeDefined();
+    expect(mod.takeFirstOrElse).toBeDefined();
+    expect(mod.takeFirstOrFail).toBeDefined();
+    expect(mod.catchSqlErrorAsDefect).toBeDefined();
+    expect(mod.sqlErrorToDefect).toBeDefined();
+    expect(mod.transaction).toBeDefined();
+    expect(mod.rawQuery).toBeDefined();
   });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -52,7 +52,29 @@ export {
   InvalidParamsError,
   ForbiddenError,
   validateParams,
+  notFound,
+  forbidden,
+  unauthorized,
+  invalidParams,
+  conflict,
+  internalError,
+  blocked,
+  rateLimited,
+  coalesce,
+  drainCoalesceMap,
+  type Validator,
 } from "./runtime/index.js";
+export {
+  makeEffectKysely,
+  takeFirstOption,
+  takeFirstOrElse,
+  takeFirstOrFail,
+  catchSqlErrorAsDefect,
+  sqlErrorToDefect,
+  transaction,
+  rawQuery,
+  type EffectKysely,
+} from "./db/effect-kysely-toolkit.js";
 export { ConnectionManager } from "./ws/connection.js";
 export { Broadcaster } from "./ws/broadcaster.js";
 export { EnvelopeEncryption } from "./crypto/envelope.js";

--- a/packages/server/src/runtime/errors.ts
+++ b/packages/server/src/runtime/errors.ts
@@ -40,6 +40,13 @@ export const conflict = (message: string, data?: unknown): RpcFailure =>
 export const internalError = (message: string): RpcFailure =>
   new RpcFailure({ code: ErrorCodes.InternalError, message });
 
+export const blocked = (message = "Blocked"): RpcFailure =>
+  new RpcFailure({ code: ErrorCodes.Blocked, message });
+
+export const rateLimited = (
+  message = "Please wait before trying again",
+): RpcFailure => new RpcFailure({ code: ErrorCodes.RateLimited, message });
+
 /** Boundary validation error — raised when an AJV validator rejects `params`. */
 export class InvalidParamsError extends Data.TaggedError("InvalidParamsError")<{
   readonly message: string;

--- a/packages/server/src/runtime/index.ts
+++ b/packages/server/src/runtime/index.ts
@@ -8,6 +8,8 @@ export {
   invalidParams,
   conflict,
   internalError,
+  blocked,
+  rateLimited,
 } from "./errors.js";
 export { validateParams, type Validator } from "./validator.js";
 export { coalesce, drainCoalesceMap } from "./coalesce.js";


### PR DESCRIPTION
## Summary

Re-export the full runtime + effect-kysely toolkit from `@moltzap/server-core`'s package entry so apps embedding the core can reuse it instead of duplicating local copies that drift.

Apps (e.g. MoltZap) wire their own services, handlers, and WS dispatch on top of `@moltzap/server-core`. They use the same building blocks the core itself uses — named `RpcFailure` factories, the `Ref`-based coalescing helpers, and the Kysely-as-Effect bridge — but today only `RpcFailure`, `InvalidParamsError`, `ForbiddenError`, and `validateParams` are surfaced. `package.json` whitelists only the `.` subpath, so deep imports aren't an option either. The net effect is that app repos copy `runtime/` and `effect-kysely-toolkit.ts` verbatim and those copies drift from upstream's.

Two small additions to `runtime/errors.ts`:

- `blocked(message?)` — `ErrorCodes.Blocked` already exists in `@moltzap/protocol` but had no factory.
- `rateLimited(message?)` — same story for `ErrorCodes.RateLimited`.

Surface added to the `.` export:

- Error factories: `notFound`, `forbidden`, `unauthorized`, `invalidParams`, `conflict`, `internalError`, `blocked`, `rateLimited`
- Coalescing: `coalesce`, `drainCoalesceMap`
- Effect-Kysely: `makeEffectKysely`, `takeFirstOption`, `takeFirstOrElse`, `takeFirstOrFail`, `catchSqlErrorAsDefect`, `sqlErrorToDefect`, `transaction`, `rawQuery`; type `EffectKysely<DB>`; type `Validator`

The smoke test in `src/__tests__/smoke.test.ts` is extended so the public surface is guarded against accidental drops.

No runtime behaviour changes — this is a purely additive re-export (plus two small factories).

## Test plan

- [x] `pnpm --filter @moltzap/server-core build` — clean
- [x] `pnpm --filter @moltzap/server-core test` — 110/110 green (smoke test extended)
- [x] `oxlint` + `oxfmt --check` on changed files — clean
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)