### PR TITLE
feat(server): schema decoding on WebhookClient.call (closes #105)

### DIFF
--- a/packages/server/src/adapters/webhook.test.ts
+++ b/packages/server/src/adapters/webhook.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { Cause, Effect, Exit, Fiber } from "effect";
+import { Cause, Effect, Exit, Fiber, Schema } from "effect";
 import {
   AsyncWebhookAdapter,
   WebhookClient,
+  WebhookDecodeError,
   WebhookDestroyedError,
   WebhookHttpError,
   WebhookNetworkError,
   WebhookTimeoutError,
 } from "./webhook.js";
+
+const OkSchema = Schema.Struct({ ok: Schema.Boolean });
 
 // -- WebhookClient (sync) ---------------------------------------------------
 
@@ -29,11 +32,12 @@ describe("WebhookClient.call", () => {
     );
 
     const result = await Effect.runPromise(
-      client.call<{ ok: boolean }>({
+      client.call({
         url: "https://hook.test/users",
         event: "users.validate",
         body: { userId: "u1" },
         timeoutMs: 5000,
+        schema: OkSchema,
       }),
     );
 
@@ -60,6 +64,7 @@ describe("WebhookClient.call", () => {
         event: "test",
         body: {},
         timeoutMs: 5000,
+        schema: Schema.Unknown,
       }),
     );
 
@@ -87,6 +92,7 @@ describe("WebhookClient.call", () => {
         event: "test.timeout",
         body: {},
         timeoutMs: 50,
+        schema: Schema.Unknown,
       }),
     );
 
@@ -98,6 +104,29 @@ describe("WebhookClient.call", () => {
     expect((err.value as WebhookTimeoutError).timeoutMs).toBe(50);
   });
 
+  it("fails with WebhookDecodeError when body doesn't match schema", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ ok: "not a boolean" }), { status: 200 }),
+    );
+
+    const exit = await Effect.runPromiseExit(
+      client.call({
+        url: "https://hook.test/x",
+        event: "test.schema",
+        body: {},
+        timeoutMs: 5000,
+        schema: OkSchema,
+      }),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const err = Cause.failureOption(exit.cause);
+    if (err._tag !== "Some") throw new Error("expected failure");
+    expect(err.value._tag).toBe("WebhookDecodeError");
+    expect((err.value as WebhookDecodeError).event).toBe("test.schema");
+  });
+
   it("fails with WebhookNetworkError on fetch rejection", async () => {
     vi.mocked(fetch).mockRejectedValue(new Error("ECONNREFUSED"));
 
@@ -107,6 +136,7 @@ describe("WebhookClient.call", () => {
         event: "test.net",
         body: {},
         timeoutMs: 5000,
+        schema: Schema.Unknown,
       }),
     );
 
@@ -137,6 +167,7 @@ describe("WebhookClient.call", () => {
         event: "test.interrupt",
         body: {},
         timeoutMs: 60000,
+        schema: Schema.Unknown,
       }),
     );
 

--- a/packages/server/src/adapters/webhook.ts
+++ b/packages/server/src/adapters/webhook.ts
@@ -1,6 +1,15 @@
 /** Webhook adapters for calling external services over HTTP. */
 
-import { Data, Deferred, Duration, Effect, HashMap, Option, Ref } from "effect";
+import {
+  Data,
+  Deferred,
+  Duration,
+  Effect,
+  HashMap,
+  Option,
+  Ref,
+  Schema,
+} from "effect";
 import { createHmac } from "node:crypto";
 import type { ContactService, PermissionService } from "../app/app-host.js";
 import type { Logger } from "../logger.js";
@@ -83,21 +92,49 @@ export class WebhookDestroyedError extends Data.TaggedError(
   }
 }
 
+/**
+ * Response body did not match the caller-supplied decoder — covers both
+ * "body wasn't valid JSON" (caught earlier as `WebhookNetworkError`) and
+ * "JSON shape didn't match schema" (this error). Fail-closed handling
+ * treats it identically to HTTP/network/timeout failures.
+ */
+export class WebhookDecodeError extends Data.TaggedError("WebhookDecodeError")<{
+  readonly url: string;
+  readonly event: string;
+  readonly cause: unknown;
+}> {
+  get message(): string {
+    const detail =
+      this.cause instanceof Error ? this.cause.message : String(this.cause);
+    return `Webhook ${this.event} response did not match schema: ${detail}`;
+  }
+}
+
 /** Union of every tagged error the webhook adapters can emit. */
 export type WebhookError =
   | WebhookHttpError
   | WebhookTimeoutError
   | WebhookNetworkError
-  | WebhookDestroyedError;
+  | WebhookDestroyedError
+  | WebhookDecodeError;
 
 // -- Sync webhook client (Users, Contacts) ------------------------------------
 
 /** Options for a single sync webhook call. */
-export interface WebhookCallOpts {
+export interface WebhookCallOpts<T> {
   readonly url: string;
   readonly event: string;
   readonly body: unknown;
   readonly timeoutMs: number;
+  /**
+   * Decoder for the webhook response. The body is read as text, parsed
+   * as JSON (or decoded as `undefined` for empty bodies), then passed
+   * through this schema — so callers get a checked value of type `T`
+   * instead of an unvalidated cast. Schema-mismatches surface as
+   * `WebhookDecodeError` and flow through the same fail-closed path as
+   * network / timeout errors.
+   */
+  readonly schema: Schema.Schema<T, any>;
   /**
    * Extra headers merged on top of `Content-Type` + `X-MoltZap-Event`.
    * Used by app-hook webhooks to attach `X-MoltZap-Signature`. Caller-
@@ -117,7 +154,8 @@ export interface WebhookCallOpts {
 type WebhookCallError =
   | WebhookHttpError
   | WebhookTimeoutError
-  | WebhookNetworkError;
+  | WebhookNetworkError
+  | WebhookDecodeError;
 
 /**
  * Best-effort read of a Response body. An unreadable body is logged
@@ -148,8 +186,8 @@ export class WebhookClient {
     this.permits = Effect.runSync(Effect.makeSemaphore(concurrency));
   }
 
-  call<T>(opts: WebhookCallOpts): Effect.Effect<T, WebhookCallError> {
-    const { url, event, timeoutMs } = opts;
+  call<T>(opts: WebhookCallOpts<T>): Effect.Effect<T, WebhookCallError> {
+    const { url, event, timeoutMs, schema } = opts;
     const body = opts.bodyJson ?? JSON.stringify(opts.body);
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -162,12 +200,17 @@ export class WebhookClient {
       catch: (err) => new WebhookNetworkError({ url, event, cause: err }),
     });
 
+    // Parse body → unknown. Empty body (fire-and-forget hooks) decodes as
+    // `undefined`; the caller's `schema` accepts or rejects that in the
+    // next stage, so no separate null-payload path is needed here.
     const parseResponse = (
       response: Response,
-    ): Effect.Effect<T, WebhookHttpError | WebhookNetworkError> =>
+    ): Effect.Effect<unknown, WebhookHttpError | WebhookNetworkError> =>
       readResponseText(response).pipe(
         Effect.flatMap(
-          (text): Effect.Effect<T, WebhookHttpError | WebhookNetworkError> => {
+          (
+            text,
+          ): Effect.Effect<unknown, WebhookHttpError | WebhookNetworkError> => {
             if (!response.ok) {
               return Effect.fail(
                 new WebhookHttpError({
@@ -178,9 +221,9 @@ export class WebhookClient {
                 }),
               );
             }
-            if (text.length === 0) return Effect.succeed(null as T);
+            if (text.length === 0) return Effect.succeed(undefined);
             return Effect.try({
-              try: () => JSON.parse(text) as T,
+              try: () => JSON.parse(text) as unknown,
               catch: (err) =>
                 new WebhookNetworkError({ url, event, cause: err }),
             });
@@ -191,6 +234,13 @@ export class WebhookClient {
     return this.permits.withPermits(1)(
       doFetch.pipe(
         Effect.flatMap(parseResponse),
+        Effect.flatMap((parsed) =>
+          Schema.decodeUnknown(schema)(parsed).pipe(
+            Effect.mapError(
+              (cause) => new WebhookDecodeError({ url, event, cause }),
+            ),
+          ),
+        ),
         Effect.timeoutFail({
           duration: Duration.millis(timeoutMs),
           onTimeout: () => new WebhookTimeoutError({ url, event, timeoutMs }),
@@ -201,6 +251,8 @@ export class WebhookClient {
 }
 
 // -- Sync webhook contact service ---------------------------------------------
+
+const ContactsCheckResponse = Schema.Struct({ inContact: Schema.Boolean });
 
 export class WebhookContactService implements ContactService {
   constructor(
@@ -215,14 +267,15 @@ export class WebhookContactService implements ContactService {
     userIdB: string,
   ): Effect.Effect<boolean, never> {
     return this.client
-      .call<{ inContact: boolean }>({
+      .call({
         url: this.url,
         event: "contacts.check",
         body: { userIdA, userIdB },
         timeoutMs: this.timeoutMs,
+        schema: ContactsCheckResponse,
       })
       .pipe(
-        Effect.map((result) => result.inContact === true),
+        Effect.map((result) => result.inContact),
         Effect.catchAll((err) =>
           Effect.sync(() => {
             this.webhookLogger.error(

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -8,13 +8,15 @@ import { UserId } from "./types.js";
 import { logger } from "../logger.js";
 import type { AppManifest, AppSession, Part } from "@moltzap/protocol";
 import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
-import type {
-  AppHooks,
-  BeforeMessageDeliveryHook,
-  HookResult,
-  OnCloseHook,
-  OnJoinHook,
-  OnSessionActiveHook,
+import {
+  HookResultSchema,
+  VoidHookSchema,
+  type AppHooks,
+  type BeforeMessageDeliveryHook,
+  type HookResult,
+  type OnCloseHook,
+  type OnJoinHook,
+  type OnSessionActiveHook,
 } from "./hooks.js";
 import type { WebhookClient } from "../adapters/webhook.js";
 import {
@@ -27,6 +29,7 @@ import {
   HashMap,
   Option,
   Ref,
+  Schema,
 } from "effect";
 import {
   RpcFailure,
@@ -497,6 +500,7 @@ export class AppHost {
                 message: ctx.message,
               },
               timeoutMs,
+              schema: HookResultSchema,
             })
           : yield* this.runHookWithTimeout<HookResult>(
               (signal) => appHooks!.beforeMessageDelivery!({ ...ctx, signal }),
@@ -866,6 +870,7 @@ export class AppHost {
                   closedBy,
                 },
                 timeoutMs,
+                schema: VoidHookSchema,
               })
             : yield* this.runHookWithTimeout<void>(
                 (signal) =>
@@ -1326,6 +1331,7 @@ export class AppHost {
     event: string;
     body: object;
     timeoutMs: number;
+    schema: Schema.Schema<T, any>;
     secret?: string;
   }): Effect.Effect<HookOutcome<T>, RpcFailure> {
     return Effect.gen(this, function* () {
@@ -1334,13 +1340,14 @@ export class AppHost {
         ? signWebhookPayload(opts.secret, bodyJson)
         : undefined;
 
-      const request = this.webhookClient.call<T>({
+      const request = this.webhookClient.call({
         url: opts.url,
         event: opts.event,
         body: undefined,
         bodyJson,
         headers: signature ? { "X-MoltZap-Signature": signature } : undefined,
         timeoutMs: opts.timeoutMs,
+        schema: opts.schema,
       });
 
       return yield* request.pipe(
@@ -1505,6 +1512,7 @@ export class AppHost {
               admittedAgentIds,
             },
             timeoutMs,
+            schema: VoidHookSchema,
           }).pipe(
             Effect.catchAllCause(() =>
               Effect.succeed({
@@ -2153,6 +2161,7 @@ export class AppHost {
               agent: { agentId, ownerId },
             },
             timeoutMs,
+            schema: VoidHookSchema,
           });
           if (outcome.timedOut) {
             this.broadcaster.sendToAgent(

--- a/packages/server/src/app/hooks.ts
+++ b/packages/server/src/app/hooks.ts
@@ -1,4 +1,5 @@
 import type { Part } from "@moltzap/protocol";
+import { Schema } from "effect";
 
 export interface BeforeMessageDeliveryContext {
   conversationId: string;
@@ -19,6 +20,41 @@ export interface HookResult {
     retry?: boolean;
   };
 }
+
+/**
+ * Wire schema for `HookResult` — runs over webhook responses so malformed
+ * payloads surface as `WebhookDecodeError` instead of leaking through an
+ * unchecked cast. `parts` in `patch` is deliberately `Schema.Unknown` to
+ * avoid importing the full `Part` protocol schema into the server-core
+ * adapter layer; the runtime `Part` shape is re-validated at the
+ * message-send boundary. The cast reconciles that intentional widening
+ * with the `Part[]` field in `HookResult`.
+ */
+export const HookResultSchema = Schema.Struct({
+  block: Schema.Boolean,
+  reason: Schema.optional(Schema.String),
+  patch: Schema.optional(
+    Schema.Struct({ parts: Schema.Array(Schema.Unknown) }),
+  ),
+  feedback: Schema.optional(
+    Schema.Struct({
+      type: Schema.Literal("error", "warning", "info"),
+      content: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+      retry: Schema.optional(Schema.Boolean),
+    }),
+  ),
+}) as unknown as Schema.Schema<HookResult, unknown>;
+
+/**
+ * Schema for fire-and-forget hook webhooks (`on_join`, `on_close`,
+ * `on_session_active`). Accepts an empty / undefined body from 204
+ * responses; any payload is ignored.
+ */
+export const VoidHookSchema: Schema.Schema<void, unknown> = Schema.transform(
+  Schema.Unknown,
+  Schema.Void,
+  { decode: () => undefined, encode: () => undefined },
+);
 
 export type BeforeMessageDeliveryHook = (
   ctx: BeforeMessageDeliveryContext,

--- a/packages/server/src/app/hooks.ts
+++ b/packages/server/src/app/hooks.ts
@@ -22,13 +22,11 @@ export interface HookResult {
 }
 
 /**
- * Wire schema for `HookResult` — runs over webhook responses so malformed
- * payloads surface as `WebhookDecodeError` instead of leaking through an
- * unchecked cast. `parts` in `patch` is deliberately `Schema.Unknown` to
- * avoid importing the full `Part` protocol schema into the server-core
- * adapter layer; the runtime `Part` shape is re-validated at the
- * message-send boundary. The cast reconciles that intentional widening
- * with the `Part[]` field in `HookResult`.
+ * Wire schema for `HookResult` webhook responses. `patch.parts` is
+ * widened to `unknown[]` here so server-core doesn't depend on the full
+ * `Part` protocol schema; the real `Part` shape is re-validated at the
+ * message-send boundary. The final cast reconciles that intentional
+ * widening with the `Part[]` field in `HookResult`.
  */
 export const HookResultSchema = Schema.Struct({
   block: Schema.Boolean,
@@ -45,11 +43,7 @@ export const HookResultSchema = Schema.Struct({
   ),
 }) as unknown as Schema.Schema<HookResult, unknown>;
 
-/**
- * Schema for fire-and-forget hook webhooks (`on_join`, `on_close`,
- * `on_session_active`). Accepts an empty / undefined body from 204
- * responses; any payload is ignored.
- */
+/** Fire-and-forget hooks (`on_join`, `on_close`, `on_session_active`) — any payload is ignored. */
 export const VoidHookSchema: Schema.Schema<void, unknown> = Schema.transform(
   Schema.Unknown,
   Schema.Void,

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -1,7 +1,7 @@
 import type { Db } from "../db/client.js";
 import type { Message, Part } from "@moltzap/protocol";
 import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
-import { Duration, Effect, Fiber, Option, Schedule } from "effect";
+import { Duration, Effect, Fiber, Option, Schedule, Schema } from "effect";
 import { SqlError } from "@effect/sql/SqlError";
 import { RpcFailure, notFound, internalError } from "../runtime/index.js";
 import { nextSnowflakeId } from "../db/snowflake.js";
@@ -282,13 +282,16 @@ export class MessageService {
     );
 
     return client
-      .call<unknown>({
+      .call({
         url: cfg.url,
         event: "messages.delivered",
         body: undefined,
         bodyJson: payload,
         timeoutMs: DELIVERY_WEBHOOK_TIMEOUT_MS,
         headers: { "X-MoltZap-Signature": signature },
+        // Fire-and-forget: receivers typically reply 204/empty, and
+        // anything they do send is discarded by `Effect.asVoid` below.
+        schema: Schema.Unknown,
       })
       .pipe(
         Effect.retry(retrySchedule),

--- a/packages/server/src/services/user.service.test.ts
+++ b/packages/server/src/services/user.service.test.ts
@@ -67,12 +67,14 @@ describe("WebhookUserService", () => {
     const result = await Effect.runPromise(svc.validateUser(UserId("user-42")));
 
     expect(result).toEqual({ valid: true });
-    expect(call).toHaveBeenCalledWith({
-      url: "https://hook.test/users",
-      event: "users.validate",
-      body: { userId: "user-42" },
-      timeoutMs: 5000,
-    });
+    expect(call).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://hook.test/users",
+        event: "users.validate",
+        body: { userId: "user-42" },
+        timeoutMs: 5000,
+      }),
+    );
   });
 
   it("returns { valid: false } when webhook returns it", async () => {

--- a/packages/server/src/services/user.service.ts
+++ b/packages/server/src/services/user.service.ts
@@ -1,7 +1,23 @@
-import { Cause, Effect } from "effect";
+import { Cause, Effect, Schema } from "effect";
 import type { WebhookClient } from "../adapters/webhook.js";
 import type { Logger } from "../logger.js";
 import { AgentId, UserId } from "../app/types.js";
+
+// Strict wire schemas — `WebhookClient.call` runs these over the parsed
+// response, so malformed payloads surface as `WebhookDecodeError` and
+// land in the fail-closed `catchAllCause` branch rather than leaking as
+// unchecked casts.
+const UserValidateResponse = Schema.Struct({ valid: Schema.Boolean });
+
+const SessionValidateResponse = Schema.Union(
+  Schema.Struct({
+    valid: Schema.Literal(true),
+    agentId: Schema.String,
+    ownerUserId: Schema.String,
+    agentStatus: Schema.optional(Schema.String),
+  }),
+  Schema.Struct({ valid: Schema.Literal(false) }),
+);
 
 /**
  * Result of resolving an app-minted bearer session token. Discriminated
@@ -52,15 +68,14 @@ export class WebhookUserService implements UserService {
 
   validateUser(userId: UserId): Effect.Effect<{ valid: boolean }, never> {
     return this.client
-      .call<{ valid: boolean }>({
+      .call({
         url: this.url,
         event: "users.validate",
         body: { userId },
         timeoutMs: this.timeoutMs,
+        schema: UserValidateResponse,
       })
       .pipe(
-        // Strict boolean check — don't trust truthy strings from external services
-        Effect.map((result) => ({ valid: result.valid === true })),
         Effect.catchAllCause((cause) =>
           Effect.sync(() => {
             this.logCauseAsFailClosed(cause, "User validation webhook", {
@@ -74,36 +89,18 @@ export class WebhookUserService implements UserService {
   }
 
   validateSession(token: string): Effect.Effect<SessionValidation, never> {
-    // Wire shape is looser than the internal discriminated union; normalize
-    // here so nothing downstream needs to re-check for missing fields.
-    interface WireResponse {
-      valid?: unknown;
-      agentId?: unknown;
-      ownerUserId?: unknown;
-      /** Optional: lets `auth/connect` skip a DB round trip when the
-       * webhook already knows the agent's status. */
-      agentStatus?: unknown;
-    }
     return this.client
-      .call<WireResponse>({
+      .call({
         url: this.url,
         event: "sessions.validate",
         body: { token },
         timeoutMs: this.timeoutMs,
+        schema: SessionValidateResponse,
       })
       .pipe(
         Effect.map((result): SessionValidation => {
           if (result.valid !== true) return { valid: false };
-          if (
-            typeof result.agentId !== "string" ||
-            typeof result.ownerUserId !== "string"
-          ) {
-            return { valid: false };
-          }
-          const agentStatus =
-            typeof result.agentStatus === "string"
-              ? result.agentStatus
-              : undefined;
+          const agentStatus = result.agentStatus;
           const agentId = AgentId(result.agentId);
           const ownerUserId = UserId(result.ownerUserId);
           return agentStatus !== undefined


### PR DESCRIPTION
## Summary
- Reintroduce the \`schema\` parameter + \`Schema.decodeUnknown\` step on \`WebhookClient.call\` that got dropped during the #103/#97 merge conflict resolution.
- Add a new \`WebhookDecodeError\` tagged variant to the \`WebhookError\` union so schema-mismatches flow through the same fail-closed path as HTTP/network/timeout errors.
- Thread the schema through every caller: \`WebhookUserService\`, \`WebhookContactService\`, \`MessageService\` delivery fanout, and \`AppHost.dispatchWebhookHook\` (with \`HookResultSchema\` + \`VoidHookSchema\` added to \`hooks.ts\`).
- \`validateSession\` drops defensive \`typeof\` checks — the schema now guarantees the union shape.

Closes #105.

## Test plan
- [x] \`pnpm -w build && pnpm -w typecheck\` — green
- [x] \`pnpm --filter @moltzap/server-core test\` — 116/116 (added \`WebhookDecodeError\` test covering schema mismatch)
- [x] No \`--no-verify\` — oxfmt hook ran and passed