### PR TITLE
feat(server-core): LoggerLive Layer with Effect.Config

### DIFF
--- a/packages/server/src/app/layers.test.ts
+++ b/packages/server/src/app/layers.test.ts
@@ -4,7 +4,7 @@ import { Effect, Layer } from "effect";
 import { expect } from "vitest";
 import type { Db } from "../db/client.js";
 import type { Database } from "../db/database.js";
-import { LoggerLive, logger } from "../logger.js";
+import { LoggerLive, getLogger } from "../logger.js";
 import { Broadcaster } from "../ws/broadcaster.js";
 import { ConnectionManager } from "../ws/connection.js";
 import { AuthService } from "../services/auth.service.js";
@@ -19,7 +19,6 @@ import {
   DbTag,
   DeliveryWebhookTag,
   EncryptionTag,
-  LoggerTag,
   ServicesLive,
   UserServiceTag,
   WebhookClientTag,
@@ -33,10 +32,10 @@ import {
  */
 const fakeDb = {} as Kysely<Database> as Db;
 
-/** Base layer — feeds the ServicesLive requirements. */
+/** Base layer — feeds the ServicesLive requirements. LoggerLive provides
+ * LoggerTag itself, so no separate `Layer.succeed(LoggerTag, …)` needed. */
 const BaseLive = Layer.mergeAll(
   Layer.succeed(DbTag, fakeDb),
-  Layer.succeed(LoggerTag, logger),
   Layer.succeed(EncryptionTag, null),
   Layer.succeed(UserServiceTag, null),
   Layer.succeed(WebhookClientTag, new WebhookClient()),
@@ -54,7 +53,9 @@ it.effect("ServicesLive resolves every service via resolveServices", () =>
     // Identity-pass-throughs from BaseLive — sanity that the plumbing
     // doesn't clone or wrap them somewhere unexpected.
     expect(services.db).toBe(fakeDb);
-    expect(services.logger).toBe(logger);
+    // LoggerLive builds pino from Effect.Config — asserting identity against
+    // getLogger() confirms the shim and the Layer agree on one singleton.
+    expect(services.logger).toBe(getLogger());
     expect(services.encryption).toBeNull();
 
     // Services that ServicesLive constructs. Each must be a real instance

--- a/packages/server/src/app/layers.ts
+++ b/packages/server/src/app/layers.ts
@@ -8,6 +8,7 @@ import { Context, Deferred, Effect, HashMap, Layer, Ref } from "effect";
 
 import type { Db } from "../db/client.js";
 import type { Logger } from "../logger.js";
+import { LoggerTag } from "../logger.js";
 import { ConnectionManager } from "../ws/connection.js";
 import { Broadcaster } from "../ws/broadcaster.js";
 import { AuthService } from "../services/auth.service.js";
@@ -31,11 +32,9 @@ import type { WebhookClient } from "../adapters/webhook.js";
 /** Postgres/PGlite database handle (Kysely<Database>). */
 export class DbTag extends Context.Tag("moltzap/Db")<DbTag, Db>() {}
 
-/** Pino logger (root). */
-export class LoggerTag extends Context.Tag("moltzap/Logger")<
-  LoggerTag,
-  Logger
->() {}
+/** Re-exported so call sites importing tags from one file still compile.
+ * Canonical definition lives in `../logger.js`. */
+export { LoggerTag };
 
 /** Optional envelope-encryption helper. null when encryption is disabled. */
 export class EncryptionTag extends Context.Tag("moltzap/Encryption")<

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -51,7 +51,6 @@ import type {
 import {
   DbTag,
   DeliveryWebhookTag,
-  LoggerTag,
   EncryptionTag,
   ServicesLive,
   UserServiceTag,
@@ -119,13 +118,12 @@ export function createCoreApp(config: CoreConfig): CoreApp {
 
   const BaseLive = Layer.mergeAll(
     Layer.succeed(DbTag, db),
-    Layer.succeed(LoggerTag, logger),
     Layer.succeed(EncryptionTag, envelope),
     Layer.succeed(UserServiceTag, config.userService ?? null),
     Layer.succeed(WebhookClientTag, webhookClient),
     Layer.succeed(DeliveryWebhookTag, config.deliveryWebhook ?? null),
-    // LoggerLive replaces Effect's default console logger with the Pino-backed
-    // Effect logger so `Effect.log*` inside services routes through Pino.
+    // Provides LoggerTag (pino built from Effect.Config) and replaces the
+    // default Effect logger so `Effect.log*` routes through the same stream.
     LoggerLive,
   );
 

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,27 +1,82 @@
 /**
- * Effect Logger backed by a Pino instance.
+ * Pino-backed logger, injectable via `LoggerTag`.
  *
- * Pino is still the actual output backend — operator-facing log format is
- * unchanged. On top of that, `effectLogger` wraps Pino as an Effect `Logger`
- * so `Effect.logInfo(...).pipe(Effect.annotateLogs({...}))` calls inside
- * services flow to the same Pino stream via `LoggerLive`.
+ * `LoggerLive` reads `LOG_LEVEL` / `NODE_ENV` through `Effect.Config` inside
+ * `Layer.effect` — so env vars are resolved at Layer evaluation time (via
+ * whatever `ConfigProvider` the runtime is using), not at module import.
  *
- * The Pino instance remains exported as `logger` / `Logger` so bootstrap,
- * startup, and synchronous paths that can't be inside an Effect continue
- * to work unchanged.
+ * Effect-context code pulls the instance via `LoggerTag`. Sync paths that
+ * can't sit inside an Effect (pool error listeners, top-level bootstrap,
+ * direct CLI entry) use `getLogger()` — it returns the Layer-built instance
+ * once `LoggerLive` has run, else a bootstrap pino with defaults.
  */
-import { Logger as EffectLogger } from "effect";
+import { Config, Context, Effect, Layer, Logger as EffectLogger } from "effect";
 import pino from "pino";
 
-export const logger = pino({
-  level: process.env["LOG_LEVEL"] ?? "info",
-  transport:
-    process.env["NODE_ENV"] !== "production"
-      ? { target: "pino-pretty", options: { colorize: true } }
-      : undefined,
-});
+export type Logger = pino.Logger;
 
-export type Logger = typeof logger;
+/** Context tag for the root pino logger. Provided by `LoggerLive`. */
+export class LoggerTag extends Context.Tag("moltzap/Logger")<
+  LoggerTag,
+  Logger
+>() {}
+
+/**
+ * Singleton written by `LoggerLive` on first build. Read by `getLogger()`
+ * and the `effectLogger` bridge so every log — sync or Effect — lands on the
+ * same pino stream.
+ */
+let current: Logger | null = null;
+
+/** Bootstrap pino with defaults only — no env reads. */
+let bootstrap: Logger | null = null;
+function getBootstrap(): Logger {
+  if (!bootstrap) bootstrap = pino({ level: "info" });
+  return bootstrap;
+}
+
+/**
+ * Returns the Layer-built pino once `LoggerLive` has evaluated, otherwise
+ * a bootstrap default. Sync accessor for paths that can't pull `LoggerTag`
+ * from an Effect context.
+ */
+export function getLogger(): Logger {
+  return current ?? getBootstrap();
+}
+
+/**
+ * @deprecated Prefer `LoggerTag` from Effect context, or `getLogger()` for
+ * sync paths. Kept as a transparent Proxy over `getLogger()` so legacy call
+ * sites using `logger.info(...)` continue to work during migration.
+ */
+export const logger: Logger = new Proxy({} as Logger, {
+  get(_target, prop) {
+    const target = getLogger() as unknown as Record<string | symbol, unknown>;
+    const value = target[prop];
+    return typeof value === "function"
+      ? (value as (...args: unknown[]) => unknown).bind(target)
+      : value;
+  },
+}) as Logger;
+
+/** Build pino from Effect.Config — env reads happen here, at Layer build. */
+const buildPino = Effect.gen(function* () {
+  const level = yield* Config.string("LOG_LEVEL").pipe(
+    Config.withDefault("info"),
+  );
+  const nodeEnv = yield* Config.string("NODE_ENV").pipe(
+    Config.withDefault("development"),
+  );
+  const instance = pino({
+    level,
+    transport:
+      nodeEnv !== "production"
+        ? { target: "pino-pretty", options: { colorize: true } }
+        : undefined,
+  });
+  current = instance;
+  return instance;
+});
 
 /**
  * Maps Effect's `LogLevel._tag` values to Pino's level method names. `All` /
@@ -43,13 +98,14 @@ const levelToPino: Record<
 };
 
 /**
- * Effect `Logger` that writes to the Pino instance. Annotations added via
- * `Effect.annotateLogs({...})` become the first-arg object on the Pino call,
- * matching the pre-migration `logger.info({...}, "msg")` shape so operator
- * tooling sees no format change.
+ * Effect `Logger` that writes to the current pino instance. Annotations added
+ * via `Effect.annotateLogs({...})` become the first-arg object on the Pino
+ * call, matching the pre-migration `logger.info({...}, "msg")` shape so
+ * operator tooling sees no format change.
  */
 export const effectLogger = EffectLogger.make(
   ({ logLevel, message, annotations }) => {
+    const log = getLogger();
     const mergedAnnotations: Record<string, unknown> = {};
     // HashMap iteration yields [key, value] tuples.
     for (const [k, v] of annotations) {
@@ -69,7 +125,7 @@ export const effectLogger = EffectLogger.make(
     // than letting the throw propagate as a defect through the Effect
     // runtime — a log-write failure is never worth crashing the fiber for.
     try {
-      logger[pinoMethod](mergedAnnotations, msg);
+      log[pinoMethod](mergedAnnotations, msg);
     } catch (err) {
       // #ignore-sloppy-code-next-line[bare-catch]: logger failure path writes to stderr since the logger itself is broken
       try {
@@ -87,11 +143,11 @@ export const effectLogger = EffectLogger.make(
 );
 
 /**
- * Layer that replaces Effect's default (console) logger with the Pino-backed
- * Effect logger. Provide this in the top-level Layer composition so all
- * `Effect.log*` calls inside services route through Pino.
+ * Provides `LoggerTag` (pino built from `Effect.Config`) AND replaces
+ * Effect's default (console) logger with the pino-backed `effectLogger` so
+ * `Effect.log*` calls inside services flow through the same stream.
  */
-export const LoggerLive = EffectLogger.replace(
-  EffectLogger.defaultLogger,
-  effectLogger,
+export const LoggerLive = Layer.mergeAll(
+  Layer.effect(LoggerTag, buildPino),
+  EffectLogger.replace(EffectLogger.defaultLogger, effectLogger),
 );


### PR DESCRIPTION
## Summary

- Move `LOG_LEVEL` / `NODE_ENV` reads out of module load. `LoggerLive` now runs `Layer.effect` that pulls both through `Config.string(...).pipe(Config.withDefault(...))` and builds pino inside the effect — the logger is injectable and env-agnostic until a runtime provides a ConfigProvider.
- Expose the pino instance via `LoggerTag` so Effect-context code can `yield* LoggerTag`. Sync paths that can't sit inside an Effect (pool error listeners, bootstrap) keep working via `getLogger()` — a shim that returns the Layer-built instance once `LoggerLive` has evaluated, else a bootstrap pino with defaults.
- Legacy `logger` export is now a transparent Proxy over `getLogger()` so existing call sites need no changes during migration.

Scope stays tight to the logger. Broader `Effect.Config` rollout already landed in PR #90.

## Test plan

- [x] `pnpm --filter @moltzap/server-core build` — clean
- [x] `pnpm --filter @moltzap/server-core test` — 110/110 pass
- [x] `src/app/layers.test.ts` asserts `services.logger === getLogger()` (one singleton across Layer + shim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)