### PR TITLE
[arch] E — Session->Task rename + cleanup

### DIFF
--- a/packages/app-sdk/src/task.ts
+++ b/packages/app-sdk/src/task.ts
@@ -1,0 +1,37 @@
+import { ConversationKeyError } from "./errors.js";
+
+/**
+ * Thin wrapper around a raw `Task` with conversation-key helpers.
+ * Replaces `AppSessionHandle`. Public shape mirrors the previous handle
+ * one-for-one with `id`/`appId`/`status`/`conversations`; the rename is
+ * purely the class + field name (`session*` → `task*`).
+ */
+export class TaskHandle {
+  readonly id: string;
+  readonly appId: string;
+  readonly status: string;
+  /** Map of conversation key -> conversation ID. */
+  readonly conversations: Record<string, string>;
+
+  constructor(raw: {
+    id: string;
+    appId: string;
+    status: string;
+    conversations: Record<string, string>;
+  }) {
+    throw new Error("not implemented");
+  }
+
+  /**
+   * Resolve a conversation key to its ID. Fails with `ConversationKeyError`
+   * when the key is not registered on this task. (Kept throw semantics for
+   * API parity with `AppSessionHandle.conversationId`.)
+   */
+  conversationId(key: string): string {
+    throw new Error("not implemented");
+  }
+
+  get isActive(): boolean {
+    throw new Error("not implemented");
+  }
+}

--- a/packages/protocol/src/schema/methods/tasks.ts
+++ b/packages/protocol/src/schema/methods/tasks.ts
@@ -1,0 +1,80 @@
+import { Type } from "@sinclair/typebox";
+import { AgentId } from "../primitives.js";
+import { TaskId, TaskSchema, TaskStatusEnum } from "../task.js";
+import { defineRpc } from "../../rpc.js";
+
+/**
+ * `tasks/create` — replaces `apps/create`. Creates a new task for
+ * an app manifest. Result wraps the task record under `task` (was
+ * `session`).
+ */
+export const TasksCreate = defineRpc({
+  name: "tasks/create",
+  params: Type.Object(
+    {
+      appId: Type.String(),
+      invitedAgentIds: Type.Array(AgentId),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({ task: TaskSchema }, { additionalProperties: false }),
+});
+
+/**
+ * `tasks/close` — replaces `apps/closeSession`. Closes a task by id.
+ */
+export const TasksClose = defineRpc({
+  name: "tasks/close",
+  params: Type.Object({ taskId: TaskId }, { additionalProperties: false }),
+  result: Type.Object(
+    { closed: Type.Boolean() },
+    { additionalProperties: false },
+  ),
+});
+
+/**
+ * `tasks/get` — replaces `apps/getSession`. Fetches a task by id.
+ */
+export const TasksGet = defineRpc({
+  name: "tasks/get",
+  params: Type.Object({ taskId: TaskId }, { additionalProperties: false }),
+  result: Type.Object({ task: TaskSchema }, { additionalProperties: false }),
+});
+
+/**
+ * `tasks/list` — replaces `apps/listSessions`. Filters by `appId` and
+ * `status`. Result key is `tasks` (was `sessions`).
+ */
+export const TasksList = defineRpc({
+  name: "tasks/list",
+  params: Type.Object(
+    {
+      appId: Type.Optional(Type.String()),
+      status: Type.Optional(TaskStatusEnum),
+      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object(
+    { tasks: Type.Array(TaskSchema) },
+    { additionalProperties: false },
+  ),
+});
+
+/**
+ * `permissions/grant` re-shape — `sessionId` replaced by `taskId`. Keeps
+ * agent / resource / access payload unchanged.
+ */
+export const PermissionsGrant = defineRpc({
+  name: "permissions/grant",
+  params: Type.Object(
+    {
+      taskId: TaskId,
+      agentId: AgentId,
+      resource: Type.String(),
+      access: Type.Array(Type.String()),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({}, { additionalProperties: false }),
+});

--- a/packages/protocol/src/schema/task-events.ts
+++ b/packages/protocol/src/schema/task-events.ts
@@ -1,0 +1,68 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { stringEnum } from "../helpers.js";
+import { TaskId } from "./task.js";
+
+/**
+ * Emitted when a task enters the `active` status and is ready for
+ * participants to send messages. Replaces `AppSessionReadyEventSchema`.
+ * Field rename: `sessionId` → `taskId` (re-branded to `TaskId`).
+ */
+export const TaskReadyEventSchema = Type.Object(
+  {
+    taskId: TaskId,
+    conversations: Type.Record(Type.String(), Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+/**
+ * Emitted when a task terminates in the `failed` status. Replaces
+ * `AppSessionFailedEventSchema`.
+ */
+export const TaskFailedEventSchema = Type.Object(
+  {
+    taskId: TaskId,
+    reason: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+/**
+ * Emitted when a task terminates in the `closed` status. Replaces
+ * `AppSessionClosedEventSchema`.
+ */
+export const TaskClosedEventSchema = Type.Object(
+  {
+    taskId: TaskId,
+    closedBy: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+/**
+ * Emitted when a task-layer hook exceeds its configured timeout.
+ *
+ * Fixes the pre-existing schema/emit mismatch: the server emits
+ * `hookName: "on_task_active"` (renamed from `"on_session_active"` as part
+ * of this slice) — now accepted by the enum alongside the previously valid
+ * hook names. `sessionId` is renamed to `taskId`.
+ */
+export const TaskHookTimeoutEventSchema = Type.Object(
+  {
+    taskId: TaskId,
+    appId: Type.String(),
+    hookName: stringEnum([
+      "before_message_delivery",
+      "on_join",
+      "on_close",
+      "on_task_active",
+    ]),
+    timeoutMs: Type.Integer(),
+  },
+  { additionalProperties: false },
+);
+
+export type TaskReadyEvent = Static<typeof TaskReadyEventSchema>;
+export type TaskFailedEvent = Static<typeof TaskFailedEventSchema>;
+export type TaskClosedEvent = Static<typeof TaskClosedEventSchema>;
+export type TaskHookTimeoutEvent = Static<typeof TaskHookTimeoutEventSchema>;

--- a/packages/protocol/src/schema/task.ts
+++ b/packages/protocol/src/schema/task.ts
@@ -1,0 +1,43 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { stringEnum, brandedId, DateTimeString } from "../helpers.js";
+import { AgentId, ConversationId } from "./primitives.js";
+
+/**
+ * Branded task identifier. Replaces `AppSessionId` from the session-era
+ * protocol. A task is the only orchestration primitive — there is no
+ * parallel session lifecycle.
+ */
+export const TaskId = brandedId("TaskId");
+
+/**
+ * Task lifecycle states. Mirrors the prior `AppSession` status enum; the
+ * `waiting | active | failed | closed` vocabulary is preserved so the
+ * rename is purely identifier-level.
+ */
+export const TaskStatusEnum = stringEnum([
+  "waiting",
+  "active",
+  "failed",
+  "closed",
+]);
+
+/**
+ * Public task record. Replaces `AppSessionSchema`. Field shape is preserved
+ * except `id` is re-branded to `TaskId`. Implementer keeps field-for-field
+ * parity; no new fields in this slice.
+ */
+export const TaskSchema = Type.Object(
+  {
+    id: TaskId,
+    appId: Type.String(),
+    initiatorAgentId: AgentId,
+    status: TaskStatusEnum,
+    conversations: Type.Record(Type.String(), ConversationId),
+    createdAt: DateTimeString,
+    closedAt: Type.Optional(DateTimeString),
+  },
+  { additionalProperties: false },
+);
+
+export type Task = Static<typeof TaskSchema>;
+export type TaskStatus = Static<typeof TaskStatusEnum>;


### PR DESCRIPTION
Architecture only. **Not for merge.**

**Spec:** #139. **Sub-issue:** #144. **Parent epic:** #134.

## Contents

Four interface stub files:

- `packages/protocol/src/schema/task.ts` — branded `TaskId`, `TaskSchema`, `TaskStatusEnum`.
- `packages/protocol/src/schema/task-events.ts` — `TaskReadyEvent`, `TaskFailedEvent`, `TaskClosedEvent`, `TaskHookTimeoutEvent` with the `on_task_active` enum fix.
- `packages/protocol/src/schema/methods/tasks.ts` — `tasks/create`, `tasks/close`, `tasks/get`, `tasks/list`, `permissions/grant` (with `taskId`).
- `packages/app-sdk/src/task.ts` — `TaskHandle` (replaces `AppSessionHandle`).

Every body is `throw new Error("not implemented")`.

Full rename table, data flow for the two bug fixes, dependency list, and traceability are in the design doc on #144.