### PR TITLE
feat: standalone conversations/archive + /unarchive RPCs (closes #58)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,7 +114,9 @@
               "protocol/methods/conversations-remove-participant",
               "protocol/methods/conversations-leave",
               "protocol/methods/conversations-mute",
-              "protocol/methods/conversations-unmute"
+              "protocol/methods/conversations-unmute",
+              "protocol/methods/conversations-archive",
+              "protocol/methods/conversations-unarchive"
             ]
           },
           {
@@ -141,6 +143,8 @@
               "protocol/events/messages-delivered",
               "protocol/events/conversations-created",
               "protocol/events/conversations-updated",
+              "protocol/events/conversations-archived",
+              "protocol/events/conversations-unarchived",
               "protocol/events/presence-changed",
               "protocol/events/surface-updated",
               "protocol/events/surface-cleared"

--- a/docs/protocol/events/conversations-archived.mdx
+++ b/docs/protocol/events/conversations-archived.mdx
@@ -1,0 +1,38 @@
+---
+title: "conversations/archived"
+description: "Fired when a conversation is archived (explicit archive call or app-session close)."
+---
+
+# conversations/archived
+
+Fired when a conversation is archived (explicit archive call or app-session close).
+
+## Data
+
+<ResponseField name="conversationId" type="string (UUID)">
+  Branded ConversationId
+</ResponseField>
+
+<ResponseField name="archivedAt" type="string (ISO 8601)">
+  The archivedAt field.
+</ResponseField>
+
+<ResponseField name="by" type="string (UUID)">
+  Branded AgentId
+</ResponseField>
+
+## Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "event",
+  "event": "conversations/archived",
+  "data": { ... }
+}
+```
+
+## Triggered By
+
+- [`conversations/archive`](/protocol/methods/conversations-archive)
+

--- a/docs/protocol/events/conversations-unarchived.mdx
+++ b/docs/protocol/events/conversations-unarchived.mdx
@@ -1,0 +1,34 @@
+---
+title: "conversations/unarchived"
+description: "Fired when a conversation is unarchived."
+---
+
+# conversations/unarchived
+
+Fired when a conversation is unarchived.
+
+## Data
+
+<ResponseField name="conversationId" type="string (UUID)">
+  Branded ConversationId
+</ResponseField>
+
+<ResponseField name="by" type="string (UUID)">
+  Branded AgentId
+</ResponseField>
+
+## Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "event",
+  "event": "conversations/unarchived",
+  "data": { ... }
+}
+```
+
+## Triggered By
+
+- [`conversations/unarchive`](/protocol/methods/conversations-unarchive)
+

--- a/docs/protocol/events/overview.mdx
+++ b/docs/protocol/events/overview.mdx
@@ -15,6 +15,8 @@ The server pushes events over WebSocket to notify agents of real-time changes. E
 | [`messages/delivered`](/protocol/events/messages-delivered) | Fired when a message is confirmed delivered to a participant. |
 | [`conversations/created`](/protocol/events/conversations-created) | Fired when you are added to a new conversation. |
 | [`conversations/updated`](/protocol/events/conversations-updated) | Fired when a conversation's metadata changes (name, participants). |
+| [`conversations/archived`](/protocol/events/conversations-archived) | Fired when a conversation is archived (explicit archive call or app-session close). |
+| [`conversations/unarchived`](/protocol/events/conversations-unarchived) | Fired when a conversation is unarchived. |
 | [`presence/changed`](/protocol/events/presence-changed) | Fired when a subscribed participant's presence status changes. |
 | [`surface/updated`](/protocol/events/surface-updated) | Fired when a surface is created or updated in a conversation. |
 | [`surface/cleared`](/protocol/events/surface-cleared) | Fired when a surface is removed from a conversation. |

--- a/docs/protocol/methods/conversations-archive.mdx
+++ b/docs/protocol/methods/conversations-archive.mdx
@@ -1,0 +1,30 @@
+---
+title: "conversations/archive"
+description: "Archive a conversation. Idempotent — archiving an already-archived conversation succeeds without changing state. Owner/admin only."
+---
+
+# conversations/archive
+
+Archive a conversation. Idempotent — archiving an already-archived conversation succeeds without changing state. Owner/admin only.
+
+## Parameters
+
+<ParamField path="conversationId" type="string (UUID)" required>
+  Branded ConversationId
+</ParamField>
+
+## Response
+
+This method returns no response body.
+
+## Errors
+
+| Code | Name | When |
+|------|------|------|
+| -32001 | Forbidden | Caller is not owner or admin |
+| -32009 | Conflict | Conversation is attached to an active app session; close the session to archive |
+
+## Related Events
+
+- [`conversations/archived`](/protocol/events/conversations-archived)
+

--- a/docs/protocol/methods/conversations-list.mdx
+++ b/docs/protocol/methods/conversations-list.mdx
@@ -17,6 +17,10 @@ List your conversations with message previews and unread counts.
   The cursor field.
 </ParamField>
 
+<ParamField path="archived" type="exclude | include | only">
+  The archived field.
+</ParamField>
+
 ## Response
 
 <ResponseField name="conversations" type="array">

--- a/docs/protocol/methods/conversations-unarchive.mdx
+++ b/docs/protocol/methods/conversations-unarchive.mdx
@@ -1,0 +1,29 @@
+---
+title: "conversations/unarchive"
+description: "Unarchive a conversation (clears archived_at). Idempotent — unarchiving an active conversation is a no-op. Owner/admin only."
+---
+
+# conversations/unarchive
+
+Unarchive a conversation (clears archived_at). Idempotent — unarchiving an active conversation is a no-op. Owner/admin only.
+
+## Parameters
+
+<ParamField path="conversationId" type="string (UUID)" required>
+  Branded ConversationId
+</ParamField>
+
+## Response
+
+This method returns no response body.
+
+## Errors
+
+| Code | Name | When |
+|------|------|------|
+| -32001 | Forbidden | Caller is not owner or admin |
+
+## Related Events
+
+- [`conversations/unarchived`](/protocol/events/conversations-unarchived)
+

--- a/packages/protocol/src/rpc-registry.ts
+++ b/packages/protocol/src/rpc-registry.ts
@@ -17,6 +17,8 @@ import {
   ConversationsAddParticipant,
   ConversationsRemoveParticipant,
   ConversationsLeave,
+  ConversationsArchive,
+  ConversationsUnarchive,
 } from "./schema/methods/conversations.js";
 import { MessagesSend, MessagesList } from "./schema/methods/messages.js";
 import {
@@ -73,6 +75,8 @@ export const rpcMethods = [
   ConversationsAddParticipant,
   ConversationsRemoveParticipant,
   ConversationsLeave,
+  ConversationsArchive,
+  ConversationsUnarchive,
   // Messages
   MessagesSend,
   MessagesList,

--- a/packages/protocol/src/schema/events.ts
+++ b/packages/protocol/src/schema/events.ts
@@ -6,13 +6,15 @@ import { ConversationId, MessageId, AgentId } from "./primitives.js";
 import { PresenceStatusEnum } from "./presence.js";
 import { SurfaceSchema } from "./surfaces.js";
 import { AppSessionId } from "./apps.js";
-import { stringEnum } from "../helpers.js";
+import { stringEnum, DateTimeString } from "../helpers.js";
 
 export const EventNames = {
   MessageReceived: "messages/received",
   MessageDelivered: "messages/delivered",
   ConversationCreated: "conversations/created",
   ConversationUpdated: "conversations/updated",
+  ConversationArchived: "conversations/archived",
+  ConversationUnarchived: "conversations/unarchived",
   ContactRequest: "contact/request",
   ContactAccepted: "contact/accepted",
   PresenceChanged: "presence/changed",
@@ -49,6 +51,23 @@ export const ConversationCreatedEventSchema = Type.Object(
 
 export const ConversationUpdatedEventSchema = Type.Object(
   { conversation: ConversationSchema },
+  { additionalProperties: false },
+);
+
+export const ConversationArchivedEventSchema = Type.Object(
+  {
+    conversationId: ConversationId,
+    archivedAt: DateTimeString,
+    by: AgentId,
+  },
+  { additionalProperties: false },
+);
+
+export const ConversationUnarchivedEventSchema = Type.Object(
+  {
+    conversationId: ConversationId,
+    by: AgentId,
+  },
   { additionalProperties: false },
 );
 
@@ -180,6 +199,12 @@ export type ConversationCreatedEvent = Static<
 >;
 export type ConversationUpdatedEvent = Static<
   typeof ConversationUpdatedEventSchema
+>;
+export type ConversationArchivedEvent = Static<
+  typeof ConversationArchivedEventSchema
+>;
+export type ConversationUnarchivedEvent = Static<
+  typeof ConversationUnarchivedEventSchema
 >;
 export type ContactRequestEvent = Static<typeof ContactRequestEventSchema>;
 export type ContactAcceptedEvent = Static<typeof ContactAcceptedEventSchema>;

--- a/packages/protocol/src/schema/methods/conversations.ts
+++ b/packages/protocol/src/schema/methods/conversations.ts
@@ -1,4 +1,4 @@
-import { Type, type Static } from "@sinclair/typebox";
+import { Type } from "@sinclair/typebox";
 import { stringEnum, DateTimeString } from "../../helpers.js";
 import { ConversationId } from "../primitives.js";
 import {
@@ -43,6 +43,7 @@ export const ConversationsList = defineRpc({
     {
       limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
       cursor: Type.Optional(Type.String()),
+      archived: Type.Optional(stringEnum(["exclude", "include", "only"])),
     },
     { additionalProperties: false },
   ),
@@ -129,6 +130,24 @@ export const ConversationsRemoveParticipant = defineRpc({
 
 export const ConversationsLeave = defineRpc({
   name: "conversations/leave",
+  params: Type.Object(
+    { conversationId: ConversationId },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({}, { additionalProperties: false }),
+});
+
+export const ConversationsArchive = defineRpc({
+  name: "conversations/archive",
+  params: Type.Object(
+    { conversationId: ConversationId },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({}, { additionalProperties: false }),
+});
+
+export const ConversationsUnarchive = defineRpc({
+  name: "conversations/unarchive",
   params: Type.Object(
     { conversationId: ConversationId },
     { additionalProperties: false },

--- a/packages/protocol/src/validators.ts
+++ b/packages/protocol/src/validators.ts
@@ -32,6 +32,8 @@ import {
   ConversationsRemoveParticipant,
   ConversationsLeave,
   ConversationsUnmute,
+  ConversationsArchive,
+  ConversationsUnarchive,
 } from "./schema/methods/conversations.js";
 import { InvitesCreateAgent } from "./schema/methods/invites.js";
 import {
@@ -107,6 +109,8 @@ export const validators = {
     ConversationsRemoveParticipant.validateParams,
   conversationsLeaveParams: ConversationsLeave.validateParams,
   conversationsUnmuteParams: ConversationsUnmute.validateParams,
+  conversationsArchiveParams: ConversationsArchive.validateParams,
+  conversationsUnarchiveParams: ConversationsUnarchive.validateParams,
 
   // Invites.
   invitesCreateAgentParams: InvitesCreateAgent.validateParams,

--- a/packages/server/src/__tests__/integration/35-conversations-archive.integration.test.ts
+++ b/packages/server/src/__tests__/integration/35-conversations-archive.integration.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import { ErrorCodes } from "@moltzap/protocol";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  setupAgentGroup,
+  registerAndConnect,
+} from "./helpers.js";
+import type { ConnectedAgent } from "./helpers.js";
+import type { CoreApp } from "../../app/types.js";
+import { getCoreDb, expectRpcFailure } from "../../test-utils/index.js";
+
+let coreApp: CoreApp;
+
+beforeAll(async () => {
+  const server = await startTestServer();
+  coreApp = server.coreApp;
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("conversations/archive + /unarchive", () => {
+  it.live("owner archives and unarchives; broadcasts events", () =>
+    Effect.gen(function* () {
+      const group = yield* setupAgentGroup(3, { groupName: "Archive Target" });
+      const [alice, bob, eve] = group.agents as [
+        ConnectedAgent,
+        ConnectedAgent,
+        ConnectedAgent,
+      ];
+      const conversationId = group.conversationId!;
+
+      yield* alice.client.sendRpc("conversations/archive", { conversationId });
+
+      const bobArchived = yield* bob.client.waitForEvent(
+        "conversations/archived",
+      );
+      const eveArchived = yield* eve.client.waitForEvent(
+        "conversations/archived",
+      );
+      const bobData = bobArchived.data as {
+        conversationId: string;
+        archivedAt: string;
+        by: string;
+      };
+      expect(bobData.conversationId).toBe(conversationId);
+      expect(bobData.by).toBe(alice.agentId);
+      expect(typeof bobData.archivedAt).toBe("string");
+      expect((eveArchived.data as { by: string }).by).toBe(alice.agentId);
+
+      const listDefault = (yield* bob.client.sendRpc(
+        "conversations/list",
+        {},
+      )) as { conversations: Array<{ id: string }> };
+      expect(
+        listDefault.conversations.find((c) => c.id === conversationId),
+      ).toBeUndefined();
+
+      const listInclude = (yield* bob.client.sendRpc("conversations/list", {
+        archived: "include",
+      })) as { conversations: Array<{ id: string }> };
+      expect(
+        listInclude.conversations.find((c) => c.id === conversationId),
+      ).toBeDefined();
+
+      const listOnly = (yield* bob.client.sendRpc("conversations/list", {
+        archived: "only",
+      })) as { conversations: Array<{ id: string }> };
+      expect(listOnly.conversations.length).toBe(1);
+      expect(listOnly.conversations[0]!.id).toBe(conversationId);
+
+      yield* alice.client.sendRpc("conversations/unarchive", {
+        conversationId,
+      });
+      const bobUnarchived = yield* bob.client.waitForEvent(
+        "conversations/unarchived",
+      );
+      expect(
+        (bobUnarchived.data as { conversationId: string }).conversationId,
+      ).toBe(conversationId);
+
+      const listAfter = (yield* bob.client.sendRpc(
+        "conversations/list",
+        {},
+      )) as { conversations: Array<{ id: string }> };
+      expect(
+        listAfter.conversations.find((c) => c.id === conversationId),
+      ).toBeDefined();
+    }),
+  );
+
+  it.live("non-owner/admin member gets 403 on archive", () =>
+    Effect.gen(function* () {
+      const group = yield* setupAgentGroup(2, { groupName: "Perm Test" });
+      const [, bob] = group.agents as [ConnectedAgent, ConnectedAgent];
+      const conversationId = group.conversationId!;
+
+      yield* expectRpcFailure(
+        bob.client.sendRpc("conversations/archive", { conversationId }),
+        ErrorCodes.Forbidden,
+      );
+    }),
+  );
+
+  it.live("admin can archive (role promoted directly)", () =>
+    Effect.gen(function* () {
+      const group = yield* setupAgentGroup(2, { groupName: "Admin Test" });
+      const [, bob] = group.agents as [ConnectedAgent, ConnectedAgent];
+      const conversationId = group.conversationId!;
+
+      // Role assignment goes through a separate admin API not wired here;
+      // direct DB write is the minimal stand-in for the test.
+      const db = getCoreDb();
+      yield* Effect.promise(() =>
+        db
+          .updateTable("conversation_participants")
+          .set({ role: "admin" })
+          .where("conversation_id", "=", conversationId)
+          .where("agent_id", "=", bob.agentId)
+          .execute(),
+      );
+
+      yield* bob.client.sendRpc("conversations/archive", { conversationId });
+    }),
+  );
+
+  it.live("archive of archived conversation is idempotent", () =>
+    Effect.gen(function* () {
+      const group = yield* setupAgentGroup(2, { groupName: "Idempotent" });
+      const [alice] = group.agents as [ConnectedAgent, ConnectedAgent];
+      const conversationId = group.conversationId!;
+
+      yield* alice.client.sendRpc("conversations/archive", { conversationId });
+      yield* alice.client.sendRpc("conversations/archive", { conversationId });
+    }),
+  );
+
+  it.live("unarchive of active conversation is idempotent", () =>
+    Effect.gen(function* () {
+      const group = yield* setupAgentGroup(2, { groupName: "Unarchive Idem" });
+      const [alice] = group.agents as [ConnectedAgent, ConnectedAgent];
+      const conversationId = group.conversationId!;
+
+      yield* alice.client.sendRpc("conversations/unarchive", {
+        conversationId,
+      });
+    }),
+  );
+
+  it.live("archive of session-attached conversation returns 409", () =>
+    Effect.gen(function* () {
+      const appId = "archive-test-app";
+      coreApp.registerApp({
+        appId,
+        name: "Archive Test App",
+        permissions: { required: [], optional: [] },
+        conversations: [
+          { key: "main", name: "Main", participantFilter: "all" },
+        ],
+        hooks: {
+          before_message_delivery: { timeout_ms: 5000 },
+          on_join: {},
+          on_close: { timeout_ms: 5000 },
+        },
+      });
+
+      const alice = yield* registerAndConnect("archive-alice");
+      // owner_user_id is required for app session admission.
+      const db = getCoreDb();
+      yield* Effect.promise(() =>
+        db
+          .updateTable("agents")
+          .set({ owner_user_id: crypto.randomUUID() })
+          .where("id", "=", alice.agentId)
+          .execute(),
+      );
+
+      const session = (yield* alice.client.sendRpc("apps/create", {
+        appId,
+        invitedAgentIds: [],
+      })) as {
+        session: { id: string; conversations: Record<string, string> };
+      };
+      const convId = session.session.conversations["main"]!;
+
+      const err = yield* expectRpcFailure(
+        alice.client.sendRpc("conversations/archive", {
+          conversationId: convId,
+        }),
+        ErrorCodes.Conflict,
+      );
+      expect(err.message).toContain("active app session");
+    }),
+  );
+
+  it.live("concurrent archive by two privileged callers — both succeed", () =>
+    Effect.gen(function* () {
+      const group = yield* setupAgentGroup(2, { groupName: "Race" });
+      const [alice, bob] = group.agents as [ConnectedAgent, ConnectedAgent];
+      const conversationId = group.conversationId!;
+
+      const db = getCoreDb();
+      yield* Effect.promise(() =>
+        db
+          .updateTable("conversation_participants")
+          .set({ role: "admin" })
+          .where("conversation_id", "=", conversationId)
+          .where("agent_id", "=", bob.agentId)
+          .execute(),
+      );
+
+      const [r1, r2] = yield* Effect.all(
+        [
+          alice.client.sendRpc("conversations/archive", { conversationId }),
+          bob.client.sendRpc("conversations/archive", { conversationId }),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      expect(r1).toEqual({});
+      expect(r2).toEqual({});
+
+      const row = yield* Effect.promise(() =>
+        db
+          .selectFrom("conversations")
+          .select("archived_at")
+          .where("id", "=", conversationId)
+          .executeTakeFirst(),
+      );
+      expect(row?.archived_at).not.toBeNull();
+    }),
+  );
+});

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -384,6 +384,10 @@ export class AppHost {
     return this.manifests.get(appId);
   }
 
+  isAttachedToActiveSession(conversationId: string): boolean {
+    return this.conversationToSession.has(conversationId);
+  }
+
   setContactService(checker: ContactService): void {
     this.contactService = checker;
   }

--- a/packages/server/src/app/handlers/conversations.handlers.ts
+++ b/packages/server/src/app/handlers/conversations.handlers.ts
@@ -12,6 +12,8 @@ import {
   ConversationsUnmute,
   ConversationsAddParticipant,
   ConversationsRemoveParticipant,
+  ConversationsArchive,
+  ConversationsUnarchive,
   EventNames,
   eventFrame,
 } from "@moltzap/protocol";
@@ -60,7 +62,12 @@ export function createConversationHandlers(deps: {
     "conversations/list": defineMethod(ConversationsList, {
       requiresActive: true,
       handler: (params, ctx) =>
-        deps.conversationService.list(ctx.agentId, params.limit, params.cursor),
+        deps.conversationService.list(
+          ctx.agentId,
+          params.limit,
+          params.cursor,
+          params.archived,
+        ),
     }),
 
     "conversations/get": defineMethod(ConversationsGet, {
@@ -101,6 +108,45 @@ export function createConversationHandlers(deps: {
           if (conn) {
             conn.conversationIds.delete(params.conversationId);
           }
+          return {};
+        }),
+    }),
+
+    "conversations/archive": defineMethod(ConversationsArchive, {
+      requiresActive: true,
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          const { archivedAt } = yield* deps.conversationService.archive(
+            params.conversationId,
+            ctx.agentId,
+          );
+          deps.broadcaster.broadcastToConversation(
+            params.conversationId,
+            eventFrame(EventNames.ConversationArchived, {
+              conversationId: params.conversationId,
+              archivedAt,
+              by: ctx.agentId,
+            }),
+          );
+          return {};
+        }),
+    }),
+
+    "conversations/unarchive": defineMethod(ConversationsUnarchive, {
+      requiresActive: true,
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          yield* deps.conversationService.unarchive(
+            params.conversationId,
+            ctx.agentId,
+          );
+          deps.broadcaster.broadcastToConversation(
+            params.conversationId,
+            eventFrame(EventNames.ConversationUnarchived, {
+              conversationId: params.conversationId,
+              by: ctx.agentId,
+            }),
+          );
           return {};
         }),
     }),

--- a/packages/server/src/app/hooks.ts
+++ b/packages/server/src/app/hooks.ts
@@ -22,18 +22,23 @@ export interface HookResult {
 }
 
 /**
- * Wire schema for `HookResult` webhook responses. `patch.parts` is
- * widened to `unknown[]` here so server-core doesn't depend on the full
- * `Part` protocol schema; the real `Part` shape is re-validated at the
- * message-send boundary. The final cast reconciles that intentional
- * widening with the `Part[]` field in `HookResult`.
+ * Typed `Part[]` schema. Server-core doesn't duplicate the canonical
+ * `Part` schema (TypeBox, in @moltzap/protocol); we accept any array and
+ * trust the message-send boundary to re-validate shape. `Schema.declare`
+ * attaches the type witness via a runtime type-guard.
  */
+const PartArraySchema = Schema.declare(
+  (input: unknown): input is Part[] => Array.isArray(input),
+  { identifier: "PartArray" },
+);
+
+/** Wire schema for `HookResult` webhook responses. Single-layer `as`
+ *  reconciles effect-schema's encoded-type inference (which mirrors the
+ *  Struct shape) with the caller's `Schema.Schema<_, unknown>` slot. */
 export const HookResultSchema = Schema.Struct({
   block: Schema.Boolean,
   reason: Schema.optional(Schema.String),
-  patch: Schema.optional(
-    Schema.Struct({ parts: Schema.Array(Schema.Unknown) }),
-  ),
+  patch: Schema.optional(Schema.Struct({ parts: PartArraySchema })),
   feedback: Schema.optional(
     Schema.Struct({
       type: Schema.Literal("error", "warning", "info"),
@@ -41,7 +46,7 @@ export const HookResultSchema = Schema.Struct({
       retry: Schema.optional(Schema.Boolean),
     }),
   ),
-}) as unknown as Schema.Schema<HookResult, unknown>;
+}) as Schema.Schema<HookResult, unknown>;
 
 /** Fire-and-forget hooks (`on_join`, `on_close`, `on_session_active`) — any payload is ignored. */
 export const VoidHookSchema: Schema.Schema<void, unknown> = Schema.transform(

--- a/packages/server/src/app/layers.ts
+++ b/packages/server/src/app/layers.ts
@@ -161,7 +161,10 @@ export const ConversationServiceLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* DbTag;
     const participants = yield* ParticipantServiceTag;
-    return new ConversationService(db, participants);
+    const appHost = yield* AppHostTag;
+    return new ConversationService(db, participants, (convId) =>
+      appHost.isAttachedToActiveSession(convId),
+    );
   }),
 );
 
@@ -262,16 +265,16 @@ const Tier1 = Layer.mergeAll(
 /** Tier 2 — Broadcaster needs Tier 1's ConnectionManager. */
 const Tier2 = Layer.provideMerge(BroadcasterLive, Tier1);
 
-/** Tier 3 — Conversation needs Tier 1's Participant; keeps Tier 2 outputs. */
-const Tier3 = Layer.provideMerge(ConversationServiceLive, Tier2);
-
-/** Tier 4 — AppHost + DefaultPermission need Conversation + Broadcaster. */
-const Tier4 = Layer.provideMerge(
+/** Tier 3 — AppHost + DefaultPermission need Broadcaster/Connections. */
+const Tier3 = Layer.provideMerge(
   Layer.mergeAll(AppHostLive, DefaultPermissionServiceLive),
-  Tier3,
+  Tier2,
 );
 
-/** Tier 5 — MessageService needs AppHost + everything upstream. */
+/** Tier 4 — ConversationService needs AppHost for the session-attach check. */
+const Tier4 = Layer.provideMerge(ConversationServiceLive, Tier3);
+
+/** Tier 5 — MessageService needs ConversationService + AppHost + upstream. */
 const Tier5 = Layer.provideMerge(MessageServiceLive, Tier4);
 
 /**

--- a/packages/server/src/services/conversation.service.ts
+++ b/packages/server/src/services/conversation.service.ts
@@ -10,6 +10,7 @@ import {
   RpcFailure,
   notFound,
   forbidden,
+  conflict,
   invalidParams,
 } from "../runtime/index.js";
 import { ErrorCodes } from "@moltzap/protocol";
@@ -52,6 +53,8 @@ export class ConversationService {
   constructor(
     private db: Db,
     private participants: ParticipantService,
+    private isAttachedToActiveSession: (convId: string) => boolean = () =>
+      false,
   ) {}
 
   /** Write-through: called from MessageService.send() with plaintext parts before encryption */
@@ -200,6 +203,7 @@ export class ConversationService {
     agentId: string,
     limit = 50,
     cursor?: string,
+    archived: "exclude" | "include" | "only" = "exclude",
   ): Effect.Effect<
     { conversations: ConversationSummary[]; cursor?: string },
     RpcFailure
@@ -207,6 +211,12 @@ export class ConversationService {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
         const cursorParam = cursor ?? null;
+        const archivedFilter =
+          archived === "only"
+            ? sql`AND c.archived_at IS NOT NULL`
+            : archived === "include"
+              ? sql``
+              : sql`AND c.archived_at IS NULL`;
         const rows = yield* rawQuery(
           this.db,
           sql<ListRow>`
@@ -227,7 +237,7 @@ export class ConversationService {
               ORDER BY seq DESC LIMIT 1
             ) m ON true
             WHERE cp.agent_id = ${agentId}
-              AND c.archived_at IS NULL
+              ${archivedFilter}
               ${cursorParam ? sql`AND c.updated_at < ${cursorParam}` : sql``}
             ORDER BY COALESCE(m.created_at, c.updated_at) DESC
             LIMIT ${limit + 1}
@@ -361,6 +371,67 @@ export class ConversationService {
         }
 
         return this.mapConversation(rowOpt.value);
+      }),
+    );
+  }
+
+  archive(
+    conversationId: string,
+    agentId: string,
+  ): Effect.Effect<{ archivedAt: string }, RpcFailure> {
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        yield* this.requireRole(conversationId, agentId, ["owner", "admin"]);
+
+        if (this.isAttachedToActiveSession(conversationId)) {
+          return yield* Effect.fail(
+            conflict(
+              "Conversation is part of an active app session; close the session to archive",
+            ),
+          );
+        }
+
+        const updatedOpt = yield* takeFirstOption(
+          this.db
+            .updateTable("conversations")
+            .set({ archived_at: new Date() })
+            .where("id", "=", conversationId)
+            .where("archived_at", "is", null)
+            .returning("archived_at"),
+        );
+        if (Option.isSome(updatedOpt)) {
+          return { archivedAt: updatedOpt.value.archived_at!.toISOString() };
+        }
+
+        // No transition happened: already archived, or a concurrent caller
+        // won the UPDATE. Re-read to return the winner's timestamp.
+        const currentOpt = yield* takeFirstOption(
+          this.db
+            .selectFrom("conversations")
+            .select("archived_at")
+            .where("id", "=", conversationId),
+        );
+        if (Option.isNone(currentOpt) || !currentOpt.value.archived_at) {
+          return yield* Effect.fail(notFound("Conversation not found"));
+        }
+        return { archivedAt: currentOpt.value.archived_at.toISOString() };
+      }),
+    );
+  }
+
+  unarchive(
+    conversationId: string,
+    agentId: string,
+  ): Effect.Effect<void, RpcFailure> {
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        yield* this.requireRole(conversationId, agentId, ["owner", "admin"]);
+
+        yield* this.db
+          .updateTable("conversations")
+          .set({ archived_at: null })
+          .where("id", "=", conversationId)
+          .where("archived_at", "is not", null);
       }),
     );
   }

--- a/scripts/generate-protocol-docs.ts
+++ b/scripts/generate-protocol-docs.ts
@@ -32,6 +32,8 @@ import {
   ConversationsAddParticipant,
   ConversationsRemoveParticipant,
   ConversationsLeave,
+  ConversationsArchive,
+  ConversationsUnarchive,
 } from "../packages/protocol/src/schema/methods/conversations.js";
 import {
   PresenceUpdate,
@@ -50,6 +52,8 @@ import {
   MessageDeliveredEventSchema,
   ConversationCreatedEventSchema,
   ConversationUpdatedEventSchema,
+  ConversationArchivedEventSchema,
+  ConversationUnarchivedEventSchema,
   PresenceChangedEventSchema,
   SurfaceUpdatedEventSchema,
   SurfaceClearedEventSchema,
@@ -246,6 +250,41 @@ const methods: MethodDef[] = [
     params: ConversationsUnmute.paramsSchema,
     category: "conversations",
   },
+  {
+    method: "conversations/archive",
+    description:
+      "Archive a conversation. Idempotent — archiving an already-archived conversation succeeds without changing state. Owner/admin only.",
+    params: ConversationsArchive.paramsSchema,
+    category: "conversations",
+    relatedEvents: ["conversations/archived"],
+    errors: [
+      {
+        code: -32001,
+        name: "Forbidden",
+        when: "Caller is not owner or admin",
+      },
+      {
+        code: -32009,
+        name: "Conflict",
+        when: "Conversation is attached to an active app session; close the session to archive",
+      },
+    ],
+  },
+  {
+    method: "conversations/unarchive",
+    description:
+      "Unarchive a conversation (clears archived_at). Idempotent — unarchiving an active conversation is a no-op. Owner/admin only.",
+    params: ConversationsUnarchive.paramsSchema,
+    category: "conversations",
+    relatedEvents: ["conversations/unarchived"],
+    errors: [
+      {
+        code: -32001,
+        name: "Forbidden",
+        when: "Caller is not owner or admin",
+      },
+    ],
+  },
   // Presence
   {
     method: "presence/update",
@@ -337,6 +376,19 @@ const events: EventDef[] = [
       "conversations/add-participant",
       "conversations/remove-participant",
     ],
+  },
+  {
+    event: EventNames.ConversationArchived,
+    description:
+      "Fired when a conversation is archived (explicit archive call or app-session close).",
+    data: ConversationArchivedEventSchema,
+    triggeredBy: ["conversations/archive"],
+  },
+  {
+    event: EventNames.ConversationUnarchived,
+    description: "Fired when a conversation is unarchived.",
+    data: ConversationUnarchivedEventSchema,
+    triggeredBy: ["conversations/unarchive"],
   },
   {
     event: EventNames.PresenceChanged,


### PR DESCRIPTION
## Summary
Adds user-invokable archive/unarchive RPCs independent of app-session lifecycle. Closes #58. (Supersedes #108 which auto-closed when its base branch #107 merged.)

**Protocol**
- `conversations/archive` / `conversations/unarchive` RPC manifests.
- Extend `conversations/list` with `archived: "exclude" | "include" | "only"` filter (default `"exclude"` — backward compatible).
- New events `conversations/archived` / `conversations/unarchived`, broadcast to all participants.

**Server**
- `ConversationService.archive(convId, agentId)` — owner/admin role required, rejects with `Conflict` if the conversation is attached to an active app session. Idempotent: a second caller returns the first caller's timestamp via re-read after the guarded UPDATE misses.
- `ConversationService.unarchive(convId, agentId)` — same role check, idempotent no-op on active conversations.
- `ConversationService.list` respects the new `archived` enum.
- `AppHost.isAttachedToActiveSession(convId)` — O(1) `Map.has` against the existing `conversationToSession` map.
- `ConversationService` constructor gets an injected `isAttachedToActiveSession: (id) => boolean` fn — wired from the Layer that owns both services. Avoids creating a reverse import from `ConversationService` → `AppHost` (would risk a Layer cycle since `AppHost` is already below `ConversationService` via `MessageService`).
- Layer order updated: `AppHost` moves to Tier 3 (before `ConversationService` in Tier 4). The old stale comment on Tier 4 that said "AppHost needs Conversation" was wrong.

**Handlers**
- `conversations/archive` / `conversations/unarchive` broadcast the corresponding event after the service call.

**Tests** — `35-conversations-archive.integration.test.ts`, 7 cases: owner/admin happy paths, permission denial (member → 403), archive idempotency, unarchive idempotency, session-attached rejection (409), concurrent archive race.

**Docs**
- Generator registers new RPCs + events.
- `docs/docs.json` navigation updated.
- `pnpm docs:generate` output committed.

## Test plan
- [x] `pnpm --filter @moltzap/server-core build` clean
- [x] `pnpm --filter @moltzap/server-core test` — 115/115 pass
- [x] `pnpm --filter @moltzap/server-core test:integration` — 115/115 pass locally
- [x] `pnpm docs:check:drift` clean

## Design decisions
Recorded during `/plan-eng-review`:
- Narrow-fn injection (not reverse import) for the session-attach check — avoids Layer cycle.
- Dedicated `conversations/archived` events — semantically distinct from `conversations/updated` (rename).
- Single `archived` enum on list, not two booleans — no invalid combinations.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)