### PR TITLE
feat(server): Effect.Config for env vars

### DIFF
--- a/packages/server/src/app/config.ts
+++ b/packages/server/src/app/config.ts
@@ -1,14 +1,4 @@
-function requireEnv(name: string, defaultValue?: string): string {
-  const value = process.env[name] ?? defaultValue;
-  if (value === undefined) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-}
-
-function optionalEnv(name: string): string | undefined {
-  return process.env[name];
-}
+import { Config, ConfigError, Effect, Option } from "effect";
 
 export interface CorsConfig {
   exact: string[];
@@ -32,61 +22,93 @@ export interface LoadedConfig {
 /** Type alias so copied infrastructure files (e.g. db/client.ts) compile without changes. */
 export type ServerConfig = LoadedConfig;
 
-export function loadCoreConfig(): LoadedConfig {
-  const devMode = process.env["MOLTZAP_DEV_MODE"] === "true";
-
-  const databaseUrl = devMode
-    ? (optionalEnv("DATABASE_URL") ?? "")
-    : requireEnv("DATABASE_URL");
-
-  if (devMode && databaseUrl.includes(".supabase.co")) {
-    throw new Error(
-      "MOLTZAP_DEV_MODE=true cannot be used with a Supabase-hosted database",
-    );
-  }
-
-  return {
-    database: {
-      url: databaseUrl,
-    },
-    encryption: {
-      masterSecret: requireEnv("ENCRYPTION_MASTER_SECRET"),
-    },
-    server: {
-      port: parseInt(requireEnv("PORT", "3000")),
-      corsOrigins: parseCorsOrigins(optionalEnv("CORS_ORIGINS"), devMode),
-    },
-    devMode,
-  };
-}
-
-function parseCorsOrigins(
+const parseCorsOrigins = (
   raw: string | undefined,
   devMode: boolean,
-): CorsConfig {
-  if (!raw) {
-    if (devMode) return { exact: ["*"], patterns: [] };
-    throw new Error(
-      "CORS_ORIGINS is required in production. Set to comma-separated origins, use regex: prefix for patterns.",
+): Effect.Effect<CorsConfig, ConfigError.ConfigError> =>
+  Effect.gen(function* () {
+    if (!raw) {
+      if (devMode) return { exact: ["*"], patterns: [] };
+      return yield* Effect.fail(
+        ConfigError.MissingData(
+          ["CORS_ORIGINS"],
+          "CORS_ORIGINS is required in production. Set to comma-separated origins, use regex: prefix for patterns.",
+        ),
+      );
+    }
+    const exact: string[] = [];
+    const patterns: RegExp[] = [];
+    for (const entry of raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
+      if (entry.startsWith("regex:")) {
+        try {
+          patterns.push(new RegExp(`^${entry.slice(6)}$`));
+        } catch (err) {
+          return yield* Effect.fail(
+            ConfigError.InvalidData(
+              ["CORS_ORIGINS"],
+              `Invalid regex in CORS_ORIGINS: "${entry.slice(6)}" — ${err instanceof Error ? err.message : String(err)}`,
+            ),
+          );
+        }
+      } else {
+        exact.push(entry);
+      }
+    }
+    return { exact, patterns };
+  });
+
+/**
+ * Effect-native server config loader. Reads env vars through `Config` so
+ * missing/invalid values surface as typed `ConfigError` instead of thrown
+ * `Error`. Callers already inside an Effect program `yield*` this; the one
+ * sync entrypoint (`loadCoreConfig`) bridges via `Effect.runSync`.
+ */
+export const ServerConfigLoader: Effect.Effect<
+  LoadedConfig,
+  ConfigError.ConfigError
+> = Effect.gen(function* () {
+  const devMode = yield* Config.boolean("MOLTZAP_DEV_MODE").pipe(
+    Config.withDefault(false),
+  );
+
+  const databaseUrl = devMode
+    ? yield* Config.string("DATABASE_URL").pipe(Config.withDefault(""))
+    : yield* Config.string("DATABASE_URL");
+
+  if (devMode && databaseUrl.includes(".supabase.co")) {
+    return yield* Effect.fail(
+      ConfigError.InvalidData(
+        ["DATABASE_URL"],
+        "MOLTZAP_DEV_MODE=true cannot be used with a Supabase-hosted database",
+      ),
     );
   }
-  const exact: string[] = [];
-  const patterns: RegExp[] = [];
-  for (const entry of raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean)) {
-    if (entry.startsWith("regex:")) {
-      try {
-        patterns.push(new RegExp(`^${entry.slice(6)}$`));
-      } catch (err) {
-        throw new Error(
-          `Invalid regex in CORS_ORIGINS: "${entry.slice(6)}" — ${err}`,
-        );
-      }
-    } else {
-      exact.push(entry);
-    }
-  }
-  return { exact, patterns };
+
+  const masterSecret = yield* Config.string("ENCRYPTION_MASTER_SECRET");
+  const port = yield* Config.integer("PORT").pipe(Config.withDefault(3000));
+  const corsRawOpt = yield* Config.option(Config.string("CORS_ORIGINS"));
+  const corsOrigins = yield* parseCorsOrigins(
+    Option.getOrUndefined(corsRawOpt),
+    devMode,
+  );
+
+  return {
+    database: { url: databaseUrl },
+    encryption: { masterSecret },
+    server: { port, corsOrigins },
+    devMode,
+  };
+});
+
+/**
+ * Sync facade for the one boot entry (`app/dev.ts`) that runs outside an
+ * Effect program. Safe here because this is the absolute process entrypoint:
+ * a `ConfigError` bubbles up as an unhandled exception and fails startup —
+ * the same outcome the previous throw-based loader produced.
+ */
+export function loadCoreConfig(): LoadedConfig {
+  return Effect.runSync(ServerConfigLoader);
 }


### PR DESCRIPTION
## Summary
- Replaces throw-based `requireEnv` / `optionalEnv` helpers in `packages/server/src/app/config.ts` with `effect/Config` primitives (`Config.string`, `Config.integer`, `Config.boolean`, `Config.option`, `Config.withDefault`).
- Missing/invalid env vars now produce a typed `ConfigError` instead of `new Error(...)`. Validation failures (Supabase URL in dev mode, invalid CORS regex, missing `CORS_ORIGINS` in prod) surface as `ConfigError.InvalidData` / `ConfigError.MissingData`.
- Exposes `ServerConfigLoader: Effect.Effect<LoadedConfig, ConfigError.ConfigError>` for callers running inside an Effect program. The existing `loadCoreConfig()` is kept as a thin `Effect.runSync` wrapper for the one sync boot entry (`app/dev.ts`) — documented inline.

Scope matches task PR4 intent: only `config.ts` is touched. No other requireEnv/optionalEnv call sites exist in the repo. The shape of `LoadedConfig` / `ServerConfig` is unchanged, so `dev.ts` and downstream consumers keep compiling without edits.

## Behaviour note
`Config.boolean("MOLTZAP_DEV_MODE")` is stricter than the old `=== "true"` check: a non-empty, non-boolean value will fail validation rather than silently coerce to `false`. Same story for `PORT` via `Config.integer`. Intentional — that's the point of typed config.

## Test plan
- [x] `pnpm --filter @moltzap/server-core exec tsc --noEmit` — clean
- [x] `pnpm --filter @moltzap/server-core test` — 110/110 passing (no existing tests targeted `requireEnv`; nothing to delete)
- [x] Full-repo `pnpm typecheck` passes via the pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)