### PR TITLE
[arch] D — humanContact unification

### DIFF
--- a/packages/protocol/src/schema/human-contact.ts
+++ b/packages/protocol/src/schema/human-contact.ts
@@ -1,0 +1,198 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { brandedId, stringEnum } from "../helpers.js";
+import { defineRpc } from "../rpc.js";
+import { UserId } from "./primitives.js";
+
+const TaskId = brandedId("TaskId");
+const AppId = brandedId("AppId");
+
+export const HumanContactTypeSchema = stringEnum([
+  "permission_grant",
+  "notification",
+  "approval_gate",
+  "onboarding_prompt",
+]);
+
+export const PermissionGrantRequestSchema = Type.Object(
+  {
+    type: Type.Literal("permission_grant"),
+    taskId: TaskId,
+    userId: UserId,
+    appId: AppId,
+    resource: Type.String(),
+    access: Type.Array(Type.String()),
+    prompt: Type.String(),
+    timeoutMs: Type.Integer(),
+  },
+  { additionalProperties: false },
+);
+
+export const NotificationRequestSchema = Type.Object(
+  {
+    type: Type.Literal("notification"),
+    taskId: TaskId,
+    userId: UserId,
+    appId: AppId,
+    prompt: Type.String(),
+    timeoutMs: Type.Integer(),
+  },
+  { additionalProperties: false },
+);
+
+export const ApprovalGateRequestSchema = Type.Object(
+  {
+    type: Type.Literal("approval_gate"),
+    taskId: TaskId,
+    userId: UserId,
+    appId: AppId,
+    prompt: Type.String(),
+    timeoutMs: Type.Integer(),
+  },
+  { additionalProperties: false },
+);
+
+export const OnboardingPromptRequestSchema = Type.Object(
+  {
+    type: Type.Literal("onboarding_prompt"),
+    taskId: TaskId,
+    userId: UserId,
+    appId: AppId,
+    prompt: Type.String(),
+    timeoutMs: Type.Integer(),
+  },
+  { additionalProperties: false },
+);
+
+export const HumanContactRequestSchema = Type.Union([
+  PermissionGrantRequestSchema,
+  NotificationRequestSchema,
+  ApprovalGateRequestSchema,
+  OnboardingPromptRequestSchema,
+]);
+
+export const PermissionGrantResponseSchema = Type.Object(
+  {
+    type: Type.Literal("permission_grant"),
+    access: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const NotificationResponseSchema = Type.Object(
+  {
+    type: Type.Literal("notification"),
+    acknowledgedAt: Type.String({ format: "date-time" }),
+  },
+  { additionalProperties: false },
+);
+
+export const ApprovalGateResponseSchema = Type.Object(
+  {
+    type: Type.Literal("approval_gate"),
+    approved: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+
+export const OnboardingPromptResponseSchema = Type.Object(
+  {
+    type: Type.Literal("onboarding_prompt"),
+    completed: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+
+export const HumanContactResponseSchema = Type.Union([
+  PermissionGrantResponseSchema,
+  NotificationResponseSchema,
+  ApprovalGateResponseSchema,
+  OnboardingPromptResponseSchema,
+]);
+
+export const HumanContactRequiredEventSchema = Type.Object(
+  {
+    requestId: Type.String({ format: "uuid" }),
+    request: HumanContactRequestSchema,
+  },
+  { additionalProperties: false },
+);
+
+export const HumanContactResolve = defineRpc({
+  name: "humanContact/resolve",
+  params: Type.Object(
+    {
+      requestId: Type.String({ format: "uuid" }),
+      response: HumanContactResponseSchema,
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({}, { additionalProperties: false }),
+});
+
+export const HumanContactReject = defineRpc({
+  name: "humanContact/reject",
+  params: Type.Object(
+    {
+      requestId: Type.String({ format: "uuid" }),
+      reason: Type.String(),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({}, { additionalProperties: false }),
+});
+
+export const HumanContactGrantsList = defineRpc({
+  name: "humanContact/grants/list",
+  params: Type.Object(
+    { appId: Type.Optional(AppId) },
+    { additionalProperties: false },
+  ),
+  result: Type.Object(
+    {
+      grants: Type.Array(
+        Type.Object(
+          {
+            appId: AppId,
+            resource: Type.String(),
+            access: Type.Array(Type.String()),
+            grantedAt: Type.String({ format: "date-time" }),
+          },
+          { additionalProperties: false },
+        ),
+      ),
+    },
+    { additionalProperties: false },
+  ),
+});
+
+export const HumanContactGrantsRevoke = defineRpc({
+  name: "humanContact/grants/revoke",
+  params: Type.Object(
+    { appId: AppId, resource: Type.String() },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({}, { additionalProperties: false }),
+});
+
+export type HumanContactType = Static<typeof HumanContactTypeSchema>;
+export type HumanContactRequest = Static<typeof HumanContactRequestSchema>;
+export type HumanContactResponse = Static<typeof HumanContactResponseSchema>;
+export type PermissionGrantRequest = Static<
+  typeof PermissionGrantRequestSchema
+>;
+export type PermissionGrantResponse = Static<
+  typeof PermissionGrantResponseSchema
+>;
+export type NotificationRequest = Static<typeof NotificationRequestSchema>;
+export type NotificationResponse = Static<typeof NotificationResponseSchema>;
+export type ApprovalGateRequest = Static<typeof ApprovalGateRequestSchema>;
+export type ApprovalGateResponse = Static<typeof ApprovalGateResponseSchema>;
+export type OnboardingPromptRequest = Static<
+  typeof OnboardingPromptRequestSchema
+>;
+export type OnboardingPromptResponse = Static<
+  typeof OnboardingPromptResponseSchema
+>;
+export type HumanContactRequiredEvent = Static<
+  typeof HumanContactRequiredEventSchema
+>;

--- a/packages/protocol/src/schema/index.ts
+++ b/packages/protocol/src/schema/index.ts
@@ -10,6 +10,7 @@ export * from "./frames.js";
 export * from "./errors.js";
 export * from "./surfaces.js";
 export * from "./events.js";
+export * from "./human-contact.js";
 export * from "./methods/auth.js";
 export * from "./methods/contacts.js";
 export * from "./methods/conversations.js";

--- a/packages/server/src/app/human-contact/grant-store.ts
+++ b/packages/server/src/app/human-contact/grant-store.ts
@@ -1,0 +1,56 @@
+import { Context, Data, Effect, Layer } from "effect";
+
+export type UserId = string & { readonly __brand: "UserId" };
+export type AppId = string & { readonly __brand: "AppId" };
+
+export interface StoredGrant {
+  readonly userId: UserId;
+  readonly appId: AppId;
+  readonly resource: string;
+  readonly access: readonly string[];
+  readonly grantedAt: string;
+}
+
+export class GrantStorageError extends Data.TaggedError("GrantStorageError")<{
+  readonly cause: unknown;
+}> {}
+
+export interface GrantStore {
+  readonly findCoveringGrant: (params: {
+    readonly userId: UserId;
+    readonly appId: AppId;
+    readonly resource: string;
+    readonly requiredAccess: readonly string[];
+  }) => Effect.Effect<StoredGrant | null, GrantStorageError>;
+
+  readonly upsertGrant: (params: {
+    readonly userId: UserId;
+    readonly appId: AppId;
+    readonly resource: string;
+    readonly access: readonly string[];
+  }) => Effect.Effect<void, GrantStorageError>;
+
+  readonly listGrants: (params: {
+    readonly userId: UserId;
+    readonly appId?: AppId;
+  }) => Effect.Effect<readonly StoredGrant[], GrantStorageError>;
+
+  readonly revokeGrant: (params: {
+    readonly userId: UserId;
+    readonly appId: AppId;
+    readonly resource: string;
+  }) => Effect.Effect<void, GrantStorageError>;
+}
+
+export class GrantStoreTag extends Context.Tag("@moltzap/server/GrantStore")<
+  GrantStoreTag,
+  GrantStore
+>() {}
+
+export const GrantStoreLive: Layer.Layer<GrantStoreTag, never, never> =
+  Layer.effect(
+    GrantStoreTag,
+    Effect.sync(() => {
+      throw new Error("not implemented");
+    }),
+  );

--- a/packages/server/src/app/human-contact/handlers.ts
+++ b/packages/server/src/app/human-contact/handlers.ts
@@ -1,0 +1,5 @@
+import type { RpcMethodRegistry } from "../../rpc/context.js";
+
+export function createHumanContactHandlers(): RpcMethodRegistry {
+  throw new Error("not implemented");
+}

--- a/packages/server/src/app/human-contact/index.ts
+++ b/packages/server/src/app/human-contact/index.ts
@@ -1,0 +1,4 @@
+export * from "./service.js";
+export * from "./pending-registry.js";
+export * from "./grant-store.js";
+export * from "./handlers.js";

--- a/packages/server/src/app/human-contact/pending-registry.ts
+++ b/packages/server/src/app/human-contact/pending-registry.ts
@@ -1,0 +1,57 @@
+import { Context, Data, Deferred, Effect, Layer } from "effect";
+import type {
+  HumanContactRequest,
+  HumanContactResponse,
+} from "@moltzap/protocol/schemas";
+import type { HumanContactError } from "./service.js";
+
+export type RequestId = string & { readonly __brand: "HumanContactRequestId" };
+
+export class UnknownRequestId extends Data.TaggedError(
+  "HumanContactUnknownRequestId",
+)<{
+  readonly requestId: RequestId;
+}> {}
+
+export class DuplicateRequestId extends Data.TaggedError(
+  "HumanContactDuplicateRequestId",
+)<{
+  readonly requestId: RequestId;
+}> {}
+
+export interface PendingHumanContactRegistry {
+  readonly register: (
+    requestId: RequestId,
+    request: HumanContactRequest,
+  ) => Effect.Effect<
+    Deferred.Deferred<HumanContactResponse, HumanContactError>,
+    DuplicateRequestId
+  >;
+
+  readonly resolveSuccess: (
+    requestId: RequestId,
+    response: HumanContactResponse,
+  ) => Effect.Effect<void, UnknownRequestId>;
+
+  readonly resolveRejected: (
+    requestId: RequestId,
+    reason: string,
+  ) => Effect.Effect<void, UnknownRequestId>;
+
+  readonly drop: (requestId: RequestId) => Effect.Effect<void, never>;
+}
+
+export class PendingHumanContactRegistryTag extends Context.Tag(
+  "@moltzap/server/PendingHumanContactRegistry",
+)<PendingHumanContactRegistryTag, PendingHumanContactRegistry>() {}
+
+export const PendingHumanContactRegistryLive: Layer.Layer<
+  PendingHumanContactRegistryTag,
+  never,
+  never
+> = Layer.effect(
+  PendingHumanContactRegistryTag,
+  Effect.sync(() => {
+    throw new Error("not implemented");
+  }),
+);

--- a/packages/server/src/app/human-contact/service.ts
+++ b/packages/server/src/app/human-contact/service.ts
@@ -1,0 +1,49 @@
+import { Context, Data, Effect, Layer } from "effect";
+import type {
+  HumanContactRequest,
+  HumanContactResponse,
+} from "@moltzap/protocol/schemas";
+
+export class TimeoutError extends Data.TaggedError("HumanContactTimeout")<{
+  readonly requestId: string;
+  readonly timeoutMs: number;
+}> {}
+
+export class ConnectionDropped extends Data.TaggedError(
+  "HumanContactConnectionDropped",
+)<{
+  readonly requestId: string;
+}> {}
+
+export class RejectedByHuman extends Data.TaggedError(
+  "HumanContactRejectedByHuman",
+)<{
+  readonly requestId: string;
+  readonly reason: string;
+}> {}
+
+export type HumanContactError =
+  | TimeoutError
+  | ConnectionDropped
+  | RejectedByHuman;
+
+export interface HumanContactService {
+  readonly humanContact: (
+    req: HumanContactRequest,
+  ) => Effect.Effect<HumanContactResponse, HumanContactError, never>;
+}
+
+export class HumanContactServiceTag extends Context.Tag(
+  "@moltzap/server/HumanContactService",
+)<HumanContactServiceTag, HumanContactService>() {}
+
+export const HumanContactServiceLive: Layer.Layer<
+  HumanContactServiceTag,
+  never,
+  never
+> = Layer.effect(
+  HumanContactServiceTag,
+  Effect.sync(() => {
+    throw new Error("not implemented");
+  }),
+);


### PR DESCRIPTION
Architecture only. Not for merge.

Slice D of the layered network refactor (spec #138 · epic #134).

**Design doc:** see body of #143.

## What this PR contains
- 5 new modules (all bodies `throw new Error("not implemented")`)
- 1 barrel (`packages/server/src/app/human-contact/index.ts`)
- 1 existing barrel edit (`packages/protocol/src/schema/index.ts` adds one line to re-export `human-contact.ts`)

Total: 7 files added, 1 file touched.

## Module map
| File | Responsibility |
|---|---|
| `packages/protocol/src/schema/human-contact.ts` | Wire schemas + RPC defs. `HumanContactRequest`/`HumanContactResponse` discriminated unions, 4 RPCs (`humanContact/resolve`, `humanContact/reject`, `humanContact/grants/list`, `humanContact/grants/revoke`), `HumanContactRequired` event. |
| `packages/server/src/app/human-contact/service.ts` | `HumanContactService` + `Tag`/`Live`. Three `Data.TaggedError` classes: `TimeoutError`, `ConnectionDropped`, `RejectedByHuman`. |
| `packages/server/src/app/human-contact/pending-registry.ts` | In-memory `Deferred` ledger keyed by `RequestId`. |
| `packages/server/src/app/human-contact/grant-store.ts` | App-scoped grant persistence (preserves existing `app_permission_grants` shape). |
| `packages/server/src/app/human-contact/handlers.ts` | RPC handler factory stub. |

## Open questions (see design doc)
1. Notification/onboarding response payload (shipping `{ acknowledgedAt }`/`{ completed }` absent an app that needs more).
2. Timeout vs shutdown race — `ConnectionDropped` wins by default.
3. `TaskId`/`AppId` brand coordination with Slice B (locally declared until #136 lands).
4. `humanContact/cancel` RPC — omitted; interruption + `Effect.ensuring(drop)` suffices.

## Verification
- `pnpm --filter @moltzap/protocol build` — clean.
- `tsc --noEmit` on the five new files — no errors in my files (unrelated task-manager/ and db/migrations/ WIP on main are Slice B/C stubs not in this branch).

Every stub body is exactly `throw new Error("not implemented")`.

See #143 for the 8-section design doc.