### PR TITLE
refactor(server): Effect-native webhook adapter with tagged errors

### DIFF
--- a/packages/server/src/adapters/webhook.test.ts
+++ b/packages/server/src/adapters/webhook.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { WebhookClient, AsyncWebhookAdapter, WebhookError } from "./webhook.js";
+import { Cause, Effect, Exit, Fiber } from "effect";
+import {
+  AsyncWebhookAdapter,
+  WebhookClient,
+  WebhookDestroyedError,
+  WebhookHttpError,
+  WebhookNetworkError,
+  WebhookTimeoutError,
+} from "./webhook.js";
 
 // -- WebhookClient (sync) ---------------------------------------------------
 
-describe("WebhookClient", () => {
+describe("WebhookClient.call", () => {
   let client: WebhookClient;
 
   beforeEach(() => {
@@ -20,12 +28,14 @@ describe("WebhookClient", () => {
       new Response(JSON.stringify({ ok: true }), { status: 200 }),
     );
 
-    const result = await client.callSync<{ ok: boolean }>({
-      url: "https://hook.test/users",
-      event: "users.validate",
-      body: { userId: "u1" },
-      timeoutMs: 5000,
-    });
+    const result = await Effect.runPromise(
+      client.call<{ ok: boolean }>({
+        url: "https://hook.test/users",
+        event: "users.validate",
+        body: { userId: "u1" },
+        timeoutMs: 5000,
+      }),
+    );
 
     expect(result).toEqual({ ok: true });
     expect(fetch).toHaveBeenCalledWith(
@@ -39,124 +49,137 @@ describe("WebhookClient", () => {
     );
   });
 
-  it("throws WebhookError with status code on non-200 response", async () => {
+  it("fails with WebhookHttpError on non-2xx status", async () => {
     vi.mocked(fetch).mockResolvedValue(
       new Response("forbidden", { status: 403 }),
     );
 
-    await expect(
-      client.callSync({
+    const exit = await Effect.runPromiseExit(
+      client.call({
         url: "https://hook.test/x",
         event: "test",
         body: {},
         timeoutMs: 5000,
       }),
-    ).rejects.toThrow(WebhookError);
-
-    try {
-      await client.callSync({
-        url: "https://hook.test/x",
-        event: "test",
-        body: {},
-        timeoutMs: 5000,
-      });
-    } catch (err) {
-      expect((err as WebhookError).statusCode).toBe(403);
-      expect((err as WebhookError).message).toContain("403");
-    }
-  });
-
-  it("throws WebhookError on timeout", async () => {
-    const timeoutErr = new DOMException(
-      "The operation was aborted",
-      "TimeoutError",
     );
-    vi.mocked(fetch).mockRejectedValue(timeoutErr);
 
-    await expect(
-      client.callSync({
-        url: "https://hook.test/x",
-        event: "test.timeout",
-        body: {},
-        timeoutMs: 100,
-      }),
-    ).rejects.toThrow(WebhookError);
-
-    try {
-      await client.callSync({
-        url: "https://hook.test/x",
-        event: "test.timeout",
-        body: {},
-        timeoutMs: 100,
-      });
-    } catch (err) {
-      expect((err as WebhookError).statusCode).toBe(0);
-      expect((err as WebhookError).message).toContain("timed out");
-    }
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag !== "Failure") return;
+    const err = Cause.failureOption(exit.cause);
+    expect(err._tag).toBe("Some");
+    if (err._tag !== "Some") return;
+    expect(err.value._tag).toBe("WebhookHttpError");
+    const httpErr = err.value as WebhookHttpError;
+    expect(httpErr.status).toBe(403);
+    expect(httpErr.body).toBe("forbidden");
   });
 
-  it("throws WebhookError on network failure", async () => {
+  it("fails with WebhookTimeoutError when timeoutMs elapses", async () => {
+    // fetch never resolves — Effect.timeoutFail triggers on the real
+    // clock. We keep the budget small (50ms) so the test stays fast.
+    vi.mocked(fetch).mockImplementation(
+      () => new Promise(() => undefined) as never,
+    );
+
+    const exit = await Effect.runPromiseExit(
+      client.call({
+        url: "https://hook.test/x",
+        event: "test.timeout",
+        body: {},
+        timeoutMs: 50,
+      }),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const err = Cause.failureOption(exit.cause);
+    if (err._tag !== "Some") throw new Error("expected failure");
+    expect(err.value._tag).toBe("WebhookTimeoutError");
+    expect((err.value as WebhookTimeoutError).timeoutMs).toBe(50);
+  });
+
+  it("fails with WebhookNetworkError on fetch rejection", async () => {
     vi.mocked(fetch).mockRejectedValue(new Error("ECONNREFUSED"));
 
-    await expect(
-      client.callSync({
+    const exit = await Effect.runPromiseExit(
+      client.call({
         url: "https://hook.test/x",
         event: "test.net",
         body: {},
         timeoutMs: 5000,
       }),
-    ).rejects.toThrow(WebhookError);
+    );
 
-    try {
-      await client.callSync({
-        url: "https://hook.test/x",
-        event: "test.net",
-        body: {},
-        timeoutMs: 5000,
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const err = Cause.failureOption(exit.cause);
+    if (err._tag !== "Some") throw new Error("expected failure");
+    expect(err.value._tag).toBe("WebhookNetworkError");
+    const netErr = err.value as WebhookNetworkError;
+    expect(netErr.cause).toBeInstanceOf(Error);
+    expect((netErr.cause as Error).message).toBe("ECONNREFUSED");
+  });
+
+  it("aborts fetch via AbortSignal on fiber interrupt", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.mocked(fetch).mockImplementation((_url, init) => {
+      capturedSignal = (init as RequestInit).signal as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        capturedSignal?.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
       });
-    } catch (err) {
-      expect((err as WebhookError).message).toContain("ECONNREFUSED");
-    }
+    });
+
+    const fiber = Effect.runFork(
+      client.call({
+        url: "https://hook.test/x",
+        event: "test.interrupt",
+        body: {},
+        timeoutMs: 60000,
+      }),
+    );
+
+    // Give the fetch mock one tick to register.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(capturedSignal?.aborted).toBe(false);
+
+    await Effect.runPromise(Fiber.interrupt(fiber));
+    expect(capturedSignal?.aborted).toBe(true);
   });
 });
 
 // -- AsyncWebhookAdapter (permissions) --------------------------------------
 
-describe("AsyncWebhookAdapter", () => {
+describe("AsyncWebhookAdapter.send", () => {
   let adapter: AsyncWebhookAdapter;
-  let needsCleanup: boolean;
 
   beforeEach(() => {
     adapter = new AsyncWebhookAdapter(5);
-    needsCleanup = true;
     vi.stubGlobal("fetch", vi.fn());
-    vi.useFakeTimers();
   });
 
-  afterEach(() => {
-    if (needsCleanup) adapter.destroy();
-    vi.useRealTimers();
+  afterEach(async () => {
+    await Effect.runPromise(adapter.shutdown);
     vi.restoreAllMocks();
   });
 
-  /** Flush microtasks so sendRequest progresses past `await fetch()` and registers the pending entry. */
-  async function flushSendRequest() {
-    await vi.advanceTimersByTimeAsync(0);
-  }
-
-  it("sends request and resolves via callback", async () => {
+  it("resolves with access when callback arrives", async () => {
     vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 202 }));
 
-    const promise = adapter.sendRequest({
-      url: "https://hook.test/perms",
-      requestId: "req-1",
-      callbackUrl: "https://me/callback",
-      callbackToken: "token",
-      body: { agentId: "a1" },
-      timeoutMs: 10000,
-    });
+    const fiber = Effect.runFork(
+      adapter.send({
+        url: "https://hook.test/perms",
+        requestId: "req-1",
+        callbackUrl: "https://me/callback",
+        callbackToken: "token",
+        body: { agentId: "a1" },
+        timeoutMs: 10_000,
+      }),
+    );
 
-    await flushSendRequest();
+    // Give the fetch promise + Deferred registration a tick.
+    await new Promise((r) => setTimeout(r, 0));
 
     expect(fetch).toHaveBeenCalledWith(
       "https://hook.test/perms",
@@ -169,142 +192,139 @@ describe("AsyncWebhookAdapter", () => {
       }),
     );
 
-    const resolved = adapter.resolveCallback("req-1", ["read", "write"]);
-    expect(resolved).toBe(true);
+    const found = await Effect.runPromise(
+      adapter.resolveCallback("req-1", ["read", "write"]),
+    );
+    expect(found).toBe(true);
 
-    const result = await promise;
-    expect(result).toEqual(["read", "write"]);
+    const exit = await Effect.runPromise(Fiber.await(fiber));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toEqual(["read", "write"]);
   });
 
-  it("throws WebhookError when server returns non-202", async () => {
+  it("fails with WebhookHttpError on non-202 response", async () => {
     vi.mocked(fetch).mockResolvedValue(new Response("bad", { status: 500 }));
 
-    const promise = adapter.sendRequest({
-      url: "https://hook.test/perms",
-      requestId: "req-err",
-      callbackUrl: "https://me/cb",
-      callbackToken: "t",
-      body: {},
-      timeoutMs: 5000,
-    });
+    const exit = await Effect.runPromiseExit(
+      adapter.send({
+        url: "https://hook.test/perms",
+        requestId: "req-err",
+        callbackUrl: "https://me/cb",
+        callbackToken: "t",
+        body: {},
+        timeoutMs: 5000,
+      }),
+    );
 
-    // Attach handler before flushing to avoid unhandled rejection warning
-    const assertion = expect(promise).rejects.toThrow(WebhookError);
-    await flushSendRequest();
-    await assertion;
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const err = Cause.failureOption(exit.cause);
+    if (err._tag !== "Some") throw new Error("expected failure");
+    expect(err.value._tag).toBe("WebhookHttpError");
+    expect((err.value as WebhookHttpError).status).toBe(500);
   });
 
-  it("returns false for resolveCallback with unknown request_id", () => {
-    expect(adapter.resolveCallback("unknown-id", ["read"])).toBe(false);
+  it("returns false for resolveCallback with unknown request_id", async () => {
+    const found = await Effect.runPromise(
+      adapter.resolveCallback("unknown-id", ["read"]),
+    );
+    expect(found).toBe(false);
   });
 
-  it("returns true for duplicate resolveCallback (idempotency)", async () => {
+  it("returns true for duplicate resolveCallback within TTL (idempotency)", async () => {
     vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 202 }));
 
-    const promise = adapter.sendRequest({
-      url: "https://hook.test/perms",
-      requestId: "req-dup",
-      callbackUrl: "https://me/cb",
-      callbackToken: "t",
-      body: {},
-      timeoutMs: 30000,
-    });
+    const fiber = Effect.runFork(
+      adapter.send({
+        url: "https://hook.test/perms",
+        requestId: "req-dup",
+        callbackUrl: "https://me/cb",
+        callbackToken: "t",
+        body: {},
+        timeoutMs: 30_000,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
 
-    await flushSendRequest();
-
-    expect(adapter.resolveCallback("req-dup", ["read"])).toBe(true);
-    await promise;
-
-    expect(adapter.resolveCallback("req-dup", ["read"])).toBe(true);
+    expect(
+      await Effect.runPromise(adapter.resolveCallback("req-dup", ["read"])),
+    ).toBe(true);
+    await Effect.runPromise(Fiber.await(fiber));
+    expect(
+      await Effect.runPromise(adapter.resolveCallback("req-dup", ["read"])),
+    ).toBe(true);
   });
 
-  it("rejects pending promise on timeout", async () => {
+  it("fails with WebhookTimeoutError when callback never arrives", async () => {
     vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 202 }));
 
-    const promise = adapter.sendRequest({
-      url: "https://hook.test/perms",
-      requestId: "req-timeout",
-      callbackUrl: "https://me/cb",
-      callbackToken: "t",
-      body: {},
-      timeoutMs: 5000,
-    });
+    const exit = await Effect.runPromiseExit(
+      adapter.send({
+        url: "https://hook.test/perms",
+        requestId: "req-timeout",
+        callbackUrl: "https://me/cb",
+        callbackToken: "t",
+        body: {},
+        timeoutMs: 10,
+      }),
+    );
 
-    await flushSendRequest();
-
-    // Attach handler before advancing timers to avoid unhandled rejection warning
-    const assertion = expect(promise).rejects.toThrow("timed out");
-    await vi.advanceTimersByTimeAsync(5001);
-    await assertion;
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const err = Cause.failureOption(exit.cause);
+    if (err._tag !== "Some") throw new Error("expected failure");
+    expect(err.value._tag).toBe("WebhookTimeoutError");
   });
 
-  it("resolveCallback returns false after TTL expiry and drops the id", async () => {
-    // After a callback resolves, the adapter remembers the id for
-    // RESOLVED_TTL_MS (5 minutes) to make repeat callbacks idempotent.
-    // Once the TTL lapses, the first repeat call must BOTH drop the id
-    // from the `resolved` map AND return false — otherwise a very late
-    // duplicate would masquerade as a fresh, unknown request.
+  it("shutdown fails all pending requests with WebhookDestroyedError", async () => {
     vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 202 }));
 
-    const promise = adapter.sendRequest({
-      url: "https://hook.test/perms",
-      requestId: "req-ttl",
-      callbackUrl: "https://me/cb",
-      callbackToken: "t",
-      body: {},
-      timeoutMs: 60000,
-    });
+    const fiber = Effect.runFork(
+      adapter.send({
+        url: "https://hook.test/perms",
+        requestId: "req-destroy",
+        callbackUrl: "https://me/cb",
+        callbackToken: "t",
+        body: {},
+        timeoutMs: 60_000,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
 
-    await flushSendRequest();
+    await Effect.runPromise(adapter.shutdown);
 
-    // Initial resolution: recorded in `resolved`, promise completes.
-    expect(adapter.resolveCallback("req-ttl", ["read"])).toBe(true);
-    await promise;
-
-    // Still within TTL — duplicate is idempotent, returns true.
-    expect(adapter.resolveCallback("req-ttl", ["read"])).toBe(true);
-
-    // Advance past the 5-minute TTL window.
-    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
-
-    // First call after expiry deletes the stale entry and returns false.
-    expect(adapter.resolveCallback("req-ttl", ["read"])).toBe(false);
-
-    // Second call confirms the id is no longer in `resolved`: it must
-    // now fall through to the "no pending entry" branch, which also
-    // returns false. This double-checks the delete in the previous step.
-    expect(adapter.resolveCallback("req-ttl", ["read"])).toBe(false);
+    const exit = await Effect.runPromise(Fiber.await(fiber));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const err = Cause.failureOption(exit.cause);
+    if (err._tag !== "Some") throw new Error("expected failure");
+    expect(err.value._tag).toBe("WebhookDestroyedError");
+    expect((err.value as WebhookDestroyedError).requestId).toBe("req-destroy");
   });
 
-  it("destroy() rejects all pending requests", async () => {
+  it("removes pending entry when the send fiber is interrupted", async () => {
+    // 202 ack → the fiber parks on Deferred.await. Interrupt it and
+    // confirm the pending map is cleared (resolveCallback returns false).
     vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 202 }));
 
-    const promise = adapter.sendRequest({
-      url: "https://hook.test/perms",
-      requestId: "req-destroy",
-      callbackUrl: "https://me/cb",
-      callbackToken: "t",
-      body: {},
-      timeoutMs: 60000,
-    });
+    const fiber = Effect.runFork(
+      adapter.send({
+        url: "https://hook.test/perms",
+        requestId: "req-interrupt",
+        callbackUrl: "https://me/cb",
+        callbackToken: "t",
+        body: {},
+        timeoutMs: 60_000,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
 
-    await flushSendRequest();
-    adapter.destroy();
-    needsCleanup = false;
+    await Effect.runPromise(Fiber.interrupt(fiber));
+    await new Promise((r) => setTimeout(r, 0));
 
-    await expect(promise).rejects.toThrow(WebhookError);
-    await expect(promise).rejects.toThrow("Adapter destroyed");
-  });
-});
-
-// -- WebhookError -----------------------------------------------------------
-
-describe("WebhookError", () => {
-  it("has correct name, message, and statusCode", () => {
-    const err = new WebhookError("bad request", 400);
-    expect(err.name).toBe("WebhookError");
-    expect(err.message).toBe("bad request");
-    expect(err.statusCode).toBe(400);
-    expect(err).toBeInstanceOf(Error);
+    const found = await Effect.runPromise(
+      adapter.resolveCallback("req-interrupt", ["read"]),
+    );
+    expect(found).toBe(false);
   });
 });

--- a/packages/server/src/adapters/webhook.ts
+++ b/packages/server/src/adapters/webhook.ts
@@ -1,10 +1,16 @@
 /** Webhook adapters for calling external services over HTTP. */
 
+import {
+  Data,
+  Deferred,
+  Duration,
+  Effect,
+  HashMap,
+  Ref,
+} from "effect";
+import { createHmac } from "node:crypto";
 import type { ContactService, PermissionService } from "../app/app-host.js";
 import type { Logger } from "../logger.js";
-import { Effect } from "effect";
-import { createHmac } from "node:crypto";
-import type { RpcFailure } from "../runtime/index.js";
 
 /**
  * HMAC-SHA256-sign a webhook payload and return the `X-MoltZap-Signature`
@@ -16,127 +22,172 @@ export function signWebhookPayload(secret: string, payload: string): string {
   return "sha256=" + createHmac("sha256", secret).update(payload).digest("hex");
 }
 
+// -- Tagged error union -------------------------------------------------------
+
 /**
- * Typed failure raised by `Effect.tryPromise` wrappers around
- * `WebhookClient.callSync`. Carries the original cause so downstream
- * log sites can extract network/timeout detail without dealing with
- * `unknown`.
+ * Non-2xx HTTP response from the remote webhook. `status` is the actual
+ * wire status; `body` captures up to ~response.text() for log context.
  */
-export class WebhookCallError extends Error {
-  override readonly name = "WebhookCallError";
-  constructor(
-    message: string,
-    readonly url: string,
-    readonly cause: unknown,
-  ) {
-    super(message);
+export class WebhookHttpError extends Data.TaggedError("WebhookHttpError")<{
+  readonly url: string;
+  readonly event: string;
+  readonly status: number;
+  readonly body: string;
+}> {
+  get message(): string {
+    return `Webhook ${this.event} returned ${this.status}: ${this.body}`;
   }
 }
 
-// -- Semaphore ----------------------------------------------------------------
-
-class Semaphore {
-  private waiting: Array<() => void> = [];
-  private active = 0;
-
-  constructor(private max: number) {}
-
-  // #ignore-sloppy-code-next-line[async-keyword, promise-type]: Semaphore callback-to-Promise queueing primitive
-  async acquire(): Promise<void> {
-    if (this.active < this.max) {
-      this.active++;
-      return;
-    }
-    return new Promise<void>((resolve) => {
-      this.waiting.push(resolve);
-    });
-  }
-
-  release(): void {
-    const next = this.waiting.shift();
-    if (next) {
-      next();
-    } else {
-      this.active--;
-    }
+/**
+ * Request exceeded its `timeoutMs` budget — fired by `Effect.timeoutFail`.
+ * Covers both sync-webhook request/response timeouts and async-adapter
+ * callback-wait timeouts; the `event` discriminates.
+ */
+export class WebhookTimeoutError extends Data.TaggedError(
+  "WebhookTimeoutError",
+)<{
+  readonly url: string;
+  readonly event: string;
+  readonly timeoutMs: number;
+}> {
+  get message(): string {
+    return `Webhook ${this.event} timed out after ${this.timeoutMs}ms`;
   }
 }
+
+/**
+ * Transport-level failure surfaced by `fetch` (DNS, connection reset,
+ * TLS). `cause` is the original thrown value so log sites can inspect
+ * `.code` / `.errno` without re-parsing a string.
+ */
+export class WebhookNetworkError extends Data.TaggedError(
+  "WebhookNetworkError",
+)<{
+  readonly url: string;
+  readonly event: string;
+  readonly cause: unknown;
+}> {
+  get message(): string {
+    const detail =
+      this.cause instanceof Error ? this.cause.message : String(this.cause);
+    return `Webhook ${this.event} failed: ${detail}`;
+  }
+}
+
+/**
+ * Emitted when `AsyncWebhookAdapter.shutdown` fires while requests are
+ * still awaiting their out-of-band callback. Callers treat this like any
+ * other fail-closed webhook error.
+ */
+export class WebhookDestroyedError extends Data.TaggedError(
+  "WebhookDestroyedError",
+)<{
+  readonly requestId: string;
+}> {
+  get message(): string {
+    return `Webhook adapter destroyed while request ${this.requestId} was pending`;
+  }
+}
+
+/** Union of every tagged error the webhook adapters can emit. */
+export type WebhookError =
+  | WebhookHttpError
+  | WebhookTimeoutError
+  | WebhookNetworkError
+  | WebhookDestroyedError;
 
 // -- Sync webhook client (Users, Contacts) ------------------------------------
 
+/** Options for a single sync webhook call. */
+export interface WebhookCallOpts {
+  readonly url: string;
+  readonly event: string;
+  readonly body: unknown;
+  readonly timeoutMs: number;
+  /**
+   * Extra headers merged on top of `Content-Type` + `X-MoltZap-Event`.
+   * Used by app-hook webhooks to attach `X-MoltZap-Signature`. Caller-
+   * supplied keys win over the defaults — but `Content-Type` and
+   * `X-MoltZap-Event` are MoltZap-controlled, so callers should not
+   * override those.
+   */
+  readonly headers?: Record<string, string>;
+  /**
+   * Pre-serialized JSON body. When provided, `body` is ignored. Used by
+   * app-hook webhooks that compute an HMAC signature over the exact
+   * bytes that go on the wire — re-serializing here would drift.
+   */
+  readonly bodyJson?: string;
+}
+
+type WebhookCallError =
+  | WebhookHttpError
+  | WebhookTimeoutError
+  | WebhookNetworkError;
+
+/**
+ * Sync webhook client: POST a payload, receive a parsed JSON response.
+ * All failures land in the typed error channel — fetch is driven through
+ * `Effect.tryPromise({ try: (signal) => fetch(url, { signal }) })` so
+ * fiber interrupt aborts the HTTP socket, and concurrency is bounded by
+ * an `Effect.Semaphore` whose permit is returned on interrupt.
+ */
 export class WebhookClient {
-  private semaphore: Semaphore;
+  private readonly permits: Effect.Semaphore;
 
   constructor(concurrency = 10) {
-    this.semaphore = new Semaphore(concurrency);
+    // `Effect.makeSemaphore` performs no async work so it's safe to
+    // `runSync` in the constructor; keeps the `new WebhookClient()`
+    // construction surface unchanged for call sites.
+    this.permits = Effect.runSync(Effect.makeSemaphore(concurrency));
   }
 
-  // #ignore-sloppy-code-next-line[async-keyword]: fetch HTTP boundary to external webhook
-  async callSync<T>(opts: {
-    url: string;
-    event: string;
-    body: unknown;
-    timeoutMs: number;
-    /**
-     * Extra headers merged on top of `Content-Type` + `X-MoltZap-Event`.
-     * Used by app-hook webhooks to attach `X-MoltZap-Signature`. Caller-
-     * supplied keys win over the defaults — but `Content-Type` and
-     * `X-MoltZap-Event` are MoltZap-controlled, so callers should not
-     * override those.
-     */
-    headers?: Record<string, string>;
-    /**
-     * Pre-serialized JSON body. When provided, `body` is ignored. Used by
-     * app-hook webhooks that compute an HMAC signature over the exact
-     * bytes that go on the wire — re-serializing here would drift.
-     */
-    bodyJson?: string;
-    // #ignore-sloppy-code-next-line[promise-type]: fetch HTTP boundary to external webhook
-  }): Promise<T> {
-    await this.semaphore.acquire();
-    try {
-      const response = await fetch(opts.url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-MoltZap-Event": opts.event,
-          ...opts.headers,
-        },
-        body: opts.bodyJson ?? JSON.stringify(opts.body),
-        signal: AbortSignal.timeout(opts.timeoutMs),
-      });
+  call<T>(opts: WebhookCallOpts): Effect.Effect<T, WebhookCallError> {
+    const { url, event, timeoutMs } = opts;
+    const body = opts.bodyJson ?? JSON.stringify(opts.body);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-MoltZap-Event": event,
+      ...opts.headers,
+    };
 
-      if (!response.ok) {
-        const text = await response.text().catch(() => "");
-        throw new WebhookError(
-          `Webhook ${opts.event} returned ${response.status}: ${text}`,
-          response.status,
-        );
-      }
+    const perform = Effect.tryPromise({
+      try: (signal) =>
+        fetch(url, { method: "POST", headers, body, signal }).then(
+          async (response) => {
+            if (!response.ok) {
+              const text = await response.text().catch(() => "");
+              throw new WebhookHttpError({
+                url,
+                event,
+                status: response.status,
+                body: text,
+              });
+            }
+            // Empty-body responses (204, or 200 with no payload) are
+            // common for fire-and-forget hooks (`on_join`, `on_close`).
+            // `response.json()` would throw on an empty body, so read
+            // as text and short-circuit.
+            const text = await response.text();
+            if (text.length === 0) return null as T;
+            return JSON.parse(text) as T;
+          },
+        ),
+      catch: (err) =>
+        err instanceof WebhookHttpError
+          ? err
+          : new WebhookNetworkError({ url, event, cause: err }),
+    });
 
-      // Empty-body responses (204, or 200 with no payload) are common for
-      // fire-and-forget hooks (`on_join`, `on_close`). `response.json()`
-      // would throw on an empty body, so read as text and short-circuit.
-      const text = await response.text();
-      if (text.length === 0) {
-        return null as T;
-      }
-      return JSON.parse(text) as T;
-    } catch (err) {
-      if (err instanceof WebhookError) throw err;
-      if (err instanceof DOMException && err.name === "TimeoutError") {
-        throw new WebhookError(
-          `Webhook ${opts.event} timed out after ${opts.timeoutMs}ms`,
-          0,
-        );
-      }
-      throw new WebhookError(
-        `Webhook ${opts.event} failed: ${(err as Error).message}`,
-        0,
-      );
-    } finally {
-      this.semaphore.release();
-    }
+    return this.permits.withPermits(1)(
+      perform.pipe(
+        Effect.timeoutFail({
+          duration: Duration.millis(timeoutMs),
+          onTimeout: () => new WebhookTimeoutError({ url, event, timeoutMs }),
+        }),
+      ),
+    );
   }
 }
 
@@ -154,147 +205,212 @@ export class WebhookContactService implements ContactService {
     userIdA: string,
     userIdB: string,
   ): Effect.Effect<boolean, never> {
-    return Effect.tryPromise({
-      try: () =>
-        this.client.callSync<{ inContact: boolean }>({
-          url: this.url,
-          event: "contacts.check",
-          body: { userIdA, userIdB },
-          timeoutMs: this.timeoutMs,
-        }),
-      catch: (err) => err,
-    }).pipe(
-      Effect.map((result) => result.inContact === true),
-      Effect.catchAll((err) =>
-        Effect.sync(() => {
-          this.webhookLogger.error(
-            { err, userIdA, userIdB, url: this.url },
-            "Contact check webhook failed, rejecting contact",
-          );
-          return false;
-        }),
-      ),
-    );
+    return this.client
+      .call<{ inContact: boolean }>({
+        url: this.url,
+        event: "contacts.check",
+        body: { userIdA, userIdB },
+        timeoutMs: this.timeoutMs,
+      })
+      .pipe(
+        Effect.map((result) => result.inContact === true),
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            this.webhookLogger.error(
+              { err, userIdA, userIdB, url: this.url },
+              "Contact check webhook failed, rejecting contact",
+            );
+            return false;
+          }),
+        ),
+      );
   }
 }
 
 // -- Async webhook adapter (Permissions) --------------------------------------
 
-interface PendingRequest {
-  resolve: (access: string[]) => void;
-  reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-}
-
+/** How long we remember a resolved request-id so repeat callbacks are idempotent. */
 const RESOLVED_TTL_MS = 5 * 60 * 1000;
 
+/** Internal map entry — a Deferred that the HTTP callback route completes. */
+type PendingMap = HashMap.HashMap<
+  string,
+  Deferred.Deferred<string[], WebhookError>
+>;
+
+/**
+ * Async webhook adapter for the out-of-band permissions flow:
+ * POST to the remote, receive `202`, then wait for a later HTTP
+ * callback to deliver the access decision.
+ *
+ * Cleanup invariants (enforced by `Effect.ensuring` / `Effect.onInterrupt`):
+ *   - Fiber interrupt removes the pending Deferred from the Ref so no
+ *     entry leaks when a caller cancels.
+ *   - `Effect.timeoutFail` fires a `WebhookTimeoutError` through the
+ *     same cleanup path.
+ *   - `shutdown` fails every still-pending Deferred with
+ *     `WebhookDestroyedError`.
+ */
 export class AsyncWebhookAdapter {
-  private pending = new Map<string, PendingRequest>();
-  private resolved = new Map<string, number>();
-  private semaphore: Semaphore;
+  private readonly pending: Ref.Ref<PendingMap>;
+  /**
+   * `resolved` is a plain Map because it's only touched from the HTTP
+   * callback handler (already synchronous at its boundary). Moving it
+   * into a Ref would buy no interrupt-safety — the handler either
+   * completes its `resolveCallback` call synchronously or it doesn't run
+   * at all.
+   */
+  private readonly resolved = new Map<string, number>();
+  private readonly permits: Effect.Semaphore;
 
   constructor(concurrency = 10) {
-    this.semaphore = new Semaphore(concurrency);
+    this.pending = Effect.runSync(Ref.make<PendingMap>(HashMap.empty()));
+    this.permits = Effect.runSync(Effect.makeSemaphore(concurrency));
   }
 
-  // #ignore-sloppy-code-next-line[async-keyword]: fetch HTTP boundary + deferred callback correlation
-  async sendRequest(opts: {
-    url: string;
-    requestId: string;
-    callbackUrl: string;
-    callbackToken: string;
-    body: unknown;
-    timeoutMs: number;
-    // #ignore-sloppy-code-next-line[promise-type]: fetch HTTP boundary with deferred callback correlation
-  }): Promise<string[]> {
-    // Register the pending entry BEFORE sending the HTTP request.
-    // A fast webhook service could call back before fetch() returns.
-    const callbackPromise = new Promise<string[]>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(opts.requestId);
-        reject(
-          new WebhookError(
-            `Permissions callback for ${opts.requestId} timed out after ${opts.timeoutMs}ms`,
-            0,
-          ),
-        );
-      }, opts.timeoutMs);
+  send(opts: {
+    readonly url: string;
+    readonly requestId: string;
+    readonly callbackUrl: string;
+    readonly callbackToken: string;
+    readonly body: unknown;
+    readonly timeoutMs: number;
+  }): Effect.Effect<string[], WebhookError> {
+    const { url, requestId, timeoutMs } = opts;
+    const event = "permissions.check";
 
-      this.pending.set(opts.requestId, { resolve, reject, timer });
-    });
+    return Effect.gen(this, function* () {
+      const deferred = yield* Deferred.make<string[], WebhookError>();
 
-    await this.semaphore.acquire();
-    try {
-      const response = await fetch(opts.url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-MoltZap-Event": "permissions.check",
-          "X-MoltZap-Callback-URL": opts.callbackUrl,
-          "X-MoltZap-Callback-Token": opts.callbackToken,
-        },
-        body: JSON.stringify({
-          request_id: opts.requestId,
-          ...(opts.body as object),
-        }),
-        signal: AbortSignal.timeout(opts.timeoutMs),
+      // Register BEFORE sending the HTTP request: a fast webhook service
+      // could fire its callback before fetch() returns.
+      yield* Ref.update(this.pending, HashMap.set(requestId, deferred));
+
+      const bodyJson = JSON.stringify({
+        request_id: requestId,
+        ...(opts.body as object),
       });
 
-      if (response.status !== 202) {
-        const text = await response.text().catch(() => "");
-        this.cancelPending(opts.requestId);
-        throw new WebhookError(
-          `Permissions webhook expected 202, got ${response.status}: ${text}`,
-          response.status,
+      const post = this.permits.withPermits(1)(
+        Effect.tryPromise({
+          try: (signal) =>
+            fetch(url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-MoltZap-Event": event,
+                "X-MoltZap-Callback-URL": opts.callbackUrl,
+                "X-MoltZap-Callback-Token": opts.callbackToken,
+              },
+              body: bodyJson,
+              signal,
+            }),
+          catch: (err) =>
+            new WebhookNetworkError({ url, event, cause: err }),
+        }).pipe(
+          Effect.flatMap((response) => {
+            if (response.status === 202) return Effect.void;
+            return Effect.tryPromise({
+              try: () => response.text().catch(() => ""),
+              catch: () =>
+                new WebhookNetworkError({
+                  url,
+                  event,
+                  cause: "failed to read error body",
+                }),
+            }).pipe(
+              Effect.flatMap((text) =>
+                Effect.fail(
+                  new WebhookHttpError({
+                    url,
+                    event,
+                    status: response.status,
+                    body: text,
+                  }),
+                ),
+              ),
+            );
+          }),
+        ),
+      );
+
+      // Await the callback after the POST succeeds. `ensuring` removes
+      // the pending entry on success, failure, AND interrupt — which is
+      // what plugs the Bug #3 leak.
+      const awaitCallback = Deferred.await(deferred).pipe(
+        Effect.timeoutFail({
+          duration: Duration.millis(timeoutMs),
+          onTimeout: () =>
+            new WebhookTimeoutError({ url, event, timeoutMs }),
+        }),
+      );
+
+      return yield* post.pipe(
+        Effect.flatMap(() => awaitCallback),
+        Effect.ensuring(
+          Ref.update(this.pending, HashMap.remove(requestId)),
+        ),
+      );
+    });
+  }
+
+  /**
+   * Deliver a callback decision to a pending request. Returns `true` if
+   * a pending Deferred was completed, or if the request id matches a
+   * still-fresh prior resolution (idempotent). Returns `false` for
+   * unknown/expired request ids.
+   */
+  resolveCallback(
+    requestId: string,
+    access: string[],
+  ): Effect.Effect<boolean, never> {
+    return Effect.gen(this, function* () {
+      // Idempotency: already resolved within TTL.
+      const resolvedAt = this.resolved.get(requestId);
+      if (resolvedAt !== undefined) {
+        if (Date.now() - resolvedAt < RESOLVED_TTL_MS) return true;
+        this.resolved.delete(requestId);
+        return false;
+      }
+
+      // Atomically remove the pending Deferred so no other fiber can
+      // also try to complete it.
+      const taken = yield* Ref.modify(this.pending, (map) => {
+        const existing = HashMap.get(map, requestId);
+        if (existing._tag === "None") return [existing, map];
+        return [existing, HashMap.remove(map, requestId)];
+      });
+
+      if (taken._tag === "None") return false;
+
+      this.resolved.set(requestId, Date.now());
+      this.pruneResolved();
+      yield* Deferred.succeed(taken.value, access);
+      return true;
+    });
+  }
+
+  /**
+   * Fail every pending request with `WebhookDestroyedError`. Called at
+   * server shutdown so awaiting fibers unblock rather than hanging on
+   * the `Deferred.await` until their timeout.
+   */
+  readonly shutdown: Effect.Effect<void, never> = Effect.gen(
+    this,
+    function* () {
+      const map = yield* Ref.getAndSet<PendingMap>(
+        this.pending,
+        HashMap.empty(),
+      );
+      for (const [requestId, deferred] of HashMap.entries(map)) {
+        yield* Deferred.fail(
+          deferred,
+          new WebhookDestroyedError({ requestId }),
         );
       }
-    } catch (err) {
-      this.cancelPending(opts.requestId);
-      throw err;
-    } finally {
-      this.semaphore.release();
-    }
-
-    return callbackPromise;
-  }
-
-  resolveCallback(requestId: string, access: string[]): boolean {
-    // Idempotency: already resolved within TTL
-    const resolvedAt = this.resolved.get(requestId);
-    if (resolvedAt !== undefined) {
-      if (Date.now() - resolvedAt < RESOLVED_TTL_MS) return true;
-      this.resolved.delete(requestId);
-      return false;
-    }
-
-    const entry = this.pending.get(requestId);
-    if (!entry) return false;
-
-    clearTimeout(entry.timer);
-    this.pending.delete(requestId);
-    this.resolved.set(requestId, Date.now());
-    entry.resolve(access);
-
-    this.pruneResolved();
-    return true;
-  }
-
-  destroy(): void {
-    for (const entry of this.pending.values()) {
-      clearTimeout(entry.timer);
-      entry.reject(new WebhookError("Adapter destroyed", 0));
-    }
-    this.pending.clear();
-    this.resolved.clear();
-  }
-
-  private cancelPending(requestId: string): void {
-    const entry = this.pending.get(requestId);
-    if (entry) {
-      clearTimeout(entry.timer);
-      this.pending.delete(requestId);
-    }
-  }
+      this.resolved.clear();
+    },
+  );
 
   private pruneResolved(): void {
     const cutoff = Date.now() - RESOLVED_TTL_MS;
@@ -323,49 +439,35 @@ export class WebhookPermissionService implements PermissionService {
     resource: string;
     access: string[];
     timeoutMs: number;
-  }): Effect.Effect<string[], Error> {
+  }): Effect.Effect<string[], WebhookError> {
     const requestId = crypto.randomUUID();
     const callbackUrl = `${this.callbackBaseUrl}/api/v1/permissions/resolve`;
 
-    return Effect.tryPromise({
-      try: () =>
-        this.adapter.sendRequest({
-          url: this.webhookUrl,
-          requestId,
-          callbackUrl,
-          callbackToken: this.callbackToken,
-          body: {
-            userId: params.userId,
-            agentId: params.agentId,
-            sessionId: params.sessionId,
-            appId: params.appId,
-            resource: params.resource,
-            access: params.access,
-          },
-          timeoutMs: params.timeoutMs,
-        }),
-      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-    }).pipe(
-      Effect.tapError((err) =>
-        Effect.sync(() =>
-          this.logger.error(
-            { err, requestId, resource: params.resource },
-            "Webhook permission request failed",
+    return this.adapter
+      .send({
+        url: this.webhookUrl,
+        requestId,
+        callbackUrl,
+        callbackToken: this.callbackToken,
+        body: {
+          userId: params.userId,
+          agentId: params.agentId,
+          sessionId: params.sessionId,
+          appId: params.appId,
+          resource: params.resource,
+          access: params.access,
+        },
+        timeoutMs: params.timeoutMs,
+      })
+      .pipe(
+        Effect.tapError((err) =>
+          Effect.sync(() =>
+            this.logger.error(
+              { err, requestId, resource: params.resource },
+              "Webhook permission request failed",
+            ),
           ),
         ),
-      ),
-    );
-  }
-}
-
-// -- Shared error type --------------------------------------------------------
-
-export class WebhookError extends Error {
-  constructor(
-    message: string,
-    public readonly statusCode: number,
-  ) {
-    super(message);
-    this.name = "WebhookError";
+      );
   }
 }

--- a/packages/server/src/adapters/webhook.ts
+++ b/packages/server/src/adapters/webhook.ts
@@ -1,13 +1,6 @@
 /** Webhook adapters for calling external services over HTTP. */
 
-import {
-  Data,
-  Deferred,
-  Duration,
-  Effect,
-  HashMap,
-  Ref,
-} from "effect";
+import { Data, Deferred, Duration, Effect, HashMap, Option, Ref } from "effect";
 import { createHmac } from "node:crypto";
 import type { ContactService, PermissionService } from "../app/app-host.js";
 import type { Logger } from "../logger.js";
@@ -137,9 +130,9 @@ export class WebhookClient {
   private readonly permits: Effect.Semaphore;
 
   constructor(concurrency = 10) {
-    // `Effect.makeSemaphore` performs no async work so it's safe to
-    // `runSync` in the constructor; keeps the `new WebhookClient()`
-    // construction surface unchanged for call sites.
+    // `Effect.makeSemaphore` is pure, so `runSync` in the constructor
+    // is safe and keeps the `new WebhookClient()` construction surface
+    // unchanged for call sites.
     this.permits = Effect.runSync(Effect.makeSemaphore(concurrency));
   }
 
@@ -152,36 +145,48 @@ export class WebhookClient {
       ...opts.headers,
     };
 
-    const perform = Effect.tryPromise({
-      try: (signal) =>
-        fetch(url, { method: "POST", headers, body, signal }).then(
-          async (response) => {
-            if (!response.ok) {
-              const text = await response.text().catch(() => "");
-              throw new WebhookHttpError({
-                url,
-                event,
-                status: response.status,
-                body: text,
-              });
-            }
-            // Empty-body responses (204, or 200 with no payload) are
-            // common for fire-and-forget hooks (`on_join`, `on_close`).
-            // `response.json()` would throw on an empty body, so read
-            // as text and short-circuit.
-            const text = await response.text();
-            if (text.length === 0) return null as T;
-            return JSON.parse(text) as T;
-          },
-        ),
-      catch: (err) =>
-        err instanceof WebhookHttpError
-          ? err
-          : new WebhookNetworkError({ url, event, cause: err }),
+    const doFetch = Effect.tryPromise({
+      try: (signal) => fetch(url, { method: "POST", headers, body, signal }),
+      catch: (err) => new WebhookNetworkError({ url, event, cause: err }),
     });
 
+    const readBody = (response: Response): Effect.Effect<string, never> =>
+      Effect.tryPromise({
+        try: () => response.text(),
+        catch: () => null,
+      }).pipe(Effect.orElseSucceed(() => ""));
+
+    const parseResponse = (
+      response: Response,
+    ): Effect.Effect<T, WebhookHttpError | WebhookNetworkError> =>
+      response.ok
+        ? readBody(response).pipe(
+            Effect.flatMap((text) =>
+              text.length === 0
+                ? Effect.succeed(null as T)
+                : Effect.try({
+                    try: () => JSON.parse(text) as T,
+                    catch: (err) =>
+                      new WebhookNetworkError({ url, event, cause: err }),
+                  }),
+            ),
+          )
+        : readBody(response).pipe(
+            Effect.flatMap((text) =>
+              Effect.fail(
+                new WebhookHttpError({
+                  url,
+                  event,
+                  status: response.status,
+                  body: text,
+                }),
+              ),
+            ),
+          );
+
     return this.permits.withPermits(1)(
-      perform.pipe(
+      doFetch.pipe(
+        Effect.flatMap(parseResponse),
         Effect.timeoutFail({
           duration: Duration.millis(timeoutMs),
           onTimeout: () => new WebhookTimeoutError({ url, event, timeoutMs }),
@@ -305,8 +310,7 @@ export class AsyncWebhookAdapter {
               body: bodyJson,
               signal,
             }),
-          catch: (err) =>
-            new WebhookNetworkError({ url, event, cause: err }),
+          catch: (err) => new WebhookNetworkError({ url, event, cause: err }),
         }).pipe(
           Effect.flatMap((response) => {
             if (response.status === 202) return Effect.void;
@@ -340,16 +344,13 @@ export class AsyncWebhookAdapter {
       const awaitCallback = Deferred.await(deferred).pipe(
         Effect.timeoutFail({
           duration: Duration.millis(timeoutMs),
-          onTimeout: () =>
-            new WebhookTimeoutError({ url, event, timeoutMs }),
+          onTimeout: () => new WebhookTimeoutError({ url, event, timeoutMs }),
         }),
       );
 
       return yield* post.pipe(
         Effect.flatMap(() => awaitCallback),
-        Effect.ensuring(
-          Ref.update(this.pending, HashMap.remove(requestId)),
-        ),
+        Effect.ensuring(Ref.update(this.pending, HashMap.remove(requestId))),
       );
     });
   }
@@ -374,12 +375,18 @@ export class AsyncWebhookAdapter {
       }
 
       // Atomically remove the pending Deferred so no other fiber can
-      // also try to complete it.
-      const taken = yield* Ref.modify(this.pending, (map) => {
-        const existing = HashMap.get(map, requestId);
-        if (existing._tag === "None") return [existing, map];
-        return [existing, HashMap.remove(map, requestId)];
-      });
+      // also try to complete it. Explicit tuple type keeps TS from
+      // widening the two branches to incompatible literal `_tag`s.
+      type Taken = Option.Option<Deferred.Deferred<string[], WebhookError>>;
+      const taken: Taken = yield* Ref.modify(
+        this.pending,
+        (map): readonly [Taken, PendingMap] => {
+          const existing: Taken = HashMap.get(map, requestId);
+          return existing._tag === "None"
+            ? [existing, map]
+            : [existing, HashMap.remove(map, requestId)];
+        },
+      );
 
       if (taken._tag === "None") return false;
 

--- a/packages/server/src/adapters/webhook.ts
+++ b/packages/server/src/adapters/webhook.ts
@@ -120,6 +120,18 @@ type WebhookCallError =
   | WebhookNetworkError;
 
 /**
+ * Best-effort read of a Response body. An unreadable body is logged
+ * context, not a failure signal, so we coerce any error to an empty
+ * string rather than propagating it.
+ */
+function readResponseText(response: Response): Effect.Effect<string, never> {
+  return Effect.tryPromise({
+    try: () => response.text(),
+    catch: () => null,
+  }).pipe(Effect.orElseSucceed(() => ""));
+}
+
+/**
  * Sync webhook client: POST a payload, receive a parsed JSON response.
  * All failures land in the typed error channel — fetch is driven through
  * `Effect.tryPromise({ try: (signal) => fetch(url, { signal }) })` so
@@ -150,39 +162,31 @@ export class WebhookClient {
       catch: (err) => new WebhookNetworkError({ url, event, cause: err }),
     });
 
-    const readBody = (response: Response): Effect.Effect<string, never> =>
-      Effect.tryPromise({
-        try: () => response.text(),
-        catch: () => null,
-      }).pipe(Effect.orElseSucceed(() => ""));
-
     const parseResponse = (
       response: Response,
     ): Effect.Effect<T, WebhookHttpError | WebhookNetworkError> =>
-      response.ok
-        ? readBody(response).pipe(
-            Effect.flatMap((text) =>
-              text.length === 0
-                ? Effect.succeed(null as T)
-                : Effect.try({
-                    try: () => JSON.parse(text) as T,
-                    catch: (err) =>
-                      new WebhookNetworkError({ url, event, cause: err }),
-                  }),
-            ),
-          )
-        : readBody(response).pipe(
-            Effect.flatMap((text) =>
-              Effect.fail(
+      readResponseText(response).pipe(
+        Effect.flatMap(
+          (text): Effect.Effect<T, WebhookHttpError | WebhookNetworkError> => {
+            if (!response.ok) {
+              return Effect.fail(
                 new WebhookHttpError({
                   url,
                   event,
                   status: response.status,
                   body: text,
                 }),
-              ),
-            ),
-          );
+              );
+            }
+            if (text.length === 0) return Effect.succeed(null as T);
+            return Effect.try({
+              try: () => JSON.parse(text) as T,
+              catch: (err) =>
+                new WebhookNetworkError({ url, event, cause: err }),
+            });
+          },
+        ),
+      );
 
     return this.permits.withPermits(1)(
       doFetch.pipe(
@@ -314,15 +318,7 @@ export class AsyncWebhookAdapter {
         }).pipe(
           Effect.flatMap((response) => {
             if (response.status === 202) return Effect.void;
-            return Effect.tryPromise({
-              try: () => response.text().catch(() => ""),
-              catch: () =>
-                new WebhookNetworkError({
-                  url,
-                  event,
-                  cause: "failed to read error body",
-                }),
-            }).pipe(
+            return readResponseText(response).pipe(
               Effect.flatMap((text) =>
                 Effect.fail(
                   new WebhookHttpError({

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -1314,10 +1314,10 @@ export class AppHost {
    *   `X-MoltZap-Signature: sha256=<hex>`. The signature covers exactly the
    *   bytes that go on the wire — we pre-serialize and hand the client
    *   `bodyJson` so it can't rewrite whitespace or reorder keys.
-   * - Enforces the hook's `timeoutMs` via `Effect.timeout`. Webhook
-   *   transport errors (non-2xx, network drop) bubble out of
-   *   `WebhookClient.callSync` as `WebhookError` and land in the
-   *   `catchAll` branch — which matches the in-process
+   * - Enforces the hook's `timeoutMs` via `WebhookClient.call` (which
+   *   wraps fetch in `Effect.timeoutFail` → `WebhookTimeoutError`).
+   *   Tagged transport errors (non-2xx, network drop, timeout) fan into
+   *   the `catchTag` branches below — matching the in-process
    *   `runHookWithTimeout` semantics so the caller's fail-closed plumbing
    *   stays identical regardless of dispatch mechanism.
    */
@@ -1334,48 +1334,32 @@ export class AppHost {
         ? signWebhookPayload(opts.secret, bodyJson)
         : undefined;
 
-      const request = Effect.tryPromise({
-        try: () =>
-          this.webhookClient.callSync<T>({
-            url: opts.url,
-            event: opts.event,
-            body: undefined,
-            bodyJson,
-            headers: signature
-              ? { "X-MoltZap-Signature": signature }
-              : undefined,
-            timeoutMs: opts.timeoutMs,
-          }),
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      const request = this.webhookClient.call<T>({
+        url: opts.url,
+        event: opts.event,
+        body: undefined,
+        bodyJson,
+        headers: signature
+          ? { "X-MoltZap-Signature": signature }
+          : undefined,
+        timeoutMs: opts.timeoutMs,
       });
 
       return yield* request.pipe(
-        Effect.timeout(`${opts.timeoutMs} millis`),
         Effect.map((result) => ({ result, timedOut: false }) as HookOutcome<T>),
-        Effect.catchTag("TimeoutException", () =>
-          Effect.succeed({
-            result: null,
-            timedOut: true as const,
-          } as HookOutcome<T>),
+        Effect.catchTag(
+          "WebhookTimeoutError",
+          () =>
+            Effect.succeed({
+              result: null,
+              timedOut: true as const,
+            } as HookOutcome<T>),
         ),
         Effect.catchAll((err) =>
           Effect.gen(function* () {
-            // WebhookClient surfaces its own timeout as a WebhookError
-            // with "timed out" in the message (HTTP-level
-            // AbortSignal.timeout fires before Effect.timeout when
-            // timeoutMs is short). Normalise both paths to
-            // timedOut:true so the caller's hookTimeout event fires
-            // consistently.
-            const msg = errorMessage(err);
-            if (/timed out/i.test(msg)) {
-              return {
-                result: null,
-                timedOut: true as const,
-              } as HookOutcome<T>;
-            }
             yield* Effect.logError("Webhook hook dispatch error").pipe(
               Effect.annotateLogs({
-                err: msg,
+                err: errorMessage(err),
                 url: opts.url,
                 event: opts.event,
               }),

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -1339,21 +1339,17 @@ export class AppHost {
         event: opts.event,
         body: undefined,
         bodyJson,
-        headers: signature
-          ? { "X-MoltZap-Signature": signature }
-          : undefined,
+        headers: signature ? { "X-MoltZap-Signature": signature } : undefined,
         timeoutMs: opts.timeoutMs,
       });
 
       return yield* request.pipe(
         Effect.map((result) => ({ result, timedOut: false }) as HookOutcome<T>),
-        Effect.catchTag(
-          "WebhookTimeoutError",
-          () =>
-            Effect.succeed({
-              result: null,
-              timedOut: true as const,
-            } as HookOutcome<T>),
+        Effect.catchTag("WebhookTimeoutError", () =>
+          Effect.succeed({
+            result: null,
+            timedOut: true as const,
+          } as HookOutcome<T>),
         ),
         Effect.catchAll((err) =>
           Effect.gen(function* () {

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -294,7 +294,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
         );
       }
 
-      const found = _webhookPermAdapter.resolveCallback(
+      const found = yield* _webhookPermAdapter.resolveCallback(
         body.request_id,
         body.access,
       );
@@ -618,7 +618,9 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     },
     // #ignore-sloppy-code-next-line[async-keyword]: server close is a Promise boundary for external callers
     async close() {
-      _webhookPermAdapter?.destroy();
+      if (_webhookPermAdapter) {
+        await Effect.runPromise(_webhookPermAdapter.shutdown);
+      }
       defaultPermissionService.destroy();
       // Interrupt in-flight delivery-webhook retries before scope close so
       // pending POSTs don't race the HTTP server teardown.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -38,8 +38,12 @@ export {
 export {
   WebhookClient,
   AsyncWebhookAdapter,
-  WebhookError,
+  WebhookHttpError,
+  WebhookTimeoutError,
+  WebhookNetworkError,
+  WebhookDestroyedError,
 } from "./adapters/webhook.js";
+export type { WebhookError } from "./adapters/webhook.js";
 
 // Config
 export { loadConfigFromFile, ConfigLoadError } from "./config/loader.js";

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -10,7 +10,6 @@ import type { DeliveryService } from "./delivery.service.js";
 import type { Broadcaster } from "../ws/broadcaster.js";
 import {
   type WebhookClient,
-  WebhookCallError,
   signWebhookPayload,
 } from "../adapters/webhook.js";
 import {
@@ -285,31 +284,28 @@ export class MessageService {
       Schedule.recurs(DELIVERY_WEBHOOK_MAX_ATTEMPTS - 1),
     );
 
-    return Effect.tryPromise({
-      try: () =>
-        client.callSync<unknown>({
-          url: cfg.url,
-          event: "messages.delivered",
-          body: undefined,
-          bodyJson: payload,
-          timeoutMs: DELIVERY_WEBHOOK_TIMEOUT_MS,
-          headers: { "X-MoltZap-Signature": signature },
-        }),
-      catch: (err) =>
-        new WebhookCallError("messages.delivered failed", cfg.url, err),
-    }).pipe(
-      Effect.retry(retrySchedule),
-      Effect.asVoid,
-      Effect.catchAll((err) =>
-        Effect.logError("Delivery webhook dropped after retries").pipe(
-          Effect.annotateLogs({
-            err: String(err),
-            url: cfg.url,
-            messageId: body.messageId,
-          }),
+    return client
+      .call<unknown>({
+        url: cfg.url,
+        event: "messages.delivered",
+        body: undefined,
+        bodyJson: payload,
+        timeoutMs: DELIVERY_WEBHOOK_TIMEOUT_MS,
+        headers: { "X-MoltZap-Signature": signature },
+      })
+      .pipe(
+        Effect.retry(retrySchedule),
+        Effect.asVoid,
+        Effect.catchAll((err) =>
+          Effect.logError("Delivery webhook dropped after retries").pipe(
+            Effect.annotateLogs({
+              err: String(err),
+              url: cfg.url,
+              messageId: body.messageId,
+            }),
+          ),
         ),
-      ),
-    );
+      );
   }
 
   list(

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -8,10 +8,7 @@ import { nextSnowflakeId } from "../db/snowflake.js";
 import type { ConversationService } from "./conversation.service.js";
 import type { DeliveryService } from "./delivery.service.js";
 import type { Broadcaster } from "../ws/broadcaster.js";
-import {
-  type WebhookClient,
-  signWebhookPayload,
-} from "../adapters/webhook.js";
+import { type WebhookClient, signWebhookPayload } from "../adapters/webhook.js";
 import {
   type EnvelopeEncryption,
   generateDek,

--- a/packages/server/src/services/user.service.test.ts
+++ b/packages/server/src/services/user.service.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { Effect } from "effect";
 import { InProcessUserService, WebhookUserService } from "./user.service.js";
-import { WebhookError, type WebhookClient } from "../adapters/webhook.js";
+import {
+  WebhookNetworkError,
+  WebhookTimeoutError,
+  type WebhookClient,
+} from "../adapters/webhook.js";
 import { makeFakeWebhookClient } from "../test-utils/fakes.js";
 import { UserId } from "../app/types.js";
 
@@ -29,30 +33,23 @@ describe("WebhookUserService", () => {
   } as never;
 
   /**
-   * Create a WebhookUserService wired to a typed fake client. The fake's
-   * `callSync` is a `vi.fn` so we still get call-assertion ergonomics, but
-   * the overall shape is enforced against the real `WebhookClient` via
-   * `makeFakeWebhookClient`'s `Pick<>` constraint — a signature change in
-   * `callSync` fails compilation here rather than at runtime.
-   *
-   * Note: `callSync` is generic (`<T>(...) => Promise<T>`), which `vi.fn`
-   * can't represent directly — Mock's call signature is non-generic. We
-   * cast via `as` after asserting the fake body's shape via the spread into
-   * `makeFakeWebhookClient`, so a drift in the non-generic portion of the
-   * signature still fails compilation.
+   * Build a WebhookUserService wired to a typed fake client. `call` is a
+   * `vi.fn` for call-assertion ergonomics; `makeFakeWebhookClient`'s
+   * `Pick<>` constraint makes a signature drift in the real client a
+   * compile error here rather than a silent runtime mismatch.
    */
   function createService() {
-    const callSync =
+    const call =
       vi.fn<
         (opts: {
           url: string;
           event: string;
           body: unknown;
           timeoutMs: number;
-        }) => Promise<unknown>
+        }) => Effect.Effect<unknown, unknown>
       >();
     const client = makeFakeWebhookClient({
-      callSync: callSync as unknown as WebhookClient["callSync"],
+      call: call as unknown as WebhookClient["call"],
     });
     const svc = new WebhookUserService(
       client,
@@ -60,17 +57,17 @@ describe("WebhookUserService", () => {
       5000,
       mockLogger,
     );
-    return { svc, callSync };
+    return { svc, call };
   }
 
-  it("calls WebhookClient.callSync with correct params", async () => {
-    const { svc, callSync } = createService();
-    callSync.mockResolvedValue({ valid: true });
+  it("calls WebhookClient.call with correct params", async () => {
+    const { svc, call } = createService();
+    call.mockReturnValue(Effect.succeed({ valid: true }));
 
     const result = await Effect.runPromise(svc.validateUser(UserId("user-42")));
 
     expect(result).toEqual({ valid: true });
-    expect(callSync).toHaveBeenCalledWith({
+    expect(call).toHaveBeenCalledWith({
       url: "https://hook.test/users",
       event: "users.validate",
       body: { userId: "user-42" },
@@ -79,8 +76,8 @@ describe("WebhookUserService", () => {
   });
 
   it("returns { valid: false } when webhook returns it", async () => {
-    const { svc, callSync } = createService();
-    callSync.mockResolvedValue({ valid: false });
+    const { svc, call } = createService();
+    call.mockReturnValue(Effect.succeed({ valid: false }));
 
     expect(
       await Effect.runPromise(svc.validateUser(UserId("bad-user"))),
@@ -89,9 +86,17 @@ describe("WebhookUserService", () => {
     });
   });
 
-  it("returns { valid: false } on WebhookError", async () => {
-    const { svc, callSync } = createService();
-    callSync.mockRejectedValue(new WebhookError("timeout", 0));
+  it("returns { valid: false } on WebhookTimeoutError", async () => {
+    const { svc, call } = createService();
+    call.mockReturnValue(
+      Effect.fail(
+        new WebhookTimeoutError({
+          url: "https://hook.test/users",
+          event: "users.validate",
+          timeoutMs: 5000,
+        }),
+      ),
+    );
 
     expect(await Effect.runPromise(svc.validateUser(UserId("user-1")))).toEqual(
       {
@@ -100,9 +105,17 @@ describe("WebhookUserService", () => {
     );
   });
 
-  it("returns { valid: false } on network error", async () => {
-    const { svc, callSync } = createService();
-    callSync.mockRejectedValue(new Error("ECONNREFUSED"));
+  it("returns { valid: false } on WebhookNetworkError", async () => {
+    const { svc, call } = createService();
+    call.mockReturnValue(
+      Effect.fail(
+        new WebhookNetworkError({
+          url: "https://hook.test/users",
+          event: "users.validate",
+          cause: new Error("ECONNREFUSED"),
+        }),
+      ),
+    );
 
     expect(await Effect.runPromise(svc.validateUser(UserId("user-1")))).toEqual(
       {

--- a/packages/server/src/services/user.service.ts
+++ b/packages/server/src/services/user.service.ts
@@ -134,7 +134,7 @@ export class WebhookUserService implements UserService {
     label: string,
     ctx: Record<string, unknown>,
   ): void {
-    if (Cause.isDieType(cause) || Cause.dieOption(cause)._tag === "Some") {
+    if (Cause.dieOption(cause)._tag === "Some") {
       this.logger.error(
         { cause: Cause.pretty(cause), ...ctx },
         `${label} defect (bug) — rejecting`,

--- a/packages/server/src/services/user.service.ts
+++ b/packages/server/src/services/user.service.ts
@@ -1,5 +1,5 @@
 import { Cause, Effect } from "effect";
-import { WebhookCallError, type WebhookClient } from "../adapters/webhook.js";
+import type { WebhookClient } from "../adapters/webhook.js";
 import type { Logger } from "../logger.js";
 import { AgentId, UserId } from "../app/types.js";
 
@@ -51,29 +51,26 @@ export class WebhookUserService implements UserService {
   ) {}
 
   validateUser(userId: UserId): Effect.Effect<{ valid: boolean }, never> {
-    return Effect.tryPromise({
-      try: () =>
-        this.client.callSync<{ valid: boolean }>({
-          url: this.url,
-          event: "users.validate",
-          body: { userId },
-          timeoutMs: this.timeoutMs,
-        }),
-      catch: (err) =>
-        new WebhookCallError("users.validate failed", this.url, err),
-    }).pipe(
-      // Strict boolean check — don't trust truthy strings from external services
-      Effect.map((result) => ({ valid: result.valid === true })),
-      Effect.catchAllCause((cause) =>
-        Effect.sync(() => {
-          this.logCauseAsFailClosed(cause, "User validation webhook", {
-            userId,
-            url: this.url,
-          });
-          return { valid: false };
-        }),
-      ),
-    );
+    return this.client
+      .call<{ valid: boolean }>({
+        url: this.url,
+        event: "users.validate",
+        body: { userId },
+        timeoutMs: this.timeoutMs,
+      })
+      .pipe(
+        // Strict boolean check — don't trust truthy strings from external services
+        Effect.map((result) => ({ valid: result.valid === true })),
+        Effect.catchAllCause((cause) =>
+          Effect.sync(() => {
+            this.logCauseAsFailClosed(cause, "User validation webhook", {
+              userId,
+              url: this.url,
+            });
+            return { valid: false };
+          }),
+        ),
+      );
   }
 
   validateSession(token: string): Effect.Effect<SessionValidation, never> {
@@ -87,61 +84,50 @@ export class WebhookUserService implements UserService {
        * webhook already knows the agent's status. */
       agentStatus?: unknown;
     }
-    return Effect.tryPromise({
-      try: () =>
-        this.client.callSync<WireResponse>({
-          url: this.url,
-          event: "sessions.validate",
-          body: { token },
-          timeoutMs: this.timeoutMs,
+    return this.client
+      .call<WireResponse>({
+        url: this.url,
+        event: "sessions.validate",
+        body: { token },
+        timeoutMs: this.timeoutMs,
+      })
+      .pipe(
+        Effect.map((result): SessionValidation => {
+          if (result.valid !== true) return { valid: false };
+          if (
+            typeof result.agentId !== "string" ||
+            typeof result.ownerUserId !== "string"
+          ) {
+            return { valid: false };
+          }
+          const agentStatus =
+            typeof result.agentStatus === "string"
+              ? result.agentStatus
+              : undefined;
+          const agentId = AgentId(result.agentId);
+          const ownerUserId = UserId(result.ownerUserId);
+          return agentStatus !== undefined
+            ? { valid: true, agentId, ownerUserId, agentStatus }
+            : { valid: true, agentId, ownerUserId };
         }),
-      catch: (err) =>
-        new WebhookCallError("sessions.validate failed", this.url, err),
-    }).pipe(
-      Effect.map((result): SessionValidation => {
-        if (result.valid !== true) return { valid: false };
-        if (
-          typeof result.agentId !== "string" ||
-          typeof result.ownerUserId !== "string"
-        ) {
-          return { valid: false };
-        }
-        const agentStatus =
-          typeof result.agentStatus === "string"
-            ? result.agentStatus
-            : undefined;
-        const agentId = AgentId(result.agentId);
-        const ownerUserId = UserId(result.ownerUserId);
-        return agentStatus !== undefined
-          ? {
-              valid: true,
-              agentId,
-              ownerUserId,
-              agentStatus,
-            }
-          : {
-              valid: true,
-              agentId,
-              ownerUserId,
-            };
-      }),
-      Effect.catchAllCause((cause) =>
-        Effect.sync((): SessionValidation => {
-          this.logCauseAsFailClosed(cause, "Session validation webhook", {
-            url: this.url,
-          });
-          return { valid: false };
-        }),
-      ),
-    );
+        Effect.catchAllCause((cause) =>
+          Effect.sync((): SessionValidation => {
+            this.logCauseAsFailClosed(cause, "Session validation webhook", {
+              url: this.url,
+            });
+            return { valid: false };
+          }),
+        ),
+      );
   }
 
   /**
-   * Fail-closed reject logging. Expected failures (`Cause.Fail` —
-   * `WebhookCallError` from the typed `catch` above) log at warn. Defects
-   * (`Cause.Die` — synchronous throws inside the pipeline, always bugs)
-   * log at error with the full pretty cause so they're visible in the
-   * normal error stream, not hidden behind a quiet auth rejection.
+   * Fail-closed reject logging. Expected failures (`Cause.Fail` — the
+   * tagged `WebhookError` variants raised by `WebhookClient.call`) log
+   * at warn. Defects (`Cause.Die` — synchronous throws inside the
+   * pipeline, always bugs) log at error with the full pretty cause so
+   * they're visible in the normal error stream, not hidden behind a
+   * quiet auth rejection.
    */
   private logCauseAsFailClosed(
     cause: Cause.Cause<unknown>,

--- a/packages/server/src/test-utils/fakes.ts
+++ b/packages/server/src/test-utils/fakes.ts
@@ -77,17 +77,17 @@ export const makeFakeService = <S extends object>(impl: Partial<S>): S =>
 /**
  * Typed test double for `WebhookClient`. Use instead of `vi.spyOn` on a real
  * instance: the `Pick<>` constraint forces the caller to match the real
- * `callSync` signature, so a contract change in `WebhookClient` breaks the
+ * `call` signature, so a contract change in `WebhookClient` breaks the
  * test at compile time rather than at runtime.
  *
  * Example:
  *   const client = makeFakeWebhookClient({
- *     callSync: async () => ({ valid: true }),
+ *     call: () => Effect.succeed({ valid: true }),
  *   });
  *   const svc = new WebhookUserService(client, "url", 5000, logger);
  */
 export const makeFakeWebhookClient = (
-  impl: Pick<WebhookClient, "callSync">,
+  impl: Pick<WebhookClient, "call">,
 ): WebhookClient => impl as WebhookClient;
 
 // ── Layer-based fakes for tagged services ──────────────────────────────────


### PR DESCRIPTION
## Summary

Rewrites `packages/server/src/adapters/webhook.ts` to Effect-native primitives, closing four bug classes from the orchestrator plan:

- **Cancellation:** fetch now uses `Effect.tryPromise({ try: (signal) => fetch(url, { signal }) })` + `Effect.timeoutFail`, so fiber interrupt aborts the in-flight HTTP request instead of orphaning it.
- **Semaphore leaks:** manual `class Semaphore` replaced with `Effect.makeSemaphore` + `withPermits(1)`, so permits are released under interrupt/timeout/die.
- **Pending-map leaks:** `AsyncWebhookAdapter` replaces `Map + setTimeout` with `Ref<HashMap<string, Deferred>>` and `Effect.ensuring(Ref.update(..., HashMap.remove))`. Cleanup runs on success, failure, and interrupt.
- **Untyped catch:** introduces `Data.TaggedError` variants (`WebhookHttpError`, `WebhookTimeoutError`, `WebhookNetworkError`, `WebhookDestroyedError`) plus `WebhookError` union. Consumers (`app-host.ts`, `user.service.ts`, `message.service.ts`) match on `_tag` instead of regex on error messages.

All public class construction is preserved (`new WebhookClient()`, `new AsyncWebhookAdapter()`) via `Effect.runSync` for pure Ref/Semaphore allocation.

## Test plan

- [x] `pnpm --filter @moltzap/server-core exec tsc --noEmit` (clean)
- [x] `pnpm --filter @moltzap/server-core exec vitest run` (109/109 passing, including 12 new webhook adapter tests covering AbortSignal propagation, pending-map cleanup on interrupt, shutdown-fails-pending, tagged-error `_tag` assertions)
- [x] Full-repo typecheck green under pre-commit hook
- [ ] CI green on this PR
- [ ] Manual smoke: exercise `AsyncWebhookAdapter.send` against a real webhook listener; confirm callback and timeout paths behave

Do not merge yet — team-lead is orchestrating merges for the Effect-native stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)