### PR TITLE
fix(evals): --legacy-peer-deps on eval-agent Dockerfile CLI install

### DIFF
--- a/packages/evals/Dockerfile.eval-agent
+++ b/packages/evals/Dockerfile.eval-agent
@@ -18,7 +18,7 @@ USER root
 RUN mkdir -p /opt/moltzap-cli && cd /opt/moltzap-cli \
     && tar xzf /tmp/moltzap-client-*.tgz --strip-components=1 \
     && node -e "const p=require('./package.json'); delete p.devDependencies; require('fs').writeFileSync('./package.json', JSON.stringify(p,null,2))" \
-    && npm install --ignore-scripts --no-package-lock /tmp/moltzap-protocol-*.tgz \
+    && npm install --ignore-scripts --no-package-lock --legacy-peer-deps /tmp/moltzap-protocol-*.tgz \
     && chmod +x dist/cli/index.js \
     && ln -s /opt/moltzap-cli/dist/cli/index.js /usr/local/bin/moltzap
 USER node


### PR DESCRIPTION
Unblocks `docker build` of `moltzap-eval-agent:local` with current @effect/platform + @effect/cli versions.

@effect/cli@^0.73 peer-declares @effect/platform@^0.94.3, everyone else uses ^0.96. npm's ERESOLVE refuses; --legacy-peer-deps lets it resolve against the hoisted platform (no functional impact, CLI only uses stable surface).

Repro on main: `docker build -f packages/evals/Dockerfile.eval-agent .` → ERESOLVE on `[4/6]`. After this: builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)