### PR TITLE
feat(app-host): add attachConversation API (closes #85)

### DIFF
--- a/docs/guides/app-hooks.mdx
+++ b/docs/guides/app-hooks.mdx
@@ -238,6 +238,41 @@ Pick one path per hook; don't wire both.
 | Your server and hook code share a release cycle | Your app team ships separately from the MoltZap operator |
 | No need for horizontal scaling of hook logic | You want to scale hook handlers behind a load balancer |
 
+## Dynamically attached conversations
+
+Manifest-declared conversations (`conversations: [{ key, name, participantFilter }]`) are wired into the hook pipeline automatically. Apps that create **additional** conversations at runtime — for example, per-participant role DMs minted inside an `on_session_active` handler — must register those conversations with the server so `before_message_delivery` fires on subsequent sends.
+
+Use the in-process API `coreApp.attachAppConversation(sessionId, conversationId, key)`:
+
+```ts
+coreApp.onSessionActive("werewolf", ({ sessionId, admittedAgentIds }) =>
+  Effect.gen(function* () {
+    for (const agentId of admittedAgentIds) {
+      const dm = yield* conversationService.create({
+        type: "dm",
+        participants: [{ type: "agent", id: agentId }],
+        initiatorAgentId: gmAgentId,
+      });
+      yield* coreApp.attachAppConversation(
+        sessionId,
+        dm.id,
+        `role_dm_${agentId}`,
+      );
+    }
+  }),
+);
+```
+
+Semantics:
+
+- Idempotent on the exact `(sessionId, conversationId, key)` triple — a second identical call is a no-op.
+- Errors (`RpcFailure` with `ErrorCodes.Conflict`) if the same `key` is already used in the session under a different `conversationId`, or if the `conversationId` is already attached under a different `key`, or if it's attached to a *different* session entirely (conversations are 1:1 with sessions in the hook pipeline).
+- Errors (`RpcFailure` with `ErrorCodes.SessionClosed` / `SessionNotFound`) if the session is closed or missing.
+
+Once attached, every `messages/send` on that conversation goes through `before_message_delivery` with the attached session's app context — the same fail-closed policy applies as for manifest-declared conversations.
+
+Pair this with `on_session_active` for the Werewolf-style pattern where the server mints per-player channels once the roster is final, *before* the game-ready event reaches clients.
+
 ## End-to-end example
 
 The integration test [`32-webhook-hooks.integration.test.ts`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/__tests__/integration/32-webhook-hooks.integration.test.ts) spins up a Node `http.createServer` as the webhook endpoint, registers a manifest that points at it, and verifies: block, patch, signed payload, timeout → fail-closed, precedence. Copy it as a starting point for your own integration coverage.

--- a/packages/server/src/__tests__/integration/33-attach-conversation.integration.test.ts
+++ b/packages/server/src/__tests__/integration/33-attach-conversation.integration.test.ts
@@ -1,0 +1,411 @@
+// ─────────────────────────────────────────────────────────────────────
+// attachConversation integration coverage (issue #85).
+//
+// Exercises `CoreApp.attachAppConversation` end-to-end: validates session
+// lifecycle handling, idempotency and conflict detection, and verifies
+// that `before_message_delivery` fires on conversations registered after
+// the session was created (which is the whole point of the API — dynamic
+// conversations like per-participant role DMs bypass the hook pipeline
+// unless attached).
+//
+// Real wall-clock timing; PGlite; real WS clients.
+// ─────────────────────────────────────────────────────────────────────
+
+import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Either, Exit } from "effect";
+
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  registerAndConnect,
+  getKyselyDb,
+} from "./helpers.js";
+import type { CoreApp } from "../../app/types.js";
+import type { ConnectedAgent } from "../../test-utils/helpers.js";
+import { ErrorCodes } from "@moltzap/protocol";
+import { RpcFailure } from "../../runtime/index.js";
+
+let coreApp: CoreApp;
+
+beforeAll(async () => {
+  const server = await startTestServer();
+  coreApp = server.coreApp;
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+function registerAppAgent(name: string): Effect.Effect<ConnectedAgent, Error> {
+  return Effect.gen(function* () {
+    const agent = yield* registerAndConnect(name);
+    const db = getKyselyDb();
+    yield* Effect.tryPromise(() =>
+      db
+        .updateTable("agents")
+        .set({ owner_user_id: crypto.randomUUID() })
+        .where("id", "=", agent.agentId)
+        .execute(),
+    );
+    return agent;
+  });
+}
+
+function registerTestApp(app: CoreApp, appId: string) {
+  app.registerApp({
+    appId,
+    name: `Test App ${appId}`,
+    permissions: { required: [], optional: [] },
+    conversations: [
+      { key: "main", name: "Main Channel", participantFilter: "all" },
+    ],
+    hooks: {
+      before_message_delivery: { timeout_ms: 5000 },
+    },
+  });
+}
+
+/** Create a bare app session (zero invitees) that goes `active` immediately. */
+function createSoloSession(
+  app: CoreApp,
+  agent: ConnectedAgent,
+  appId: string,
+): Effect.Effect<{ sessionId: string }, Error> {
+  return Effect.gen(function* () {
+    const res = (yield* agent.client.sendRpc("apps/create", {
+      appId,
+      invitedAgentIds: [],
+    })) as { session: { id: string } };
+    return { sessionId: res.session.id };
+  });
+}
+
+describe("Scenario 33: attachConversation", () => {
+  it.live("attaches a dynamic DM and inserts one row", () =>
+    Effect.gen(function* () {
+      const initiator = yield* registerAppAgent("attach-init");
+      const peer = yield* registerAppAgent("attach-peer");
+
+      registerTestApp(coreApp, "attach-basic");
+
+      const { sessionId } = yield* createSoloSession(
+        coreApp,
+        initiator,
+        "attach-basic",
+      );
+
+      const dm = (yield* initiator.client.sendRpc("conversations/create", {
+        type: "dm",
+        participants: [{ type: "agent", id: peer.agentId }],
+      })) as { conversation: { id: string } };
+      const dmId = dm.conversation.id;
+
+      yield* coreApp.attachAppConversation(sessionId, dmId, "role_dm_peer");
+
+      const db = getKyselyDb();
+      const rows = yield* Effect.tryPromise(() =>
+        db
+          .selectFrom("app_session_conversations")
+          .select(["conversation_key", "conversation_id"])
+          .where("session_id", "=", sessionId)
+          .where("conversation_id", "=", dmId)
+          .execute(),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.conversation_key).toBe("role_dm_peer");
+    }),
+  );
+
+  it.live("is idempotent on exact (sessionId, convId, key)", () =>
+    Effect.gen(function* () {
+      const initiator = yield* registerAppAgent("attach-idem-init");
+      const peer = yield* registerAppAgent("attach-idem-peer");
+
+      registerTestApp(coreApp, "attach-idem");
+
+      const { sessionId } = yield* createSoloSession(
+        coreApp,
+        initiator,
+        "attach-idem",
+      );
+
+      const dm = (yield* initiator.client.sendRpc("conversations/create", {
+        type: "dm",
+        participants: [{ type: "agent", id: peer.agentId }],
+      })) as { conversation: { id: string } };
+      const dmId = dm.conversation.id;
+
+      yield* coreApp.attachAppConversation(sessionId, dmId, "role_dm_peer");
+      yield* coreApp.attachAppConversation(sessionId, dmId, "role_dm_peer");
+
+      const db = getKyselyDb();
+      const rows = yield* Effect.tryPromise(() =>
+        db
+          .selectFrom("app_session_conversations")
+          .select(["conversation_key", "conversation_id"])
+          .where("session_id", "=", sessionId)
+          .where("conversation_id", "=", dmId)
+          .execute(),
+      );
+      expect(rows).toHaveLength(1);
+    }),
+  );
+
+  it.live(
+    "rejects a second attach with a different key for the same convId",
+    () =>
+      Effect.gen(function* () {
+        const initiator = yield* registerAppAgent("attach-keyswap-init");
+        const peer = yield* registerAppAgent("attach-keyswap-peer");
+
+        registerTestApp(coreApp, "attach-keyswap");
+
+        const { sessionId } = yield* createSoloSession(
+          coreApp,
+          initiator,
+          "attach-keyswap",
+        );
+
+        const dm = (yield* initiator.client.sendRpc("conversations/create", {
+          type: "dm",
+          participants: [{ type: "agent", id: peer.agentId }],
+        })) as { conversation: { id: string } };
+        const dmId = dm.conversation.id;
+
+        yield* coreApp.attachAppConversation(sessionId, dmId, "role_dm_a");
+
+        const second = yield* Effect.exit(
+          coreApp.attachAppConversation(sessionId, dmId, "role_dm_b"),
+        );
+        expect(Exit.isFailure(second)).toBe(true);
+        if (Exit.isFailure(second)) {
+          // The Cause wraps an RpcFailure; the RpcFailure-code assertion has
+          // its own dedicated test below. Here we just confirm the message
+          // surfaces the conflict.
+          expect(JSON.stringify(second.cause)).toContain("already attached");
+        }
+      }),
+  );
+
+  it.live(
+    "rejects a second attach with a different convId for the same key",
+    () =>
+      Effect.gen(function* () {
+        const initiator = yield* registerAppAgent("attach-convswap-init");
+        const peerA = yield* registerAppAgent("attach-convswap-a");
+        const peerB = yield* registerAppAgent("attach-convswap-b");
+
+        registerTestApp(coreApp, "attach-convswap");
+
+        const { sessionId } = yield* createSoloSession(
+          coreApp,
+          initiator,
+          "attach-convswap",
+        );
+
+        const dmA = (yield* initiator.client.sendRpc("conversations/create", {
+          type: "dm",
+          participants: [{ type: "agent", id: peerA.agentId }],
+        })) as { conversation: { id: string } };
+        const dmB = (yield* initiator.client.sendRpc("conversations/create", {
+          type: "dm",
+          participants: [{ type: "agent", id: peerB.agentId }],
+        })) as { conversation: { id: string } };
+
+        yield* coreApp.attachAppConversation(
+          sessionId,
+          dmA.conversation.id,
+          "role_dm",
+        );
+
+        const second = yield* Effect.exit(
+          coreApp.attachAppConversation(
+            sessionId,
+            dmB.conversation.id,
+            "role_dm",
+          ),
+        );
+        expect(Exit.isFailure(second)).toBe(true);
+        if (Exit.isFailure(second)) {
+          expect(JSON.stringify(second.cause)).toContain(
+            "is already in use for session",
+          );
+        }
+      }),
+  );
+
+  it.live("rejects attach to a closed session", () =>
+    Effect.gen(function* () {
+      const initiator = yield* registerAppAgent("attach-closed-init");
+      const peer = yield* registerAppAgent("attach-closed-peer");
+
+      registerTestApp(coreApp, "attach-closed");
+
+      const { sessionId } = yield* createSoloSession(
+        coreApp,
+        initiator,
+        "attach-closed",
+      );
+
+      yield* initiator.client.sendRpc("apps/closeSession", { sessionId });
+
+      const dm = (yield* initiator.client.sendRpc("conversations/create", {
+        type: "dm",
+        participants: [{ type: "agent", id: peer.agentId }],
+      })) as { conversation: { id: string } };
+
+      const result = yield* Effect.exit(
+        coreApp.attachAppConversation(sessionId, dm.conversation.id, "role_dm"),
+      );
+      expect(Exit.isFailure(result)).toBe(true);
+      if (Exit.isFailure(result)) {
+        // RpcFailure { code: SessionClosed } comes through as a tagged error.
+        const flat = JSON.stringify(result.cause);
+        expect(flat).toMatch(/closed session/i);
+      }
+    }),
+  );
+
+  it.live(
+    "rejects attach of a conversation already tied to another session",
+    () =>
+      Effect.gen(function* () {
+        const initiator = yield* registerAppAgent("attach-xsess-init");
+        const peer = yield* registerAppAgent("attach-xsess-peer");
+
+        registerTestApp(coreApp, "attach-xsess");
+
+        const a = yield* createSoloSession(coreApp, initiator, "attach-xsess");
+        const b = yield* createSoloSession(coreApp, initiator, "attach-xsess");
+
+        const dm = (yield* initiator.client.sendRpc("conversations/create", {
+          type: "dm",
+          participants: [{ type: "agent", id: peer.agentId }],
+        })) as { conversation: { id: string } };
+
+        yield* coreApp.attachAppConversation(
+          a.sessionId,
+          dm.conversation.id,
+          "role_dm",
+        );
+
+        const second = yield* Effect.exit(
+          coreApp.attachAppConversation(
+            b.sessionId,
+            dm.conversation.id,
+            "role_dm",
+          ),
+        );
+        expect(Exit.isFailure(second)).toBe(true);
+        if (Exit.isFailure(second)) {
+          expect(JSON.stringify(second.cause)).toMatch(/already attached/);
+        }
+      }),
+  );
+
+  it.live(
+    "before_message_delivery fires on an attached conversation (patch path)",
+    () =>
+      Effect.gen(function* () {
+        const initiator = yield* registerAppAgent("attach-hook-init");
+        const peer = yield* registerAppAgent("attach-hook-peer");
+
+        registerTestApp(coreApp, "attach-hook");
+
+        coreApp.onBeforeMessageDelivery("attach-hook", (ctx) => ({
+          block: false,
+          patch: {
+            parts: [
+              {
+                type: "text" as const,
+                text:
+                  "[ATTACHED] " +
+                  (ctx.message.parts[0] as { text: string }).text,
+              },
+            ],
+          },
+        }));
+
+        const { sessionId } = yield* createSoloSession(
+          coreApp,
+          initiator,
+          "attach-hook",
+        );
+
+        const dm = (yield* initiator.client.sendRpc("conversations/create", {
+          type: "dm",
+          participants: [{ type: "agent", id: peer.agentId }],
+        })) as { conversation: { id: string } };
+        const dmId = dm.conversation.id;
+
+        // Sanity: before attaching, the hook is bypassed — the convId is not
+        // in AppHost.conversationToSession, so runBeforeMessageDelivery
+        // returns null and the message passes through unchanged.
+        const preAttach = (yield* initiator.client.sendRpc("messages/send", {
+          conversationId: dmId,
+          parts: [{ type: "text", text: "pre-attach" }],
+        })) as { message: { parts: Array<{ text: string }> } };
+        expect(preAttach.message.parts[0]!.text).toBe("pre-attach");
+
+        yield* coreApp.attachAppConversation(sessionId, dmId, "role_dm");
+
+        // Post-attach: hook fires and patches the parts.
+        const postAttach = (yield* initiator.client.sendRpc("messages/send", {
+          conversationId: dmId,
+          parts: [{ type: "text", text: "post-attach" }],
+        })) as {
+          message: { parts: Array<{ text: string }>; patchedBy?: string };
+        };
+        expect(postAttach.message.parts[0]!.text).toBe(
+          "[ATTACHED] post-attach",
+        );
+        expect(postAttach.message.patchedBy).toBe("attach-hook");
+      }),
+  );
+
+  // Non-regression: hard proof the returned error is an RpcFailure with a
+  // Conflict code, not some other channel. The JSON-stringified Cause checks
+  // above are cheap but don't verify the error class.
+  it.live("conflict surfaces as RpcFailure with Conflict code", () =>
+    Effect.gen(function* () {
+      const initiator = yield* registerAppAgent("attach-ecode-init");
+      const peer = yield* registerAppAgent("attach-ecode-peer");
+
+      registerTestApp(coreApp, "attach-ecode");
+
+      const { sessionId } = yield* createSoloSession(
+        coreApp,
+        initiator,
+        "attach-ecode",
+      );
+      const dm = (yield* initiator.client.sendRpc("conversations/create", {
+        type: "dm",
+        participants: [{ type: "agent", id: peer.agentId }],
+      })) as { conversation: { id: string } };
+
+      yield* coreApp.attachAppConversation(
+        sessionId,
+        dm.conversation.id,
+        "role_dm",
+      );
+      const either = yield* Effect.either(
+        coreApp.attachAppConversation(
+          sessionId,
+          dm.conversation.id,
+          "role_dm_two",
+        ),
+      );
+      expect(Either.isLeft(either)).toBe(true);
+      if (Either.isLeft(either)) {
+        expect(either.left).toBeInstanceOf(RpcFailure);
+        expect(either.left.code).toBe(ErrorCodes.Conflict);
+      }
+    }),
+  );
+});

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -933,6 +933,147 @@ export class AppHost {
     );
   }
 
+  /**
+   * Attach a dynamically-created conversation to an existing app session.
+   *
+   * Apps that create conversations outside the manifest (e.g. per-participant
+   * role DMs inside an `on_session_active` handler) must register them with
+   * `AppHost` so `before_message_delivery` fires on subsequent sends. Without
+   * this call `conversationToSession.get(convId)` returns `undefined` and the
+   * hook is silently skipped (see `runBeforeMessageDelivery`).
+   *
+   * Semantics:
+   * - Validates the session exists and isn't closed.
+   * - Idempotent on exact `(sessionId, conversationId, key)` match — a second
+   *   identical call is a no-op.
+   * - Errors if `key` is already used in the session under a different
+   *   `conversationId`, or if `conversationId` is already attached to the
+   *   session under a different `key`, or if `conversationId` is already
+   *   attached to a *different* session.
+   */
+  attachConversation(
+    sessionId: string,
+    conversationId: string,
+    key: string,
+  ): Effect.Effect<void, RpcFailure> {
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        const sessionOpt = yield* takeFirstOption(
+          this.db
+            .selectFrom("app_sessions")
+            .select(["id", "app_id", "status"])
+            .where("id", "=", sessionId),
+        );
+        const session = Option.getOrNull(sessionOpt);
+        if (!session) {
+          return yield* Effect.fail(
+            new RpcFailure({
+              code: ErrorCodes.SessionNotFound,
+              message: "Session not found",
+            }),
+          );
+        }
+        if (session.status === "closed") {
+          return yield* Effect.fail(
+            new RpcFailure({
+              code: ErrorCodes.SessionClosed,
+              message: "Cannot attach a conversation to a closed session",
+            }),
+          );
+        }
+
+        // Cross-session collision: a convId can only belong to one session's
+        // hook pipeline at a time (AppHost.conversationToSession is 1:1).
+        const crossSession = this.conversationToSession.get(conversationId);
+        if (crossSession && crossSession.id !== sessionId) {
+          return yield* Effect.fail(
+            new RpcFailure({
+              code: ErrorCodes.Conflict,
+              message: `Conversation ${conversationId} is already attached to session ${crossSession.id}`,
+            }),
+          );
+        }
+
+        // Single query covers both uniqueness checks: either the convId or the
+        // key is already present for this session. At most two rows come back
+        // (one per dimension) — bounded by the (session_id, conversation_key)
+        // primary key and by the 1:1 cross-session invariant above.
+        const existingRows = yield* this.db
+          .selectFrom("app_session_conversations")
+          .select(["conversation_key", "conversation_id"])
+          .where("session_id", "=", sessionId)
+          .where((eb) =>
+            eb.or([
+              eb("conversation_id", "=", conversationId),
+              eb("conversation_key", "=", key),
+            ]),
+          );
+
+        let convIdMatch: { conversation_key: string } | null = null;
+        let keyMatch: { conversation_id: string } | null = null;
+        for (const row of existingRows) {
+          if (row.conversation_id === conversationId) convIdMatch = row;
+          if (row.conversation_key === key) keyMatch = row;
+        }
+
+        if (
+          convIdMatch &&
+          keyMatch &&
+          convIdMatch.conversation_key === key &&
+          keyMatch.conversation_id === conversationId
+        ) {
+          // Exact (sessionId, convId, key) triple already recorded — no-op.
+          // Refresh the in-memory maps in case they diverged from the DB
+          // (e.g. after a server restart before a lazy rehydrate).
+          this.conversationToSession.set(conversationId, {
+            id: sessionId,
+            appId: session.app_id,
+          });
+          const existingSet = this.sessionToConversations.get(sessionId);
+          if (existingSet) existingSet.add(conversationId);
+          else
+            this.sessionToConversations.set(
+              sessionId,
+              new Set([conversationId]),
+            );
+          return;
+        }
+
+        if (convIdMatch && convIdMatch.conversation_key !== key) {
+          return yield* Effect.fail(
+            new RpcFailure({
+              code: ErrorCodes.Conflict,
+              message: `Conversation ${conversationId} is already attached to session ${sessionId} under key "${convIdMatch.conversation_key}"`,
+            }),
+          );
+        }
+        if (keyMatch && keyMatch.conversation_id !== conversationId) {
+          return yield* Effect.fail(
+            new RpcFailure({
+              code: ErrorCodes.Conflict,
+              message: `Conversation key "${key}" is already in use for session ${sessionId}`,
+            }),
+          );
+        }
+
+        yield* this.db.insertInto("app_session_conversations").values({
+          session_id: sessionId,
+          conversation_key: key,
+          conversation_id: conversationId,
+        });
+
+        this.conversationToSession.set(conversationId, {
+          id: sessionId,
+          appId: session.app_id,
+        });
+        const convSet = this.sessionToConversations.get(sessionId);
+        if (convSet) convSet.add(conversationId);
+        else
+          this.sessionToConversations.set(sessionId, new Set([conversationId]));
+      }),
+    );
+  }
+
   getSession(
     sessionId: string,
     callerAgentId: string,

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -613,6 +613,9 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     listAppSessions(callerAgentId, opts) {
       return appHost.listSessions(callerAgentId, opts);
     },
+    attachAppConversation(sessionId, conversationId, key) {
+      return appHost.attachConversation(sessionId, conversationId, key);
+    },
     // #ignore-sloppy-code-next-line[async-keyword]: server close is a Promise boundary for external callers
     async close() {
       _webhookPermAdapter?.destroy();

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -149,5 +149,16 @@ export interface CoreApp {
     callerAgentId: string,
     opts?: { appId?: string; status?: string; limit?: number },
   ) => Effect.Effect<AppSession[], RpcFailure>;
+  /**
+   * Register a dynamically-created conversation with an app session so
+   * `before_message_delivery` fires on subsequent sends. Typical use: an app
+   * creates per-participant DMs inside its `on_session_active` handler, then
+   * attaches each under a distinct key (e.g. `role_dm_<agentId>`).
+   */
+  attachAppConversation: (
+    sessionId: string,
+    conversationId: string,
+    key: string,
+  ) => Effect.Effect<void, RpcFailure>;
   close: () => Promise<void>;
 }


### PR DESCRIPTION
## Summary

Adds `AppHost.attachConversation(sessionId, conversationId, key): Effect.Effect<void, RpcFailure>` so apps can register dynamically-created conversations with `conversationToSession` after session creation. Required so `before_message_delivery` fires on conversations created outside the manifest.

Closes #85. Stacks on #99 (#84).

## Why

`before_message_delivery` only fires on conversations in `conversationToSession`, which is populated from `manifest.conversations` during `createSession`. Conversations created afterwards via `conversationService.create` (e.g. per-participant role DMs) are never dispatched to the hook.

Arena's Werewolf game creates one private role DM per player inside its `on_session_active` handler — those DMs need to invoke the hook pipeline (for channel-role / phase / duplicate-action guards) to catch `/kill` attempts from role DMs.

## API

- Idempotent on exact match `(sessionId, conversationId, key)`.
- Errors on key collision (same key, different conv) or conv collision (same conv, different key) within a session.
- Errors if session is closed.
- Writes to `app_session_conversations` + updates the in-memory `conversationToSession` / `sessionToConversations` maps.
- Exposed on `CoreApp` as `attachAppConversation(sessionId, conversationId, key)`.

## Tests

- `app-host.test.ts` — unit coverage (insert, idempotent, conv/key conflicts, closed-session, cross-session, post-attach hook invocation, RpcFailure `Conflict` code).
- `packages/server/src/__tests__/integration/33-attach-conversation.integration.test.ts` — create session, create DM via `conversationService.create`, `attachAppConversation`, send message, verify `before_message_delivery` fires.

## Docs

`docs/guides/app-hooks.mdx` — new section on dynamic attachment.

## Consumer

moltzap-arena — werewolf-app role DMs attach inside the `on_session_active` handler's role-DM-creation transaction.

## Stacked

Base: `feat/issue-84-on-session-active` (#99) · Next: #86 (handler factory exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)