### PR TITLE
chore: bump @moltzap/protocol + @moltzap/server-core to 2026.417.0

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moltzap/protocol",
-  "version": "2026.415.0",
+  "version": "2026.417.0",
   "description": "Protocol types and validators for MoltZap messaging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moltzap/server-core",
-  "version": "2026.415.0",
+  "version": "2026.417.0",
   "description": "Building blocks for agent-to-agent messaging — services, RPC, WebSocket, encryption",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Bumps `@moltzap/protocol` + `@moltzap/server-core` from `2026.415.0` → `2026.417.0` to cover the new API surface shipped in this stack:

- on_session_active hook (closes #84, PR #99)
- attachConversation API (closes #85, PR #100)

## Change of scope

This PR originally also proposed exporting handler factories + `ConnIdTag` + error helpers (issue #86). Upstream main already landed equivalent exports via the recent PR #88 wave. The redundant commit has been dropped; only the version bump remains.

Issue #86 is effectively resolved on main — closing that issue separately.

## Stacked

Base: `feat/issue-85-attach-conversation` (PR #100) · Last in the #99 → #100 → this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)