### PR TITLE
feat(server-core): ConnectionManager.subscribeAgentsToConversation helper

### DIFF
--- a/packages/server/src/app/handlers/conversations.handlers.ts
+++ b/packages/server/src/app/handlers/conversations.handlers.ts
@@ -45,10 +45,11 @@ export function createConversationHandlers(deps: {
             creatorConn.conversationIds.add(conversation.id);
           }
 
+          deps.connections.subscribeAgentsToConversation(
+            params.participants.map((p) => p.id),
+            conversation.id,
+          );
           for (const participant of params.participants) {
-            for (const conn of deps.connections.getByAgent(participant.id)) {
-              conn.conversationIds.add(conversation.id);
-            }
             deps.broadcaster.sendToAgent(
               participant.id,
               eventFrame(EventNames.ConversationCreated, { conversation }),

--- a/packages/server/src/ws/connection.test.ts
+++ b/packages/server/src/ws/connection.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import type { AuthenticatedContext } from "../rpc/context.js";
+import type { AgentId } from "../app/types.js";
+import { ConnectionManager, type MoltZapConnection } from "./connection.js";
+
+/**
+ * Pure-unit coverage for ConnectionManager.subscribeAgentsToConversation.
+ *
+ * The helper exists so downstream apps (e.g. moltzap-arena's Werewolf) can
+ * create conversations via ConversationService.create and still reach the
+ * same state the `conversations/create` RPC handler reaches — without
+ * duplicating the subscription loop in every caller.
+ */
+
+const noopWrite: MoltZapConnection["write"] = () => Effect.void;
+const noopShutdown: MoltZapConnection["shutdown"] = Effect.void;
+
+function makeConn(id: string, agentId: string | null): MoltZapConnection {
+  const auth: AuthenticatedContext | null = agentId
+    ? {
+        agentId: agentId as AgentId,
+        agentStatus: "active",
+        ownerUserId: null,
+      }
+    : null;
+  return {
+    id,
+    write: noopWrite,
+    shutdown: noopShutdown,
+    auth,
+    lastPong: Date.now(),
+    conversationIds: new Set<string>(),
+    mutedConversations: new Set<string>(),
+  };
+}
+
+describe("ConnectionManager.subscribeAgentsToConversation", () => {
+  it("subscribes every matching connection to the conversation", () => {
+    const manager = new ConnectionManager();
+    const a1 = makeConn("c-alice-1", "alice");
+    const a2 = makeConn("c-alice-2", "alice");
+    const b1 = makeConn("c-bob-1", "bob");
+    const c1 = makeConn("c-carol-1", "carol");
+    manager.add(a1);
+    manager.add(a2);
+    manager.add(b1);
+    manager.add(c1);
+
+    const subscribed = manager.subscribeAgentsToConversation(
+      ["alice", "bob"],
+      "conv-1",
+    );
+
+    expect(new Set(subscribed)).toEqual(
+      new Set(["c-alice-1", "c-alice-2", "c-bob-1"]),
+    );
+    expect(a1.conversationIds.has("conv-1")).toBe(true);
+    expect(a2.conversationIds.has("conv-1")).toBe(true);
+    expect(b1.conversationIds.has("conv-1")).toBe(true);
+    expect(c1.conversationIds.has("conv-1")).toBe(false);
+  });
+
+  it("skips connections that have not authenticated", () => {
+    const manager = new ConnectionManager();
+    const authed = makeConn("c-authed", "alice");
+    const unauthed = makeConn("c-unauthed", null);
+    manager.add(authed);
+    manager.add(unauthed);
+
+    const subscribed = manager.subscribeAgentsToConversation(
+      ["alice"],
+      "conv-1",
+    );
+
+    expect(subscribed).toEqual(["c-authed"]);
+    expect(unauthed.conversationIds.has("conv-1")).toBe(false);
+  });
+
+  it("is idempotent — repeated calls do not double-subscribe", () => {
+    const manager = new ConnectionManager();
+    const conn = makeConn("c-1", "alice");
+    manager.add(conn);
+
+    manager.subscribeAgentsToConversation(["alice"], "conv-1");
+    manager.subscribeAgentsToConversation(["alice"], "conv-1");
+
+    expect(conn.conversationIds.size).toBe(1);
+    expect(conn.conversationIds.has("conv-1")).toBe(true);
+  });
+
+  it("returns empty when no connections match", () => {
+    const manager = new ConnectionManager();
+    manager.add(makeConn("c-1", "alice"));
+
+    const subscribed = manager.subscribeAgentsToConversation(
+      ["bob", "carol"],
+      "conv-1",
+    );
+
+    expect(subscribed).toEqual([]);
+  });
+
+  it("handles an empty agentIds list", () => {
+    const manager = new ConnectionManager();
+    const conn = makeConn("c-1", "alice");
+    manager.add(conn);
+
+    const subscribed = manager.subscribeAgentsToConversation([], "conv-1");
+
+    expect(subscribed).toEqual([]);
+    expect(conn.conversationIds.has("conv-1")).toBe(false);
+  });
+});

--- a/packages/server/src/ws/connection.ts
+++ b/packages/server/src/ws/connection.ts
@@ -40,6 +40,35 @@ export class ConnectionManager {
     );
   }
 
+  /**
+   * Subscribe all currently-connected sockets of the given agents to a
+   * conversation. Adds `conversationId` to each matching connection's
+   * `conversationIds` set so subsequent `Broadcaster.broadcastToConversation`
+   * calls reach those sockets. Idempotent: a connection already subscribed is
+   * a no-op (Set semantics). Returns the list of connection ids that were
+   * subscribed (for observability + tests).
+   *
+   * Exposed for downstream apps that create conversations via
+   * `ConversationService.create` directly (rather than the `conversations/
+   * create` RPC handler, which already does this work internally). Without
+   * this helper, every consumer re-implements the same loop and drifts when
+   * the subscription shape changes.
+   */
+  subscribeAgentsToConversation(
+    agentIds: readonly string[],
+    conversationId: string,
+  ): string[] {
+    const subscribed: string[] = [];
+    const agentSet = new Set(agentIds);
+    for (const conn of this.connections.values()) {
+      if (!conn.auth) continue;
+      if (!agentSet.has(conn.auth.agentId)) continue;
+      conn.conversationIds.add(conversationId);
+      subscribed.push(conn.id);
+    }
+    return subscribed;
+  }
+
   entries(): IterableIterator<[string, MoltZapConnection]> {
     return this.connections.entries();
   }


### PR DESCRIPTION
Adds `ConnectionManager.subscribeAgentsToConversation(agentIds, conversationId)` and uses it in the `conversations/create` RPC handler. Exported for downstream apps that create conversations via `ConversationService.create` directly.

**Repro:** moltzap-arena's werewolf-app creates per-player role DMs in `on_session_active` via `conversationService.create`. Without this helper, role DMs silently skip broadcast — agents never receive their role assignments. In a live 4-player game three of four agents said 'I haven't received my secret role in any DM — can someone confirm?' within the first discussion phase.

Consolidating on `ConnectionManager` prevents drift.

Changes:
- `ws/connection.ts` — `subscribeAgentsToConversation(agentIds, convId): connId[]`. Idempotent, skips unauth'd connections.
- `app/handlers/conversations.handlers.ts` — `conversations/create` uses the helper.
- `ws/connection.test.ts` (new) — 5 pure unit tests.

Full submodule suite 121/121 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)