### PR TITLE
fix(server-core): post-merge simplify pass on PRs #78-82

### DIFF
--- a/docs/protocol/methods/auth-connect.mdx
+++ b/docs/protocol/methods/auth-connect.mdx
@@ -13,16 +13,16 @@ Authenticate a WebSocket connection. Must be the first message on a new connecti
   The agentKey field.
 </ParamField>
 
-<ParamField path="sessionToken" type="string">
-  The sessionToken field.
-</ParamField>
-
-<ParamField path="minProtocol" type="string" required>
+<ParamField path="minProtocol" type="string">
   The minProtocol field.
 </ParamField>
 
-<ParamField path="maxProtocol" type="string" required>
+<ParamField path="maxProtocol" type="string">
   The maxProtocol field.
+</ParamField>
+
+<ParamField path="sessionToken" type="string">
+  The sessionToken field.
 </ParamField>
 
 ## Response

--- a/packages/protocol/src/schema/methods/auth.ts
+++ b/packages/protocol/src/schema/methods/auth.ts
@@ -42,22 +42,29 @@ export const HelloOkSchema = Type.Object(
 // RpcDefinition manifests — one per wire method.
 // ---------------------------------------------------------------------------
 
+// XOR via Union: each branch has `additionalProperties: false`, so a
+// payload carrying both `agentKey` and `sessionToken` fails both branches
+// and AnyOf rejects at the validator — the handler doesn't re-check.
 export const Connect = defineRpc({
   name: "auth/connect",
-  params: Type.Object(
-    {
-      /** Agent API key — `moltzap_agent_<keyId>_<secret>`. Exactly one of
-       * `agentKey` or `sessionToken` must be present. */
-      agentKey: Type.Optional(Type.String()),
-      /** App-minted bearer token. Resolved via `UserService.validateSession`
-       * during auth/connect. Exactly one of `agentKey` or `sessionToken`
-       * must be present. */
-      sessionToken: Type.Optional(Type.String()),
-      minProtocol: Type.String(),
-      maxProtocol: Type.String(),
-    },
-    { additionalProperties: false },
-  ),
+  params: Type.Union([
+    Type.Object(
+      {
+        agentKey: Type.String(),
+        minProtocol: Type.String(),
+        maxProtocol: Type.String(),
+      },
+      { additionalProperties: false },
+    ),
+    Type.Object(
+      {
+        sessionToken: Type.String(),
+        minProtocol: Type.String(),
+        maxProtocol: Type.String(),
+      },
+      { additionalProperties: false },
+    ),
+  ]),
   result: HelloOkSchema,
 });
 

--- a/packages/server/src/adapters/webhook.ts
+++ b/packages/server/src/adapters/webhook.ts
@@ -3,7 +3,35 @@
 import type { ContactService, PermissionService } from "../app/app-host.js";
 import type { Logger } from "../logger.js";
 import { Effect } from "effect";
+import { createHmac } from "node:crypto";
 import type { RpcFailure } from "../runtime/index.js";
+
+/**
+ * HMAC-SHA256-sign a webhook payload and return the `X-MoltZap-Signature`
+ * header value (`sha256=<hex>`). Receivers recompute over the exact JSON
+ * bytes we send, so callers must pass the same `payload` string they will
+ * write to the HTTP body.
+ */
+export function signWebhookPayload(secret: string, payload: string): string {
+  return "sha256=" + createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+/**
+ * Typed failure raised by `Effect.tryPromise` wrappers around
+ * `WebhookClient.callSync`. Carries the original cause so downstream
+ * log sites can extract network/timeout detail without dealing with
+ * `unknown`.
+ */
+export class WebhookCallError extends Error {
+  override readonly name = "WebhookCallError";
+  constructor(
+    message: string,
+    readonly url: string,
+    readonly cause: unknown,
+  ) {
+    super(message);
+  }
+}
 
 // -- Semaphore ----------------------------------------------------------------
 

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { signWebhookPayload } from "../adapters/webhook.js";
 import type { Kysely } from "kysely";
 import type { AppSessionStatus, Database } from "../db/database.js";
 import type { Broadcaster } from "../ws/broadcaster.js";
@@ -1167,7 +1167,7 @@ export class AppHost {
     return Effect.gen(this, function* () {
       const bodyJson = JSON.stringify(opts.body);
       const signature = opts.secret
-        ? `sha256=${createHmac("sha256", opts.secret).update(bodyJson).digest("hex")}`
+        ? signWebhookPayload(opts.secret, bodyJson)
         : undefined;
 
       const request = Effect.tryPromise({

--- a/packages/server/src/app/handlers/auth.handlers.ts
+++ b/packages/server/src/app/handlers/auth.handlers.ts
@@ -21,7 +21,7 @@ import {
   AgentsList,
 } from "@moltzap/protocol";
 import type { RpcFailure } from "../../runtime/index.js";
-import { invalidParams, unauthorized } from "../../runtime/index.js";
+import { unauthorized } from "../../runtime/index.js";
 import {
   catchSqlErrorAsDefect,
   takeFirstOption,
@@ -71,26 +71,17 @@ export function createCoreAuthHandlers(deps: {
               return yield* buildHelloOk(conn.auth, deps);
             }
 
-            const hasAgentKey = typeof params.agentKey === "string";
-            const hasSessionToken = typeof params.sessionToken === "string";
-            if (hasAgentKey === hasSessionToken) {
-              return yield* Effect.fail(
-                invalidParams(
-                  "Exactly one of `agentKey` or `sessionToken` required",
-                ),
-              );
-            }
-
-            const auth: AuthenticatedContext = hasSessionToken
-              ? yield* authenticateSession(
-                  params.sessionToken as string,
-                  deps.userService,
-                  deps.db,
-                )
-              : yield* authenticateAgentKey(
-                  params.agentKey as string,
-                  deps.authService,
-                );
+            const auth: AuthenticatedContext =
+              "sessionToken" in params
+                ? yield* authenticateSession(
+                    params.sessionToken,
+                    deps.userService,
+                    deps.db,
+                  )
+                : yield* authenticateAgentKey(
+                    params.agentKey,
+                    deps.authService,
+                  );
 
             conn.auth = auth;
 
@@ -234,8 +225,13 @@ function authenticateSession(
       if (!result.valid) {
         return yield* Effect.fail(unauthorized("Authentication failed"));
       }
-      // `result` is now narrowed to the `valid: true` branch; agentId and
-      // ownerUserId are guaranteed present by the discriminated union.
+      if (result.agentStatus !== undefined) {
+        return {
+          agentId: result.agentId,
+          agentStatus: result.agentStatus,
+          ownerUserId: result.ownerUserId,
+        };
+      }
       const rowOpt = yield* takeFirstOption(
         db
           .selectFrom("agents")

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -11,6 +11,7 @@ import { NodeHttpServer } from "@effect/platform-node";
 import {
   Cause,
   Deferred,
+  Duration,
   Effect,
   Exit,
   Layer,
@@ -72,6 +73,30 @@ function safeEqual(a: string, b: string): boolean {
   const bufB = Buffer.from(b);
   if (bufA.length !== bufB.length) return false;
   return timingSafeEqual(bufA, bufB);
+}
+
+const USER_HOOK_TIMEOUT_MS = 2_000;
+
+function runUserHook<TArgs>(
+  hook: (args: TArgs) => void | Promise<void>,
+  args: TArgs,
+  label: string,
+  logCtx: Record<string, unknown>,
+): Effect.Effect<void> {
+  return Effect.tryPromise({
+    try: () => Promise.resolve(hook(args)),
+    catch: (err) => err,
+  }).pipe(
+    Effect.timeoutFail({
+      duration: Duration.millis(USER_HOOK_TIMEOUT_MS),
+      onTimeout: () => new Error(`${label} timed out`),
+    }),
+    Effect.catchAll((err) =>
+      Effect.sync(() => {
+        logger.error({ err, ...logCtx }, `${label} error`);
+      }),
+    ),
+  );
 }
 
 export function createCoreApp(config: CoreConfig): CoreApp {
@@ -427,21 +452,11 @@ export function createCoreApp(config: CoreConfig): CoreApp {
               ).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
               const agentName = agentRow?.name ?? agentId;
               for (const hook of connectionHooks) {
-                yield* Effect.tryPromise({
-                  try: () =>
-                    Promise.resolve(
-                      hook({ agentId, agentName, ownerUserId, connId }),
-                    ),
-                  catch: (err) => err,
-                }).pipe(
-                  Effect.catchAll((err) =>
-                    Effect.sync(() =>
-                      logger.error(
-                        { err, agentId, connId },
-                        "Connection hook error",
-                      ),
-                    ),
-                  ),
+                yield* runUserHook(
+                  hook,
+                  { agentId, agentName, ownerUserId, connId },
+                  "Connection hook",
+                  { agentId, connId },
                 );
               }
             }
@@ -463,26 +478,17 @@ export function createCoreApp(config: CoreConfig): CoreApp {
               const conn = connections.get(connId);
               const authCtx = conn?.auth ?? null;
               if (authCtx) presenceService.setOffline(authCtx.agentId);
-              // Disconnection hooks fire for connections that successfully
-              // authenticated. They run sequentially so an earlier hook's
-              // cleanup (e.g. `last_seen_at` update) completes before the
-              // next one observes the post-close state.
+              // Run sequentially so an earlier hook's cleanup (e.g.
+              // `last_seen_at`) completes before the next hook observes
+              // the post-close state.
               if (authCtx) {
                 const { agentId, ownerUserId } = authCtx;
                 for (const hook of disconnectionHooks) {
-                  yield* Effect.tryPromise({
-                    try: () =>
-                      Promise.resolve(hook({ agentId, ownerUserId, connId })),
-                    catch: (err) => err,
-                  }).pipe(
-                    Effect.catchAll((err) =>
-                      Effect.sync(() =>
-                        logger.error(
-                          { err, agentId, connId },
-                          "Disconnection hook error",
-                        ),
-                      ),
-                    ),
+                  yield* runUserHook(
+                    hook,
+                    { agentId, ownerUserId, connId },
+                    "Disconnection hook",
+                    { agentId, connId },
                   );
                 }
               }
@@ -610,6 +616,9 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     async close() {
       _webhookPermAdapter?.destroy();
       defaultPermissionService.destroy();
+      // Interrupt in-flight delivery-webhook retries before scope close so
+      // pending POSTs don't race the HTTP server teardown.
+      await Effect.runPromise(messageService.close());
       // `appHost.destroy()` runs before connections close, so any RPC
       // in-flight may observe cleared manifests. The drain sleep below is
       // the only mitigation today — tracked in /review output 2026-04-16.

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -1,15 +1,18 @@
 import type { Db } from "../db/client.js";
 import type { Message, Part } from "@moltzap/protocol";
 import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
-import { Duration, Effect, Option, Schedule } from "effect";
-import { createHmac } from "node:crypto";
+import { Duration, Effect, Fiber, Option, Schedule } from "effect";
 import { SqlError } from "@effect/sql/SqlError";
 import { RpcFailure, notFound, internalError } from "../runtime/index.js";
 import { nextSnowflakeId } from "../db/snowflake.js";
 import type { ConversationService } from "./conversation.service.js";
 import type { DeliveryService } from "./delivery.service.js";
 import type { Broadcaster } from "../ws/broadcaster.js";
-import type { WebhookClient } from "../adapters/webhook.js";
+import {
+  type WebhookClient,
+  WebhookCallError,
+  signWebhookPayload,
+} from "../adapters/webhook.js";
 import {
   type EnvelopeEncryption,
   generateDek,
@@ -52,6 +55,10 @@ const DELIVERY_WEBHOOK_TIMEOUT_MS = 5_000;
 const DELIVERY_WEBHOOK_MAX_ATTEMPTS = 3;
 
 export class MessageService {
+  private deliveryWebhookFibers = new Set<
+    Fiber.RuntimeFiber<unknown, unknown>
+  >();
+
   constructor(
     private db: Db,
     private conversations: ConversationService,
@@ -62,6 +69,12 @@ export class MessageService {
     private deliveryWebhook: DeliveryWebhookConfig | null = null,
     private webhookClient: WebhookClient | null = null,
   ) {}
+
+  close(): Effect.Effect<void, never> {
+    const pending = [...this.deliveryWebhookFibers];
+    this.deliveryWebhookFibers.clear();
+    return pending.length > 0 ? Fiber.interruptAll(pending) : Effect.void;
+  }
 
   send(
     conversationId: string,
@@ -219,13 +232,11 @@ export class MessageService {
             (id) => id !== senderAgentId && !deliveredSet.has(id),
           );
           if (offlineRecipientAgentIds.length > 0) {
-            yield* Effect.forkDaemon(
-              this.fireDeliveryWebhook({
-                conversationId,
-                messageId: message.id,
-                offlineRecipientAgentIds,
-              }),
-            );
+            this.spawnDeliveryWebhook({
+              conversationId,
+              messageId: message.id,
+              offlineRecipientAgentIds,
+            });
           }
         }
 
@@ -238,12 +249,21 @@ export class MessageService {
     );
   }
 
-  /**
-   * Detached daemon effect: POST `body` to the configured delivery webhook,
-   * HMAC-SHA256 signed, with bounded exponential-jittered retry. Never fails
-   * the caller — the final error channel is `never`; all outcomes log and
-   * return unit.
-   */
+  private spawnDeliveryWebhook(body: {
+    conversationId: string;
+    messageId: string;
+    offlineRecipientAgentIds: string[];
+  }): void {
+    const fibers = this.deliveryWebhookFibers;
+    const fiber = Effect.runFork(
+      this.fireDeliveryWebhook(body),
+    ) as Fiber.RuntimeFiber<unknown, unknown>;
+    fibers.add(fiber);
+    fiber.addObserver(() => {
+      fibers.delete(fiber);
+    });
+  }
+
   private fireDeliveryWebhook(body: {
     conversationId: string;
     messageId: string;
@@ -251,12 +271,12 @@ export class MessageService {
   }): Effect.Effect<void, never> {
     const cfg = this.deliveryWebhook;
     const client = this.webhookClient;
+    // Defensive: TS narrowing doesn't propagate across the fork boundary
+    // in `spawnDeliveryWebhook`, so we re-check here.
     if (!cfg || !client) return Effect.void;
 
     const payload = JSON.stringify(body);
-    const signature =
-      "sha256=" +
-      createHmac("sha256", cfg.secret).update(payload).digest("hex");
+    const signature = signWebhookPayload(cfg.secret, payload);
 
     // 1s base, doubled per attempt, ±50% jitter. `intersect` with `recurs`
     // caps the retry count at `MAX_ATTEMPTS - 1` so total attempts = MAX.
@@ -275,7 +295,8 @@ export class MessageService {
           timeoutMs: DELIVERY_WEBHOOK_TIMEOUT_MS,
           headers: { "X-MoltZap-Signature": signature },
         }),
-      catch: (err) => err,
+      catch: (err) =>
+        new WebhookCallError("messages.delivered failed", cfg.url, err),
     }).pipe(
       Effect.retry(retrySchedule),
       Effect.asVoid,

--- a/packages/server/src/services/user.service.ts
+++ b/packages/server/src/services/user.service.ts
@@ -1,5 +1,5 @@
-import { Effect } from "effect";
-import type { WebhookClient } from "../adapters/webhook.js";
+import { Cause, Effect } from "effect";
+import { WebhookCallError, type WebhookClient } from "../adapters/webhook.js";
 import type { Logger } from "../logger.js";
 
 /**
@@ -10,6 +10,11 @@ import type { Logger } from "../logger.js";
  * The wire shape from webhooks is looser (optional fields); the
  * `WebhookUserService` normalizer rejects partial payloads so anything
  * reaching a call site already satisfies this invariant.
+ *
+ * `agentStatus` is optional: when the webhook returns it we skip the
+ * `auth/connect` follow-up DB query that gates `requiresActive`. When
+ * absent, the handler falls back to a single `SELECT status FROM agents`
+ * (one extra round trip per bearer-token auth).
  */
 export type SessionValidation =
   | { readonly valid: false }
@@ -17,6 +22,7 @@ export type SessionValidation =
       readonly valid: true;
       readonly agentId: string;
       readonly ownerUserId: string;
+      readonly agentStatus?: string;
     };
 
 export interface UserService {
@@ -52,16 +58,17 @@ export class WebhookUserService implements UserService {
           body: { userId },
           timeoutMs: this.timeoutMs,
         }),
-      catch: (err) => err,
+      catch: (err) =>
+        new WebhookCallError("users.validate failed", this.url, err),
     }).pipe(
       // Strict boolean check — don't trust truthy strings from external services
       Effect.map((result) => ({ valid: result.valid === true })),
       Effect.catchAllCause((cause) =>
         Effect.sync(() => {
-          this.logger.error(
-            { err: cause, userId, url: this.url },
-            "User validation webhook failed, rejecting user",
-          );
+          this.logCauseAsFailClosed(cause, "User validation webhook", {
+            userId,
+            url: this.url,
+          });
           return { valid: false };
         }),
       ),
@@ -75,6 +82,9 @@ export class WebhookUserService implements UserService {
       valid?: unknown;
       agentId?: unknown;
       ownerUserId?: unknown;
+      /** Optional: lets `auth/connect` skip a DB round trip when the
+       * webhook already knows the agent's status. */
+      agentStatus?: unknown;
     }
     return Effect.tryPromise({
       try: () =>
@@ -84,7 +94,8 @@ export class WebhookUserService implements UserService {
           body: { token },
           timeoutMs: this.timeoutMs,
         }),
-      catch: (err) => err,
+      catch: (err) =>
+        new WebhookCallError("sessions.validate failed", this.url, err),
     }).pipe(
       Effect.map((result): SessionValidation => {
         if (result.valid !== true) return { valid: false };
@@ -94,21 +105,56 @@ export class WebhookUserService implements UserService {
         ) {
           return { valid: false };
         }
-        return {
-          valid: true,
-          agentId: result.agentId,
-          ownerUserId: result.ownerUserId,
-        };
+        const agentStatus =
+          typeof result.agentStatus === "string"
+            ? result.agentStatus
+            : undefined;
+        return agentStatus !== undefined
+          ? {
+              valid: true,
+              agentId: result.agentId,
+              ownerUserId: result.ownerUserId,
+              agentStatus,
+            }
+          : {
+              valid: true,
+              agentId: result.agentId,
+              ownerUserId: result.ownerUserId,
+            };
       }),
       Effect.catchAllCause((cause) =>
         Effect.sync((): SessionValidation => {
-          this.logger.error(
-            { err: cause, url: this.url },
-            "Session validation webhook failed, rejecting",
-          );
+          this.logCauseAsFailClosed(cause, "Session validation webhook", {
+            url: this.url,
+          });
           return { valid: false };
         }),
       ),
     );
+  }
+
+  /**
+   * Fail-closed reject logging. Expected failures (`Cause.Fail` —
+   * `WebhookCallError` from the typed `catch` above) log at warn. Defects
+   * (`Cause.Die` — synchronous throws inside the pipeline, always bugs)
+   * log at error with the full pretty cause so they're visible in the
+   * normal error stream, not hidden behind a quiet auth rejection.
+   */
+  private logCauseAsFailClosed(
+    cause: Cause.Cause<unknown>,
+    label: string,
+    ctx: Record<string, unknown>,
+  ): void {
+    if (Cause.isDieType(cause) || Cause.dieOption(cause)._tag === "Some") {
+      this.logger.error(
+        { cause: Cause.pretty(cause), ...ctx },
+        `${label} defect (bug) — rejecting`,
+      );
+    } else {
+      this.logger.warn(
+        { cause: Cause.pretty(cause), ...ctx },
+        `${label} failed — rejecting`,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up cleanups from the combined review agents flagged on the PR #78-82 cluster after they merged. Nothing that blocks operation — correctness/typing/operability improvements surfaced by the 3-agent review team (reuse, quality, efficiency).

## Changes

### HIGH

- **H1**: Track delivery-webhook daemon fibers on `MessageService`; interrupt on `close()` so shutdown doesn't stall waiting for retries or race HTTP teardown. Wired into `CoreApp.close()`.
- **H2**: Schema-level XOR for `auth/connect` — replace `agentKey?: string` + `sessionToken?: string` + handler check with a `Type.Union` of two disjoint object shapes. Malformed payloads fail at the validator boundary; handler narrows via `in` and drops the hand-rolled guard.

### MED

- **M3**: Extract `runUserHook<T>` helper in server.ts; both connection and disconnection dispatch sites use it.
- **M4**: Promote `signWebhookPayload(secret, payload)` into `adapters/webhook.ts`; reused by app-host's hook dispatch and message.service's delivery webhook.
- **M6**: 2s per-hook timeout inside `runUserHook` so a slow disconnection hook can't stall socket teardown.
- **M7**: Split defect vs failure handling in `WebhookUserService.validate*`: defects log at error with `Cause.pretty`, typed failures log at warn. Webhook-client bugs are now visible, not silently masked as auth rejections.
- **M8**: Typed `WebhookCallError` replaces `catch: (err) => err` in user.service and message.service.

### LOW

- Comment the defensive guard at the top of `fireDeliveryWebhook` (TS narrowing doesn't propagate through `runFork`).
- Optional `agentStatus` on `SessionValidation`; `authenticateSession` skips the extra `SELECT status FROM agents` round trip when the webhook supplied it.

## Test plan

- [x] \`pnpm -r build\` passes (7 packages)
- [x] \`pnpm -r test\` passes: 477 tests
- [x] \`scripts/sloppy-code-guard.sh\` clean
- [x] \`pnpm check\` (lint + format) — 0 errors, 20 pre-existing warnings
- [x] Protocol docs regenerated for the \`auth/connect\` schema change
- [ ] Merge once CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)