### PR TITLE
feat(server): branded identifier types for user/agent/conversation/session/app

### DIFF
--- a/packages/server/src/__tests__/integration/30-user-validation-cache.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-user-validation-cache.integration.test.ts
@@ -21,16 +21,16 @@ import {
   registerAndConnect,
   getKyselyDb,
 } from "./helpers.js";
-import type { CoreApp } from "../../app/types.js";
+import type { CoreApp, UserId } from "../../app/types.js";
 import type { UserService } from "../../services/user.service.js";
 import type { ConnectedAgent } from "../../test-utils/helpers.js";
 
 let coreApp: CoreApp;
 /** Observable counter — assertion target for the coalescing behavior. */
-let validateCalls: Array<{ userId: string }>;
+let validateCalls: Array<{ userId: UserId }>;
 
 class CountingUserService implements UserService {
-  validateUser(userId: string): Effect.Effect<{ valid: boolean }, never> {
+  validateUser(userId: UserId): Effect.Effect<{ valid: boolean }, never> {
     // Small async delay so concurrent admitAgent fibers overlap — without
     // the delay the Ref.modify path inside `coalesce` could still pass a
     // broken implementation because each fiber completes its work

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -4,6 +4,7 @@ import type { AppSessionStatus, Database } from "../db/database.js";
 import type { Broadcaster } from "../ws/broadcaster.js";
 import type { ConnectionManager } from "../ws/connection.js";
 import type { UserService } from "../services/user.service.js";
+import { UserId } from "./types.js";
 import { logger } from "../logger.js";
 import type { AppManifest, AppSession, Part } from "@moltzap/protocol";
 import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
@@ -588,7 +589,7 @@ export class AppHost {
         // Validate initiator's user before persisting anything
         if (this.userService) {
           const { valid } = yield* this.userService.validateUser(
-            initiator.owner_user_id,
+            UserId(initiator.owner_user_id),
           );
           if (!valid) {
             return yield* Effect.fail(
@@ -1388,7 +1389,7 @@ export class AppHost {
       // has/set pattern we used previously had a race where both fibers
       // could create separate Deferreds and fire redundant webhooks.
       if (this.userService && agent.owner_user_id) {
-        const userId = agent.owner_user_id;
+        const userId = UserId(agent.owner_user_id);
         const userService = this.userService;
         checks.push(
           Effect.gen(this, function* () {

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -1,5 +1,5 @@
 import type { Kysely } from "kysely";
-import type { Effect } from "effect";
+import { Brand, type Effect } from "effect";
 import type { RpcMethodDef } from "../rpc/context.js";
 import type { AppManifest, AppSession } from "@moltzap/protocol";
 import type { Database } from "../db/database.js";
@@ -17,6 +17,28 @@ import type {
   OnCloseHook,
   OnJoinHook,
 } from "./hooks.js";
+
+/**
+ * Branded identifier types. Each constructor is a nominal brand — it wraps a
+ * validated string into the branded type at a trust boundary (HTTP handler,
+ * DB row mapper, webhook body decoder) without runtime cost. Branded IDs are
+ * assignable TO `string`, but a plain `string` is not assignable TO a brand
+ * without an explicit constructor call, so the compiler catches ID swaps.
+ */
+export type UserId = string & Brand.Brand<"UserId">;
+export const UserId = Brand.nominal<UserId>();
+
+export type AgentId = string & Brand.Brand<"AgentId">;
+export const AgentId = Brand.nominal<AgentId>();
+
+export type ConversationId = string & Brand.Brand<"ConversationId">;
+export const ConversationId = Brand.nominal<ConversationId>();
+
+export type SessionId = string & Brand.Brand<"SessionId">;
+export const SessionId = Brand.nominal<SessionId>();
+
+export type AppId = string & Brand.Brand<"AppId">;
+export const AppId = Brand.nominal<AppId>();
 
 export interface CoreConfig {
   db: Kysely<Database>;

--- a/packages/server/src/rpc/context.ts
+++ b/packages/server/src/rpc/context.ts
@@ -2,11 +2,12 @@ import type { Effect } from "effect";
 import type { RpcDefinition, Static, TSchema } from "@moltzap/protocol";
 import type { RpcFailure } from "../runtime/index.js";
 import type { ConnIdTag } from "../app/layers.js";
+import type { AgentId, UserId } from "../app/types.js";
 
 export interface AuthenticatedContext {
-  agentId: string;
+  agentId: AgentId;
   agentStatus: string;
-  ownerUserId: string | null;
+  ownerUserId: UserId | null;
 }
 
 /**

--- a/packages/server/src/rpc/router.test.ts
+++ b/packages/server/src/rpc/router.test.ts
@@ -5,6 +5,7 @@ import { ErrorCodes, type RequestFrame } from "@moltzap/protocol";
 import { createRpcRouter } from "./router.js";
 import type { AuthenticatedContext, RpcMethodDef } from "./context.js";
 import { ForbiddenError, RpcFailure } from "../runtime/index.js";
+import { AgentId, UserId } from "../app/types.js";
 
 // Router tests assemble handler fixtures directly as `RpcMethodDef` literals
 // rather than going through `defineMethod` — these aren't real RPC methods
@@ -13,13 +14,13 @@ import { ForbiddenError, RpcFailure } from "../runtime/index.js";
 const makeMethod = (def: RpcMethodDef): RpcMethodDef => def;
 
 const activeAgent: AuthenticatedContext = {
-  agentId: "agent-1",
+  agentId: AgentId("agent-1"),
   agentStatus: "active",
-  ownerUserId: "user-1",
+  ownerUserId: UserId("user-1"),
 };
 
 const pendingAgent: AuthenticatedContext = {
-  agentId: "agent-2",
+  agentId: AgentId("agent-2"),
   agentStatus: "pending_claim",
   ownerUserId: null,
 };

--- a/packages/server/src/services/auth.service.ts
+++ b/packages/server/src/services/auth.service.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import type { Db } from "../db/client.js";
 import type { Register, Static } from "@moltzap/protocol";
+import { AgentId, UserId } from "../app/types.js";
 
 type RegisterParams = Static<typeof Register.paramsSchema>;
 import {
@@ -21,7 +22,7 @@ export class AuthService {
 
   registerAgent(
     params: RegisterParams,
-  ): Effect.Effect<{ agentId: string; apiKey: string }, never> {
+  ): Effect.Effect<{ agentId: AgentId; apiKey: string }, never> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
         const { apiKey, keyId, secretHash } = generateApiKey();
@@ -41,7 +42,7 @@ export class AuthService {
           "Failed to insert agent",
         );
 
-        const agentId = result.id;
+        const agentId = AgentId(result.id);
 
         yield* Effect.logInfo("Agent registered").pipe(
           Effect.annotateLogs({ agentId, name: params.name }),
@@ -54,9 +55,9 @@ export class AuthService {
 
   authenticateAgent(apiKey: string): Effect.Effect<
     {
-      agentId: string;
+      agentId: AgentId;
       status: string;
-      ownerUserId: string | null;
+      ownerUserId: UserId | null;
     } | null,
     never
   > {
@@ -78,9 +79,10 @@ export class AuthService {
         if (hashSecret(parsed.secret) !== row.api_key_secret_hash) return null;
 
         return {
-          agentId: row.id,
+          agentId: AgentId(row.id),
           status: row.status,
-          ownerUserId: row.owner_user_id ?? null,
+          ownerUserId:
+            row.owner_user_id === null ? null : UserId(row.owner_user_id),
         };
       }),
     );

--- a/packages/server/src/services/user.service.test.ts
+++ b/packages/server/src/services/user.service.test.ts
@@ -3,14 +3,17 @@ import { Effect } from "effect";
 import { InProcessUserService, WebhookUserService } from "./user.service.js";
 import { WebhookError, type WebhookClient } from "../adapters/webhook.js";
 import { makeFakeWebhookClient } from "../test-utils/fakes.js";
+import { UserId } from "../app/types.js";
 
 describe("InProcessUserService", () => {
   it("always returns { valid: true }", async () => {
     const svc = new InProcessUserService();
-    expect(await Effect.runPromise(svc.validateUser("any-user"))).toEqual({
+    expect(
+      await Effect.runPromise(svc.validateUser(UserId("any-user"))),
+    ).toEqual({
       valid: true,
     });
-    expect(await Effect.runPromise(svc.validateUser(""))).toEqual({
+    expect(await Effect.runPromise(svc.validateUser(UserId("")))).toEqual({
       valid: true,
     });
   });
@@ -64,7 +67,7 @@ describe("WebhookUserService", () => {
     const { svc, callSync } = createService();
     callSync.mockResolvedValue({ valid: true });
 
-    const result = await Effect.runPromise(svc.validateUser("user-42"));
+    const result = await Effect.runPromise(svc.validateUser(UserId("user-42")));
 
     expect(result).toEqual({ valid: true });
     expect(callSync).toHaveBeenCalledWith({
@@ -79,7 +82,9 @@ describe("WebhookUserService", () => {
     const { svc, callSync } = createService();
     callSync.mockResolvedValue({ valid: false });
 
-    expect(await Effect.runPromise(svc.validateUser("bad-user"))).toEqual({
+    expect(
+      await Effect.runPromise(svc.validateUser(UserId("bad-user"))),
+    ).toEqual({
       valid: false,
     });
   });
@@ -88,17 +93,21 @@ describe("WebhookUserService", () => {
     const { svc, callSync } = createService();
     callSync.mockRejectedValue(new WebhookError("timeout", 0));
 
-    expect(await Effect.runPromise(svc.validateUser("user-1"))).toEqual({
-      valid: false,
-    });
+    expect(await Effect.runPromise(svc.validateUser(UserId("user-1")))).toEqual(
+      {
+        valid: false,
+      },
+    );
   });
 
   it("returns { valid: false } on network error", async () => {
     const { svc, callSync } = createService();
     callSync.mockRejectedValue(new Error("ECONNREFUSED"));
 
-    expect(await Effect.runPromise(svc.validateUser("user-1"))).toEqual({
-      valid: false,
-    });
+    expect(await Effect.runPromise(svc.validateUser(UserId("user-1")))).toEqual(
+      {
+        valid: false,
+      },
+    );
   });
 });

--- a/packages/server/src/services/user.service.ts
+++ b/packages/server/src/services/user.service.ts
@@ -1,6 +1,7 @@
 import { Cause, Effect } from "effect";
 import { WebhookCallError, type WebhookClient } from "../adapters/webhook.js";
 import type { Logger } from "../logger.js";
+import { AgentId, UserId } from "../app/types.js";
 
 /**
  * Result of resolving an app-minted bearer session token. Discriminated
@@ -20,13 +21,13 @@ export type SessionValidation =
   | { readonly valid: false }
   | {
       readonly valid: true;
-      readonly agentId: string;
-      readonly ownerUserId: string;
+      readonly agentId: AgentId;
+      readonly ownerUserId: UserId;
       readonly agentStatus?: string;
     };
 
 export interface UserService {
-  validateUser(userId: string): Effect.Effect<{ valid: boolean }, never>;
+  validateUser(userId: UserId): Effect.Effect<{ valid: boolean }, never>;
   /**
    * Validate an app-minted session token during auth/connect. Optional —
    * cores that don't support bearer-token auth omit it entirely. Returns
@@ -36,7 +37,7 @@ export interface UserService {
 }
 
 export class InProcessUserService implements UserService {
-  validateUser(_userId: string): Effect.Effect<{ valid: boolean }, never> {
+  validateUser(_userId: UserId): Effect.Effect<{ valid: boolean }, never> {
     return Effect.succeed({ valid: true });
   }
 }
@@ -49,7 +50,7 @@ export class WebhookUserService implements UserService {
     private logger: Logger,
   ) {}
 
-  validateUser(userId: string): Effect.Effect<{ valid: boolean }, never> {
+  validateUser(userId: UserId): Effect.Effect<{ valid: boolean }, never> {
     return Effect.tryPromise({
       try: () =>
         this.client.callSync<{ valid: boolean }>({
@@ -109,17 +110,19 @@ export class WebhookUserService implements UserService {
           typeof result.agentStatus === "string"
             ? result.agentStatus
             : undefined;
+        const agentId = AgentId(result.agentId);
+        const ownerUserId = UserId(result.ownerUserId);
         return agentStatus !== undefined
           ? {
               valid: true,
-              agentId: result.agentId,
-              ownerUserId: result.ownerUserId,
+              agentId,
+              ownerUserId,
               agentStatus,
             }
           : {
               valid: true,
-              agentId: result.agentId,
-              ownerUserId: result.ownerUserId,
+              agentId,
+              ownerUserId,
             };
       }),
       Effect.catchAllCause((cause) =>


### PR DESCRIPTION
## Summary

Introduces nominal branded types for the five primary identifiers in `packages/server/src/app/types.ts`:
`UserId`, `AgentId`, `ConversationId`, `SessionId`, `AppId`. Each is `string & Brand.Brand<"Name">` with a
`Brand.nominal<T>()` constructor. No runtime cost — just compile-time protection against ID swaps
(e.g. passing an agent ID where a user ID is expected).

Branded strings are assignable **to** `string`, but plain strings require an explicit constructor call
to flow **into** a brand. So the top of the auth trust boundary is branded, and IDs propagate outward
without cascading edits.

## Scope

Intentionally narrow — PR5 in the effect-ification series. Branding is applied at the auth trust
boundary only; call sites deeper in the stack still use `string` and will be tightened in follow-ups.

Changed files (8):

- `app/types.ts` — brand definitions + constructors
- `rpc/context.ts` — `AuthenticatedContext.agentId`, `ownerUserId`
- `services/auth.service.ts` — `registerAgent` / `authenticateAgent` return types branded; DB rows wrapped at the mapper
- `services/user.service.ts` — `SessionValidation` branded; `UserService.validateUser` takes `UserId`; webhook decoder wraps strings
- `app/app-host.ts` — two DB-boundary call sites wrap `owner_user_id` into `UserId`
- `rpc/router.test.ts`, `services/user.service.test.ts`, `__tests__/integration/30-user-validation-cache.integration.test.ts` — test fixtures updated

## Out of scope (follow-ups)

- `CoreApp` public interface parameters still take `string` — widening those is a public-surface change
- `packages/client` untouched
- Most handler / service call sites still pass `string`; will tighten incrementally once brands exist
- `ConversationId`, `SessionId`, `AppId` are defined but not yet applied at any call site — reserved for
  their respective trust-boundary PRs (conversation store, session lifecycle, app manifest loader)

## Test plan

- [x] `pnpm --filter @moltzap/server-core exec tsc --noEmit` clean
- [x] `pnpm --filter @moltzap/server-core test` — 110/110 pass
- [ ] Reviewer: confirm no plain-string ID flows through the new branded return types

🤖 Generated with [Claude Code](https://claude.com/claude-code)