### PR TITLE
feat: schema-validate JSON/YAML at trust boundaries

### DIFF
--- a/packages/evals/src/e2e-infra/runner.ts
+++ b/packages/evals/src/e2e-infra/runner.ts
@@ -3,7 +3,7 @@
  * analyze. Each phase's own JSDoc documents its shape and concurrency.
  */
 
-import { Duration, Effect } from "effect";
+import { Duration, Effect, Either, Schema } from "effect";
 import {
   startCoreTestServer,
   stopCoreTestServer,
@@ -37,6 +37,29 @@ const EVAL_PHASE_CONCURRENCY = 4;
 /** Settle window after a group message so bystander agents can pipe a side reply. */
 const BYSTANDER_SETTLE_MS = 3000;
 
+/**
+ * Wire shape of the `conversationContext` JSON built in `generateResult`.
+ * The runner both produces and consumes it, so a decode failure here means
+ * the producer and consumer have drifted — surface it as a validation error
+ * rather than silently casting and reading `undefined` fields.
+ */
+const MessagePartSchema = Schema.Struct({
+  type: Schema.String,
+  text: Schema.optional(Schema.String),
+});
+
+const ConversationContextSchema = Schema.Struct({
+  conversationId: Schema.String.pipe(Schema.nonEmptyString()),
+  senderId: Schema.String.pipe(Schema.nonEmptyString()),
+  messageId: Schema.String.pipe(Schema.nonEmptyString()),
+  parts: Schema.Array(MessagePartSchema).pipe(Schema.minItems(1)),
+  createdAt: Schema.optional(Schema.String),
+});
+
+const decodeConversationContext = Schema.decodeUnknownEither(
+  Schema.parseJson(ConversationContextSchema),
+);
+
 /** Validate a MoltZap message response against protocol constraints. */
 function validateResponse(result: GeneratedResult): ValidatedResult {
   const errors: string[] = [];
@@ -50,42 +73,17 @@ function validateResponse(result: GeneratedResult): ValidatedResult {
     errors.push("Agent response is empty");
   }
 
-  // The response text is what we got from the agent via MoltZap.
-  // We validate context metadata embedded during generation.
   if (result.conversationContext) {
-    try {
-      const ctx = JSON.parse(result.conversationContext) as {
-        conversationId?: string;
-        senderId?: string;
-        messageId?: string;
-        parts?: Array<{ type: string; text?: string }>;
-      };
-
-      if (!ctx.conversationId) {
-        errors.push("Response missing conversationId");
-      }
-      if (!ctx.senderId) {
-        errors.push("Response missing sender agent ID");
-      }
-      if (!ctx.messageId) {
-        errors.push("Response missing message ID");
-      }
-      if (!ctx.parts || ctx.parts.length === 0) {
-        errors.push("Response has no message parts");
-      } else {
-        const hasText = ctx.parts.some(
-          (p) => p.type === "text" && p.text && p.text.trim() !== "",
-        );
-        if (!hasText) {
-          errors.push("Response has no non-empty text parts");
-        }
-      }
-    } catch (err) {
-      errors.push(
-        `Conversation context is not valid JSON: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+    const decoded = decodeConversationContext(result.conversationContext);
+    if (Either.isLeft(decoded)) {
+      errors.push(`Invalid conversation context: ${decoded.left.message}`);
+    } else {
+      const hasText = decoded.right.parts.some(
+        (p) => p.type === "text" && p.text && p.text.trim() !== "",
       );
+      if (!hasText) {
+        errors.push("Response has no non-empty text parts");
+      }
     }
   }
 

--- a/packages/server/src/adapters/webhook.test.ts
+++ b/packages/server/src/adapters/webhook.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Schema } from "effect";
 import { WebhookClient, AsyncWebhookAdapter, WebhookError } from "./webhook.js";
+
+const OkSchema = Schema.Struct({ ok: Schema.Boolean });
+const AnySchema = Schema.Unknown;
 
 // -- WebhookClient (sync) ---------------------------------------------------
 
@@ -20,11 +24,12 @@ describe("WebhookClient", () => {
       new Response(JSON.stringify({ ok: true }), { status: 200 }),
     );
 
-    const result = await client.callSync<{ ok: boolean }>({
+    const result = await client.callSync({
       url: "https://hook.test/users",
       event: "users.validate",
       body: { userId: "u1" },
       timeoutMs: 5000,
+      schema: OkSchema,
     });
 
     expect(result).toEqual({ ok: true });
@@ -50,6 +55,7 @@ describe("WebhookClient", () => {
         event: "test",
         body: {},
         timeoutMs: 5000,
+        schema: AnySchema,
       }),
     ).rejects.toThrow(WebhookError);
 
@@ -59,6 +65,7 @@ describe("WebhookClient", () => {
         event: "test",
         body: {},
         timeoutMs: 5000,
+        schema: AnySchema,
       });
     } catch (err) {
       expect((err as WebhookError).statusCode).toBe(403);
@@ -79,6 +86,7 @@ describe("WebhookClient", () => {
         event: "test.timeout",
         body: {},
         timeoutMs: 100,
+        schema: AnySchema,
       }),
     ).rejects.toThrow(WebhookError);
 
@@ -88,10 +96,53 @@ describe("WebhookClient", () => {
         event: "test.timeout",
         body: {},
         timeoutMs: 100,
+        schema: AnySchema,
       });
     } catch (err) {
       expect((err as WebhookError).statusCode).toBe(0);
       expect((err as WebhookError).message).toContain("timed out");
+    }
+  });
+
+  it("throws WebhookError when JSON is malformed", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response("not json", { status: 200 }),
+    );
+
+    try {
+      await client.callSync({
+        url: "https://hook.test/x",
+        event: "test.badjson",
+        body: {},
+        timeoutMs: 5000,
+        schema: OkSchema,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WebhookError);
+      expect((err as WebhookError).statusCode).toBe(0);
+      expect((err as WebhookError).message).toContain("invalid JSON");
+    }
+  });
+
+  it("throws WebhookError when response does not match schema", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ ok: "yes" }), { status: 200 }),
+    );
+
+    try {
+      await client.callSync({
+        url: "https://hook.test/x",
+        event: "test.badshape",
+        body: {},
+        timeoutMs: 5000,
+        schema: OkSchema,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WebhookError);
+      expect((err as WebhookError).statusCode).toBe(0);
+      expect((err as WebhookError).message).toContain("did not match schema");
     }
   });
 
@@ -104,6 +155,7 @@ describe("WebhookClient", () => {
         event: "test.net",
         body: {},
         timeoutMs: 5000,
+        schema: AnySchema,
       }),
     ).rejects.toThrow(WebhookError);
 
@@ -113,6 +165,7 @@ describe("WebhookClient", () => {
         event: "test.net",
         body: {},
         timeoutMs: 5000,
+        schema: AnySchema,
       });
     } catch (err) {
       expect((err as WebhookError).message).toContain("ECONNREFUSED");

--- a/packages/server/src/adapters/webhook.ts
+++ b/packages/server/src/adapters/webhook.ts
@@ -2,7 +2,7 @@
 
 import type { ContactService, PermissionService } from "../app/app-host.js";
 import type { Logger } from "../logger.js";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { createHmac } from "node:crypto";
 import type { RpcFailure } from "../runtime/index.js";
 
@@ -78,6 +78,15 @@ export class WebhookClient {
     body: unknown;
     timeoutMs: number;
     /**
+     * Decoder for the webhook response. The body is read as text, parsed
+     * as JSON (or decoded as `undefined` for empty bodies), then passed
+     * through this schema — so callers get a checked value of type `T`
+     * instead of an unvalidated cast. Malformed responses surface as
+     * `WebhookError` with statusCode 0 and the same "rejecting" plumbing
+     * as network / timeout failures.
+     */
+    schema: Schema.Schema<T, any>;
+    /**
      * Extra headers merged on top of `Content-Type` + `X-MoltZap-Event`.
      * Used by app-hook webhooks to attach `X-MoltZap-Signature`. Caller-
      * supplied keys win over the defaults — but `Content-Type` and
@@ -115,13 +124,31 @@ export class WebhookClient {
       }
 
       // Empty-body responses (204, or 200 with no payload) are common for
-      // fire-and-forget hooks (`on_join`, `on_close`). `response.json()`
-      // would throw on an empty body, so read as text and short-circuit.
+      // fire-and-forget hooks (`on_join`, `on_close`). Decode `undefined`
+      // through the caller's schema — schemas for those callers accept it;
+      // schemas that require a payload fail decode and surface below.
       const text = await response.text();
+      let parsed: unknown;
       if (text.length === 0) {
-        return null as T;
+        parsed = undefined;
+      } else {
+        try {
+          parsed = JSON.parse(text);
+        } catch (err) {
+          throw new WebhookError(
+            `Webhook ${opts.event} returned invalid JSON: ${(err as Error).message}`,
+            0,
+          );
+        }
       }
-      return JSON.parse(text) as T;
+      try {
+        return Schema.decodeUnknownSync(opts.schema)(parsed);
+      } catch (err) {
+        throw new WebhookError(
+          `Webhook ${opts.event} response did not match schema: ${(err as Error).message}`,
+          0,
+        );
+      }
     } catch (err) {
       if (err instanceof WebhookError) throw err;
       if (err instanceof DOMException && err.name === "TimeoutError") {
@@ -142,6 +169,8 @@ export class WebhookClient {
 
 // -- Sync webhook contact service ---------------------------------------------
 
+const ContactsCheckResponse = Schema.Struct({ inContact: Schema.Boolean });
+
 export class WebhookContactService implements ContactService {
   constructor(
     private client: WebhookClient,
@@ -156,15 +185,16 @@ export class WebhookContactService implements ContactService {
   ): Effect.Effect<boolean, never> {
     return Effect.tryPromise({
       try: () =>
-        this.client.callSync<{ inContact: boolean }>({
+        this.client.callSync({
           url: this.url,
           event: "contacts.check",
           body: { userIdA, userIdB },
           timeoutMs: this.timeoutMs,
+          schema: ContactsCheckResponse,
         }),
       catch: (err) => err,
     }).pipe(
-      Effect.map((result) => result.inContact === true),
+      Effect.map((result) => result.inContact),
       Effect.catchAll((err) =>
         Effect.sync(() => {
           this.webhookLogger.error(

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -27,6 +27,7 @@ import {
   HashMap,
   Option,
   Ref,
+  Schema,
 } from "effect";
 import {
   RpcFailure,
@@ -167,6 +168,36 @@ type HookOutcome<T> =
   | { result: T; timedOut: false }
   | { result: null; timedOut: true }
   | { result: null; timedOut: false };
+
+/**
+ * Wire schema for the `before_message_delivery` webhook response. Mirrors
+ * the in-process `HookResult` interface in `./hooks.ts`; drift between the
+ * two shapes would mean a webhook hook accidentally mismatches behavior
+ * with its in-process equivalent.
+ *
+ * The `patch.parts` field is an opaque `Part[]` (defined in the protocol
+ * package) — we validate only that it is an array at this boundary; per-
+ * part validation happens later in the delivery pipeline.
+ */
+const HookResultSchema = Schema.Struct({
+  block: Schema.Boolean,
+  reason: Schema.optional(Schema.String),
+  patch: Schema.optional(Schema.Struct({ parts: Schema.Array(Schema.Any) })),
+  feedback: Schema.optional(
+    Schema.Struct({
+      type: Schema.Literal("error", "warning", "info"),
+      content: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+      retry: Schema.optional(Schema.Boolean),
+    }),
+  ),
+}) as unknown as Schema.Schema<HookResult>;
+
+/**
+ * Fire-and-forget hook schema (`on_join`, `on_close`). Receivers typically
+ * reply 204 or `{}`; the caller discards the value entirely, so anything
+ * decodes successfully.
+ */
+const VoidHookSchema = Schema.Unknown as unknown as Schema.Schema<void>;
 
 interface PendingPermission {
   targetUserId: string;
@@ -485,7 +516,7 @@ export class AppHost {
           manifest?.hooks?.before_message_delivery?.timeout_ms ?? 5000;
 
         const outcome: HookOutcome<HookResult> = webhookUrl
-          ? yield* this.dispatchWebhookHook<HookResult>({
+          ? yield* this.dispatchWebhookHook({
               url: webhookUrl,
               event: "app.before_message_delivery",
               secret: manifest?.hooks?.secret,
@@ -497,6 +528,7 @@ export class AppHost {
                 message: ctx.message,
               },
               timeoutMs,
+              schema: HookResultSchema,
             })
           : yield* this.runHookWithTimeout<HookResult>(
               (signal) => appHooks!.beforeMessageDelivery!({ ...ctx, signal }),
@@ -855,7 +887,7 @@ export class AppHost {
           };
 
           const outcome: HookOutcome<void> = onCloseWebhook
-            ? yield* this.dispatchWebhookHook<void>({
+            ? yield* this.dispatchWebhookHook({
                 url: onCloseWebhook,
                 event: "app.on_close",
                 secret: manifest?.hooks?.secret,
@@ -866,6 +898,7 @@ export class AppHost {
                   closedBy,
                 },
                 timeoutMs,
+                schema: VoidHookSchema,
               })
             : yield* this.runHookWithTimeout<void>(
                 (signal) =>
@@ -1326,6 +1359,7 @@ export class AppHost {
     event: string;
     body: object;
     timeoutMs: number;
+    schema: Schema.Schema<T, any>;
     secret?: string;
   }): Effect.Effect<HookOutcome<T>, RpcFailure> {
     return Effect.gen(this, function* () {
@@ -1336,7 +1370,7 @@ export class AppHost {
 
       const request = Effect.tryPromise({
         try: () =>
-          this.webhookClient.callSync<T>({
+          this.webhookClient.callSync({
             url: opts.url,
             event: opts.event,
             body: undefined,
@@ -1345,6 +1379,7 @@ export class AppHost {
               ? { "X-MoltZap-Signature": signature }
               : undefined,
             timeoutMs: opts.timeoutMs,
+            schema: opts.schema,
           }),
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       });
@@ -1525,6 +1560,7 @@ export class AppHost {
               admittedAgentIds,
             },
             timeoutMs,
+            schema: VoidHookSchema,
           }).pipe(
             Effect.catchAllCause(() =>
               Effect.succeed({
@@ -2162,7 +2198,7 @@ export class AppHost {
 
         if (webhookUrl) {
           const timeoutMs = manifest.hooks?.on_join?.timeout_ms ?? 5000;
-          const outcome = yield* this.dispatchWebhookHook<void>({
+          const outcome = yield* this.dispatchWebhookHook({
             url: webhookUrl,
             event: "app.on_join",
             secret: manifest.hooks?.secret,
@@ -2173,6 +2209,7 @@ export class AppHost {
               agent: { agentId, ownerId },
             },
             timeoutMs,
+            schema: VoidHookSchema,
           });
           if (outcome.timedOut) {
             this.broadcaster.sendToAgent(

--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -186,4 +186,21 @@ server:
     const config = await Effect.runPromise(loadConfigFromFile("test.yaml"));
     expect(config.server?.cors_origins).toEqual(["https://app.example.com"]);
   });
+
+  // Top-level YAML trust boundary: previously an unchecked `as unknown` cast
+  // on `parseYaml`. A scalar / array / null top level used to make every
+  // subsequent `Config.nested(...)` silently report a missing key. The
+  // schema at the boundary now rejects these cases with a clear message.
+  it.each([
+    ["scalar string", "hello"],
+    ["array", "- 1\n- 2\n"],
+    ["null", "~"],
+  ])("rejects non-mapping YAML top-level (%s)", async (_label, yaml) => {
+    vi.mocked(readFileSync).mockReturnValue(yaml);
+
+    const exit = await Effect.runPromiseExit(loadConfigFromFile("test.yaml"));
+    const err = expectConfigLoadError(exit);
+    expect(err.kind).toBe("yaml");
+    expect(err.message).toMatch(/top-level value must be a mapping/);
+  });
 });

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -9,9 +9,22 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { dirname } from "node:path";
 import { parse as parseYaml } from "yaml";
-import { Data, Effect, ConfigProvider, Match } from "effect";
+import { Data, Effect, ConfigProvider, Either, Match, Schema } from "effect";
 import type { ConfigError } from "effect/ConfigError";
 import { MoltZapConfig, type MoltZapAppConfig } from "./effect-config.js";
+
+/**
+ * Top-level YAML document shape. `ConfigProvider.fromJson` silently
+ * accepts any input — handing it a scalar, array, or `null` turns every
+ * subsequent `Config.nested(...)` lookup into a "missing key" error that
+ * hides the real problem (the file is not a config mapping). Decoding
+ * at the boundary fails loudly with one clear message instead.
+ */
+const YamlDocumentSchema = Schema.Record({
+  key: Schema.String,
+  value: Schema.Unknown,
+});
+const decodeYamlDocument = Schema.decodeUnknownEither(YamlDocumentSchema);
 
 /** Union of failure modes when loading a config file. */
 export type ConfigLoadErrorKind = "read" | "yaml" | "env" | "validation";
@@ -107,7 +120,7 @@ export const loadConfigFromFile = (
     });
 
     const parsed = yield* Effect.try({
-      try: () => parseYaml(raw) as unknown,
+      try: (): unknown => parseYaml(raw),
       catch: (cause) =>
         new ConfigLoadError({
           kind: "yaml",
@@ -117,7 +130,19 @@ export const loadConfigFromFile = (
         }),
     });
 
-    const interp = interpolateEnvVars(parsed, configPath);
+    const decoded = decodeYamlDocument(parsed);
+    if (Either.isLeft(decoded)) {
+      return yield* Effect.fail(
+        new ConfigLoadError({
+          kind: "yaml",
+          path: configPath,
+          message: `Invalid YAML in "${configPath}": top-level value must be a mapping (${decoded.left.message})`,
+          cause: decoded.left,
+        }),
+      );
+    }
+
+    const interp = interpolateEnvVars(decoded.right, configPath);
     if (!interp.ok) return yield* Effect.fail(interp.error);
 
     // `fromJson` walks the nested object and produces flat paths that

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -1,7 +1,7 @@
 import type { Db } from "../db/client.js";
 import type { Message, Part } from "@moltzap/protocol";
 import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
-import { Duration, Effect, Fiber, Option, Schedule } from "effect";
+import { Duration, Effect, Fiber, Option, Schedule, Schema } from "effect";
 import { SqlError } from "@effect/sql/SqlError";
 import { RpcFailure, notFound, internalError } from "../runtime/index.js";
 import { nextSnowflakeId } from "../db/snowflake.js";
@@ -287,13 +287,16 @@ export class MessageService {
 
     return Effect.tryPromise({
       try: () =>
-        client.callSync<unknown>({
+        client.callSync({
           url: cfg.url,
           event: "messages.delivered",
           body: undefined,
           bodyJson: payload,
           timeoutMs: DELIVERY_WEBHOOK_TIMEOUT_MS,
           headers: { "X-MoltZap-Signature": signature },
+          // Fire-and-forget: receivers typically reply 204/empty, and
+          // anything they do send is discarded by `Effect.asVoid` below.
+          schema: Schema.Unknown,
         }),
       catch: (err) =>
         new WebhookCallError("messages.delivered failed", cfg.url, err),

--- a/packages/server/src/services/user.service.test.ts
+++ b/packages/server/src/services/user.service.test.ts
@@ -70,12 +70,14 @@ describe("WebhookUserService", () => {
     const result = await Effect.runPromise(svc.validateUser(UserId("user-42")));
 
     expect(result).toEqual({ valid: true });
-    expect(callSync).toHaveBeenCalledWith({
-      url: "https://hook.test/users",
-      event: "users.validate",
-      body: { userId: "user-42" },
-      timeoutMs: 5000,
-    });
+    expect(callSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://hook.test/users",
+        event: "users.validate",
+        body: { userId: "user-42" },
+        timeoutMs: 5000,
+      }),
+    );
   });
 
   it("returns { valid: false } when webhook returns it", async () => {

--- a/packages/server/src/services/user.service.ts
+++ b/packages/server/src/services/user.service.ts
@@ -1,7 +1,23 @@
-import { Cause, Effect } from "effect";
+import { Cause, Effect, Schema } from "effect";
 import { WebhookCallError, type WebhookClient } from "../adapters/webhook.js";
 import type { Logger } from "../logger.js";
 import { AgentId, UserId } from "../app/types.js";
+
+// Strict wire schemas — `callSync` runs these over the parsed response, so
+// malformed payloads surface as a `WebhookError` and land in the
+// fail-closed `catchAllCause` branch rather than leaking as unchecked
+// casts.
+const UserValidateResponse = Schema.Struct({ valid: Schema.Boolean });
+
+const SessionValidateResponse = Schema.Union(
+  Schema.Struct({
+    valid: Schema.Literal(true),
+    agentId: Schema.String,
+    ownerUserId: Schema.String,
+    agentStatus: Schema.optional(Schema.String),
+  }),
+  Schema.Struct({ valid: Schema.Literal(false) }),
+);
 
 /**
  * Result of resolving an app-minted bearer session token. Discriminated
@@ -53,17 +69,16 @@ export class WebhookUserService implements UserService {
   validateUser(userId: UserId): Effect.Effect<{ valid: boolean }, never> {
     return Effect.tryPromise({
       try: () =>
-        this.client.callSync<{ valid: boolean }>({
+        this.client.callSync({
           url: this.url,
           event: "users.validate",
           body: { userId },
           timeoutMs: this.timeoutMs,
+          schema: UserValidateResponse,
         }),
       catch: (err) =>
         new WebhookCallError("users.validate failed", this.url, err),
     }).pipe(
-      // Strict boolean check — don't trust truthy strings from external services
-      Effect.map((result) => ({ valid: result.valid === true })),
       Effect.catchAllCause((cause) =>
         Effect.sync(() => {
           this.logCauseAsFailClosed(cause, "User validation webhook", {
@@ -77,53 +92,26 @@ export class WebhookUserService implements UserService {
   }
 
   validateSession(token: string): Effect.Effect<SessionValidation, never> {
-    // Wire shape is looser than the internal discriminated union; normalize
-    // here so nothing downstream needs to re-check for missing fields.
-    interface WireResponse {
-      valid?: unknown;
-      agentId?: unknown;
-      ownerUserId?: unknown;
-      /** Optional: lets `auth/connect` skip a DB round trip when the
-       * webhook already knows the agent's status. */
-      agentStatus?: unknown;
-    }
     return Effect.tryPromise({
       try: () =>
-        this.client.callSync<WireResponse>({
+        this.client.callSync({
           url: this.url,
           event: "sessions.validate",
           body: { token },
           timeoutMs: this.timeoutMs,
+          schema: SessionValidateResponse,
         }),
       catch: (err) =>
         new WebhookCallError("sessions.validate failed", this.url, err),
     }).pipe(
       Effect.map((result): SessionValidation => {
         if (result.valid !== true) return { valid: false };
-        if (
-          typeof result.agentId !== "string" ||
-          typeof result.ownerUserId !== "string"
-        ) {
-          return { valid: false };
-        }
-        const agentStatus =
-          typeof result.agentStatus === "string"
-            ? result.agentStatus
-            : undefined;
+        const agentStatus = result.agentStatus;
         const agentId = AgentId(result.agentId);
         const ownerUserId = UserId(result.ownerUserId);
         return agentStatus !== undefined
-          ? {
-              valid: true,
-              agentId,
-              ownerUserId,
-              agentStatus,
-            }
-          : {
-              valid: true,
-              agentId,
-              ownerUserId,
-            };
+          ? { valid: true, agentId, ownerUserId, agentStatus }
+          : { valid: true, agentId, ownerUserId };
       }),
       Effect.catchAllCause((cause) =>
         Effect.sync((): SessionValidation => {


### PR DESCRIPTION
## Summary
- Replace three unvalidated JSON/YAML parses with `effect/Schema` decoders at trust boundaries: the evals runner's `conversationContext`, the server config loader's YAML top level, and `WebhookClient.callSync` response bodies.
- Malformed payloads now surface as typed errors (`ConfigLoadError` kind `"yaml"`, `WebhookError` with `statusCode 0`) instead of silent casts that only blow up on later property access.
- Downstream services (`UserService`, `ContactService`, `AppHost` hooks) declare wire schemas and drop the runtime `typeof` checks the schema now enforces.

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — all workspace tests green (110 → 115 server tests; new coverage for non-mapping YAML, malformed JSON, and schema-mismatch responses)
- [ ] Review by maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)