### PR TITLE
feat(client): require Effect handler for channel onMessage

### DIFF
--- a/packages/client/src/channel-core.test.ts
+++ b/packages/client/src/channel-core.test.ts
@@ -28,9 +28,11 @@ function customSetup(): {
     service: fake.service,
     logger: { info: () => {}, warn: () => {}, error: errorSpy },
   });
-  core.onInbound((m) => {
-    received.push(m);
-  });
+  core.onInbound((m) =>
+    Effect.sync(() => {
+      received.push(m);
+    }),
+  );
   return { fake, core, received, errorSpy };
 }
 
@@ -52,9 +54,11 @@ describe("MoltZapChannelCore", () => {
     service = fake.service;
     core = new MoltZapChannelCore({ service });
     inbound = [];
-    core.onInbound((msg) => {
-      inbound.push(msg);
-    });
+    core.onInbound((msg) =>
+      Effect.sync(() => {
+        inbound.push(msg);
+      }),
+    );
   });
 
   describe("lifecycle", () => {
@@ -239,20 +243,22 @@ describe("MoltZapChannelCore", () => {
       expect(inbound[0]!.replyToId).toBe("msg-parent-123");
     });
 
-    it("logs and swallows errors from the inbound handler", async () => {
+    it("logs failures from the inbound handler's Effect error channel and keeps the consumer alive", async () => {
       const { fake, errorSpy, core } = customSetup();
       fake.state.setConversation("conv-1", { type: "dm", participants: [] });
       fake.state.setAgentName("agent-alice", "Alice");
 
-      let handlerShouldThrow = true;
+      let handlerShouldFail = true;
       const received: EnrichedInboundMessage[] = [];
-      // Replace the setup's default capture handler with one that can throw.
-      core.onInbound((m) => {
-        if (handlerShouldThrow) {
-          throw new Error("handler boom");
-        }
-        received.push(m);
-      });
+      // Replace the setup's default capture handler with one that can fail.
+      core.onInbound((m) =>
+        Effect.gen(function* () {
+          if (handlerShouldFail) {
+            yield* Effect.fail(new Error("handler boom"));
+          }
+          received.push(m);
+        }),
+      );
 
       fake.emit.message(buildMessage({ id: "msg-1" }));
       await flushDispatchChain();
@@ -261,11 +267,39 @@ describe("MoltZapChannelCore", () => {
       expect(errorSpy).toHaveBeenCalledOnce();
 
       // Recovery: subsequent message lands cleanly.
-      handlerShouldThrow = false;
+      handlerShouldFail = false;
       fake.emit.message(buildMessage({ id: "msg-2" }));
       await flushDispatchChain();
       expect(received).toHaveLength(1);
       expect(received[0]!.id).toBe("msg-2");
+    });
+
+    it("logs synchronous defects thrown from inside the handler's Effect", async () => {
+      const { fake, errorSpy, core } = customSetup();
+      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+
+      core.onInbound((_m) =>
+        Effect.sync(() => {
+          throw new Error("sync defect");
+        }),
+      );
+
+      fake.emit.message(buildMessage({ id: "msg-1" }));
+      await flushDispatchChain();
+
+      expect(errorSpy).toHaveBeenCalledOnce();
+
+      // Consumer fiber survives a defect and continues to dispatch later messages.
+      const next: EnrichedInboundMessage[] = [];
+      core.onInbound((m) =>
+        Effect.sync(() => {
+          next.push(m);
+        }),
+      );
+      fake.emit.message(buildMessage({ id: "msg-2" }));
+      await flushDispatchChain();
+      expect(next.map((r) => r.id)).toEqual(["msg-2"]);
     });
   });
 
@@ -313,11 +347,15 @@ describe("MoltZapChannelCore", () => {
       const handlerBarriers: Array<() => void> = [];
       const order: string[] = [];
 
-      core.onInbound(async (m) => {
-        order.push(`enter:${m.id}`);
-        await new Promise<void>((resolve) => handlerBarriers.push(resolve));
-        order.push(`exit:${m.id}`);
-      });
+      core.onInbound((m) =>
+        Effect.gen(function* () {
+          order.push(`enter:${m.id}`);
+          yield* Effect.async<void>((resume) => {
+            handlerBarriers.push(() => resume(Effect.void));
+          });
+          order.push(`exit:${m.id}`);
+        }),
+      );
 
       fake.emit.message(buildMessage({ id: "msg-1" }));
       fake.emit.message(buildMessage({ id: "msg-2" }));
@@ -348,8 +386,8 @@ describe("MoltZapChannelCore", () => {
 
       const firstHandler = vi.fn();
       const secondHandler = vi.fn();
-      core.onInbound(firstHandler);
-      core.onInbound(secondHandler);
+      core.onInbound((m) => Effect.sync(() => firstHandler(m)));
+      core.onInbound((m) => Effect.sync(() => secondHandler(m)));
 
       fake.emit.message(buildMessage());
       await flushDispatchChain();
@@ -678,8 +716,8 @@ describe("MoltZapChannelCore", () => {
     });
   });
 
-  describe("handleInbound does not commit context on handler throw", () => {
-    it("leaves markers unadvanced so the next message re-sees the same context entries", async () => {
+  describe("handleInbound does not commit context on handler failure", () => {
+    it("leaves markers unadvanced when the handler's Effect fails so the next message re-sees the same context entries", async () => {
       const { fake, core } = customSetup();
       fake.state.setConversation("conv-1", { type: "dm", participants: [] });
       fake.state.setAgentName("agent-alice", "Alice");
@@ -693,16 +731,18 @@ describe("MoltZapChannelCore", () => {
         },
       ]);
 
-      let shouldThrow = true;
+      let shouldFail = true;
       const received: EnrichedInboundMessage[] = [];
-      core.onInbound((m) => {
-        received.push(m);
-        if (shouldThrow) {
-          throw new Error("inbound handler boom");
-        }
-      });
+      core.onInbound((m) =>
+        Effect.gen(function* () {
+          received.push(m);
+          if (shouldFail) {
+            yield* Effect.fail(new Error("inbound handler boom"));
+          }
+        }),
+      );
 
-      // First message: handler throws after capturing the enriched payload.
+      // First message: handler fails after capturing the enriched payload.
       // commitContext() must NOT run, so the fake's contextEntries remain.
       fake.emit.message(buildMessage({ id: "msg-1" }));
       await flushDispatchChain();
@@ -710,7 +750,7 @@ describe("MoltZapChannelCore", () => {
 
       // Second message: handler succeeds. Because the first message didn't
       // commit, the fake still returns the same entries.
-      shouldThrow = false;
+      shouldFail = false;
       fake.emit.message(buildMessage({ id: "msg-2" }));
       await flushDispatchChain();
       expect(received[1]!.contextBlocks.crossConversation).toHaveLength(1);

--- a/packages/client/src/channel-core.ts
+++ b/packages/client/src/channel-core.ts
@@ -2,7 +2,7 @@
  * Shared message-enrichment helper for MoltZap channel adapters.
  */
 
-import { Effect, Fiber, Queue } from "effect";
+import { Cause, Effect, Fiber, Queue } from "effect";
 import type { Message, PermissionsRequiredEvent } from "@moltzap/protocol";
 import type {
   CrossConversationEntry,
@@ -78,9 +78,15 @@ export interface ChannelCoreOptions {
   logger?: WsClientLogger;
 }
 
-export type InboundHandler = (
+/**
+ * Handler invoked for every enriched inbound message. Returns an Effect so the
+ * error channel is part of the type — callers fail with a tagged error and the
+ * consumer fiber logs it instead of dropping it on the floor like a Promise
+ * rejection would.
+ */
+export type InboundHandler<E = unknown> = (
   msg: EnrichedInboundMessage,
-) => Promise<void> | void;
+) => Effect.Effect<void, E>;
 
 const noopLogger = {
   info: () => {},
@@ -110,7 +116,7 @@ export class MoltZapChannelCore {
   private readonly service: ChannelService;
   private readonly logger: WsClientLogger;
   private connected = false;
-  private inboundHandler: InboundHandler | null = null;
+  private inboundHandler: InboundHandler<unknown> | null = null;
   /** Inbound messages enqueue synchronously; a single forked consumer fiber
    * serialises delivery so handlers execute one-at-a-time in arrival order. */
   private readonly inboundQueue: Queue.Queue<Message> = Effect.runSync(
@@ -131,16 +137,19 @@ export class MoltZapChannelCore {
       Queue.unsafeOffer(this.inboundQueue, message);
     });
 
-    // Handler failures are caught and logged so the consumer fiber survives.
+    // Both typed failures (Effect.fail) and defects (sync throws inside the
+    // handler's Effect) are caught — Cause.squash collapses either into a
+    // single value for the logger so the consumer fiber survives a misbehaving
+    // handler in either mode.
     const consumer = Effect.forever(
       Queue.take(this.inboundQueue).pipe(
         Effect.flatMap((message) =>
           this.dispatchInboundEffect(message).pipe(
-            Effect.catchAll((err) =>
+            Effect.catchAllCause((cause) =>
               Effect.sync(() =>
                 this.logger.error(
-                  { messageId: message.id, err },
-                  "MoltZapChannelCore: inbound handler threw",
+                  { messageId: message.id, err: Cause.squash(cause) },
+                  "MoltZapChannelCore: inbound handler failed",
                 ),
               ),
             ),
@@ -168,8 +177,8 @@ export class MoltZapChannelCore {
   }
 
   /** Replaces any previous handler. */
-  onInbound(handler: InboundHandler): void {
-    this.inboundHandler = handler;
+  onInbound<E>(handler: InboundHandler<E>): void {
+    this.inboundHandler = handler as InboundHandler<unknown>;
   }
 
   onDisconnect(handler: () => void): void {
@@ -317,18 +326,17 @@ export class MoltZapChannelCore {
     });
   }
 
-  private dispatchInboundEffect(message: Message): Effect.Effect<void, Error> {
+  private dispatchInboundEffect(
+    message: Message,
+  ): Effect.Effect<void, unknown> {
     return Effect.gen(this, function* () {
       if (!this.inboundHandler) return;
       const { enriched, commitContext } =
         yield* MoltZapChannelCore.enrichMessage(this.service, message);
-      // `inboundHandler` is user code and may return a Promise, so we bridge
-      // via `tryPromise` — the consumer fiber awaits this to preserve
-      // arrival-order delivery.
-      yield* Effect.tryPromise({
-        try: () => Promise.resolve(this.inboundHandler!(enriched)),
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      });
+      // The handler is user code returning an Effect — yield it directly so
+      // its typed error channel propagates to the consumer fiber, which logs
+      // and continues. We await it inline to preserve arrival-order delivery.
+      yield* this.inboundHandler(enriched);
       if (commitContext) commitContext();
     });
   }

--- a/packages/nanoclaw-channel/src/channels/moltzap.ts
+++ b/packages/nanoclaw-channel/src/channels/moltzap.ts
@@ -72,7 +72,7 @@ export class MoltZapChannel implements Channel {
     private readonly ownAgentId: string,
     private readonly evalMode: boolean = false,
   ) {
-    core.onInbound((msg) => this.handleInbound(msg));
+    core.onInbound((msg) => Effect.sync(() => this.handleInbound(msg)));
     core.onDisconnect(() => {
       logger.warn({ channel: "moltzap" }, "MoltZap disconnected");
     });

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -312,52 +312,55 @@ export function createMoltzapChannelPlugin() {
 
         const core = new MoltZapChannelCore({ service, logger: wsLogger });
 
-        // #ignore-sloppy-code-next-line[async-keyword]: core.onInbound handler signature contract
-        core.onInbound(async (enriched) => {
-          const chatType =
-            enriched.conversationMeta?.type === "group" ? "group" : "direct";
-          const fromId = `agent:${enriched.sender.id}`;
+        core.onInbound((enriched) =>
+          Effect.gen(function* () {
+            const chatType =
+              enriched.conversationMeta?.type === "group" ? "group" : "direct";
+            const fromId = `agent:${enriched.sender.id}`;
 
-          log?.info?.(
-            `MoltZap: inbound from ${fromId}: ${enriched.text.slice(0, 80)}`,
-          );
-
-          setStatus({
-            accountId,
-            lastInboundAt: Date.now(),
-            lastEventAt: Date.now(),
-          });
-
-          const crossConvBlock = formatCrossConvOpenClaw(
-            enriched.contextBlocks.crossConversationMessages ?? [],
-            { ownAgentId: service.ownAgentId ?? "" },
-          );
-          const bodyForAgent = crossConvBlock
-            ? `${crossConvBlock}\n\n${enriched.text}`
-            : enriched.text;
-
-          if (crossConvBlock) {
             log?.info?.(
-              `MoltZap: BodyForAgent has cross-conv context (${enriched.contextBlocks.crossConversationMessages?.length ?? 0} msgs) for ${enriched.conversationId}: ${bodyForAgent.slice(0, 500)}`,
+              `MoltZap: inbound from ${fromId}: ${enriched.text.slice(0, 80)}`,
             );
-          }
 
-          if (
-            !ctx.channelRuntime?.reply?.dispatchReplyWithBufferedBlockDispatcher
-          ) {
-            return;
-          }
+            setStatus({
+              accountId,
+              lastInboundAt: Date.now(),
+              lastEventAt: Date.now(),
+            });
 
-          const groupSubject = enriched.conversationMeta?.name;
-          const groupMembers =
-            enriched.conversationMeta?.type === "group"
-              ? enriched.conversationMeta.participants.join(",")
-              : undefined;
+            const crossConvBlock = formatCrossConvOpenClaw(
+              enriched.contextBlocks.crossConversationMessages ?? [],
+              { ownAgentId: service.ownAgentId ?? "" },
+            );
+            const bodyForAgent = crossConvBlock
+              ? `${crossConvBlock}\n\n${enriched.text}`
+              : enriched.text;
 
-          try {
-            const result =
-              await ctx.channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher(
-                {
+            if (crossConvBlock) {
+              log?.info?.(
+                `MoltZap: BodyForAgent has cross-conv context (${enriched.contextBlocks.crossConversationMessages?.length ?? 0} msgs) for ${enriched.conversationId}: ${bodyForAgent.slice(0, 500)}`,
+              );
+            }
+
+            const dispatch =
+              ctx.channelRuntime?.reply
+                ?.dispatchReplyWithBufferedBlockDispatcher;
+            if (!dispatch) {
+              return;
+            }
+
+            const groupSubject = enriched.conversationMeta?.name;
+            const groupMembers =
+              enriched.conversationMeta?.type === "group"
+                ? enriched.conversationMeta.participants.join(",")
+                : undefined;
+
+            // Bridge OpenClaw's Promise-shaped dispatch into Effect, then
+            // catchAll back to a logged no-op so a single failed reply doesn't
+            // crash the consumer fiber.
+            const result = yield* Effect.tryPromise({
+              try: () =>
+                dispatch({
                   ctx: {
                     Body: enriched.text,
                     BodyForAgent: bodyForAgent,
@@ -411,17 +414,23 @@ export function createMoltzapChannelPlugin() {
                       return Effect.runPromise(deliverEffect);
                     },
                   },
-                },
-              );
-            if (!result.queuedFinal) {
+                }),
+              catch: (err: unknown) => err,
+            }).pipe(
+              Effect.catchAll((err) =>
+                Effect.sync(() => {
+                  log?.error?.(`MoltZap: dispatch error: ${err}`);
+                  return null;
+                }),
+              ),
+            );
+            if (result && !result.queuedFinal) {
               log?.debug?.(
                 `MoltZap: dispatch completed without final reply for ${enriched.conversationId}`,
               );
             }
-          } catch (err: unknown) {
-            log?.error?.(`MoltZap: dispatch error: ${err}`);
-          }
-        });
+          }),
+        );
 
         // Forward non-message events for status/logging.
         // Sync dispatcher — no async work, just log + setStatus. // #ignore-sloppy-code[async-keyword]: comment prose only, not code


### PR DESCRIPTION
## Summary

- `MoltZapChannelCore.onInbound` now takes `(msg) => Effect.Effect<void, E>` instead of `(msg) => Promise<void> | void`. Handler errors live in the Effect type system rather than vanishing into unawaited Promise rejections.
- The consumer fiber catches both typed failures and sync defects via `Effect.catchAllCause` + `Cause.squash`, so a misbehaving handler logs once and the fiber survives.
- Adapters updated: `nanoclaw-channel/src/channels/moltzap.ts` wraps its sync handler in `Effect.sync`; `openclaw-channel/src/openclaw-entry.ts` rebuilds the dispatch handler as an `Effect.gen` that bridges OpenClaw's Promise-based reply API via `Effect.tryPromise`.
- Tests: previously-silent-error coverage in `channel-core.test.ts` rewritten to assert on the Effect error channel, plus a new test for sync defects thrown inside the handler's Effect.

## Test plan

- [x] `pnpm --filter @moltzap/client test` (154 unit + integration tests pass)
- [x] `pnpm --filter @moltzap/openclaw-channel test` (77 tests pass)
- [x] `pnpm --filter @moltzap/nanoclaw-channel test` (18 tests pass)
- [x] `pnpm typecheck` (clean)
- [x] `pnpm lint` (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)