### PR TITLE
refactor(server): move Ref construction into Layer.effect

### DIFF
--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -287,9 +287,6 @@ export class AppHost {
   private manifests = new Map<string, AppManifest>();
   private contactService: ContactService | null = null;
   private permissionService: PermissionService | null = null;
-  private inflightPermissions = Effect.runSync(
-    Ref.make(HashMap.empty<string, Deferred.Deferred<string[], Error>>()),
-  );
   private hooks = new Map<string, AppHooks>();
   private conversationToSession = new Map<
     string,
@@ -310,6 +307,14 @@ export class AppHost {
      * path, which we deliberately avoid.
      */
     private webhookClient: WebhookClient,
+    /**
+     * Coalesce map for in-flight permission requests. Constructed in the
+     * AppHost Layer so `Ref.make` runs inside an Effect rather than via
+     * `Effect.runSync` at field-initializer time.
+     */
+    private inflightPermissions: Ref.Ref<
+      HashMap.HashMap<string, Deferred.Deferred<string[], Error>>
+    >,
   ) {}
 
   registerApp(manifest: AppManifest): void {
@@ -1244,10 +1249,8 @@ export class AppHost {
       // calls. Uses the same `coalesce` helper as `inflightPermissions` so
       // concurrent admitAgent fibers for the same owner race-safely share
       // one in-flight validateUser call (see runtime/coalesce.ts).
-      const userValidationCache = Effect.runSync(
-        Ref.make(
-          HashMap.empty<string, Deferred.Deferred<{ valid: boolean }, never>>(),
-        ),
+      const userValidationCache = yield* Ref.make(
+        HashMap.empty<string, Deferred.Deferred<{ valid: boolean }, never>>(),
       );
 
       // Run per-agent admissions concurrently, wrapping each in Exit to

--- a/packages/server/src/app/layers.ts
+++ b/packages/server/src/app/layers.ts
@@ -4,7 +4,7 @@
  * Dependency order is encoded in each `Layer.effect`'s `yield*` chain.
  * Tag string convention: `moltzap/<ClassName>`.
  */
-import { Context, Effect, Layer } from "effect";
+import { Context, Deferred, Effect, HashMap, Layer, Ref } from "effect";
 
 import type { Db } from "../db/client.js";
 import type { Logger } from "../logger.js";
@@ -187,12 +187,16 @@ export const AppHostLive = Layer.effect(
     const connections = yield* ConnectionManagerTag;
     const userService = yield* UserServiceTag;
     const webhookClient = yield* WebhookClientTag;
+    const inflightPermissions = yield* Ref.make(
+      HashMap.empty<string, Deferred.Deferred<string[], Error>>(),
+    );
     return new AppHost(
       db,
       broadcaster,
       connections,
       userService,
       webhookClient,
+      inflightPermissions,
     );
   }),
 );


### PR DESCRIPTION
## Summary

- Remove `Effect.runSync(Ref.make(...))` from the `AppHost` class field initializer; construct the Ref inside `AppHostLive` via `yield* Ref.make(...)` and inject it through the constructor so Ref creation stays inside the Effect runtime.
- Replace `Effect.runSync(Ref.make(...))` inside `admitAgentsAsync` with a direct `yield* Ref.make(...)` since that block is already an `Effect.gen`.

No behavior change — the Ref is constructed once per AppHost instance as before; it's just no longer created via a synchronous runtime escape hatch.

## Test plan
- [x] `pnpm --filter @moltzap/server-core exec tsc --noEmit`
- [x] Server unit tests (110 passed, including `app/layers.test.ts` and `app/app-host.test.ts`)
- [x] `23-coalesce-race` + `30-user-validation-cache` integration tests pass
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)