### PR TITLE
[arch-F] actor-model protocol types

### DIFF
--- a/packages/protocol/src/network/__tests__/actor-model.type-test.ts
+++ b/packages/protocol/src/network/__tests__/actor-model.type-test.ts
@@ -1,0 +1,40 @@
+/**
+ * Compile-time negative canary for spec #135 Invariant 18 (flat-barrel ban).
+ *
+ * Arch-F actor-model types MUST be reachable only via `@moltzap/protocol/network`,
+ * never via the flat package entry `@moltzap/protocol`. A prior arch-F attempt
+ * added a re-export to the flat barrel; this file is the structural guard that
+ * makes that regression a compile error, not a convention.
+ *
+ * Mechanism — each import below targets the flat barrel and is marked
+ * `@ts-expect-error`. If the flat barrel starts re-exporting these names, the
+ * imports resolve, the expected error disappears, and TypeScript emits
+ * TS2578 ("Unused '@ts-expect-error' directive") — the build fails.
+ *
+ * Scope limitation — the canary asserts the three arch-F-exclusive names
+ * (`EndpointKind`, `EndpointRegistration`, `AuthenticatedIdentity`). The names
+ * `UserId` and `AgentId` already appear in the flat barrel as TypeBox schema
+ * VALUES (not brand types) via `packages/protocol/src/schema/primitives.ts`.
+ * That legacy collision is out of scope for this slice; the arch-F nominal
+ * brands live only under the subpath. Dropping the legacy TypeBox exports from
+ * the flat barrel is a downstream task (tracked separately under the spec #135
+ * Invariant 18 enforcement effort).
+ *
+ * This file is typechecked under the protocol package's `tsconfig.json`;
+ * vitest never executes it at runtime. The type assertions are the test.
+ */
+
+// @ts-expect-error — `EndpointKind` must not be reachable via the flat barrel (spec #135 Invariant 18).
+import type { EndpointKind as _EndpointKindFlat } from "@moltzap/protocol";
+
+// @ts-expect-error — `EndpointRegistration` must not be reachable via the flat barrel (spec #135 Invariant 18).
+import type { EndpointRegistration as _EndpointRegistrationFlat } from "@moltzap/protocol";
+
+// @ts-expect-error — `AuthenticatedIdentity` must not be reachable via the flat barrel (spec #135 Invariant 18).
+import type { AuthenticatedIdentity as _AuthenticatedIdentityFlat } from "@moltzap/protocol";
+
+// Silence `noUnusedLocals` for the type-only aliases above.
+export type _FlatBarrelCanary =
+  | _EndpointKindFlat
+  | _EndpointRegistrationFlat
+  | _AuthenticatedIdentityFlat;

--- a/packages/protocol/src/network/actor-model.ts
+++ b/packages/protocol/src/network/actor-model.ts
@@ -13,25 +13,42 @@
  * Two endpoint kinds (closed set):
  *   - `"agent"` — an AgentId, addressable via the network.
  *   - `"task-manager"` — a task-layer coordinator (e.g. `default-dm`,
- *     `default-group`, `app`). The network layer does NOT distinguish
- *     task-manager sub-kinds; those are a task-layer concern (arch-C).
+ *     `default-group`, `app`).
+ *
+ * `EndpointKind` (here) and `TaskManagerEndpointRegistration.kind` (arch-C) are
+ * **independent discriminators on two different tables**, not a refinement
+ * relationship. `EndpointKind` distinguishes in-memory network registrations
+ * (agent socket vs task-manager endpoint). Arch-C's `TaskManagerEndpointRegistration.kind`
+ * discriminates among the three task-manager flavors (`default-dm`,
+ * `default-group`, `app`) in the persistent `task_manager_endpoints` table.
+ * Neither union refines the other; they are first-class siblings.
  *
  * Reachability — these types are exposed via `@moltzap/protocol/network`
  * (the subpath entry carved out by arch-A). They MUST NOT be re-exported
  * from `packages/protocol/src/index.ts` (the flat barrel). Invariant 18 of
- * spec #135 is load-bearing and binds this slice.
+ * spec #135 is load-bearing and binds this slice. A prior arch-F attempt
+ * added `export * from "./network/actor-model.js"` to the flat barrel; the
+ * negative-canary `.type-test.ts` alongside this file is the compile-time
+ * guard against that regression.
  *
  * Stub status — this file is types only. No values, no runtime, no
  * implementation bodies. Every declaration below is the contract downstream
  * slices bind to.
  */
 
-/* ── Identity brands ────────────────────────────────────────────────────── */
+// `EndpointAddress` is declared in arch-A (`packages/protocol/src/network/index.ts`)
+// and has exactly one declaration site across the monorepo. Import as a type;
+// do NOT redeclare — hard constraint 3 of sub-issue #157.
+import type { EndpointAddress } from "./index.js";
+
+/* ── Identity brands (canonical declaration sites) ──────────────────────── */
 
 /**
  * The human principal. Issued by the identity layer; crosses the network
  * boundary only inside `AuthenticatedIdentity.ownerUserId`. Never confused
  * with an `AgentId` — the brand prevents it structurally.
+ *
+ * Canonical declaration site: this module. New in arch-F.
  */
 export type UserId = string & { readonly __brand: "UserId" };
 
@@ -39,20 +56,13 @@ export type UserId = string & { readonly __brand: "UserId" };
  * An agent actor. Owned by zero-or-one user (see `AuthenticatedIdentity`).
  * Addressable as an endpoint via `EndpointRegistration` where
  * `kind === "agent"`. Distinct from `UserId` at the type level.
+ *
+ * Canonical declaration site: this module. Arch-C (#142) currently
+ * re-declares `AgentId` at `packages/protocol/src/task/task-manager.ts`; a
+ * follow-up revision on #142 drops that declaration and imports from here
+ * so exactly one nominal `AgentId` exists across the monorepo.
  */
 export type AgentId = string & { readonly __brand: "AgentId" };
-
-/**
- * Network-addressable endpoint identifier. Resolves to either an agent or a
- * task manager; the kind is carried alongside the address in
- * `EndpointRegistration`. The network layer routes by `EndpointAddress`
- * without inspecting the owning identity.
- *
- * Arch-A declared this same brand inline in `network/index.ts`; arch-F
- * promotes the declaration to this module and the barrel re-exports it.
- * Callers still import it from `@moltzap/protocol/network`.
- */
-export type EndpointAddress = string & { readonly __brand: "EndpointAddress" };
 
 /* ── Endpoint kind (closed union) ───────────────────────────────────────── */
 
@@ -61,9 +71,10 @@ export type EndpointAddress = string & { readonly __brand: "EndpointAddress" };
  * is exhaustive by construction; adding a kind is an architect-level change
  * (new spec or arch sub-issue), not an implementer-level addition.
  *
- * Task-manager sub-kinds (`default-dm`, `default-group`, `app`, ...) are NOT
- * represented here. They live in arch-C's `TaskManagerEndpointRegistration`
- * on the task-layer side of the boundary.
+ * Task-manager sub-kinds (`default-dm`, `default-group`, `app`) are NOT
+ * represented here — they are a separate discriminator on a different
+ * table (arch-C's persistent `task_manager_endpoints`). See module docstring
+ * for the independence invariant.
  */
 export type EndpointKind = "agent" | "task-manager";
 
@@ -77,6 +88,12 @@ export type EndpointKind = "agent" | "task-manager";
  * Exhaustiveness — consumers MUST switch on `kind` and end with an
  * `absurd(x: never)` default. Adding a branch here is a deliberate breaking
  * change; the compiler forces every consumer to update.
+ *
+ * Peer symmetry — neither branch carries an originator, initiator, owner,
+ * or role flag at the network layer. Peer symmetry ("multi-agent
+ * bidirectional") is encoded by the *absence* of such fields; downstream
+ * code that wants per-conversation roles stores them in a task-layer
+ * per-conversation record (arch-C), not on the network registration.
  */
 export type EndpointRegistration =
   | {
@@ -106,22 +123,4 @@ export type EndpointRegistration =
 export type AuthenticatedIdentity = {
   readonly agentId: AgentId;
   readonly ownerUserId: UserId | null;
-};
-
-/* ── Conversation peer ──────────────────────────────────────────────────── */
-
-/**
- * A peer admitted to a conversation. Carries no originator/recipient flag —
- * MoltZap conversations are bidirectional graphs with no privileged sender.
- * `admittedAt` is a Unix milliseconds timestamp assigned by the task layer
- * at admission.
- *
- * Peer symmetry is the invariant this type encodes: any field that would
- * distinguish one peer from another by role (originator, initiator, owner)
- * is a spec violation and belongs in a task-layer per-conversation record,
- * not here.
- */
-export type ConversationPeer = {
-  readonly agentId: AgentId;
-  readonly admittedAt: number;
 };

--- a/packages/protocol/src/network/actor-model.ts
+++ b/packages/protocol/src/network/actor-model.ts
@@ -1,0 +1,127 @@
+/**
+ * `@moltzap/protocol/network/actor-model` — actor-model protocol types.
+ *
+ * The MoltZap system is a bidirectional graph with two identity levels and
+ * two endpoint kinds. This module codifies that shape so downstream slices
+ * (arch-C, arch-G, implement-*) cannot accidentally collapse it.
+ *
+ * Two identity levels:
+ *   - `UserId` — the human principal. Owns agents; scopes grants.
+ *   - `AgentId` — an agent actor. Addressable as an endpoint; acts on behalf
+ *     of a user (or `null` for system-owned agents).
+ *
+ * Two endpoint kinds (closed set):
+ *   - `"agent"` — an AgentId, addressable via the network.
+ *   - `"task-manager"` — a task-layer coordinator (e.g. `default-dm`,
+ *     `default-group`, `app`). The network layer does NOT distinguish
+ *     task-manager sub-kinds; those are a task-layer concern (arch-C).
+ *
+ * Reachability — these types are exposed via `@moltzap/protocol/network`
+ * (the subpath entry carved out by arch-A). They MUST NOT be re-exported
+ * from `packages/protocol/src/index.ts` (the flat barrel). Invariant 18 of
+ * spec #135 is load-bearing and binds this slice.
+ *
+ * Stub status — this file is types only. No values, no runtime, no
+ * implementation bodies. Every declaration below is the contract downstream
+ * slices bind to.
+ */
+
+/* ── Identity brands ────────────────────────────────────────────────────── */
+
+/**
+ * The human principal. Issued by the identity layer; crosses the network
+ * boundary only inside `AuthenticatedIdentity.ownerUserId`. Never confused
+ * with an `AgentId` — the brand prevents it structurally.
+ */
+export type UserId = string & { readonly __brand: "UserId" };
+
+/**
+ * An agent actor. Owned by zero-or-one user (see `AuthenticatedIdentity`).
+ * Addressable as an endpoint via `EndpointRegistration` where
+ * `kind === "agent"`. Distinct from `UserId` at the type level.
+ */
+export type AgentId = string & { readonly __brand: "AgentId" };
+
+/**
+ * Network-addressable endpoint identifier. Resolves to either an agent or a
+ * task manager; the kind is carried alongside the address in
+ * `EndpointRegistration`. The network layer routes by `EndpointAddress`
+ * without inspecting the owning identity.
+ *
+ * Arch-A declared this same brand inline in `network/index.ts`; arch-F
+ * promotes the declaration to this module and the barrel re-exports it.
+ * Callers still import it from `@moltzap/protocol/network`.
+ */
+export type EndpointAddress = string & { readonly __brand: "EndpointAddress" };
+
+/* ── Endpoint kind (closed union) ───────────────────────────────────────── */
+
+/**
+ * The closed set of endpoint kinds the network layer recognises. The union
+ * is exhaustive by construction; adding a kind is an architect-level change
+ * (new spec or arch sub-issue), not an implementer-level addition.
+ *
+ * Task-manager sub-kinds (`default-dm`, `default-group`, `app`, ...) are NOT
+ * represented here. They live in arch-C's `TaskManagerEndpointRegistration`
+ * on the task-layer side of the boundary.
+ */
+export type EndpointKind = "agent" | "task-manager";
+
+/* ── Endpoint registration (discriminated union) ────────────────────────── */
+
+/**
+ * Registration record for an endpoint addressable on the network. The
+ * discriminator is `kind`; each branch carries exactly the fields the
+ * network layer needs to route and authorize traffic for that kind.
+ *
+ * Exhaustiveness — consumers MUST switch on `kind` and end with an
+ * `absurd(x: never)` default. Adding a branch here is a deliberate breaking
+ * change; the compiler forces every consumer to update.
+ */
+export type EndpointRegistration =
+  | {
+      readonly kind: "agent";
+      readonly address: EndpointAddress;
+      readonly agentId: AgentId;
+      /**
+       * The user the agent acts on behalf of. `null` for system-owned
+       * agents (no human owner). The network layer does not derive grants
+       * from this field; it is carried for downstream authorization.
+       */
+      readonly ownerUserId: UserId | null;
+    }
+  | {
+      readonly kind: "task-manager";
+      readonly address: EndpointAddress;
+    };
+
+/* ── Authenticated identity ─────────────────────────────────────────────── */
+
+/**
+ * The identity the network layer attaches to an authenticated connection
+ * after `auth/connect` completes. Carries the connecting agent and the
+ * owning user (or `null` for system-owned agents). Task-layer authorization
+ * reads both fields; the network layer reads neither beyond routing.
+ */
+export type AuthenticatedIdentity = {
+  readonly agentId: AgentId;
+  readonly ownerUserId: UserId | null;
+};
+
+/* ── Conversation peer ──────────────────────────────────────────────────── */
+
+/**
+ * A peer admitted to a conversation. Carries no originator/recipient flag —
+ * MoltZap conversations are bidirectional graphs with no privileged sender.
+ * `admittedAt` is a Unix milliseconds timestamp assigned by the task layer
+ * at admission.
+ *
+ * Peer symmetry is the invariant this type encodes: any field that would
+ * distinguish one peer from another by role (originator, initiator, owner)
+ * is a spec violation and belongs in a task-layer per-conversation record,
+ * not here.
+ */
+export type ConversationPeer = {
+  readonly agentId: AgentId;
+  readonly admittedAt: number;
+};

--- a/packages/protocol/src/network/index.ts
+++ b/packages/protocol/src/network/index.ts
@@ -55,14 +55,25 @@ export type RpcError = {
   readonly data?: unknown;
 };
 
-/* ── Network primitives — endpoint + opaque payload ─────────────────────── */
+/* ── Actor-model identity + endpoint types (arch-F) ─────────────────────── */
 
 /**
- * Branded identifier for a network-addressable endpoint (an agent, a session
- * participant, a session). Decoded at the network boundary; passed opaquely
- * by the task layer. Never parsed at the network layer beyond schema check.
+ * Actor-model types live in `./actor-model.ts`. Re-exported here so consumers
+ * reach them via `@moltzap/protocol/network` without a deeper subpath. The
+ * flat package barrel (`packages/protocol/src/index.ts`) MUST NOT re-export
+ * these types; spec #135 Invariant 18 binds this constraint.
  */
-export type EndpointAddress = string & { readonly __brand: "EndpointAddress" };
+export type {
+  UserId,
+  AgentId,
+  EndpointAddress,
+  EndpointKind,
+  EndpointRegistration,
+  AuthenticatedIdentity,
+  ConversationPeer,
+} from "./actor-model.js";
+
+/* ── Network primitives — opaque payload ────────────────────────────────── */
 
 /**
  * Opaque payload bytes carried end-to-end by the network layer. The network

--- a/packages/protocol/src/network/index.ts
+++ b/packages/protocol/src/network/index.ts
@@ -55,31 +55,42 @@ export type RpcError = {
   readonly data?: unknown;
 };
 
-/* ── Actor-model identity + endpoint types (arch-F) ─────────────────────── */
+/* ── Network primitives — endpoint + opaque payload ─────────────────────── */
 
 /**
- * Actor-model types live in `./actor-model.ts`. Re-exported here so consumers
- * reach them via `@moltzap/protocol/network` without a deeper subpath. The
- * flat package barrel (`packages/protocol/src/index.ts`) MUST NOT re-export
- * these types; spec #135 Invariant 18 binds this constraint.
+ * Branded identifier for a network-addressable endpoint (an agent, a session
+ * participant, a session). Decoded at the network boundary; passed opaquely
+ * by the task layer. Never parsed at the network layer beyond schema check.
+ *
+ * Canonical declaration site: this file (arch-A). Arch-F imports this type
+ * from here; it MUST NOT be re-declared elsewhere (hard constraint — unique
+ * brand declarations, sub-issue #157).
  */
-export type {
-  UserId,
-  AgentId,
-  EndpointAddress,
-  EndpointKind,
-  EndpointRegistration,
-  AuthenticatedIdentity,
-  ConversationPeer,
-} from "./actor-model.js";
-
-/* ── Network primitives — opaque payload ────────────────────────────────── */
+export type EndpointAddress = string & { readonly __brand: "EndpointAddress" };
 
 /**
  * Opaque payload bytes carried end-to-end by the network layer. The network
  * layer MUST NOT decode, validate, or inspect `OpaquePayload` — only route it.
  */
 export type OpaquePayload = string & { readonly __brand: "OpaquePayload" };
+
+/* ── Actor-model identity + endpoint types (arch-F) ─────────────────────── */
+
+/**
+ * Actor-model types live in `./actor-model.ts`. Re-exported here so consumers
+ * reach them via `@moltzap/protocol/network` without a deeper subpath. The
+ * flat package barrel (`packages/protocol/src/index.ts`) MUST NOT re-export
+ * these names; spec #135 Invariant 18 binds this constraint. The negative-
+ * canary `.type-test.ts` alongside `actor-model.ts` is the compile-time
+ * guard.
+ */
+export type {
+  UserId,
+  AgentId,
+  EndpointKind,
+  EndpointRegistration,
+  AuthenticatedIdentity,
+} from "./actor-model.js";
 
 /* ── Network RPC method manifests ───────────────────────────────────────── */
 


### PR DESCRIPTION
Architecture only; not for merge.

Scope: narrow. Adds `packages/protocol/src/network/actor-model.ts` with
the actor-model protocol types (branded `UserId`/`AgentId`/`EndpointAddress`,
closed `EndpointKind` union, `EndpointRegistration` discriminated union,
`AuthenticatedIdentity`, `ConversationPeer`). Reach via
`@moltzap/protocol/network`. **Does not** modify
`packages/protocol/src/index.ts` (flat barrel) — spec #135 Invariant 18.

Out of scope: server-side refactor (ConnectionManager / DeliveryService /
Broadcaster) is #158 (arch-G).

Design doc: https://github.com/chughtapan/moltzap/issues/134#issuecomment-4284253012

Base branch is `arch/a-protocol-split` because this slice binds to
arch-A's subpath `exports` carve-out (`./network`, `./task`).

Stub status: 1 new file, 1 barrel re-export edit. Every declaration is
types only; no runtime values, no implementation bodies.

Refs #157 (sub-issue), #134 (epic), #140 (arch-A base)