### PR TITLE
feat(observability): platform-wide telemetry for agent messaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,5 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @moltzap/protocol build
-      - run: pnpm --filter @moltzap/server-core build
+      - run: pnpm --filter @moltzap/server-core... build
       - run: pnpm --filter @moltzap/server-core test:integration

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -32,6 +32,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
+    "@moltzap/observability": "workspace:*",
     "@moltzap/protocol": "workspace:*",
     "commander": "^13.0.0",
     "ws": "^8.18.0"

--- a/packages/client/src/channel-core.telemetry.test.ts
+++ b/packages/client/src/channel-core.telemetry.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MoltZapChannelCore } from "./channel-core.js";
+import {
+  createFakeChannelService,
+  buildMessage,
+  flushDispatchChain,
+} from "./test-utils/index.js";
+import {
+  type DispatchCompleteEvent,
+  type DispatchStartEvent,
+} from "@moltzap/observability";
+import {
+  captureTelemetry,
+  resetTelemetry,
+} from "@moltzap/observability/test-utils";
+
+describe("MoltZapChannelCore telemetry — invariants", () => {
+  beforeEach(resetTelemetry);
+  afterEach(resetTelemetry);
+
+  it("fires one dispatch.start and one dispatch.complete per inbound", async () => {
+    const { events } = captureTelemetry();
+    const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+    const core = new MoltZapChannelCore({
+      service: fake.service,
+      queueStatsIntervalMs: 0,
+    });
+    core.onInbound(() => Promise.resolve());
+
+    fake.emit.message(buildMessage({ id: "m1" }));
+    await flushDispatchChain();
+
+    const starts = events.filter((e) => e.event === "dispatch.start");
+    const completes = events.filter((e) => e.event === "dispatch.complete");
+    expect(starts).toHaveLength(1);
+    expect(completes).toHaveLength(1);
+    expect((starts[0] as DispatchStartEvent).msgId).toBe("m1");
+    expect((completes[0] as DispatchCompleteEvent).outcome).toBe("final");
+  });
+
+  it("handler throw produces dispatch.complete outcome=error; chain continues", async () => {
+    const { events } = captureTelemetry();
+    const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+    let callCount = 0;
+    const core = new MoltZapChannelCore({
+      service: fake.service,
+      queueStatsIntervalMs: 0,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    core.onInbound(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error("boom");
+    });
+
+    fake.emit.message(buildMessage({ id: "m1" }));
+    fake.emit.message(buildMessage({ id: "m2" }));
+    await flushDispatchChain();
+
+    const completes = events.filter(
+      (e) => e.event === "dispatch.complete",
+    ) as DispatchCompleteEvent[];
+    expect(completes).toHaveLength(2);
+    expect(completes[0]!.outcome).toBe("error");
+    expect(completes[0]!.errorReason).toBe("boom");
+    expect(completes[1]!.outcome).toBe("final");
+    expect(core.getQueueStats().depth).toBe(0);
+    expect(core.getQueueStats().inflight).toBe(0);
+  });
+
+  it("invariant: 10 sequential messages preserve order, inflight <= 1, depth returns to 0", async () => {
+    captureTelemetry();
+    const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+    const order: string[] = [];
+    const inflightSamples: number[] = [];
+    const core = new MoltZapChannelCore({
+      service: fake.service,
+      queueStatsIntervalMs: 0,
+    });
+    core.onInbound(async (m) => {
+      inflightSamples.push(core.getQueueStats().inflight);
+      await new Promise((r) => setTimeout(r, 1));
+      order.push(m.id);
+    });
+
+    for (let i = 0; i < 10; i++) {
+      fake.emit.message(buildMessage({ id: `m${i}` }));
+    }
+    await flushDispatchChain();
+    // Also wait enough real time for the setTimeouts in the handler
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(order).toEqual([
+      "m0",
+      "m1",
+      "m2",
+      "m3",
+      "m4",
+      "m5",
+      "m6",
+      "m7",
+      "m8",
+      "m9",
+    ]);
+    for (const n of inflightSamples) expect(n).toBeLessThanOrEqual(1);
+    expect(core.getQueueStats().depth).toBe(0);
+    expect(core.getQueueStats().inflight).toBe(0);
+  });
+
+  it("chaos test: 100 messages with random handler delays (0-20ms), order preserved, no counter drift", async () => {
+    captureTelemetry();
+    const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+    const order: string[] = [];
+    let maxInflight = 0;
+    const core = new MoltZapChannelCore({
+      service: fake.service,
+      queueStatsIntervalMs: 0,
+    });
+    core.onInbound(async (m) => {
+      const inflight = core.getQueueStats().inflight;
+      if (inflight > maxInflight) maxInflight = inflight;
+      const delayMs = Math.floor(Math.random() * 20);
+      await new Promise((r) => setTimeout(r, delayMs));
+      order.push(m.id);
+    });
+
+    const ids: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      const id = `m${i.toString().padStart(3, "0")}`;
+      ids.push(id);
+      fake.emit.message(buildMessage({ id }));
+    }
+    await flushDispatchChain();
+    // Wait for all timeouts to drain. 100 * 20ms worst case = 2s; 3s is safe.
+    await new Promise((r) => setTimeout(r, 3000));
+
+    expect(order).toHaveLength(100);
+    expect(order).toEqual(ids);
+    expect(maxInflight).toBeLessThanOrEqual(1);
+    expect(core.getQueueStats().depth).toBe(0);
+    expect(core.getQueueStats().inflight).toBe(0);
+  }, 10_000);
+
+  it("chaos test: mid-flight disconnect + reconnect, no messages lost", async () => {
+    captureTelemetry();
+    const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+    const delivered: string[] = [];
+    const core = new MoltZapChannelCore({
+      service: fake.service,
+      queueStatsIntervalMs: 0,
+    });
+    core.onInbound(async (m) => {
+      await new Promise((r) => setTimeout(r, 5));
+      delivered.push(m.id);
+    });
+
+    // Send 5 messages, mid-flight fire disconnect+reconnect, then 5 more.
+    for (let i = 0; i < 5; i++) {
+      fake.emit.message(buildMessage({ id: `a${i}` }));
+    }
+    fake.emit.disconnect();
+    fake.emit.reconnect();
+    for (let i = 0; i < 5; i++) {
+      fake.emit.message(buildMessage({ id: `b${i}` }));
+    }
+
+    await flushDispatchChain();
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(delivered).toHaveLength(10);
+    expect(core.getQueueStats().depth).toBe(0);
+    expect(core.getQueueStats().inflight).toBe(0);
+  });
+
+  it("queue.stats emits on state changes, suppresses idle zero-zero heartbeats", async () => {
+    const { events } = captureTelemetry();
+    const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+    const core = new MoltZapChannelCore({
+      service: fake.service,
+      queueStatsIntervalMs: 20,
+    });
+    core.onInbound(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    await core.connect();
+
+    // Idle period: depth=0, inflight=0. One initial emission, then silence.
+    await new Promise((r) => setTimeout(r, 80));
+    const idleStats = events.filter((e) => e.event === "queue.stats");
+    expect(idleStats).toHaveLength(1);
+    expect((idleStats[0] as { depth: number }).depth).toBe(0);
+
+    // Activity: a message in flight changes state, should emit again.
+    fake.emit.message(buildMessage({ id: "x1" }));
+    await new Promise((r) => setTimeout(r, 50));
+    const activeStats = events.filter((e) => e.event === "queue.stats");
+    expect(activeStats.length).toBeGreaterThan(1);
+
+    await core.disconnect();
+  });
+});

--- a/packages/client/src/channel-core.ts
+++ b/packages/client/src/channel-core.ts
@@ -5,6 +5,7 @@
 import type { Message } from "@moltzap/protocol";
 import type { CrossConversationEntry, CrossConvMessage } from "./service.js";
 import type { WsClientLogger } from "./ws-client.js";
+import { telemetry, SCHEMA_VERSION } from "@moltzap/observability";
 
 export interface EnrichedSender {
   type: "agent" | "user";
@@ -65,6 +66,11 @@ export interface ChannelService {
 export interface ChannelCoreOptions {
   service: ChannelService;
   logger?: WsClientLogger;
+  /**
+   * Milliseconds between `queue.stats` telemetry emissions. Default 5000.
+   * Set to 0 to disable the periodic stats timer (useful in tests).
+   */
+  queueStatsIntervalMs?: number;
 }
 
 export type InboundHandler = (
@@ -95,6 +101,12 @@ function extractTextContent(parts: Message["parts"]): string {
  * is side-effectful (advances per-conversation markers), so a second core
  * would consume entries the first expected.
  */
+export interface QueueStats {
+  depth: number;
+  inflight: number;
+  oldestQueuedAgeMs?: number;
+}
+
 export class MoltZapChannelCore {
   private readonly service: ChannelService;
   private readonly logger: WsClientLogger;
@@ -104,30 +116,138 @@ export class MoltZapChannelCore {
   private disconnectHandlers: Array<() => void> = [];
   private reconnectHandlers: Array<() => void> = [];
 
+  private inflight = 0;
+  private enqueuedAt = new Map<string, number>();
+  private queueStatsTimer: NodeJS.Timeout | null = null;
+  private lastEmittedStats: { depth: number; inflight: number } | null = null;
+  private readonly queueStatsIntervalMs: number;
+
   constructor(opts: ChannelCoreOptions) {
     this.service = opts.service;
     this.logger = opts.logger ?? noopLogger;
+    this.queueStatsIntervalMs = opts.queueStatsIntervalMs ?? 5000;
 
     this.service.on("message", (message) => {
-      this.dispatchChain = this.dispatchChain
-        .then(() => this.handleInbound(message))
-        .catch((err) => {
+      const agentId = this.service.ownAgentId;
+      this.enqueuedAt.set(message.id, Date.now());
+
+      const startHandler = async (): Promise<void> => {
+        const dispatchStartedAt = Date.now();
+        this.inflight++;
+        if (agentId) {
+          telemetry.emit({
+            event: "dispatch.start",
+            source: "agent",
+            schemaVersion: SCHEMA_VERSION,
+            ts: dispatchStartedAt,
+            msgId: message.id,
+            convId: message.conversationId,
+            agentId,
+            queueDepth: this.enqueuedAt.size,
+            inflight: this.inflight,
+          });
+        }
+        let outcome: "final" | "error" = "final";
+        let errorReason: string | undefined;
+        try {
+          await this.handleInbound(message);
+        } catch (err) {
+          outcome = "error";
+          errorReason = err instanceof Error ? err.message : String(err);
           this.logger.error(
             { messageId: message.id, err },
             "MoltZapChannelCore: inbound handler threw",
           );
-        });
+        } finally {
+          this.inflight--;
+          this.enqueuedAt.delete(message.id);
+          if (agentId) {
+            telemetry.emit({
+              event: "dispatch.complete",
+              source: "agent",
+              schemaVersion: SCHEMA_VERSION,
+              ts: Date.now(),
+              msgId: message.id,
+              convId: message.conversationId,
+              agentId,
+              durationMs: Date.now() - dispatchStartedAt,
+              outcome,
+              errorReason,
+            });
+          }
+        }
+      };
+
+      this.dispatchChain = this.dispatchChain.then(startHandler);
     });
 
     this.service.on("disconnect", () => {
       this.connected = false;
+      this.stopQueueStatsTimer();
       for (const h of this.disconnectHandlers) h();
     });
 
     this.service.on("reconnect", () => {
       this.connected = true;
+      this.startQueueStatsTimer();
       for (const h of this.reconnectHandlers) h();
     });
+  }
+
+  private startQueueStatsTimer(): void {
+    if (this.queueStatsTimer !== null) return;
+    if (this.queueStatsIntervalMs <= 0) return;
+    this.queueStatsTimer = setInterval(() => {
+      const agentId = this.service.ownAgentId;
+      if (!agentId) return;
+      const stats = this.getQueueStats();
+      // Only emit when state changes. Skip duplicate zero heartbeats for
+      // idle agents; emit exactly one "back to zero" transition.
+      const last = this.lastEmittedStats;
+      if (
+        last &&
+        last.depth === stats.depth &&
+        last.inflight === stats.inflight
+      ) {
+        return;
+      }
+      this.lastEmittedStats = { depth: stats.depth, inflight: stats.inflight };
+      telemetry.emit({
+        event: "queue.stats",
+        source: "agent",
+        schemaVersion: SCHEMA_VERSION,
+        ts: Date.now(),
+        agentId,
+        depth: stats.depth,
+        inflight: stats.inflight,
+        oldestQueuedAgeMs: stats.oldestQueuedAgeMs,
+      });
+    }, this.queueStatsIntervalMs);
+    this.queueStatsTimer.unref?.();
+  }
+
+  private stopQueueStatsTimer(): void {
+    if (this.queueStatsTimer !== null) {
+      clearInterval(this.queueStatsTimer);
+      this.queueStatsTimer = null;
+    }
+  }
+
+  getQueueStats(): QueueStats {
+    let oldestQueuedAgeMs: number | undefined;
+    if (this.enqueuedAt.size > 0) {
+      const now = Date.now();
+      let oldest = now;
+      for (const t of this.enqueuedAt.values()) {
+        if (t < oldest) oldest = t;
+      }
+      oldestQueuedAgeMs = now - oldest;
+    }
+    return {
+      depth: this.enqueuedAt.size,
+      inflight: this.inflight,
+      oldestQueuedAgeMs,
+    };
   }
 
   /** Replaces any previous handler. */
@@ -146,9 +266,11 @@ export class MoltZapChannelCore {
   async connect(): Promise<void> {
     await this.service.connect();
     this.connected = true;
+    this.startQueueStatsTimer();
   }
 
   async disconnect(): Promise<void> {
+    this.stopQueueStatsTimer();
     this.service.close();
     this.connected = false;
   }

--- a/packages/client/src/channel-core.ts
+++ b/packages/client/src/channel-core.ts
@@ -73,9 +73,18 @@ export interface ChannelCoreOptions {
   queueStatsIntervalMs?: number;
 }
 
+/**
+ * Rollups need to distinguish "agent replied" from "agent received but chose
+ * not to respond." Returning void or undefined maps to outcome "final"
+ * (backwards-compatible for handlers predating this contract).
+ */
+export interface InboundHandlerResult {
+  outcome: "final" | "skipped";
+}
+
 export type InboundHandler = (
   msg: EnrichedInboundMessage,
-) => Promise<void> | void;
+) => Promise<void | InboundHandlerResult> | void | InboundHandlerResult;
 
 const noopLogger = {
   info: () => {},
@@ -147,10 +156,11 @@ export class MoltZapChannelCore {
             inflight: this.inflight,
           });
         }
-        let outcome: "final" | "error" = "final";
+        let outcome: "final" | "skipped" | "error" = "final";
         let errorReason: string | undefined;
         try {
-          await this.handleInbound(message);
+          const result = await this.handleInbound(message);
+          if (result?.outcome === "skipped") outcome = "skipped";
         } catch (err) {
           outcome = "error";
           errorReason = err instanceof Error ? err.message : String(err);
@@ -362,13 +372,16 @@ export class MoltZapChannelCore {
     };
   }
 
-  private async handleInbound(message: Message): Promise<void> {
+  private async handleInbound(
+    message: Message,
+  ): Promise<void | InboundHandlerResult> {
     if (!this.inboundHandler) return;
     const { enriched, commitContext } = await MoltZapChannelCore.enrichMessage(
       this.service,
       message,
     );
-    await this.inboundHandler(enriched);
+    const result = await this.inboundHandler(enriched);
     commitContext?.();
+    return result;
   }
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -17,6 +17,8 @@ export {
   type EnrichedInboundMessage,
   type EnrichedSender,
   type InboundHandler,
+  type InboundHandlerResult,
+  type QueueStats,
 } from "./channel-core.js";
 export {
   MoltZapWsClient,

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -9,6 +9,7 @@ import {
   EventNames,
 } from "@moltzap/protocol";
 import { MoltZapWsClient, type WsClientLogger } from "./ws-client.js";
+import { telemetry, SCHEMA_VERSION } from "@moltzap/observability";
 
 export interface ConversationMeta {
   id: string;
@@ -133,6 +134,8 @@ export class MoltZapService {
     return this._connected;
   }
 
+  private reconnectAttempts = 0;
+
   async connect(): Promise<HelloOk> {
     this.client = new MoltZapWsClient({
       serverUrl: this.opts.serverUrl,
@@ -141,12 +144,32 @@ export class MoltZapService {
       onEvent: (event) => this.handleEvent(event),
       onDisconnect: () => {
         this._connected = false;
+        if (this.ownAgentId) {
+          telemetry.emit({
+            event: "connection.disconnect",
+            source: "agent",
+            schemaVersion: SCHEMA_VERSION,
+            ts: Date.now(),
+            agentId: this.ownAgentId,
+          });
+        }
         for (const h of this.disconnectHandlers) h();
       },
       onReconnect: (helloOk) => {
         this._connected = true;
+        this.reconnectAttempts++;
         const hello = helloOk as HelloOk;
         this.populateFromHello(hello);
+        if (this.ownAgentId) {
+          telemetry.emit({
+            event: "connection.reconnect",
+            source: "agent",
+            schemaVersion: SCHEMA_VERSION,
+            ts: Date.now(),
+            agentId: this.ownAgentId,
+            attemptN: this.reconnectAttempts,
+          });
+        }
         for (const h of this.reconnectHandlers) h(hello);
       },
     });
@@ -441,11 +464,26 @@ export class MoltZapService {
     text: string,
     opts?: { replyTo?: string },
   ): Promise<void> {
-    await this.sendRpc("messages/send", {
+    const response = (await this.sendRpc("messages/send", {
       conversationId: convId,
       parts: [{ type: "text", text }],
       ...(opts?.replyTo ? { replyToId: opts.replyTo } : {}),
-    });
+    })) as { message?: { id?: string } };
+
+    const msgId = response?.message?.id;
+    if (msgId && this.ownAgentId) {
+      telemetry.emit({
+        event: "outbound.sent",
+        source: "agent",
+        schemaVersion: SCHEMA_VERSION,
+        ts: Date.now(),
+        msgId,
+        replyToMsgId: opts?.replyTo,
+        convId,
+        agentId: this.ownAgentId,
+        chars: text.length,
+      });
+    }
   }
 
   async sendToAgent(
@@ -683,6 +721,22 @@ export class MoltZapService {
           !this.agentNames.has(msg.sender.id)
         ) {
           void this.resolveAgentName(msg.sender.id);
+        }
+        if (msg.sender.id !== this.ownAgentId && this.ownAgentId) {
+          telemetry.emit({
+            event: "inbound.received",
+            source: "agent",
+            schemaVersion: SCHEMA_VERSION,
+            ts: Date.now(),
+            msgId: msg.id,
+            convId: msg.conversationId,
+            senderAgentId: msg.sender.id,
+            agentId: this.ownAgentId,
+            chars: msg.parts.reduce(
+              (n, p) => n + (p.type === "text" ? p.text.length : 0),
+              0,
+            ),
+          });
         }
         // Emit to external handlers (only non-own messages)
         if (msg.sender.id !== this.ownAgentId) {

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@moltzap/observability",
+  "version": "0.1.0",
+  "description": "Platform-wide telemetry for MoltZap: event schema, in-process emitter, pino sink, JSONL collector, metrics rollup",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chughtapan/moltzap"
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./test-utils": {
+      "types": "./dist/test-utils.d.ts",
+      "import": "./dist/test-utils.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "pino": "^9.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/observability/src/__tests__/collector.test.ts
+++ b/packages/observability/src/__tests__/collector.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { telemetry } from "../telemetry.js";
+import { TelemetryCollector } from "../collector.js";
+import { SCHEMA_VERSION, type TelemetryEvent } from "../events.js";
+
+function fakeEvent(i: number): TelemetryEvent {
+  return {
+    event: "message.sent",
+    source: "server",
+    schemaVersion: SCHEMA_VERSION,
+    ts: 1_700_000_000_000 + i,
+    msgId: `m${i}`,
+    convId: "c1",
+    senderAgentId: "a1",
+    senderKind: "agent",
+    bytes: 10,
+  };
+}
+
+describe("TelemetryCollector", () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    telemetry.reset();
+    dir = mkdtempSync(join(tmpdir(), "collector-test-"));
+    path = join(dir, "telemetry.jsonl");
+  });
+
+  afterEach(() => {
+    telemetry.reset();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes one JSON line per event in arrival order", async () => {
+    telemetry.configure({ enabled: true });
+    const c = new TelemetryCollector(path);
+    c.start();
+
+    telemetry.emit(fakeEvent(1));
+    telemetry.emit(fakeEvent(2));
+    telemetry.emit(fakeEvent(3));
+
+    await c.stop();
+
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(3);
+    expect(JSON.parse(lines[0]!).msgId).toBe("m1");
+    expect(JSON.parse(lines[1]!).msgId).toBe("m2");
+    expect(JSON.parse(lines[2]!).msgId).toBe("m3");
+  });
+
+  it("flushes and closes the file on stop()", async () => {
+    telemetry.configure({ enabled: true });
+    const c = new TelemetryCollector(path);
+    c.start();
+    telemetry.emit(fakeEvent(1));
+    await c.stop();
+
+    // After stop, further emits should NOT appear in the file.
+    telemetry.emit(fakeEvent(2));
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+  });
+
+  it("writes no partial lines (every line is complete JSON)", async () => {
+    telemetry.configure({ enabled: true });
+    const c = new TelemetryCollector(path);
+    c.start();
+
+    for (let i = 0; i < 100; i++) telemetry.emit(fakeEvent(i));
+    await c.stop();
+
+    const raw = readFileSync(path, "utf-8");
+    // Trailing newline is acceptable; no partial JSON.
+    const lines = raw.trim().split("\n");
+    expect(lines).toHaveLength(100);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it("exposes captured events only when keepInMemory is true", async () => {
+    telemetry.configure({ enabled: true });
+    const c = new TelemetryCollector(path, { keepInMemory: true });
+    c.start();
+    telemetry.emit(fakeEvent(1));
+    telemetry.emit(fakeEvent(2));
+
+    expect(c.events).toHaveLength(2);
+    expect(c.events![0]!.event).toBe("message.sent");
+    await c.stop();
+  });
+
+  it("does not retain events in memory by default", async () => {
+    telemetry.configure({ enabled: true });
+    const c = new TelemetryCollector(path);
+    c.start();
+    telemetry.emit(fakeEvent(1));
+    expect(c.events).toBeNull();
+    await c.stop();
+  });
+});

--- a/packages/observability/src/__tests__/rollup.test.ts
+++ b/packages/observability/src/__tests__/rollup.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { computeMetrics, rollupFromFile } from "../rollup.js";
+import { SCHEMA_VERSION, type TelemetryEvent } from "../events.js";
+
+function msgSent(msgId: string, ts: number, convId = "c1"): TelemetryEvent {
+  return {
+    event: "message.sent",
+    source: "server",
+    schemaVersion: SCHEMA_VERSION,
+    ts,
+    msgId,
+    convId,
+    senderAgentId: "a1",
+    senderKind: "agent",
+    bytes: 10,
+  };
+}
+
+function dispatchComplete(
+  msgId: string,
+  ts: number,
+  durationMs: number,
+): TelemetryEvent {
+  return {
+    event: "dispatch.complete",
+    source: "agent",
+    schemaVersion: SCHEMA_VERSION,
+    ts,
+    msgId,
+    convId: "c1",
+    agentId: "a1",
+    durationMs,
+    outcome: "final",
+  };
+}
+
+describe("computeMetrics", () => {
+  it("counts events by name", () => {
+    const events = [msgSent("m1", 1), msgSent("m2", 2), msgSent("m3", 3)];
+    const m = computeMetrics(events);
+    expect(m.counts["message.sent"]).toBe(3);
+  });
+
+  it("computes p50/p90/p99 of dispatch.complete.durationMs", () => {
+    const events: TelemetryEvent[] = [];
+    // Durations 1..100ms. p50=50, p90=90, p99=99.
+    for (let i = 1; i <= 100; i++) {
+      events.push(dispatchComplete(`m${i}`, 1000 + i, i));
+    }
+    const m = computeMetrics(events);
+    // Nearest-rank: p50 of 100 sorted vals → index ceil(0.5*100)-1 = 49 → value 50
+    expect(m.dispatchLatency.p50).toBe(50);
+    expect(m.dispatchLatency.p90).toBe(90);
+    expect(m.dispatchLatency.p99).toBe(99);
+  });
+
+  it("finds idle gaps > 30s between events", () => {
+    const events = [
+      msgSent("m1", 1_000_000),
+      msgSent("m2", 1_005_000), // 5s gap, not a gap
+      msgSent("m3", 1_050_000), // 45s gap - should show up
+      msgSent("m4", 1_055_000),
+    ];
+    const m = computeMetrics(events);
+    expect(m.idleGapsMs).toEqual([45_000]);
+  });
+
+  it("groups message counts by conversation", () => {
+    const events = [
+      msgSent("m1", 1, "c1"),
+      msgSent("m2", 2, "c1"),
+      msgSent("m3", 3, "c2"),
+    ];
+    const m = computeMetrics(events);
+    expect(m.messagesByConv["c1"]).toBe(2);
+    expect(m.messagesByConv["c2"]).toBe(1);
+  });
+
+  it("handles empty event stream without crashing", () => {
+    const m = computeMetrics([]);
+    expect(m.counts).toEqual({});
+    expect(m.dispatchLatency.p50).toBe(0);
+    expect(m.idleGapsMs).toEqual([]);
+  });
+});
+
+describe("rollupFromFile", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rollup-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads JSONL from disk and produces metrics.json", () => {
+    const path = join(dir, "telemetry.jsonl");
+    const events = [msgSent("m1", 1), msgSent("m2", 2)];
+    writeFileSync(path, events.map((e) => JSON.stringify(e)).join("\n") + "\n");
+
+    const m = rollupFromFile(path);
+    expect(m.counts["message.sent"]).toBe(2);
+  });
+});

--- a/packages/observability/src/__tests__/telemetry.test.ts
+++ b/packages/observability/src/__tests__/telemetry.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import pino from "pino";
+import { telemetry } from "../telemetry.js";
+import { SCHEMA_VERSION, type TelemetryEvent } from "../events.js";
+
+function sampleEvent(): TelemetryEvent {
+  return {
+    event: "message.sent",
+    source: "server",
+    schemaVersion: SCHEMA_VERSION,
+    ts: 1_700_000_000_000,
+    msgId: "m1",
+    convId: "c1",
+    senderAgentId: "a1",
+    senderKind: "agent",
+    bytes: 42,
+  };
+}
+
+describe("telemetry singleton", () => {
+  beforeEach(() => {
+    telemetry.reset();
+  });
+
+  it("is a no-op before configure()", () => {
+    // No logger, no subscribers, no throw
+    expect(() => telemetry.emit(sampleEvent())).not.toThrow();
+  });
+
+  it("fires pino logger when configured", () => {
+    const logLines: unknown[] = [];
+    const logger = pino(
+      { level: "info" },
+      {
+        write(chunk: string) {
+          logLines.push(JSON.parse(chunk));
+        },
+      },
+    );
+    telemetry.configure({ logger, enabled: true });
+
+    telemetry.emit(sampleEvent());
+
+    expect(logLines).toHaveLength(1);
+    const line = logLines[0] as { event: string; msgId: string };
+    expect(line.event).toBe("message.sent");
+    expect(line.msgId).toBe("m1");
+  });
+
+  it("fires all subscribers synchronously", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const c = vi.fn();
+    telemetry.configure({ enabled: true });
+    telemetry.subscribe(a);
+    telemetry.subscribe(b);
+    telemetry.subscribe(c);
+
+    const evt = sampleEvent();
+    telemetry.emit(evt);
+
+    expect(a).toHaveBeenCalledWith(evt);
+    expect(b).toHaveBeenCalledWith(evt);
+    expect(c).toHaveBeenCalledWith(evt);
+  });
+
+  it("subscriber throw does not propagate to caller or block peers", () => {
+    const a = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const b = vi.fn();
+    telemetry.configure({ enabled: true });
+    telemetry.subscribe(a);
+    telemetry.subscribe(b);
+
+    expect(() => telemetry.emit(sampleEvent())).not.toThrow();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("pino throw does not propagate and subscribers still fire", () => {
+    const badLogger = {
+      info: () => {
+        throw new Error("bad logger");
+      },
+    } as unknown as pino.Logger;
+    const sub = vi.fn();
+    telemetry.configure({ logger: badLogger, enabled: true });
+    telemetry.subscribe(sub);
+
+    expect(() => telemetry.emit(sampleEvent())).not.toThrow();
+    expect(sub).toHaveBeenCalledTimes(1);
+  });
+
+  it("enabled:false is a full no-op for both sinks", () => {
+    const logLines: unknown[] = [];
+    const logger = pino(
+      { level: "info" },
+      { write: (c: string) => logLines.push(c) },
+    );
+    const sub = vi.fn();
+    telemetry.configure({ logger, enabled: false });
+    telemetry.subscribe(sub);
+
+    telemetry.emit(sampleEvent());
+
+    expect(logLines).toHaveLength(0);
+    expect(sub).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribe removes the handler", () => {
+    const a = vi.fn();
+    telemetry.configure({ enabled: true });
+    const off = telemetry.subscribe(a);
+    off();
+
+    telemetry.emit(sampleEvent());
+
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  it("reset() clears subscribers and disables the logger", () => {
+    const logLines: unknown[] = [];
+    const logger = pino(
+      { level: "info" },
+      { write: (c: string) => logLines.push(c) },
+    );
+    const sub = vi.fn();
+    telemetry.configure({ logger, enabled: true });
+    telemetry.subscribe(sub);
+
+    telemetry.reset();
+    telemetry.emit(sampleEvent());
+
+    expect(sub).not.toHaveBeenCalled();
+    expect(logLines).toHaveLength(0);
+  });
+});

--- a/packages/observability/src/collector.ts
+++ b/packages/observability/src/collector.ts
@@ -1,0 +1,69 @@
+/**
+ * TelemetryCollector — subscribes to the telemetry singleton and writes each
+ * event as one JSON line to disk via a buffered append stream.
+ *
+ * Usage:
+ *   const c = new TelemetryCollector("/path/to/telemetry.jsonl");
+ *   c.start();
+ *   // ... do work that emits events ...
+ *   await c.stop();
+ *
+ * By default the collector does NOT retain events in memory, so it is safe
+ * for long-running servers emitting thousands of events. Tests that need to
+ * assert against the captured stream can opt in with `{ keepInMemory: true }`.
+ */
+
+import { createWriteStream, type WriteStream } from "node:fs";
+import { telemetry } from "./telemetry.js";
+import type { TelemetryEvent } from "./events.js";
+
+export interface TelemetryCollectorOptions {
+  keepInMemory?: boolean;
+}
+
+export class TelemetryCollector {
+  private readonly _events: TelemetryEvent[] | null;
+  private stream: WriteStream | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(
+    private readonly path: string,
+    opts: TelemetryCollectorOptions = {},
+  ) {
+    this._events = opts.keepInMemory ? [] : null;
+  }
+
+  /**
+   * Captured events, when constructed with `{ keepInMemory: true }`.
+   * Returns `null` in production mode to avoid unbounded memory growth.
+   */
+  get events(): ReadonlyArray<TelemetryEvent> | null {
+    return this._events;
+  }
+
+  start(): void {
+    if (this.stream !== null) return;
+    this.stream = createWriteStream(this.path, { flags: "a" });
+    this.unsubscribe = telemetry.subscribe((event) => {
+      if (this._events !== null) this._events.push(event);
+      this.stream?.write(JSON.stringify(event) + "\n");
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+    if (this.stream !== null) {
+      const stream = this.stream;
+      this.stream = null;
+      await new Promise<void>((resolve, reject) => {
+        stream.end((err?: Error | null) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    }
+  }
+}

--- a/packages/observability/src/events.ts
+++ b/packages/observability/src/events.ts
@@ -1,0 +1,162 @@
+/**
+ * Telemetry event schema for MoltZap platform observability.
+ *
+ * Single discriminated union covering message lifecycle, dispatch timing,
+ * queue depth, connection state, and RPC errors. Each event carries:
+ *   - schemaVersion: additive-only field compatibility marker
+ *   - ts: milliseconds since epoch
+ *   - source: which side of the connection emitted it
+ *
+ * Rule: new fields MUST be optional until schemaVersion bumps to "2".
+ * This keeps every moltzap app consuming `@moltzap/observability` forward-compatible.
+ */
+
+export const SCHEMA_VERSION = "1" as const;
+
+interface BaseEvent {
+  schemaVersion: typeof SCHEMA_VERSION;
+  ts: number;
+}
+
+export interface AgentConnectedEvent extends BaseEvent {
+  event: "agent.connected";
+  source: "server";
+  agentId: string;
+}
+
+export interface AgentDisconnectedEvent extends BaseEvent {
+  event: "agent.disconnected";
+  source: "server";
+  agentId: string;
+}
+
+export interface ConversationCreatedEvent extends BaseEvent {
+  event: "conversation.created";
+  source: "server";
+  convId: string;
+  type: "dm" | "group";
+  participantIds: string[];
+}
+
+export interface MessageSentEvent extends BaseEvent {
+  event: "message.sent";
+  source: "server";
+  msgId: string;
+  convId: string;
+  senderAgentId: string;
+  senderKind: "agent" | "user";
+  chars: number;
+}
+
+export interface MessageReceivedEvent extends BaseEvent {
+  event: "message.received";
+  source: "server";
+  msgId: string;
+  convId: string;
+  senderAgentId: string;
+  chars: number;
+}
+
+export type RpcErrorReason =
+  | "method_not_found"
+  | "invalid_params"
+  | "forbidden_pending_claim"
+  | "forbidden_no_active_agent"
+  | "handler_rejected"
+  | "handler_error";
+
+export interface RpcErrorEvent extends BaseEvent {
+  event: "rpc.error";
+  source: "server";
+  method: string;
+  code: number;
+  message: string;
+  /**
+   * Categorizes WHY the RPC failed. Lets rollup separate expected transient
+   * conditions (e.g. pending_claim during onboarding) from real failures.
+   */
+  reason: RpcErrorReason;
+  agentId?: string;
+  connId?: string;
+}
+
+export interface InboundReceivedEvent extends BaseEvent {
+  event: "inbound.received";
+  source: "agent";
+  msgId: string;
+  convId: string;
+  senderAgentId: string;
+  agentId: string;
+  chars: number;
+}
+
+export interface DispatchStartEvent extends BaseEvent {
+  event: "dispatch.start";
+  source: "agent";
+  msgId: string;
+  convId: string;
+  agentId: string;
+  queueDepth: number;
+  inflight: number;
+}
+
+export interface DispatchCompleteEvent extends BaseEvent {
+  event: "dispatch.complete";
+  source: "agent";
+  msgId: string;
+  convId: string;
+  agentId: string;
+  durationMs: number;
+  outcome: "final" | "skipped" | "error";
+  errorReason?: string;
+}
+
+export interface OutboundSentEvent extends BaseEvent {
+  event: "outbound.sent";
+  source: "agent";
+  msgId: string;
+  replyToMsgId?: string;
+  convId: string;
+  agentId: string;
+  chars: number;
+}
+
+export interface QueueStatsEvent extends BaseEvent {
+  event: "queue.stats";
+  source: "agent";
+  agentId: string;
+  depth: number;
+  inflight: number;
+  oldestQueuedAgeMs?: number;
+}
+
+export interface ConnectionDisconnectEvent extends BaseEvent {
+  event: "connection.disconnect";
+  source: "agent";
+  agentId: string;
+  reason?: string;
+}
+
+export interface ConnectionReconnectEvent extends BaseEvent {
+  event: "connection.reconnect";
+  source: "agent";
+  agentId: string;
+  attemptN: number;
+}
+
+export type TelemetryEvent =
+  | AgentConnectedEvent
+  | AgentDisconnectedEvent
+  | ConversationCreatedEvent
+  | MessageSentEvent
+  | MessageReceivedEvent
+  | RpcErrorEvent
+  | InboundReceivedEvent
+  | DispatchStartEvent
+  | DispatchCompleteEvent
+  | OutboundSentEvent
+  | QueueStatsEvent
+  | ConnectionDisconnectEvent
+  | ConnectionReconnectEvent;
+
+export type TelemetryHandler = (event: TelemetryEvent) => void;

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @moltzap/observability
+ *
+ * Platform-wide telemetry for MoltZap. See README for event catalog and
+ * integration patterns.
+ */
+
+export { telemetry } from "./telemetry.js";
+export { TelemetryCollector } from "./collector.js";
+export { computeMetrics, rollupFromFile, type Metrics } from "./rollup.js";
+export {
+  SCHEMA_VERSION,
+  type TelemetryEvent,
+  type TelemetryHandler,
+  type AgentConnectedEvent,
+  type AgentDisconnectedEvent,
+  type ConversationCreatedEvent,
+  type MessageSentEvent,
+  type MessageReceivedEvent,
+  type RpcErrorEvent,
+  type RpcErrorReason,
+  type InboundReceivedEvent,
+  type DispatchStartEvent,
+  type DispatchCompleteEvent,
+  type OutboundSentEvent,
+  type QueueStatsEvent,
+  type ConnectionDisconnectEvent,
+  type ConnectionReconnectEvent,
+} from "./events.js";

--- a/packages/observability/src/rollup.ts
+++ b/packages/observability/src/rollup.ts
@@ -1,0 +1,88 @@
+/**
+ * Telemetry rollup — reads a telemetry.jsonl file and produces a metrics
+ * summary (counts, latency percentiles, rates, idle gaps).
+ *
+ * Intended to run after a game/session completes. Rollup is a pure function
+ * over events so it's trivial to test with fixtures.
+ */
+
+import { readFileSync } from "node:fs";
+import type { TelemetryEvent } from "./events.js";
+
+export interface Metrics {
+  counts: Record<string, number>;
+  messagesByConv: Record<string, number>;
+  dispatchLatency: {
+    p50: number;
+    p90: number;
+    p99: number;
+    max: number;
+    count: number;
+  };
+  idleGapsMs: number[];
+  eventSpanMs: number;
+}
+
+/** Nearest-rank percentile on a pre-sorted ascending array. Returns 0 if empty. */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.max(0, Math.ceil(p * sorted.length) - 1);
+  return sorted[idx]!;
+}
+
+const IDLE_GAP_THRESHOLD_MS = 30_000;
+
+export function computeMetrics(events: TelemetryEvent[]): Metrics {
+  const counts: Record<string, number> = {};
+  const messagesByConv: Record<string, number> = {};
+  const dispatchDurations: number[] = [];
+  const idleGapsMs: number[] = [];
+
+  let prevTs: number | null = null;
+  let firstTs: number | null = null;
+  let lastTs: number | null = null;
+
+  for (const evt of events) {
+    counts[evt.event] = (counts[evt.event] ?? 0) + 1;
+
+    if (firstTs === null) firstTs = evt.ts;
+    lastTs = evt.ts;
+
+    if (prevTs !== null) {
+      const delta = evt.ts - prevTs;
+      if (delta > IDLE_GAP_THRESHOLD_MS) idleGapsMs.push(delta);
+    }
+    prevTs = evt.ts;
+
+    if (evt.event === "message.sent" || evt.event === "message.received") {
+      messagesByConv[evt.convId] = (messagesByConv[evt.convId] ?? 0) + 1;
+    }
+
+    if (evt.event === "dispatch.complete") {
+      dispatchDurations.push(evt.durationMs);
+    }
+  }
+
+  const sorted = [...dispatchDurations].sort((a, b) => a - b);
+
+  return {
+    counts,
+    messagesByConv,
+    dispatchLatency: {
+      p50: percentile(sorted, 0.5),
+      p90: percentile(sorted, 0.9),
+      p99: percentile(sorted, 0.99),
+      max: sorted.length > 0 ? sorted[sorted.length - 1]! : 0,
+      count: sorted.length,
+    },
+    idleGapsMs,
+    eventSpanMs: firstTs !== null && lastTs !== null ? lastTs - firstTs : 0,
+  };
+}
+
+export function rollupFromFile(path: string): Metrics {
+  const raw = readFileSync(path, "utf-8");
+  const lines = raw.split("\n").filter((l) => l.length > 0);
+  const events: TelemetryEvent[] = lines.map((l) => JSON.parse(l));
+  return computeMetrics(events);
+}

--- a/packages/observability/src/telemetry.ts
+++ b/packages/observability/src/telemetry.ts
@@ -1,0 +1,92 @@
+/**
+ * Module-level telemetry singleton.
+ *
+ * Every instrumentation site across server-core, client, channel plugins, and
+ * consumer apps calls telemetry.emit(event). The helper fans out to two sinks:
+ *   1. pino (if configured) - structured JSON log line
+ *   2. subscribers (if any) - synchronous in-process callbacks
+ *
+ * Design notes:
+ *   - Both sinks are wrapped in try/catch. Observability failures must NEVER
+ *     crash the caller.
+ *   - enabled:false is a full no-op (intended for MOLTZAP_TELEMETRY_ENABLED=false).
+ *   - reset() is for test isolation. Apps call configure() once at startup.
+ *   - Singleton is module-scoped. In vitest fork/thread pools, each worker
+ *     gets its own copy. Within a worker, tests must call reset() in afterEach
+ *     (see @moltzap/observability/test-utils for a shared helper).
+ */
+
+import type { Logger } from "pino";
+import type { TelemetryEvent, TelemetryHandler } from "./events.js";
+
+interface TelemetryState {
+  logger: Logger | null;
+  enabled: boolean;
+  subscribers: Set<TelemetryHandler>;
+}
+
+const state: TelemetryState = {
+  logger: null,
+  enabled: false,
+  subscribers: new Set(),
+};
+
+function safeInvokeLogger(event: TelemetryEvent): void {
+  if (!state.logger) return;
+  try {
+    state.logger.info(event, event.event);
+  } catch {
+    // Observability must never crash the caller. Swallow.
+  }
+}
+
+function safeInvokeSubscribers(event: TelemetryEvent): void {
+  for (const handler of state.subscribers) {
+    try {
+      handler(event);
+    } catch (err) {
+      // One subscriber's exception must not block peers. Log to pino if
+      // available so the failure is still observable, then continue.
+      if (state.logger) {
+        try {
+          state.logger.warn(
+            { handlerErr: err instanceof Error ? err.message : String(err) },
+            "telemetry subscriber threw",
+          );
+        } catch {
+          // Logger itself is broken. Nothing we can do.
+        }
+      }
+    }
+  }
+}
+
+export const telemetry = {
+  /** Configure the singleton. Typically called once at app startup. */
+  configure(opts: { logger?: Logger; enabled?: boolean }): void {
+    if (opts.logger !== undefined) state.logger = opts.logger;
+    if (opts.enabled !== undefined) state.enabled = opts.enabled;
+  },
+
+  /** Emit a telemetry event. Fires pino + subscribers. No-op if disabled. */
+  emit(event: TelemetryEvent): void {
+    if (!state.enabled) return;
+    safeInvokeLogger(event);
+    safeInvokeSubscribers(event);
+  },
+
+  /** Subscribe to every telemetry event. Returns an unsubscribe function. */
+  subscribe(handler: TelemetryHandler): () => void {
+    state.subscribers.add(handler);
+    return () => {
+      state.subscribers.delete(handler);
+    };
+  },
+
+  /** Reset all singleton state. Tests call this in afterEach. */
+  reset(): void {
+    state.logger = null;
+    state.enabled = false;
+    state.subscribers.clear();
+  },
+};

--- a/packages/observability/src/test-utils.ts
+++ b/packages/observability/src/test-utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared test helpers for moltzap packages that use the telemetry singleton.
+ *
+ * Every test package should import `resetTelemetry` and call it in afterEach
+ * to prevent cross-test contamination. The singleton's mutable state (logger,
+ * enabled, subscribers) leaks across tests within the same vitest worker
+ * otherwise.
+ *
+ * Usage (in a test file or setup file):
+ *   import { afterEach } from "vitest";
+ *   import { resetTelemetry } from "@moltzap/observability/test-utils";
+ *   afterEach(resetTelemetry);
+ */
+
+import { telemetry } from "./telemetry.js";
+
+export function resetTelemetry(): void {
+  telemetry.reset();
+}
+
+/**
+ * Subscribe to telemetry for the duration of one test. Returns the captured
+ * events array and an unsubscribe function (auto-called by resetTelemetry but
+ * available for explicit teardown).
+ */
+export function captureTelemetry(): {
+  events: import("./events.js").TelemetryEvent[];
+  stop: () => void;
+} {
+  const events: import("./events.js").TelemetryEvent[] = [];
+  const stop = telemetry.subscribe((e) => events.push(e));
+  telemetry.configure({ enabled: true });
+  return { events, stop };
+}

--- a/packages/observability/tsconfig.json
+++ b/packages/observability/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/packages/observability/vitest.config.ts
+++ b/packages/observability/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/openclaw-channel/package.json
+++ b/packages/openclaw-channel/package.json
@@ -33,6 +33,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@moltzap/observability": "workspace:*",
     "@testcontainers/postgresql": "^10.18.0",
     "@types/pg": "^8.11.0",
     "@types/ws": "^8.5.0",

--- a/packages/openclaw-channel/src/openclaw-entry.inbound-contract.test.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.inbound-contract.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Message } from "@moltzap/protocol";
 import type { CrossConversationEntry, CrossConvMessage } from "@moltzap/client";
+import type { DispatchCompleteEvent } from "@moltzap/observability";
+import {
+  captureTelemetry,
+  resetTelemetry,
+} from "@moltzap/observability/test-utils";
 
 // Capture handlers registered via service.on()
 let capturedOnMessage: ((msg: Message) => void) | null = null;
@@ -426,5 +431,48 @@ describe("Flow 5: Inbound contract — dispatchReplyWithBufferedBlockDispatcher"
     ).ctx;
     expect(ctx.Body).toBe("Plain message");
     expect(ctx.BodyForAgent).toBe("Plain message");
+  });
+
+  describe("dispatch outcome propagates to telemetry", () => {
+    let events: ReturnType<typeof captureTelemetry>["events"];
+
+    beforeEach(() => {
+      ({ events } = captureTelemetry());
+    });
+    afterEach(resetTelemetry);
+
+    it.each([
+      {
+        name: "outcome=final when queuedFinal is true",
+        mock: () => mockDispatch.mockResolvedValueOnce({ queuedFinal: true }),
+        expectedOutcome: "final" as const,
+      },
+      {
+        name: "outcome=skipped when queuedFinal is false",
+        mock: () => mockDispatch.mockResolvedValueOnce({ queuedFinal: false }),
+        expectedOutcome: "skipped" as const,
+      },
+      {
+        name: "outcome=error when dispatch throws",
+        mock: () =>
+          mockDispatch.mockRejectedValueOnce(new Error("dispatch-blew-up")),
+        expectedOutcome: "error" as const,
+        expectedErrorReason: "dispatch-blew-up",
+      },
+    ])("$name", async ({ mock, expectedOutcome, expectedErrorReason }) => {
+      mock();
+      capturedOnMessage!(makeMessage());
+      await vi.waitFor(() => {
+        const completes = events.filter((e) => e.event === "dispatch.complete");
+        expect(completes.length).toBeGreaterThanOrEqual(1);
+      });
+      const complete = events.find(
+        (e) => e.event === "dispatch.complete",
+      ) as DispatchCompleteEvent;
+      expect(complete.outcome).toBe(expectedOutcome);
+      if (expectedErrorReason !== undefined) {
+        expect(complete.errorReason).toBe(expectedErrorReason);
+      }
+    });
   });
 });

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -307,7 +307,7 @@ export const moltzapChannelPlugin = {
         if (
           !ctx.channelRuntime?.reply?.dispatchReplyWithBufferedBlockDispatcher
         ) {
-          return;
+          return { outcome: "skipped" };
         }
 
         const groupSubject = enriched.conversationMeta?.name;
@@ -316,60 +316,58 @@ export const moltzapChannelPlugin = {
             ? enriched.conversationMeta.participants.join(",")
             : undefined;
 
-        try {
-          const result =
-            await ctx.channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher(
-              {
-                ctx: {
-                  Body: enriched.text,
-                  BodyForAgent: bodyForAgent,
-                  From: fromId,
-                  To: account.agentName ?? accountId,
-                  SessionKey: `agent:main:moltzap:${chatType === "group" ? "group" : "dm"}:${enriched.conversationId}`,
-                  AccountId: accountId,
-                  Provider: CHANNEL_ID,
-                  Surface: CHANNEL_ID,
-                  OriginatingChannel: CHANNEL_ID,
-                  OriginatingTo: enriched.conversationId,
-                  ChatType: chatType,
-                  ...(groupSubject ? { GroupSubject: groupSubject } : {}),
-                  ...(groupMembers ? { GroupMembers: groupMembers } : {}),
-                  ...(enriched.conversationMeta?.name
-                    ? { ConversationLabel: enriched.conversationMeta.name }
-                    : {}),
-                  SenderName: enriched.sender.name,
-                },
-                cfg: ctx.cfg,
-                dispatcherOptions: {
-                  deliver: async (
-                    payload: { text?: string; body?: string },
-                    info?: { kind?: string },
-                  ) => {
-                    if (info?.kind !== "final") return true;
-                    const text = payload.text ?? payload.body;
-                    if (!text) return true;
-                    try {
-                      await core.sendReply(enriched.conversationId, text);
-                      log?.info?.(
-                        `MoltZap: outbound reply to ${enriched.conversationId}: ${text.slice(0, 80)}`,
-                      );
-                      return true;
-                    } catch (sendErr) {
-                      log?.error?.(`MoltZap: failed to send reply: ${sendErr}`);
-                      return false;
-                    }
-                  },
+        const result =
+          await ctx.channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher(
+            {
+              ctx: {
+                Body: enriched.text,
+                BodyForAgent: bodyForAgent,
+                From: fromId,
+                To: account.agentName ?? accountId,
+                SessionKey: `agent:main:moltzap:${chatType === "group" ? "group" : "dm"}:${enriched.conversationId}`,
+                AccountId: accountId,
+                Provider: CHANNEL_ID,
+                Surface: CHANNEL_ID,
+                OriginatingChannel: CHANNEL_ID,
+                OriginatingTo: enriched.conversationId,
+                ChatType: chatType,
+                ...(groupSubject ? { GroupSubject: groupSubject } : {}),
+                ...(groupMembers ? { GroupMembers: groupMembers } : {}),
+                ...(enriched.conversationMeta?.name
+                  ? { ConversationLabel: enriched.conversationMeta.name }
+                  : {}),
+                SenderName: enriched.sender.name,
+              },
+              cfg: ctx.cfg,
+              dispatcherOptions: {
+                deliver: async (
+                  payload: { text?: string; body?: string },
+                  info?: { kind?: string },
+                ) => {
+                  if (info?.kind !== "final") return true;
+                  const text = payload.text ?? payload.body;
+                  if (!text) return true;
+                  try {
+                    await core.sendReply(enriched.conversationId, text);
+                    log?.info?.(
+                      `MoltZap: outbound reply to ${enriched.conversationId}: ${text.slice(0, 80)}`,
+                    );
+                    return true;
+                  } catch (sendErr) {
+                    log?.error?.(`MoltZap: failed to send reply: ${sendErr}`);
+                    return false;
+                  }
                 },
               },
-            );
-          if (!result.queuedFinal) {
-            log?.debug?.(
-              `MoltZap: dispatch completed without final reply for ${enriched.conversationId}`,
-            );
-          }
-        } catch (err: unknown) {
-          log?.error?.(`MoltZap: dispatch error: ${err}`);
+            },
+          );
+        if (!result.queuedFinal) {
+          log?.debug?.(
+            `MoltZap: dispatch completed without final reply for ${enriched.conversationId}`,
+          );
+          return { outcome: "skipped" };
         }
+        return { outcome: "final" };
       });
 
       // Forward non-message events for status/logging

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@hono/node-server": "^1.13.7",
     "@hono/node-ws": "^1.0.5",
+    "@moltzap/observability": "workspace:*",
     "@moltzap/protocol": "workspace:*",
     "hono": "^4.6.0",
     "kysely": "^0.27.0",

--- a/packages/server-core/src/rpc/context.ts
+++ b/packages/server-core/src/rpc/context.ts
@@ -1,4 +1,4 @@
-export type AuthenticatedContext =
+export type AuthenticatedContext = (
   | {
       kind: "user";
       userId: string;
@@ -9,7 +9,11 @@ export type AuthenticatedContext =
       agentId: string;
       agentStatus: string;
       ownerUserId: string | null;
-    };
+    }
+) & {
+  /** WS connection ID, populated by apps that track per-connection state. */
+  connectionId?: string;
+};
 
 export type RpcHandler = (
   params: unknown,

--- a/packages/server-core/src/rpc/router.test.ts
+++ b/packages/server-core/src/rpc/router.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, afterEach } from "vitest";
 import { createRpcRouter, RpcError } from "./router.js";
 import { ErrorCodes, type RequestFrame } from "@moltzap/protocol";
 import type { AuthenticatedContext } from "./context.js";
+import {
+  captureTelemetry,
+  resetTelemetry,
+} from "@moltzap/observability/test-utils";
 
 const activeAgent: AuthenticatedContext = {
   kind: "agent",
@@ -85,5 +89,60 @@ describe("createRpcRouter", () => {
       activeAgent,
     );
     expect(res.result).toEqual({ name: "alice" });
+  });
+
+  describe("telemetry emits", () => {
+    afterEach(resetTelemetry);
+
+    it("emits rpc.error for unknown method with reason=method_not_found", async () => {
+      const { events } = captureTelemetry();
+      await dispatch(frame("test/nonexistent"), activeAgent);
+      const rpcErrors = events.filter((e) => e.event === "rpc.error");
+      expect(rpcErrors).toHaveLength(1);
+      const err = rpcErrors[0]!;
+      if (err.event !== "rpc.error") return;
+      expect(err.code).toBe(ErrorCodes.MethodNotFound);
+      expect(err.method).toBe("test/nonexistent");
+      expect(err.agentId).toBe("agent-1");
+      expect(err.reason).toBe("method_not_found");
+    });
+
+    it("emits rpc.error for InvalidParams with reason=invalid_params", async () => {
+      const { events } = captureTelemetry();
+      await dispatch(frame("test/validated", {}), activeAgent);
+      const rpcErrors = events.filter((e) => e.event === "rpc.error");
+      expect(rpcErrors).toHaveLength(1);
+      if (rpcErrors[0]!.event !== "rpc.error") return;
+      expect(rpcErrors[0]!.code).toBe(ErrorCodes.InvalidParams);
+      expect(rpcErrors[0]!.reason).toBe("invalid_params");
+    });
+
+    it("emits rpc.error when handler throws RpcError with reason=handler_rejected", async () => {
+      const { events } = captureTelemetry();
+      await dispatch(frame("test/throw"), activeAgent);
+      const rpcErrors = events.filter((e) => e.event === "rpc.error");
+      expect(rpcErrors).toHaveLength(1);
+      if (rpcErrors[0]!.event !== "rpc.error") return;
+      expect(rpcErrors[0]!.code).toBe(ErrorCodes.NotFound);
+      expect(rpcErrors[0]!.message).toBe("Not found");
+      expect(rpcErrors[0]!.reason).toBe("handler_rejected");
+    });
+
+    it("emits rpc.error for Forbidden on pending agent with reason=forbidden_pending_claim", async () => {
+      const { events } = captureTelemetry();
+      await dispatch(frame("test/active-only"), pendingAgent);
+      const rpcErrors = events.filter((e) => e.event === "rpc.error");
+      expect(rpcErrors).toHaveLength(1);
+      if (rpcErrors[0]!.event !== "rpc.error") return;
+      expect(rpcErrors[0]!.code).toBe(ErrorCodes.Forbidden);
+      expect(rpcErrors[0]!.reason).toBe("forbidden_pending_claim");
+    });
+
+    it("does NOT emit rpc.error on successful dispatch", async () => {
+      const { events } = captureTelemetry();
+      await dispatch(frame("test/echo", { ok: 1 }), activeAgent);
+      const rpcErrors = events.filter((e) => e.event === "rpc.error");
+      expect(rpcErrors).toHaveLength(0);
+    });
   });
 });

--- a/packages/server-core/src/rpc/router.ts
+++ b/packages/server-core/src/rpc/router.ts
@@ -2,6 +2,33 @@ import type { RequestFrame, ResponseFrame } from "@moltzap/protocol";
 import { ErrorCodes } from "@moltzap/protocol";
 import type { AuthenticatedContext, RpcMethodRegistry } from "./context.js";
 import { logger } from "../logger.js";
+import {
+  telemetry,
+  SCHEMA_VERSION,
+  type RpcErrorReason,
+} from "@moltzap/observability";
+
+function emitRpcError(opts: {
+  method: string;
+  code: number;
+  message: string;
+  reason: RpcErrorReason;
+  ctx: AuthenticatedContext;
+}): void {
+  const { method, code, message, reason, ctx } = opts;
+  telemetry.emit({
+    event: "rpc.error",
+    source: "server",
+    schemaVersion: SCHEMA_VERSION,
+    ts: Date.now(),
+    method,
+    code,
+    message,
+    reason,
+    agentId: ctx.kind === "agent" ? ctx.agentId : undefined,
+    connId: ctx.connectionId,
+  });
+}
 
 export function createRpcRouter(methods: RpcMethodRegistry) {
   return async function dispatch(
@@ -15,6 +42,13 @@ export function createRpcRouter(methods: RpcMethodRegistry) {
     const method = methods[methodName];
     if (!method) {
       logger.warn({ requestId, method: methodName }, "Unknown RPC method");
+      emitRpcError({
+        method: methodName,
+        code: ErrorCodes.MethodNotFound,
+        message: `Unknown method: ${methodName}`,
+        reason: "method_not_found",
+        ctx,
+      });
       return errorResponse(
         requestId,
         ErrorCodes.MethodNotFound,
@@ -24,6 +58,13 @@ export function createRpcRouter(methods: RpcMethodRegistry) {
 
     const params = frame.params ?? {};
     if (method.validator && !method.validator(params)) {
+      emitRpcError({
+        method: methodName,
+        code: ErrorCodes.InvalidParams,
+        message: "Invalid parameters",
+        reason: "invalid_params",
+        ctx,
+      });
       return errorResponse(
         requestId,
         ErrorCodes.InvalidParams,
@@ -33,18 +74,26 @@ export function createRpcRouter(methods: RpcMethodRegistry) {
 
     if (method.requiresActive) {
       if (ctx.kind === "agent" && ctx.agentStatus !== "active") {
-        return errorResponse(
-          requestId,
-          ErrorCodes.Forbidden,
-          "Agent must be claimed before performing this action",
-        );
+        const msg = "Agent must be claimed before performing this action";
+        emitRpcError({
+          method: methodName,
+          code: ErrorCodes.Forbidden,
+          message: msg,
+          reason: "forbidden_pending_claim",
+          ctx,
+        });
+        return errorResponse(requestId, ErrorCodes.Forbidden, msg);
       }
       if (ctx.kind === "user" && !ctx.activeAgentId) {
-        return errorResponse(
-          requestId,
-          ErrorCodes.Forbidden,
-          "No active agent. Claim an agent first.",
-        );
+        const msg = "No active agent. Claim an agent first.";
+        emitRpcError({
+          method: methodName,
+          code: ErrorCodes.Forbidden,
+          message: msg,
+          reason: "forbidden_no_active_agent",
+          ctx,
+        });
+        return errorResponse(requestId, ErrorCodes.Forbidden, msg);
       }
     }
 
@@ -63,12 +112,26 @@ export function createRpcRouter(methods: RpcMethodRegistry) {
           { requestId, method: methodName, errorCode: err.code, durationMs },
           err.message,
         );
+        emitRpcError({
+          method: methodName,
+          code: err.code,
+          message: err.message,
+          reason: "handler_rejected",
+          ctx,
+        });
         return errorResponse(requestId, err.code, err.message);
       }
       logger.error(
         { requestId, method: methodName, err, durationMs },
         "RPC handler error",
       );
+      emitRpcError({
+        method: methodName,
+        code: -32603,
+        message: "Internal error",
+        reason: "handler_error",
+        ctx,
+      });
       return errorResponse(requestId, -32603, "Internal error");
     }
   };

--- a/packages/server-core/src/services/conversation.service.ts
+++ b/packages/server-core/src/services/conversation.service.ts
@@ -15,6 +15,7 @@ import { RpcError } from "../rpc/router.js";
 import { ErrorCodes } from "@moltzap/protocol";
 import { ParticipantService } from "./participant.service.js";
 import { sql } from "kysely";
+import { telemetry, SCHEMA_VERSION } from "@moltzap/observability";
 
 const MAX_GROUP_PARTICIPANTS = 256;
 
@@ -136,6 +137,19 @@ export class ConversationService {
         { conversationId, type, participantCount: participantRefs.length + 1 },
         "Conversation created",
       );
+
+      telemetry.emit({
+        event: "conversation.created",
+        source: "server",
+        schemaVersion: SCHEMA_VERSION,
+        ts: Date.now(),
+        convId: conversationId,
+        type,
+        participantIds: [
+          `${creatorRef.type}:${creatorRef.id}`,
+          ...participantRefs.map((r) => `${r.type}:${r.id}`),
+        ],
+      });
 
       return this.mapConversation(conv);
     });

--- a/packages/server-core/src/services/message.service.ts
+++ b/packages/server-core/src/services/message.service.ts
@@ -2,6 +2,7 @@ import type { Db } from "../db/client.js";
 import type { Logger } from "../logger.js";
 import type { Message, ParticipantRef, Part } from "@moltzap/protocol";
 import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
+import { telemetry, SCHEMA_VERSION } from "@moltzap/observability";
 import { RpcError } from "../rpc/router.js";
 import { nextSnowflakeId } from "../db/snowflake.js";
 import type { ConversationService } from "./conversation.service.js";
@@ -112,6 +113,21 @@ export class MessageService {
       { conversationId, messageId: message.id, seq: message.seq },
       "Message sent",
     );
+
+    telemetry.emit({
+      event: "message.sent",
+      source: "server",
+      schemaVersion: SCHEMA_VERSION,
+      ts: Date.now(),
+      msgId: message.id,
+      convId: conversationId,
+      senderAgentId: senderRef.id,
+      senderKind: senderRef.type === "agent" ? "agent" : "user",
+      chars: parts.reduce(
+        (n, p) => n + (p.type === "text" ? p.text.length : 0),
+        0,
+      ),
+    });
 
     return message;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
         specifier: ^8.18.0
         version: 8.20.0
     devDependencies:
+      '@moltzap/observability':
+        specifier: workspace:*
+        version: link:../observability
       '@testcontainers/postgresql':
         specifier: ^10.18.0
         version: 10.28.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   packages/client:
     dependencies:
+      '@moltzap/observability':
+        specifier: workspace:*
+        version: link:../observability
       '@moltzap/protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -143,6 +146,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/observability:
+    dependencies:
+      pino:
+        specifier: ^9.6.0
+        version: 9.14.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/openclaw-channel:
     dependencies:
       '@moltzap/client':
@@ -222,6 +241,9 @@ importers:
       '@hono/node-ws':
         specifier: ^1.0.5
         version: 1.3.0(@hono/node-server@1.19.12(hono@4.12.9))(hono@4.12.9)
+      '@moltzap/observability':
+        specifier: workspace:*
+        version: link:../observability
       '@moltzap/protocol':
         specifier: workspace:*
         version: link:../protocol


### PR DESCRIPTION
## Summary

Platform-wide observability layer for MoltZap, so every app built on moltzap (not just the arena evals harness) can answer:
- **What messages are flowing**, at what rate, between whom?
- **How long** is each agent actually taking to process an inbound before replying?
- **What is an agent's current queue depth** and inflight work?
- **Which RPCs are failing**, and why (real error vs. expected transient)?
- **When did connections drop/reconnect**, and how many attempts did it take?
- **Is an agent producing a final reply, skipping silently, or erroring?** (new in the openclaw plugin commits)

This is the foundation. Arena-side wiring and game-specific signals (command-parse near-miss detection, phase reminder cycles, LLM-metric extraction) land in follow-up PRs detailed below.

**Trigger:** arena's e2e evals with gpt-5.4 on 2w+5v / 3w+7v Werewolf scenarios hang silently because agents stop voting mid-game. The replay trace shows *what was said* but not *what was processed*, *when*, *how long it took*, or *why commands weren't extracted*. Diagnosing this without platform observability means reading 1000-line OpenClaw stdout dumps per agent, guessing. This PR makes the infrastructure layer observable so diagnosis is a matter of reading `metrics.json`.

## Why it's shaped this way

- **Reusable across apps, not arena-specific.** The submodule hosts the platform; arena is one consumer. Roast Battle, management agents, or any future app built on moltzap gets the same signals for free.
- **Single call site, two sinks.** Every instrumentation site calls one helper (`telemetry.emit`) which fans to pino (structured log lines, zero-config for any app tailing logs) AND in-process subscribers (typed callbacks for eval harnesses aggregating in real time). No drift between the two streams.
- **No service-constructor intrusion.** The helper is a module-level singleton (same pattern as pino itself). Zero breaking changes to existing service signatures.
- **Fail-safe.** Every emit + subscriber call is wrapped in try/catch. Observability failures never crash the caller. Off-switch via `MOLTZAP_TELEMETRY_ENABLED=false` env var.
- **`schemaVersion` on every event** + additive-only compatibility rule. Downstream consumers pinning old versions don't silently drift.

## What's in this PR (6 commits)

### 1. `feat(observability): scaffold @moltzap/observability package` (8d08689)

New workspace package containing:
- `events.ts` — discriminated-union schema for 13 event types, each with `schemaVersion` and `ts`. Includes structured `rpc.error.reason` field (method_not_found, invalid_params, forbidden_pending_claim, forbidden_no_active_agent, handler_rejected, handler_error) so rollups can separate real failures from transient onboarding conditions.
- `telemetry.ts` — the singleton. `configure({ logger, enabled })`, `emit(event)`, `subscribe(handler)`, `reset()`. Both sinks wrapped in try/catch.
- `collector.ts` — `TelemetryCollector` that subscribes to the singleton and writes one JSONL line per event to disk via `fs.createWriteStream`. `keepInMemory: true` opt-in for tests; default `false` for prod so long-running servers don't accumulate events forever.
- `rollup.ts` — `computeMetrics(events)` returns counts by event type, messages-per-conversation, `dispatch.complete` p50/p90/p99/max latency, idle gaps over 30s.
- `test-utils.ts` — exports `resetTelemetry` (for `afterEach`) and `captureTelemetry()` (subscribe + configure in one call). Every downstream test uses these.

**19 unit tests:** emit fires pino + subscribers, subscriber-throw doesn't propagate, bad-logger throw doesn't propagate, `enabled: false` is a full no-op, `reset()` clears state, collector JSONL output, `keepInMemory` gates in-memory retention, rollup percentile math, idle-gap detection, empty event stream.

### 2. `feat(server-core): emit telemetry for message lifecycle and RPC errors` (60bb689)

- `message.service.ts` emits `message.sent` after broadcast (msgId + convId + sender + char count).
- `conversation.service.ts` emits `conversation.created` at end of transaction.
- `rpc/router.ts` emits `rpc.error` at every error branch with a structured `reason` field. Call signature is an options object (no positional-arg sprawl).
- `rpc/context.ts` gains optional `connectionId?: string` so apps threading WS connection IDs don't need a structural cast.

**5 new unit tests** asserting the correct telemetry fires per error branch (and that no event fires on success).

### 3. `feat(client): emit telemetry for agent dispatch, connection, and queue state` (395e7c7)

- `service.ts` emits `inbound.received`, `outbound.sent` (using the msgId from the `messages/send` RPC response, so no `sendReply` signature change needed), and `connection.disconnect` / `connection.reconnect` with attempt counter.
- `channel-core.ts` wraps `dispatchChain` externally with inflight counter + `enqueuedAt: Map<msgId, timestamp>`. Emits `dispatch.start` / `dispatch.complete` and a periodic `queue.stats` (configurable interval, `unref()`-ed, cleared on disconnect/close). Emits only on state change — idle agents emit once, then silent.

**6 new tests** including invariant test (10 sequential messages, inflight ≤ 1), **100-message chaos test with random handler delays**, and **mid-flight disconnect/reconnect chaos test**.

### 4. `ci: build @moltzap/server-core's workspace deps before integration tests` (737c367)

Test-integration job uses `pnpm --filter @moltzap/server-core... build` so the full dep graph (observability + protocol + server-core) builds in topo order. Replaces hardcoded list that would drift as new platform packages land.

### 5. `feat(client): allow InboundHandler to signal dispatch outcome` (869f9fc)

Extends InboundHandler contract: handlers can return `{ outcome: "final" | "skipped" }` to distinguish "agent produced a final reply" from "agent processed the message but chose not to respond." Returning void/undefined maps to `"final"` (backwards-compatible). Thrown errors still map to `"error"` via existing dispatch-chain try/finally.

### 6. `feat(openclaw-channel): propagate dispatch outcome from OpenClaw to telemetry` (916708e)

OpenClaw's `dispatchReplyWithBufferedBlockDispatcher` returns `{queuedFinal: boolean}`. The plugin now threads this through channel-core's new InboundHandler return value so `dispatch.complete` fires with the right outcome: `final` when agent replied, `skipped` when dispatcher was unavailable or agent produced no final block, `error` when dispatch threw. Rollups can now compute "what percentage of inbound messages result in a reply" — load-bearing for diagnosing the eval failure mode this platform is being built for.

**3 new tests** via parameterized `it.each` covering all three outcome branches.

## Out of scope (follow-up PRs)

| Step | Work | Scope |
|---|---|---|
| 6 | Fix Docker log capture in `@moltzap/evals/docker-manager.ts` — `docker cp <container>:/tmp/openclaw/. agent-logs/<name>/internal/` to pull OpenClaw's internal pino logs out. | Submodule, small (~10 LOC) |
| 7 | LLM-metrics extractor: parse OpenClaw internal pino for `prompt_tokens`, `completion_tokens`, `first_token_ms`, `total_ms`, `finish_reason`. | Submodule, new `llm-log-parser.ts` |
| 8 | Arena-side: `GameMaster.getParticipationSnapshot()` + `arena-telemetry-events.ts`. | Arena repo, separate PR |
| 9 | Arena wiring: `createApp` calls `telemetry.configure(...)`; `e2e-game-test.ts` instantiates `TelemetryCollector`; rollup produces `metrics.json`. | Arena repo, separate PR |
| 10 | Performance benchmark + final e2e run on 2w+5v failing scenario. | Arena repo, validation |

## Test Plan

- [x] `pnpm --filter @moltzap/observability test` → 19/19 pass
- [x] `pnpm --filter @moltzap/server-core test` → 26/26 pass
- [x] `pnpm --filter @moltzap/client test` → 119/119 pass
- [x] `pnpm --filter @moltzap/openclaw-channel test` → 92/92 pass
- [x] All 4 packages build clean
- [x] Pre-commit guards pass on every commit (oxfmt, typecheck, sloppy-code-guard)
- [x] CI `ci` + `test-integration` jobs passing on the branch
- [x] `/review` pass — 0 critical, findings addressed
- [x] `/simplify` pass — memory leak in collector fixed (keepInMemory opt-in), `JSON.stringify` hot-path replaced with `parts.reduce`, redundant `queueDepth` state dropped, `bytes` → `chars` rename for honesty, narration comments stripped, `emitRpcError` converted to options object, duplicated test helpers replaced with shared `captureTelemetry()`, outcome-propagation tests converted to `it.each` table
- [x] 256 tests pass across 4 packages

## How a reviewer can verify this works

**Architectural invariants:**
- No protocol changes. `@moltzap/protocol` untouched. No new wire-format events. No new RPC methods.
- No service-constructor signature changes. Any existing `new MessageService(...)` call keeps working.
- `MOLTZAP_TELEMETRY_ENABLED=false` at startup turns every emit into a no-op.

**Functional verification:**
- Check out branch, run the 4 test commands above. 256 tests pass.
- To see the chaos test reasoning: `pnpm --filter @moltzap/client exec vitest run channel-core.telemetry` — 100-message chaos test with random delays; a counter-drift bug in `dispatchChain` would fail the "counters return to zero" assertion.
- To see outcome propagation: `pnpm --filter @moltzap/openclaw-channel exec vitest run openclaw-entry.inbound-contract -t "dispatch outcome"` — 3 parameterized tests asserting outcome="final"/"skipped"/"error" based on mocked dispatch behavior.
- Subscribe to telemetry from any app code:
  ```ts
  import { telemetry } from "@moltzap/observability";
  telemetry.configure({ logger, enabled: true });
  telemetry.subscribe((event) => console.log(event));
  ```

**Risk assessment:**
- Hot-path cost: each `telemetry.emit` is one sync function call + pino line (~µs). Off-budget test is in Step 10; nothing in this diff should move the needle measurably.
- Dispatch ordering: `dispatchChain` wrap does not modify `.then()` semantics — it adds a counter increment + emit before/after the existing handler. Invariant + chaos tests cover this.
- Memory: `TelemetryCollector` defaults to no in-memory retention; `enqueuedAt` Map is cleaned in the handler's finally block; `queue.stats` timer is `unref()`-ed and cleared on disconnect/close.
- Dispatch outcome backwards-compat: handlers returning void still work. Only new channel adapters wanting to signal "skipped" need the new return shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)