### PR TITLE
feat: add shared trace judgment bundle helper

### DIFF
--- a/packages/evals/src/e2e-infra/__tests__/judgment-bundle.test.ts
+++ b/packages/evals/src/e2e-infra/__tests__/judgment-bundle.test.ts
@@ -209,7 +209,9 @@ describe("buildJudgmentBundle", () => {
       "message",
       "message",
     ]);
-    expect(bundle.requirements.judgeRubric).toBe("Verify content preservation only.");
+    expect(bundle.requirements.judgeRubric).toBe(
+      "Verify content preservation only.",
+    );
     expect(bundle.agents[0]?.promptInputs).toMatchObject({
       modelName: "openclaw-eval",
       scenarioId: "ARENA-000",

--- a/packages/evals/src/e2e-infra/__tests__/judgment-bundle.test.ts
+++ b/packages/evals/src/e2e-infra/__tests__/judgment-bundle.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildJudgmentBundle,
+  buildTraceJudgmentBundle,
   writeJudgmentBundleArtifacts,
   type JudgmentBundleTraceEvent,
 } from "../judgment-bundle.js";
@@ -139,6 +140,83 @@ describe("buildJudgmentBundle", () => {
     ]);
     expect(bundle.outcomes[0]?.status).toBe("completed");
     expect(bundle.context?.transcript).toHaveLength(2);
+    expect(bundle.metadata?.modelName).toBe("openclaw-eval");
+  });
+
+  it("builds trace-driven bundles through the shared helper", () => {
+    const bundle = buildTraceJudgmentBundle({
+      project: "moltzap-arena",
+      runId: "arena-ARENA-000-1-openclaw-eval",
+      scenario: {
+        id: "ARENA-000",
+        name: "arena canary",
+        description: "Checks that arena preserves the shared-contract trace.",
+        expectedBehavior: "keep the canary prompt and response intact",
+        validationChecks: ["prompt preserved", "response preserved"],
+        judgeRubric: "Verify content preservation only.",
+      },
+      runtime: "openclaw",
+      modelName: "openclaw-eval",
+      contractMode: "shared",
+      agents: [
+        {
+          id: "agent-1",
+          name: "Agent-1",
+          role: "werewolf",
+          promptInputs: { runNumber: 1 },
+        },
+      ],
+      events: [
+        {
+          type: "message",
+          from: "TaskMaster",
+          to: "Agent-1",
+          channel: "dm",
+          text: "hello",
+          ts: 2,
+        },
+        {
+          type: "message",
+          from: "Agent-1",
+          channel: "dm",
+          text: "/kill target:Agent-2",
+          ts: 3,
+        },
+        {
+          type: "state",
+          snapshot: { phase: "night" },
+          ts: 1,
+        },
+      ],
+      outcomes: [
+        {
+          agentId: "agent-1",
+          status: "completed",
+          endedAt: "2026-04-19T00:00:03.000Z",
+        },
+      ],
+      context: {
+        conversationContext: '{"phase":"night"}',
+        validationErrors: [],
+      },
+      metadata: {
+        multiAgent: false,
+      },
+    });
+
+    expect(bundle.events.map((event) => event.type)).toEqual([
+      "state",
+      "message",
+      "message",
+    ]);
+    expect(bundle.requirements.judgeRubric).toBe("Verify content preservation only.");
+    expect(bundle.agents[0]?.promptInputs).toMatchObject({
+      modelName: "openclaw-eval",
+      scenarioId: "ARENA-000",
+      runNumber: 1,
+      runtime: "openclaw",
+    });
+    expect(bundle.metadata?.modelName).toBe("openclaw-eval");
   });
 
   it("writes JSON and YAML bundle artifacts", () => {

--- a/packages/evals/src/e2e-infra/judgment-bundle.ts
+++ b/packages/evals/src/e2e-infra/judgment-bundle.ts
@@ -60,6 +60,15 @@ export interface AgentDeclaration {
   metadata?: Readonly<Record<string, unknown>>;
 }
 
+export interface JudgmentBundleAgentInput {
+  id: string;
+  name: string;
+  role?: string;
+  artifact?: ExecutionArtifact;
+  promptInputs?: Readonly<Record<string, unknown>>;
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
 export interface RunRequirements {
   expectedBehavior: string;
   validationChecks: ReadonlyArray<string>;
@@ -92,6 +101,15 @@ export interface JudgmentBundle {
   outcomes: ReadonlyArray<AgentOutcome>;
   context?: Readonly<Record<string, unknown>>;
   metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface JudgmentBundleScenarioInput {
+  id: string;
+  name: string;
+  description: string;
+  expectedBehavior: string;
+  validationChecks: ReadonlyArray<string>;
+  judgeRubric?: string;
 }
 
 const ExecutionArtifactSchema = Type.Union([
@@ -270,6 +288,42 @@ function buildAgentDeclaration(opts: {
   };
 }
 
+function buildBundleAgentDeclaration(opts: {
+  agent: JudgmentBundleAgentInput;
+  runtime: RuntimeKind;
+  modelName: string;
+  scenarioId: string;
+}): AgentDeclaration {
+  return {
+    id: opts.agent.id,
+    name: opts.agent.name,
+    role: opts.agent.role,
+    artifact:
+      opts.agent.artifact ?? {
+        _tag: "DockerImageArtifact",
+        image: "moltzap-eval-agent:local",
+        pullPolicy: "if-missing",
+      },
+    promptInputs: {
+      modelName: opts.modelName,
+      scenarioId: opts.scenarioId,
+      runtime: opts.runtime,
+      ...opts.agent.promptInputs,
+    },
+    metadata: {
+      ...opts.agent.metadata,
+      runtime: opts.runtime,
+      modelName: opts.modelName,
+    },
+  };
+}
+
+function sortTraceEvents(
+  events: ReadonlyArray<JudgmentBundleTraceEvent>,
+): ReadonlyArray<JudgmentBundleTraceEvent> {
+  return [...events].sort((left, right) => left.ts - right.ts);
+}
+
 function outgoingMessagesFromScenario(scenario: EvalScenario): string[] {
   return [
     scenario.setupMessage,
@@ -353,6 +407,60 @@ function mapTelemetryEventToTraceEvent(
   }
 }
 
+export function buildTraceJudgmentBundle(opts: {
+  project: string;
+  runId: string;
+  scenario: JudgmentBundleScenarioInput;
+  runtime: RuntimeKind;
+  modelName: string;
+  contractMode: "legacy" | "shared";
+  agents: ReadonlyArray<JudgmentBundleAgentInput>;
+  events: ReadonlyArray<JudgmentBundleTraceEvent>;
+  outcomes: ReadonlyArray<AgentOutcome>;
+  context?: Readonly<Record<string, unknown>>;
+  metadata?: Readonly<Record<string, unknown>>;
+}): JudgmentBundle {
+  const bundle: JudgmentBundle = {
+    runId: opts.runId,
+    project: opts.project,
+    scenarioId: opts.scenario.id,
+    name: opts.scenario.name,
+    description: opts.scenario.description,
+    requirements: {
+      expectedBehavior: opts.scenario.expectedBehavior,
+      validationChecks: opts.scenario.validationChecks,
+      ...(opts.scenario.judgeRubric !== undefined
+        ? { judgeRubric: opts.scenario.judgeRubric }
+        : {}),
+    },
+    agents: opts.agents.map((agent) =>
+      buildBundleAgentDeclaration({
+        agent,
+        runtime: opts.runtime,
+        modelName: opts.modelName,
+        scenarioId: opts.scenario.id,
+      }),
+    ),
+    events: sortTraceEvents(opts.events),
+    outcomes: opts.outcomes,
+    context: {
+      modelName: opts.modelName,
+      contractMode: opts.contractMode,
+      runtime: opts.runtime,
+      ...opts.context,
+    },
+    metadata: {
+      contractMode: opts.contractMode,
+      generatedAt: new Date().toISOString(),
+      modelName: opts.modelName,
+      runtime: opts.runtime,
+      ...opts.metadata,
+    },
+  };
+
+  return Value.Parse(JudgmentBundleSchema, bundle);
+}
+
 export function buildJudgmentBundle(opts: {
   project: string;
   runId: string;
@@ -384,25 +492,30 @@ export function buildJudgmentBundle(opts: {
     return traceEvent;
   });
 
-  const bundle: JudgmentBundle = {
-    runId: opts.runId,
+  return buildTraceJudgmentBundle({
     project: opts.project,
-    scenarioId: opts.scenario.id,
-    name: opts.scenario.name,
-    description: opts.scenario.description,
-    requirements: {
+    runId: opts.runId,
+    scenario: {
+      id: opts.scenario.id,
+      name: opts.scenario.name,
+      description: opts.scenario.description,
       expectedBehavior: opts.scenario.expectedBehavior,
       validationChecks: opts.scenario.validationChecks,
     },
+    runtime: opts.runtime,
+    modelName: opts.generated.modelName,
+    contractMode: opts.contractMode,
     agents: [
-      buildAgentDeclaration({
-        agentId: opts.agentId,
-        agentName: opts.agentName,
-        runtime: opts.runtime,
-        modelName: opts.generated.modelName,
-        scenario: opts.scenario,
-        runNumber: opts.generated.runNumber,
-      }),
+      {
+        ...buildAgentDeclaration({
+          agentId: opts.agentId,
+          agentName: opts.agentName,
+          runtime: opts.runtime,
+          modelName: opts.generated.modelName,
+          scenario: opts.scenario,
+          runNumber: opts.generated.runNumber,
+        }),
+      },
     ],
     events,
     outcomes: [
@@ -416,19 +529,12 @@ export function buildJudgmentBundle(opts: {
     context: {
       conversationContext: opts.generated.conversationContext,
       transcript: opts.generated.transcript ?? [],
-      modelName: opts.generated.modelName,
-      contractMode: opts.contractMode,
-      runtime: opts.runtime,
       validationErrors: opts.validated.validationErrors,
     },
     metadata: {
-      contractMode: opts.contractMode,
-      generatedAt: new Date().toISOString(),
       runNumber: opts.generated.runNumber,
     },
-  };
-
-  return Value.Parse(JudgmentBundleSchema, bundle);
+  });
 }
 
 export function writeJudgmentBundleArtifacts(
@@ -452,6 +558,7 @@ export function deriveJudgmentRunId(opts: {
   scenarioId: string;
   runNumber: number;
   modelName: string;
+  projectPrefix?: string;
 }): string {
-  return `moltzap-${opts.scenarioId}-${opts.runNumber}-${opts.modelName.replace(/[^\w.-]+/g, "_")}`;
+  return `${opts.projectPrefix ?? "moltzap"}-${opts.scenarioId}-${opts.runNumber}-${opts.modelName.replace(/[^\w.-]+/g, "_")}`;
 }

--- a/packages/evals/src/e2e-infra/judgment-bundle.ts
+++ b/packages/evals/src/e2e-infra/judgment-bundle.ts
@@ -298,12 +298,11 @@ function buildBundleAgentDeclaration(opts: {
     id: opts.agent.id,
     name: opts.agent.name,
     role: opts.agent.role,
-    artifact:
-      opts.agent.artifact ?? {
-        _tag: "DockerImageArtifact",
-        image: "moltzap-eval-agent:local",
-        pullPolicy: "if-missing",
-      },
+    artifact: opts.agent.artifact ?? {
+      _tag: "DockerImageArtifact",
+      image: "moltzap-eval-agent:local",
+      pullPolicy: "if-missing",
+    },
     promptInputs: {
       modelName: opts.modelName,
       scenarioId: opts.scenarioId,


### PR DESCRIPTION
## Summary
- add a shared  helper for shared-contract emitters
- let callers reuse canonical run-id generation with a project prefix
- cover the new helper with judgment-bundle tests

## Linked work
- arena follow-up: https://github.com/chughtapan/moltzap-arena/pull/84
- tracker: https://github.com/chughtapan/cc-judge/issues/63
- upstream anchor: https://github.com/chughtapan/moltzap-arena/issues/83
