### PR TITLE
[arch-G] Effect-native server stack + Broadcaster removal

### DIFF
--- a/packages/server/src/network/connection-manager.ts
+++ b/packages/server/src/network/connection-manager.ts
@@ -1,0 +1,227 @@
+/**
+ * Network-layer endpoint registry + agent-endpoint resolver (arch-G).
+ *
+ * Replaces `packages/server/src/ws/broadcaster.ts` + `packages/server/src/ws/connection.ts`.
+ * Every delivery target (agent sockets, task-manager webhooks, in-process
+ * task managers) is a `LiveEndpoint` with:
+ *   - one `Queue<EventFrame>` sized by the endpoint's `BackpressurePolicy`,
+ *   - one scoped fiber that drains the queue into the transport,
+ *   - a `Scope` that tears the fiber and the transport down together.
+ *
+ * `ConnectionManager.register(endpoint)` is the single entry point. Fan-out
+ * is not a primitive — `Effect.forEach(participants, (to) => send(to, …))`
+ * runs in the caller. The network layer exposes one delivery method:
+ * `DeliveryService.send(to, payload)` (module 2).
+ *
+ * `AgentEndpointResolver` answers `AgentId -> EndpointAddress` for the
+ * network layer only. It lives in the network layer per the VP-review
+ * clarification on spec #142 (locked).
+ *
+ * Stub status — architect budget. Every body is `throw new Error(...)`. The
+ * implement-* pass fills in the queue wiring, the scoped draining fiber, and
+ * the backend-specific transport (WebSocket / webhook / in-process).
+ */
+
+import type { Effect, Queue, Scope } from "effect";
+import type { EventFrame } from "@moltzap/protocol/network";
+import type { BackpressurePolicy } from "./delivery-service.js";
+
+/* ── Branded identifiers (re-declared locally) ─────────────────────────── */
+/*
+ * Arch-A's `../app/network-layer.ts` owns the canonical declarations, but
+ * the network subtree's TS project boundary (composite: true, rootDir: ".")
+ * prevents importing from the parent-project `app/` directory. The brands
+ * are structural, so re-declaring here is identity-preserving: a value
+ * branded in `app/network-layer.ts` is assignable to the local brand and
+ * vice-versa. Implement-* collapses the duplicates when arch-A's
+ * `app/network-layer.ts` moves under `src/network/layer.ts`.
+ */
+
+export type AgentId = string & { readonly __brand: "AgentId" };
+export type EndpointAddress = string & { readonly __brand: "EndpointAddress" };
+export type ConnectionId = string & { readonly __brand: "ConnectionId" };
+
+/** Opaque view of a live connection at the network layer — matches arch-A's
+ *  `NetworkConnection`. Re-declared for the same rootDir reason. */
+export interface NetworkConnection {
+  readonly id: ConnectionId;
+  readonly agentId: AgentId | null;
+  readonly write: (rawFrame: string) => NetworkWriteOutcome;
+}
+
+/** Discriminated outcome of a network write. */
+export type NetworkWriteOutcome =
+  | { readonly _tag: "Written" }
+  | { readonly _tag: "BackpressureDropped" }
+  | { readonly _tag: "ConnectionClosed" };
+
+/* ── LiveEndpoint ──────────────────────────────────────────────────────── */
+
+/**
+ * Endpoint kind — closed union. The network layer does not distinguish
+ * task-manager sub-kinds (`default-dm`, `default-group`, `app`); those live
+ * in the task-manager registry (arch-C). Here only "agent" vs "task-manager"
+ * is visible, matching spec Invariant 3.
+ */
+export type EndpointKind = "agent" | "task-manager";
+
+/**
+ * A registered delivery target. One per logical endpoint — an agent's WS
+ * connection, a task-manager webhook URL, or an in-process task-manager
+ * handle. Created by a transport (e.g. WS upgrade path, webhook registrar)
+ * and handed to `ConnectionManager.register`.
+ *
+ * Ownership: the `scope` is the teardown boundary for both the draining
+ * fiber and the underlying transport. `register` forks a drain fiber into
+ * this scope; closing the scope interrupts the fiber and closes the
+ * transport.
+ */
+export interface LiveEndpoint {
+  readonly address: EndpointAddress;
+  readonly kind: EndpointKind;
+  /** Backing connection, if the transport is a WebSocket. Null for webhook
+   *  or in-process endpoints. Surfaced so the `NetworkConnectionManager`
+   *  read surface (arch-A) can answer connId→conn lookups. */
+  readonly connection: NetworkConnection | null;
+  /** Bounded queue. Size and overflow behavior come from `policy`. */
+  readonly queue: Queue.Queue<EventFrame>;
+  readonly policy: BackpressurePolicy;
+  /** Endpoint-owned scope. Closing it tears down the drain fiber + transport. */
+  readonly scope: Scope.CloseableScope;
+}
+
+/* ── ConnectionManager service ─────────────────────────────────────────── */
+
+/**
+ * Endpoint registry. One entry per registered `EndpointAddress`. The
+ * network layer's only write surface — all delivery flows through
+ * `DeliveryService.send`, which resolves the address through this manager.
+ *
+ * This interface is the superset of arch-A's narrowed `NetworkConnectionManager`
+ * read surface (`get` / `has` / `size` by `ConnectionId`). Arch-G's impl
+ * satisfies both views.
+ */
+export interface ConnectionManager {
+  /**
+   * Register a new live endpoint. Forks the scoped drain fiber into
+   * `endpoint.scope`. Fails with `EndpointAlreadyRegistered` if the address
+   * is already present — registration is not idempotent; re-registration is
+   * a caller bug.
+   */
+  readonly register: (
+    endpoint: LiveEndpoint,
+  ) => Effect.Effect<void, EndpointAlreadyRegistered, never>;
+
+  /**
+   * Unregister an endpoint. Closes the endpoint's scope (tearing down the
+   * drain fiber and the transport). Fails with `EndpointNotRegistered` if
+   * the address is unknown.
+   */
+  readonly unregister: (
+    address: EndpointAddress,
+  ) => Effect.Effect<void, EndpointNotRegistered, never>;
+
+  /**
+   * Look up a live endpoint by address. Used by `DeliveryService.send`.
+   * Fails with `EndpointNotRegistered` if the address is unknown.
+   */
+  readonly lookup: (
+    address: EndpointAddress,
+  ) => Effect.Effect<LiveEndpoint, EndpointNotRegistered, never>;
+
+  /** Snapshot of currently-registered agent endpoints. For presence seeding
+   *  and test assertions; not a delivery path. */
+  readonly connectedAgents: () => Effect.Effect<
+    ReadonlyArray<AgentId>,
+    never,
+    never
+  >;
+
+  /* ── Arch-A read surface (satisfied by the same impl) ───────────────── */
+
+  readonly get: (connId: ConnectionId) => NetworkConnection | undefined;
+  readonly has: (connId: ConnectionId) => boolean;
+  readonly size: () => number;
+}
+
+/** Context tag for {@link ConnectionManager}. */
+export declare const ConnectionManagerTag: import("effect").Context.Tag<
+  ConnectionManagerTag,
+  ConnectionManager
+>;
+export interface ConnectionManagerTag {
+  readonly _: unique symbol;
+}
+
+/* ── AgentEndpointResolver service ─────────────────────────────────────── */
+
+/**
+ * Maps an `AgentId` to the `EndpointAddress` used for delivery. Owned by
+ * the network layer per the VP-review clarification on spec #142
+ * ("AgentId → EndpointAddress resolver lives in network layer"). The task
+ * layer does not know about endpoint addressing; it hands an `AgentId` to
+ * the app-layer fan-out, which resolves via this service and calls
+ * `network.send`.
+ *
+ * Fails with `AgentNotReachable` when the agent has no currently-registered
+ * endpoint.
+ */
+export interface AgentEndpointResolver {
+  readonly resolve: (
+    agentId: AgentId,
+  ) => Effect.Effect<EndpointAddress, AgentNotReachable, never>;
+}
+
+/** Context tag for {@link AgentEndpointResolver}. */
+export declare const AgentEndpointResolverTag: import("effect").Context.Tag<
+  AgentEndpointResolverTag,
+  AgentEndpointResolver
+>;
+export interface AgentEndpointResolverTag {
+  readonly _: unique symbol;
+}
+
+/* ── Tagged errors ─────────────────────────────────────────────────────── */
+
+/** Re-registration of the same `EndpointAddress`. Caller bug. */
+export class EndpointAlreadyRegistered {
+  readonly _tag = "EndpointAlreadyRegistered" as const;
+  constructor(readonly address: EndpointAddress) {
+    throw new Error("not implemented");
+  }
+}
+
+/** Lookup / unregister for an unknown `EndpointAddress`. */
+export class EndpointNotRegistered {
+  readonly _tag = "EndpointNotRegistered" as const;
+  constructor(readonly address: EndpointAddress) {
+    throw new Error("not implemented");
+  }
+}
+
+/** `resolve(agentId)` found no registered endpoint. Not a delivery error —
+ *  the caller decides whether to queue, drop, or defer. */
+export class AgentNotReachable {
+  readonly _tag = "AgentNotReachable" as const;
+  constructor(readonly agentId: AgentId) {
+    throw new Error("not implemented");
+  }
+}
+
+/* ── Not-implemented stub bodies ───────────────────────────────────────── */
+
+/** Constructor stub — the implement-* pass replaces with a real class +
+ *  `Layer.scoped` that wires the internal map and the per-endpoint drain
+ *  fibers. */
+export declare const makeConnectionManager: () => Effect.Effect<
+  ConnectionManager,
+  never,
+  Scope.Scope
+>;
+
+/** Constructor stub for the resolver. Backed by the registry map from
+ *  `ConnectionManager` plus an in-memory agent→address index maintained on
+ *  `register` / `unregister`. */
+export declare const makeAgentEndpointResolver: (
+  cm: ConnectionManager,
+) => Effect.Effect<AgentEndpointResolver, never, never>;

--- a/packages/server/src/network/connection-manager.ts
+++ b/packages/server/src/network/connection-manager.ts
@@ -23,6 +23,9 @@
  */
 
 import type { Effect, Queue, Scope } from "effect";
+// `Ref` and `Option` are only used in type-position (see `LiveEndpoint.failure`);
+// imported inline via `import("effect").Ref` / `.Option` to avoid widening the
+// value-import surface.
 import type { EventFrame } from "@moltzap/protocol/network";
 import type { BackpressurePolicy } from "./delivery-service.js";
 
@@ -66,6 +69,46 @@ export type NetworkWriteOutcome =
 export type EndpointKind = "agent" | "task-manager";
 
 /**
+ * Transport-agnostic frame sink. The drain fiber calls `send(frame)` for each
+ * dequeued frame and the `Transport` is responsible for serialization + I/O
+ * (WS `write`, webhook POST, in-process push). Returning a failing Effect
+ * tears down the endpoint's scope; the endpoint's teardown handler is called
+ * from `Scope.close`.
+ *
+ * Three concrete `Transport` implementations land in implement-*:
+ *   - WS transport — wraps `NetworkConnection.write`.
+ *   - Webhook transport — `WebhookClient.call` with retry budget.
+ *   - In-process transport — direct `Queue.offer` on the peer's inbox.
+ *
+ * The `Transport` interface is what makes the endpoint abstraction actually
+ * transport-agnostic (flagged by codex review). The drain fiber never branches
+ * on `EndpointKind`; it branches on whatever `Transport.send` does.
+ */
+export interface Transport {
+  readonly send: (
+    frame: EventFrame,
+  ) => Effect.Effect<void, TransportError, never>;
+  /** Called by `Scope.close` to release transport resources (close WS, drop
+   *  webhook retry budget, etc.). Idempotent. */
+  readonly teardown: () => Effect.Effect<void, never, never>;
+}
+
+/**
+ * Transport I/O failure as seen by the drain fiber. The fiber logs + triggers
+ * endpoint teardown; the error surfaces to callers only as
+ * `DeliveryTransportFailed` during the brief window before `unregister` runs.
+ */
+export class TransportError {
+  readonly _tag = "TransportError" as const;
+  constructor(
+    readonly address: EndpointAddress,
+    readonly cause: unknown,
+  ) {
+    throw new Error("not implemented");
+  }
+}
+
+/**
  * A registered delivery target. One per logical endpoint — an agent's WS
  * connection, a task-manager webhook URL, or an in-process task-manager
  * handle. Created by a transport (e.g. WS upgrade path, webhook registrar)
@@ -73,8 +116,15 @@ export type EndpointKind = "agent" | "task-manager";
  *
  * Ownership: the `scope` is the teardown boundary for both the draining
  * fiber and the underlying transport. `register` forks a drain fiber into
- * this scope; closing the scope interrupts the fiber and closes the
- * transport.
+ * this scope; closing the scope interrupts the fiber and calls
+ * `transport.teardown`.
+ *
+ * Failure latch: `failure` is set by the drain fiber when `transport.send`
+ * returns a failing Effect; once set, `ConnectionManager.lookup` returns an
+ * endpoint whose next `send` short-circuits with `DeliveryTransportFailed`.
+ * The drain fiber then closes the scope (triggering `unregister`); subsequent
+ * lookups fail with `EndpointNotRegistered`. This is the state backing for
+ * `DeliveryTransportFailed` in `delivery-service.ts`.
  */
 export interface LiveEndpoint {
   readonly address: EndpointAddress;
@@ -83,11 +133,19 @@ export interface LiveEndpoint {
    *  or in-process endpoints. Surfaced so the `NetworkConnectionManager`
    *  read surface (arch-A) can answer connId→conn lookups. */
   readonly connection: NetworkConnection | null;
+  /** Transport-agnostic frame sink. Drives the drain fiber. */
+  readonly transport: Transport;
   /** Bounded queue. Size and overflow behavior come from `policy`. */
   readonly queue: Queue.Queue<EventFrame>;
   readonly policy: BackpressurePolicy;
   /** Endpoint-owned scope. Closing it tears down the drain fiber + transport. */
   readonly scope: Scope.CloseableScope;
+  /** Set by the drain fiber on transport failure. Consulted by `send` before
+   *  enqueue so callers get `DeliveryTransportFailed` during the teardown
+   *  window. `Ref<Option<TransportError>>` at implement-* time. */
+  readonly failure: import("effect").Ref.Ref<
+    import("effect").Option.Option<TransportError>
+  >;
 }
 
 /* ── ConnectionManager service ─────────────────────────────────────────── */
@@ -210,13 +268,23 @@ export class AgentNotReachable {
 
 /* ── Not-implemented stub bodies ───────────────────────────────────────── */
 
+/** Opaque forward-reference to `../runtime/layers.ts#LoggerTag`. Re-declared
+ *  here for the same rootDir reason as `AgentId` / `EndpointAddress` above:
+ *  the network subtree cannot import from the parent-project `runtime/`. The
+ *  brands are structural; arch-G's impl satisfies both. Implement-*
+ *  collapses the duplicates at the move to `src/network/layer.ts`. */
+export interface LoggerTag {
+  readonly _: unique symbol;
+}
+
 /** Constructor stub — the implement-* pass replaces with a real class +
  *  `Layer.scoped` that wires the internal map and the per-endpoint drain
- *  fibers. */
+ *  fibers. Requires `LoggerTag` because the drain fiber logs transport
+ *  failures before tearing the endpoint down (see `LiveEndpoint.failure`). */
 export declare const makeConnectionManager: () => Effect.Effect<
   ConnectionManager,
   never,
-  Scope.Scope
+  Scope.Scope | LoggerTag
 >;
 
 /** Constructor stub for the resolver. Backed by the registry map from

--- a/packages/server/src/network/connection-manager.ts
+++ b/packages/server/src/network/connection-manager.ts
@@ -27,7 +27,10 @@ import type { Effect, Queue, Scope } from "effect";
 // imported inline via `import("effect").Ref` / `.Option` to avoid widening the
 // value-import surface.
 import type { EventFrame } from "@moltzap/protocol/network";
-import type { BackpressurePolicy } from "./delivery-service.js";
+import type {
+  BackpressurePolicy,
+  InvalidBackpressurePolicy,
+} from "./delivery-service.js";
 
 /* ── Branded identifiers (re-declared locally) ─────────────────────────── */
 /*
@@ -164,11 +167,17 @@ export interface ConnectionManager {
    * Register a new live endpoint. Forks the scoped drain fiber into
    * `endpoint.scope`. Fails with `EndpointAlreadyRegistered` if the address
    * is already present — registration is not idempotent; re-registration is
-   * a caller bug.
+   * a caller bug. Fails with `InvalidBackpressurePolicy` if
+   * `endpoint.policy` violates the documented invariants
+   * (see `BackpressurePolicy` in `./delivery-service.js`).
    */
   readonly register: (
     endpoint: LiveEndpoint,
-  ) => Effect.Effect<void, EndpointAlreadyRegistered, never>;
+  ) => Effect.Effect<
+    void,
+    EndpointAlreadyRegistered | InvalidBackpressurePolicy,
+    never
+  >;
 
   /**
    * Unregister an endpoint. Closes the endpoint's scope (tearing down the
@@ -268,23 +277,22 @@ export class AgentNotReachable {
 
 /* ── Not-implemented stub bodies ───────────────────────────────────────── */
 
-/** Opaque forward-reference to `../runtime/layers.ts#LoggerTag`. Re-declared
- *  here for the same rootDir reason as `AgentId` / `EndpointAddress` above:
- *  the network subtree cannot import from the parent-project `runtime/`. The
- *  brands are structural; arch-G's impl satisfies both. Implement-*
- *  collapses the duplicates at the move to `src/network/layer.ts`. */
-export interface LoggerTag {
-  readonly _: unique symbol;
-}
-
 /** Constructor stub — the implement-* pass replaces with a real class +
  *  `Layer.scoped` that wires the internal map and the per-endpoint drain
- *  fibers. Requires `LoggerTag` because the drain fiber logs transport
- *  failures before tearing the endpoint down (see `LiveEndpoint.failure`). */
+ *  fibers.
+ *
+ *  The drain fiber logs transport failures via `Effect.log` (Effect's
+ *  built-in logging surface), NOT via an explicit `LoggerTag` requirement.
+ *  `LoggerLive` from `../logger.ts` installs a pino-backed `Logger` via
+ *  `Logger.replace(defaultLogger, pino)` — so `Effect.log` routes through
+ *  the same pino stream the rest of the stack uses, with zero Context
+ *  dependency at this layer. Round-2 codex review flagged an earlier version
+ *  that required a placeholder `LoggerTag`; dropping the requirement
+ *  sidesteps the tag-identity concern entirely. */
 export declare const makeConnectionManager: () => Effect.Effect<
   ConnectionManager,
   never,
-  Scope.Scope | LoggerTag
+  Scope.Scope
 >;
 
 /** Constructor stub for the resolver. Backed by the registry map from

--- a/packages/server/src/network/delivery-service.ts
+++ b/packages/server/src/network/delivery-service.ts
@@ -104,6 +104,28 @@ export class BackpressureExceeded {
 }
 
 /**
+ * Registration rejected the caller's `BackpressurePolicy` because it violates
+ * one of the invariants documented on `BackpressurePolicy` above
+ * (`maxQueueDepth < 1`, or `Block.maxQueueDepth` beyond the register-time
+ * ceiling). Surfaced on `ConnectionManager.register`'s error channel so
+ * callers see a typed failure rather than a thrown assertion. `reason` is a
+ * short machine-readable discriminator; `message` is for operator logs.
+ */
+export class InvalidBackpressurePolicy {
+  readonly _tag = "InvalidBackpressurePolicy" as const;
+  constructor(
+    readonly address: EndpointAddress,
+    readonly policy: BackpressurePolicy,
+    readonly reason:
+      | "max-queue-depth-below-one"
+      | "block-max-queue-depth-above-ceiling",
+    readonly message: string,
+  ) {
+    throw new Error("not implemented");
+  }
+}
+
+/**
  * The endpoint's drain fiber failed to write to the transport and the
  * endpoint has been torn down. `send` after a transport failure sees this
  * only for a brief window before `unregister` runs; most callers will see

--- a/packages/server/src/network/delivery-service.ts
+++ b/packages/server/src/network/delivery-service.ts
@@ -1,0 +1,134 @@
+/**
+ * Network-layer delivery primitive (arch-G).
+ *
+ * `DeliveryService.send(to, payload)` is the ONE delivery method exposed by
+ * the network layer. It resolves `to` through `ConnectionManager.lookup`,
+ * then enqueues the payload onto the endpoint's queue under its
+ * `BackpressurePolicy`. No fan-out primitive — callers iterate with
+ * `Effect.forEach(participants, (to) => send(to, …))`. See spec Invariant 6.
+ *
+ * Transport errors (socket write failures, webhook non-2xx, etc.) never
+ * leak to the caller: the endpoint's drain fiber catches them, logs, and
+ * the endpoint's scope is closed. `send` fails only with the errors named
+ * in `DeliveryError`.
+ *
+ * Replaces `packages/server/src/ws/broadcaster.ts` — which is fan-out + fork
+ * + silent catch — with a typed, non-fan-out `send` primitive. The
+ * broadcaster module is listed for removal in the arch-G design doc
+ * (§ "files to remove at implement-* time").
+ */
+
+import type { Effect } from "effect";
+import type { EventFrame } from "@moltzap/protocol/network";
+import type {
+  EndpointAddress,
+  EndpointNotRegistered,
+  ConnectionManagerTag,
+} from "./connection-manager.js";
+
+/* ── Backpressure policy (closed union) ────────────────────────────────── */
+
+/**
+ * How a full endpoint queue behaves on enqueue. Closed discriminated union —
+ * `default` in an exhaustive match is `absurd(x: never)`. Chosen per
+ * endpoint at registration time; the network layer has no global fallback
+ * (every endpoint names its own).
+ *
+ * Semantics:
+ *   - `Fail`         — `send` fails with `BackpressureExceeded`. Caller
+ *                      decides whether to drop, retry, or queue upstream.
+ *   - `DropOldest`   — oldest queued frame is discarded; new frame is
+ *                      enqueued. `send` succeeds.
+ *   - `Block`        — `send` suspends until the queue has capacity or the
+ *                      endpoint is unregistered (which interrupts).
+ */
+export type BackpressurePolicy =
+  | { readonly _tag: "Fail"; readonly maxQueueDepth: number }
+  | { readonly _tag: "DropOldest"; readonly maxQueueDepth: number }
+  | { readonly _tag: "Block"; readonly maxQueueDepth: number };
+
+/* ── DeliveryService service ───────────────────────────────────────────── */
+
+/**
+ * The single delivery primitive at the network layer. `payload` is an
+ * `EventFrame` — the network-wire envelope. The network layer treats the
+ * contents as opaque beyond the envelope; parsing happens at the task
+ * manager (spec Invariant 3).
+ *
+ * Requires `ConnectionManagerTag` to resolve addresses. Implemented over
+ * `ConnectionManager.lookup` + the endpoint's `Queue` and
+ * `BackpressurePolicy`.
+ */
+export interface DeliveryService {
+  readonly send: (
+    to: EndpointAddress,
+    payload: EventFrame,
+  ) => Effect.Effect<void, DeliveryError, ConnectionManagerTag>;
+}
+
+/** Context tag for {@link DeliveryService}. */
+export declare const DeliveryServiceTag: import("effect").Context.Tag<
+  DeliveryServiceTag,
+  DeliveryService
+>;
+export interface DeliveryServiceTag {
+  readonly _: unique symbol;
+}
+
+/* ── Tagged errors ─────────────────────────────────────────────────────── */
+
+/**
+ * Enqueue failed because the endpoint's queue was at `maxQueueDepth` and the
+ * endpoint's policy is `Fail`. Deterministic failure — the caller sees this
+ * instead of a dropped frame.
+ */
+export class BackpressureExceeded {
+  readonly _tag = "BackpressureExceeded" as const;
+  constructor(
+    readonly address: EndpointAddress,
+    readonly policy: BackpressurePolicy,
+  ) {
+    throw new Error("not implemented");
+  }
+}
+
+/**
+ * The endpoint's drain fiber failed to write to the transport and the
+ * endpoint has been torn down. `send` after a transport failure sees this
+ * only for a brief window before `unregister` runs; most callers will see
+ * `EndpointNotRegistered` instead. Kept as a distinct tag so observability
+ * can distinguish transport-induced teardown from explicit `unregister`.
+ */
+export class DeliveryTransportFailed {
+  readonly _tag = "DeliveryTransportFailed" as const;
+  constructor(
+    readonly address: EndpointAddress,
+    readonly cause: unknown,
+  ) {
+    throw new Error("not implemented");
+  }
+}
+
+/**
+ * Closed discriminated union of `send` failures. Every caller discriminates
+ * on `_tag`.
+ *
+ *   - `EndpointNotRegistered`   — address unknown (from `ConnectionManager.lookup`).
+ *   - `BackpressureExceeded`    — queue full; `Fail` policy.
+ *   - `DeliveryTransportFailed` — transport I/O failed; endpoint is being torn down.
+ */
+export type DeliveryError =
+  | EndpointNotRegistered
+  | BackpressureExceeded
+  | DeliveryTransportFailed;
+
+/* ── Not-implemented stub bodies ───────────────────────────────────────── */
+
+/** Constructor stub. The implement-* pass builds this over
+ *  `ConnectionManager.lookup` + `Queue.offer` / `Queue.unsafeOffer`
+ *  depending on `BackpressurePolicy`. */
+export declare const makeDeliveryService: () => Effect.Effect<
+  DeliveryService,
+  never,
+  ConnectionManagerTag
+>;

--- a/packages/server/src/network/delivery-service.ts
+++ b/packages/server/src/network/delivery-service.ts
@@ -34,6 +34,17 @@ import type {
  * endpoint at registration time; the network layer has no global fallback
  * (every endpoint names its own).
  *
+ * Invariants (enforced by `ConnectionManager.register` at implement-* time —
+ * registration fails with `EndpointAlreadyRegistered`'s sibling
+ * `InvalidBackpressurePolicy` if violated):
+ *   - `maxQueueDepth >= 1`. `0` is not permitted (would make every enqueue
+ *     fail/drop/block trivially); negative values are rejected.
+ *   - `Block.maxQueueDepth` has an implicit register-time ceiling of `10_000`
+ *     to bound worst-case memory per endpoint. The implement-* pass names
+ *     the constant.
+ *   - `Block` has no timeout — `send` suspends until capacity or interrupt.
+ *     If a bounded wait is needed, the caller wraps with `Effect.timeout`.
+ *
  * Semantics:
  *   - `Fail`         — `send` fails with `BackpressureExceeded`. Caller
  *                      decides whether to drop, retry, or queue upstream.

--- a/packages/server/src/rpc/handler-runtime.ts
+++ b/packages/server/src/rpc/handler-runtime.ts
@@ -1,0 +1,215 @@
+/**
+ * Handler-runtime contract — per-surface Effect `Context` constraints +
+ * manifest-driven binders for the two handler surfaces (arch-G).
+ *
+ * Arch-A established `defineNetworkMethod<D, R>` and `NetworkRequiredContext`
+ * for the network surface (`packages/server/src/rpc/network-context.ts`).
+ * Arch-G adds the task-surface twin (`defineTaskMethod<D, R>`,
+ * `TaskRequiredContext`) AND the router-facing discriminated union that a
+ * per-process dispatcher uses to route a frame to the correct surface.
+ *
+ * Boundary enforcement (spec Invariants 16–18): a task handler may NOT
+ * yield a network-only tag not listed in `TaskRequiredContext`; a network
+ * handler may NOT yield `TaskServiceTag`, `AppHostTag`, `MessageStoreTag`,
+ * `HumanContactTag` (already enforced by arch-A). Both rules are compile-
+ * time: `R extends <Surface>RequiredContext` on the binder generic.
+ *
+ * The negative type-test snippet that asserts a forbidden tag fails
+ * `tsc --build` lives at `handler-runtime.type-test.ts` (sibling file,
+ * placeholder `it.todo(...)` entries filled by implement-*).
+ *
+ * Stub status — type declarations and signatures only. Binder bodies raise
+ * "not implemented".
+ */
+
+import type { Effect, Context } from "effect";
+import type { RpcDefinition, Static, TSchema } from "@moltzap/protocol/network";
+import type { RpcFailure } from "../runtime/index.js";
+import type {
+  NetworkRequiredContext,
+  NetworkRpcMethodDef,
+  AuthenticatedContext,
+} from "./network-context.js";
+
+/* ── Task-surface required context ─────────────────────────────────────── */
+
+/**
+ * The EXACT set of Context tags a task-layer RPC handler may yield. The
+ * task layer may reach INTO the network layer for delivery (spec
+ * Invariant 6: fan-out is `Effect.forEach(participants, send)`), so the
+ * network outputs are included here as a subset.
+ *
+ * Declared as an abstract union; the concrete tag unions are imported from
+ * `../app/network-layer.js` (arch-A) and `../runtime/layers.js` (arch-G
+ * module 5). This file does not import the task-layer service modules
+ * directly — only their tag types — so the handler runtime can sit at the
+ * `rpc/` tier without pulling service implementations into its transitive
+ * closure.
+ */
+export type TaskRequiredContext =
+  | NetworkRequiredContext
+  | TaskServiceTag
+  | AppHostTag
+  | MessageStoreTag
+  | HumanContactTag
+  | TaskManagerRegistryTag
+  | TaskConnIdTag;
+
+/* ── Task-surface tag forward declarations ─────────────────────────────── */
+/*
+ * These tag types are materialized in `../runtime/layers.js` (module 5).
+ * Forward-declared here so the handler-runtime module does not depend on
+ * the service-implementation modules.
+ */
+
+export interface TaskServiceTag {
+  readonly _: unique symbol;
+}
+export declare const TaskServiceTag: Context.Tag<
+  TaskServiceTag,
+  TaskServiceSurface
+>;
+
+export interface AppHostTag {
+  readonly _: unique symbol;
+}
+export declare const AppHostTag: Context.Tag<AppHostTag, AppHostSurface>;
+
+export interface MessageStoreTag {
+  readonly _: unique symbol;
+}
+export declare const MessageStoreTag: Context.Tag<
+  MessageStoreTag,
+  MessageStoreSurface
+>;
+
+export interface HumanContactTag {
+  readonly _: unique symbol;
+}
+export declare const HumanContactTag: Context.Tag<
+  HumanContactTag,
+  HumanContactSurface
+>;
+
+export interface TaskManagerRegistryTag {
+  readonly _: unique symbol;
+}
+export declare const TaskManagerRegistryTag: Context.Tag<
+  TaskManagerRegistryTag,
+  TaskManagerRegistrySurface
+>;
+
+export interface TaskConnIdTag {
+  readonly _: unique symbol;
+}
+export declare const TaskConnIdTag: Context.Tag<TaskConnIdTag, string>;
+
+/* ── Placeholder surfaces (materialized by arch-G module 5) ────────────── */
+
+/** Concrete shape defined in `../runtime/layers.js`. Opaque here. */
+export interface TaskServiceSurface {
+  readonly _: unique symbol;
+}
+export interface AppHostSurface {
+  readonly _: unique symbol;
+}
+export interface MessageStoreSurface {
+  readonly _: unique symbol;
+}
+export interface HumanContactSurface {
+  readonly _: unique symbol;
+}
+export interface TaskManagerRegistrySurface {
+  readonly _: unique symbol;
+}
+
+/* ── Task handler type + method def ────────────────────────────────────── */
+
+/**
+ * A task-layer RPC handler. Fails with `RpcFailure` (mapped 1:1 to a wire
+ * error frame) and requires a subset of `TaskRequiredContext`.
+ *
+ *   R extends TaskRequiredContext
+ *
+ * is the compile-time boundary: a handler that yields a tag outside that
+ * union fails at `defineTaskMethod` registration.
+ */
+export type TaskRpcHandler<P = unknown, A = unknown> = (
+  params: P,
+  ctx: AuthenticatedContext,
+) => Effect.Effect<A, RpcFailure, TaskRequiredContext>;
+
+/** Discriminant-tagged task method record. Mirrors `NetworkRpcMethodDef`. */
+export interface TaskRpcMethodDef {
+  readonly layer: "task";
+  readonly handler: TaskRpcHandler;
+  readonly validator?: (params: unknown) => boolean;
+  readonly requiresActive?: boolean;
+}
+
+/** Registry of task methods keyed by wire method string. */
+export type TaskRpcMethodRegistry = Readonly<Record<string, TaskRpcMethodDef>>;
+
+/* ── Task binder ──────────────────────────────────────────────────────── */
+
+/**
+ * Manifest-driven binder for a task-layer RPC method. Mirrors
+ * `defineNetworkMethod`. The generic `R` is inferred from the handler's
+ * Effect and constrained to `TaskRequiredContext`.
+ *
+ *     defineTaskMethod(MessagesSend, {
+ *       handler: (params, ctx) => Effect.gen(function*() {
+ *         const svc = yield* TaskServiceTag;        // allowed
+ *         const del = yield* NetworkDeliveryServiceTag; // allowed (network subset)
+ *         ...
+ *       }),
+ *     })
+ *
+ * Forbidden tag access (for example an agent ID being pulled from an
+ * identity-layer tag that's not in `TaskRequiredContext`) fails at this
+ * generic constraint — not at runtime.
+ */
+export function defineTaskMethod<
+  D extends RpcDefinition<string, TSchema, TSchema>,
+  R extends TaskRequiredContext,
+>(
+  _definition: D,
+  _def: {
+    readonly handler: (
+      params: Static<D["paramsSchema"]>,
+      ctx: AuthenticatedContext,
+    ) => Effect.Effect<Static<D["resultSchema"]>, RpcFailure, R>;
+    readonly requiresActive?: boolean;
+  },
+): TaskRpcMethodDef {
+  throw new Error("not implemented");
+}
+
+/* ── Cross-surface dispatcher record ───────────────────────────────────── */
+
+/**
+ * The server hosts two logical routers side-by-side. The process-level
+ * router reads the method name from an incoming frame, looks it up in the
+ * combined registry, and routes based on `layer` to the correct surface's
+ * `Effect.provide(<layer>LayerLive)` call.
+ *
+ * Closed on `layer` so `switch (m.layer) { default: absurd(m.layer) }`
+ * stays exhaustive as future surfaces are added only through this file.
+ */
+export type AnyRpcMethodDef = NetworkRpcMethodDef | TaskRpcMethodDef;
+
+/** Combined registry. Method names must not collide across surfaces — the
+ *  router asserts disjointness at construction. */
+export interface CombinedRegistry {
+  readonly network: Readonly<Record<string, NetworkRpcMethodDef>>;
+  readonly task: TaskRpcMethodRegistry;
+}
+
+/**
+ * Build the combined registry from two surface-specific registries.
+ * Rejects collisions.
+ */
+export declare const combineRegistries: (
+  network: Readonly<Record<string, NetworkRpcMethodDef>>,
+  task: TaskRpcMethodRegistry,
+) => CombinedRegistry;

--- a/packages/server/src/rpc/handler-runtime.ts
+++ b/packages/server/src/rpc/handler-runtime.ts
@@ -99,10 +99,21 @@ export declare const TaskManagerRegistryTag: Context.Tag<
   TaskManagerRegistrySurface
 >;
 
+/** Request-scoped connection id for the task surface. Branded — same shape as
+ *  the network-layer `ConnectionId` brand. Raw `string` here was a review
+ *  finding (codex #5); branding prevents cross-use of arbitrary strings as
+ *  conn ids. */
+export type TaskConnectionId = string & {
+  readonly __brand: "TaskConnectionId";
+};
+
 export interface TaskConnIdTag {
   readonly _: unique symbol;
 }
-export declare const TaskConnIdTag: Context.Tag<TaskConnIdTag, string>;
+export declare const TaskConnIdTag: Context.Tag<
+  TaskConnIdTag,
+  TaskConnectionId
+>;
 
 /* ── Placeholder surfaces (materialized by arch-G module 5) ────────────── */
 
@@ -199,17 +210,33 @@ export function defineTaskMethod<
 export type AnyRpcMethodDef = NetworkRpcMethodDef | TaskRpcMethodDef;
 
 /** Combined registry. Method names must not collide across surfaces — the
- *  router asserts disjointness at construction. */
+ *  router asserts disjointness at construction. Kept as two maps rather than
+ *  a flattened `Record<string, AnyRpcMethodDef>` so the router preserves the
+ *  per-surface type discriminant at the dispatch site (see `AnyRpcMethodDef`
+ *  comment above). The flat shape was considered and rejected: flattening
+ *  loses the `layer` tag at the type level, which the exhaustive-match
+ *  dispatcher relies on. */
 export interface CombinedRegistry {
   readonly network: Readonly<Record<string, NetworkRpcMethodDef>>;
   readonly task: TaskRpcMethodRegistry;
 }
 
+/** Caller supplied overlapping method names across the two surfaces. Defect —
+ *  the router cannot route a name that is claimed by both surfaces. */
+export class RegistryCollision {
+  readonly _tag = "RegistryCollision" as const;
+  constructor(readonly methods: ReadonlyArray<string>) {
+    throw new Error("not implemented");
+  }
+}
+
 /**
- * Build the combined registry from two surface-specific registries.
- * Rejects collisions.
+ * Build the combined registry from two surface-specific registries. Fails
+ * with `RegistryCollision` naming every offending method. Total — the
+ * error is on the Effect channel, not a thrown exception (spec Invariant:
+ * typed errors, not thrown).
  */
 export declare const combineRegistries: (
   network: Readonly<Record<string, NetworkRpcMethodDef>>,
   task: TaskRpcMethodRegistry,
-) => CombinedRegistry;
+) => Effect.Effect<CombinedRegistry, RegistryCollision, never>;

--- a/packages/server/src/rpc/handler-runtime.type-test.ts
+++ b/packages/server/src/rpc/handler-runtime.type-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Negative type tests for the handler-runtime per-surface constraints.
+ *
+ * Stub status — `it.todo` placeholders; implement-* fills each one with a
+ * concrete `@ts-expect-error` snippet. CI running `tsc --noEmit` (or
+ * vitest's type-check mode) on this file fails if the boundary ever
+ * regresses.
+ *
+ * The entries exercise both directions:
+ *   - A network handler that yields a task-surface tag → `R ⊉ NetworkRequiredContext`.
+ *   - A task handler that yields an identity-only tag → `R ⊉ TaskRequiredContext`.
+ *   - An allowed network → allowed path (positive canary).
+ *   - An allowed task   → allowed path (positive canary).
+ */
+
+import { describe, it } from "vitest";
+
+describe("handler-runtime boundary", () => {
+  it.todo("network handler yielding TaskServiceTag fails to typecheck");
+  it.todo("network handler yielding AppHostTag fails to typecheck");
+  it.todo("network handler yielding HumanContactTag fails to typecheck");
+  it.todo("task handler yielding an identity-only tag fails to typecheck");
+  it.todo(
+    "network handler yielding NetworkDeliveryServiceTag typechecks (positive)",
+  );
+  it.todo(
+    "task handler yielding NetworkDeliveryServiceTag typechecks (network subset)",
+  );
+  it.todo("task handler yielding TaskServiceTag typechecks (positive)");
+});

--- a/packages/server/src/runtime/layers.ts
+++ b/packages/server/src/runtime/layers.ts
@@ -43,22 +43,25 @@ import type {
 
 /**
  * Base-tier tag union — supplied at process startup from the standalone
- * entry. `DbTag` and `LoggerTag` survive unchanged from the existing
- * `app/layers.ts`; canonical definitions migrate with the implement-* move.
+ * entry. Re-exports the canonical tag classes so this module's "same tag
+ * identity" promise (at the file-level docstring above) actually holds:
+ * `Effect.Context` uses class-reference identity, so two separately-declared
+ * placeholder interfaces would resolve against the real service tags as
+ * different keys. Round-2 codex review flagged the earlier placeholder form.
+ *
+ *   - `DbTag` / `EncryptionTag` — canonical source `../app/layers.js`
+ *     (existing arch-A-era layers file; implement-* will migrate both to
+ *     dedicated modules under `../db/` and `../crypto/` respectively,
+ *     preserving identity via re-export).
+ *   - `LoggerTag` — canonical source `../logger.js`
+ *     (`Context.Tag("moltzap/Logger")`; survives the refactor unchanged).
  */
-export type BaseTierInputs = DbTag | LoggerTag | EncryptionTag;
+export type { DbTag, EncryptionTag } from "../app/layers.js";
+export type { LoggerTag } from "../logger.js";
+import type { DbTag, EncryptionTag } from "../app/layers.js";
+import type { LoggerTag } from "../logger.js";
 
-/** Placeholder tag forwards. Canonical: `../db/client.ts`, `../logger.ts`,
- *  `../crypto/envelope.ts`. Not duplicated here. */
-export interface DbTag {
-  readonly _: unique symbol;
-}
-export interface LoggerTag {
-  readonly _: unique symbol;
-}
-export interface EncryptionTag {
-  readonly _: unique symbol;
-}
+export type BaseTierInputs = DbTag | LoggerTag | EncryptionTag;
 
 /* ── NetworkLayerLive ─────────────────────────────────────────────────── */
 
@@ -114,7 +117,13 @@ export declare const NetworkLayerLive: Layer.Layer<
  *   - `MessageStoreTag`          — message persistence; yields Effect + typed errors.
  *   - `HumanContactTag`          — unified human-contact abstraction (spec Invariant 12).
  *   - `TaskManagerRegistryTag`   — taskId → TaskManager resolver.
- *   - `TaskConnIdTag`            — request-scoped conn id for task handlers.
+ *
+ * `TaskConnIdTag` is intentionally NOT in this union. It is request-scoped
+ * (each incoming RPC gets a fresh conn id), so it's provided per-request
+ * via `Effect.provideService(TaskConnIdTag, connId)` at the task-handler
+ * dispatcher (see `provideTaskLayer` below) — symmetric with how
+ * `NetworkConnIdTag` is handled by arch-A's `provideNetworkLayer`. Round-2
+ * codex review flagged the earlier inclusion as a scope asymmetry.
  *
  * `TaskServiceTag` is abstract here (its concrete surface is defined by
  * arch-C; arch-G names it so the Layer shape is frozen).
@@ -131,8 +140,7 @@ export type TaskLayerOutputs =
   | AppHostTag
   | MessageStoreTag
   | HumanContactTag
-  | TaskManagerRegistryTag
-  | TaskConnIdTag;
+  | TaskManagerRegistryTag;
 
 /**
  * Provides every task-layer service tag (plus every network tag, since the
@@ -184,10 +192,17 @@ export declare const provideNetworkLayer: <A, E>(
 
 /**
  * Task-handler dispatcher adapter. Mirror of `provideNetworkLayer` for the
- * task surface.
+ * task surface. Applies `Effect.provide(TaskLayerLive)` + per-request
+ * `Effect.provideService(TaskConnIdTag, connId)` — the conn-id tag is NOT
+ * in `TaskLayerOutputs` (it's request-scoped, not process-scoped), so the
+ * handler's `R` lists it explicitly.
  */
 export declare const provideTaskLayer: <A, E>(
-  handler: import("effect").Effect.Effect<A, E, TaskLayerOutputs>,
+  handler: import("effect").Effect.Effect<
+    A,
+    E,
+    TaskLayerOutputs | TaskConnIdTag
+  >,
   connId: TaskConnectionId,
 ) => import("effect").Effect.Effect<A, E, never>;
 

--- a/packages/server/src/runtime/layers.ts
+++ b/packages/server/src/runtime/layers.ts
@@ -1,0 +1,199 @@
+/**
+ * Layer composition for the refactored server stack (arch-G module 5).
+ *
+ * Names `NetworkLayerLive`, `TaskLayerLive`, and `AppRuntimeLive`; wires
+ * the service-tag graph that every handler resolves through. The router
+ * provides `NetworkLayerLive` to network-surface handlers and
+ * `TaskLayerLive` to task-surface handlers — forbidden tag access is a
+ * compile-time error because the tag is simply not in the Layer's output
+ * union.
+ *
+ * Replaces `packages/server/src/app/layers.ts` at implement-* time. Listed
+ * under "files to remove at implement-* time" in the arch-G design doc —
+ * every export migrated here is available with the same tag identity so
+ * call sites only change their import path. The old file is deleted in the
+ * same PR (spec clean-break).
+ *
+ * Stub status — every `Layer` is `declare const … : Layer.Layer<…>`. The
+ * implement-* pass replaces each `declare` with a `Layer.effect(TAG, …)`.
+ */
+
+import type { Layer } from "effect";
+
+import type {
+  NetworkLayerOutputs,
+  NetworkConnIdTag,
+} from "../app/network-layer.js";
+import type {
+  ConnectionManagerTag,
+  AgentEndpointResolverTag,
+} from "../network/connection-manager.js";
+import type { DeliveryServiceTag } from "../network/delivery-service.js";
+import type {
+  TaskServiceTag,
+  AppHostTag,
+  MessageStoreTag,
+  HumanContactTag,
+  TaskManagerRegistryTag,
+  TaskConnIdTag,
+} from "../rpc/handler-runtime.js";
+
+/* ── Base tier (Db + Logger) ──────────────────────────────────────────── */
+
+/**
+ * Base-tier tag union — supplied at process startup from the standalone
+ * entry. `DbTag` and `LoggerTag` survive unchanged from the existing
+ * `app/layers.ts`; canonical definitions migrate with the implement-* move.
+ */
+export type BaseTierInputs = DbTag | LoggerTag | EncryptionTag;
+
+/** Placeholder tag forwards. Canonical: `../db/client.ts`, `../logger.ts`,
+ *  `../crypto/envelope.ts`. Not duplicated here. */
+export interface DbTag {
+  readonly _: unique symbol;
+}
+export interface LoggerTag {
+  readonly _: unique symbol;
+}
+export interface EncryptionTag {
+  readonly _: unique symbol;
+}
+
+/* ── NetworkLayerLive ─────────────────────────────────────────────────── */
+
+/**
+ * Outputs of `NetworkLayerLive`. Superset of arch-A's `NetworkLayerOutputs`
+ * (which published the four narrow service tags) extended with the arch-G
+ * concrete tags:
+ *
+ *   - `ConnectionManagerTag`      — endpoint registry (module 1)
+ *   - `DeliveryServiceTag`        — `send(to, payload)` primitive (module 2)
+ *   - `AgentEndpointResolverTag`  — AgentId → EndpointAddress (module 1)
+ *
+ * The four arch-A tags (`NetworkConnectionManagerTag`,
+ * `NetworkDeliveryServiceTag`, `NetworkAuthServiceTag`,
+ * `ContactCheckServiceTag`) remain — the arch-G `ConnectionManager` impl
+ * satisfies the arch-A read-surface interface; the two delivery tags name
+ * the SAME runtime instance (the concrete instance provides both
+ * interfaces — one narrow, one full). Implement-* wires the single instance
+ * through both tags.
+ */
+export type NetworkLayerFullOutputs =
+  | NetworkLayerOutputs
+  | ConnectionManagerTag
+  | DeliveryServiceTag
+  | AgentEndpointResolverTag;
+
+/**
+ * Provides every network-layer service tag. Requires `BaseTierInputs`
+ * (Db + Logger + Encryption). Provides NO task-layer tag — that is the
+ * structural guarantee behind spec Invariant 16.
+ *
+ * `Layer.mergeAll(ConnectionManagerLive, DeliveryServiceLive,
+ * AgentEndpointResolverLive, NetworkAuthServiceLive, ContactCheckServiceLive)`
+ * at implement-* time; each Layer's inputs resolve against `BaseTierInputs`
+ * + sibling network outputs (ConnectionManager is the only cross-sibling
+ * dep — DeliveryService and AgentEndpointResolver both consume it).
+ */
+export declare const NetworkLayerLive: Layer.Layer<
+  NetworkLayerFullOutputs,
+  never,
+  BaseTierInputs
+>;
+
+/* ── TaskLayerLive ─────────────────────────────────────────────────────── */
+
+/**
+ * Outputs of `TaskLayerLive`. Includes every network output (the task
+ * layer is built ON TOP of the network layer — spec Invariant 6) plus the
+ * task-surface service tags.
+ *
+ *   - `TaskServiceTag`           — the 12-method CRUD surface (spec Invariant 7).
+ *   - `AppHostTag`               — app runtime; survives the refactor.
+ *   - `MessageStoreTag`          — message persistence; yields Effect + typed errors.
+ *   - `HumanContactTag`          — unified human-contact abstraction (spec Invariant 12).
+ *   - `TaskManagerRegistryTag`   — taskId → TaskManager resolver.
+ *   - `TaskConnIdTag`            — request-scoped conn id for task handlers.
+ *
+ * `TaskServiceTag` is abstract here (its concrete surface is defined by
+ * arch-C; arch-G names it so the Layer shape is frozen).
+ *
+ * Forbidden: appending an identity-layer tag that is NOT in the union
+ * above would widen `TaskLayerOutputs` and silently admit identity tags
+ * into task handlers. The union is closed here and in
+ * `handler-runtime.TaskRequiredContext`; adding a new task-surface
+ * capability means editing BOTH locations intentionally.
+ */
+export type TaskLayerOutputs =
+  | NetworkLayerFullOutputs
+  | TaskServiceTag
+  | AppHostTag
+  | MessageStoreTag
+  | HumanContactTag
+  | TaskManagerRegistryTag
+  | TaskConnIdTag;
+
+/**
+ * Provides every task-layer service tag (plus every network tag, since the
+ * task layer consumes `DeliveryService.send` for participant fan-out).
+ * Requires `BaseTierInputs`.
+ */
+export declare const TaskLayerLive: Layer.Layer<
+  TaskLayerOutputs,
+  never,
+  BaseTierInputs
+>;
+
+/* ── AppRuntimeLive ────────────────────────────────────────────────────── */
+
+/**
+ * Per-process top-level runtime. Composes `TaskLayerLive` (which transitively
+ * provides `NetworkLayerLive`) with the base tier. `server.ts` /
+ * `standalone.ts` build their `Runtime` from this. Nothing above this
+ * layer is in arch-G scope — process bootstrap (env parsing, migration
+ * runner, HTTP server start) remains unchanged.
+ */
+export declare const AppRuntimeLive: Layer.Layer<
+  TaskLayerOutputs,
+  never,
+  never
+>;
+
+/* ── Router wiring ─────────────────────────────────────────────────────── */
+
+/**
+ * Network-handler dispatcher adapter. Applies `Effect.provide(NetworkLayerLive)`
+ * + `Effect.provideService(NetworkConnIdTag, connId)` to each handler
+ * Effect before running.
+ *
+ * The router's network path resolves ONLY `NetworkLayerFullOutputs` — a
+ * network handler whose inferred `R` includes (for example) `TaskServiceTag`
+ * fails to typecheck at `defineNetworkMethod` (arch-A). This Layer is the
+ * RUNTIME-side witness of that same constraint: providing it satisfies
+ * exactly the tags the compile-time constraint permitted.
+ */
+export declare const provideNetworkLayer: <A, E>(
+  handler: import("effect").Effect.Effect<
+    A,
+    E,
+    NetworkLayerFullOutputs | NetworkConnIdTag
+  >,
+  connId: import("../app/network-layer.js").ConnectionId,
+) => import("effect").Effect.Effect<A, E, never>;
+
+/**
+ * Task-handler dispatcher adapter. Mirror of `provideNetworkLayer` for the
+ * task surface.
+ */
+export declare const provideTaskLayer: <A, E>(
+  handler: import("effect").Effect.Effect<A, E, TaskLayerOutputs>,
+  connId: string,
+) => import("effect").Effect.Effect<A, E, never>;
+
+/* ── Not-implemented stub bodies ───────────────────────────────────────── */
+
+/**
+ * Implementation helper stub. Arch-G does not ship Layer bodies; every
+ * `declare const` above becomes a `Layer.effect` at implement-* time.
+ */
+export declare const __archGNotImplemented: never;

--- a/packages/server/src/runtime/layers.ts
+++ b/packages/server/src/runtime/layers.ts
@@ -56,8 +56,8 @@ import type {
  *   - `LoggerTag` — canonical source `../logger.js`
  *     (`Context.Tag("moltzap/Logger")`; survives the refactor unchanged).
  */
-export type { DbTag, EncryptionTag } from "../app/layers.js";
-export type { LoggerTag } from "../logger.js";
+export { DbTag, EncryptionTag } from "../app/layers.js";
+export { LoggerTag } from "../logger.js";
 import type { DbTag, EncryptionTag } from "../app/layers.js";
 import type { LoggerTag } from "../logger.js";
 

--- a/packages/server/src/runtime/layers.ts
+++ b/packages/server/src/runtime/layers.ts
@@ -36,6 +36,7 @@ import type {
   HumanContactTag,
   TaskManagerRegistryTag,
   TaskConnIdTag,
+  TaskConnectionId,
 } from "../rpc/handler-runtime.js";
 
 /* ── Base tier (Db + Logger) ──────────────────────────────────────────── */
@@ -187,7 +188,7 @@ export declare const provideNetworkLayer: <A, E>(
  */
 export declare const provideTaskLayer: <A, E>(
   handler: import("effect").Effect.Effect<A, E, TaskLayerOutputs>,
-  connId: string,
+  connId: TaskConnectionId,
 ) => import("effect").Effect.Effect<A, E, never>;
 
 /* ── Not-implemented stub bodies ───────────────────────────────────────── */

--- a/packages/server/src/services/service-surface.md
+++ b/packages/server/src/services/service-surface.md
@@ -1,0 +1,222 @@
+# Service surface migration checklist (arch-G)
+
+Scope: every existing server-side service whose public surface returns
+`Promise<T>` or throws. Arch-G does not migrate these here — the list is
+the contract that `implement-senior` consumes to sequence the Promise→Effect
+conversion across slices. Ordering and cross-service coordination are the
+implementer's call; this file names the target shapes so they cannot drift.
+
+Hard rules (spec + arch-G hard constraints):
+
+1. No `Promise<T>` on a public signature. Every public function returns
+   `Effect<T, E, R>` where `E` is a named error tag or a discriminated
+   union and `R` is the service's Context requirement (or `never`).
+2. No thrown exceptions on the success path. Thrown errors reserved for
+   unrecoverable defects (OOM, corrupted invariants); those collapse to
+   `InternalError` at the router edge.
+3. No `any`, no `Record<string, unknown>` on public signatures.
+4. Each service's error channel is closed. Where today a service throws a
+   mix of `RpcFailure` and unchecked errors, the target shape names every
+   tag.
+5. No dual-path services. When a service migrates, the old shape is
+   removed in the same PR; callers update in the same PR. (Spec clean-break
+   constraint; no shims.)
+
+Each row's `Target shape` is the public surface after migration. The
+`Error channel` column is the closed union the caller must match on. The
+`Touchpoints` column points at callers that change in the same PR — the
+implementer uses this to size the slice.
+
+Services already Effect-shaped (`AuthService`, `ConversationService`,
+`ParticipantService`, `DeliveryService`, `MessageService`) are listed so
+their Context requirements get formalized under the arch-G layer split
+(`TaskLayerLive` inputs) — none stay as ad-hoc class constructors with
+positional `Db` / `Broadcaster` / `AppHost` arguments.
+
+---
+
+## Services in scope
+
+### 1. `AuthService` — `packages/server/src/services/auth.service.ts`
+
+- Current shape: `Effect<T, never>` on most methods; `registerAgent` is
+  closure-captured over `Db`, not resolved from Context.
+- Target shape: same per-method Effects, exposed via `AuthServiceTag`;
+  constructor replaced by `Layer.effect(AuthServiceTag, …)`.
+- Error channel: `never` (where correct) or tagged `AuthError` union.
+- Touchpoints: `auth/register`, `auth/claim`, `auth/connect` handlers.
+
+### 2. `ParticipantService` — `packages/server/src/services/participant.service.ts`
+
+- Current shape: `Effect<T, RpcFailure>` with Db closed over.
+- Target shape: unchanged methods; resolved via `ParticipantServiceTag`.
+  `RpcFailure` stays as the typed failure channel.
+- Error channel: `RpcFailure` (closed — see `runtime/errors.ts`).
+- Touchpoints: every handler under `app/handlers/` that validates agent IDs.
+
+### 3. `ConversationService` — `packages/server/src/services/conversation.service.ts`
+
+- Current shape: `Effect<T, RpcFailure>` with Db + ParticipantService +
+  ConnectionManager closed over in the constructor; plus an
+  `isAttachedToActiveSession` callback closure.
+- Target shape: resolved via `ConversationServiceTag`; closure-captured
+  callback replaced by yielding `AppHostTag` (task-layer context only) at
+  the one call site that needs it. `ConnectionManagerTag` yielded at the
+  subscribe-agents-to-conversation site instead of being held.
+- Error channel: `RpcFailure`.
+- Touchpoints: `conversations/*` handlers, `ConversationService.create`.
+
+### 4. `DeliveryService` (task-shaped) — `packages/server/src/services/delivery.service.ts`
+
+- NOTE: This is the per-message tracking service, distinct from the
+  network-layer `DeliveryService` in `network/delivery-service.ts`
+  (arch-G module 2). The task-shaped service is renamed.
+- Rename to `MessageDeliveryTracker` (or move under `task/`) in
+  implement-* to disambiguate from the network primitive. `DeliveryError`
+  shadowing also resolved.
+- Target shape: `Effect<T, RpcFailure>` resolved via
+  `MessageDeliveryTrackerTag`.
+- Error channel: `RpcFailure`.
+- Touchpoints: `MessageService.send` delivery recording.
+
+### 5. `PresenceService` — `packages/server/src/services/presence.service.ts`
+
+- Current shape: synchronous, mutable `Map`-backed class. Every method is
+  `void` or returns a value directly; no Effect wrapping at all.
+- Target shape: all writes return `Effect.Effect<void, never, never>`
+  (writes must be sequenced via the runtime to interact correctly with the
+  new subscribe-notify fanout). Reads stay synchronous where they are
+  pure map reads; async-observable ones return `Effect`.
+- Error channel: `never` (in-memory) — subscription push returns
+  `Effect<void, DeliveryError, ConnectionManagerTag | DeliveryServiceTag>`
+  once the push path moves through `DeliveryService.send`.
+- Touchpoints: `presence/update`, `presence/subscribe`, the connection
+  teardown hook in the WS router.
+
+### 6. `MessageService` — `packages/server/src/services/message.service.ts`
+
+- Current shape: `Effect<…, RpcFailure>` with `Broadcaster` closed over
+  alongside Db, ConversationService, DeliveryService, AppHost,
+  DeliveryWebhookConfig, WebhookClient. Uses `Broadcaster.broadcastToConversation`
+  for fan-out.
+- Target shape: constructor eliminated; resolved via `MessageServiceTag`.
+  Fan-out switches from `Broadcaster.broadcastToConversation` to
+  `Effect.forEach(participants, (to) => DeliveryService.send(to, frame))`
+  (spec Invariant 6; arch-G modules 1–2). Delivery webhook fire-and-forget
+  fibers stay but get a named scope (no more untracked `Effect.runFork`).
+- Error channel: `RpcFailure` on the success path; delivery errors
+  collapsed into the existing webhook-failure logging path.
+- Touchpoints: `messages/send` handler, `AppHost` hook dispatch, the two
+  tests under `__tests__/` that currently assert broadcaster behavior.
+
+### 7. `UserService` (`WebhookUserService` + `NullUserService`) — `packages/server/src/services/user.service.ts`
+
+- Current shape: `Effect<…, never>` surface already; `WebhookUserService`
+  closes over `WebhookClient` + `Logger`.
+- Target shape: resolved via `UserServiceTag` (union of
+  `UserService | null` kept — `null` is a first-class configured state).
+  `WebhookClient` resolved via `WebhookClientTag`.
+- Error channel: `never` externally; internal webhook decode failures
+  collapse to `{valid: false}` (current behavior preserved).
+- Touchpoints: `auth/connect`, contact-check-seeded operations.
+
+### 8. `AppHost` — `packages/server/src/app/app-host.ts`
+
+- Current shape: mixed `Effect<…, RpcFailure>` and `Effect<…, never>` APIs
+  with `Db`, `Broadcaster`, `ConnectionManager`, `UserService`,
+  `WebhookClient`, and a `Ref<HashMap<string, Deferred<string[], Error>>>`
+  all closed over the constructor.
+- Target shape: resolved via `AppHostTag`; broadcaster dependency REMOVED
+  (the app-layer `humanContact` prompts fan out via
+  `DeliveryService.send`); pending-permissions `Ref` stays (moves under
+  `HumanContactTag` in the humanContact refactor — arch-B/C scope).
+- Error channel: existing `RpcFailure` + `HookTimeout` + `HookExecutionError`.
+  Must close the union explicitly; a named `AppHostError` collects them.
+- Touchpoints: `apps/*` handlers, the permission-grant flow, and every
+  hook-dispatch call site.
+
+### 9. `DefaultPermissionService` — inside `packages/server/src/app/app-host.ts`
+
+- Current shape: class with `requestPermission(params): Effect<string[], Error>`
+  that closes over `Broadcaster`.
+- Target shape: absorbed into the unified `humanContact` abstraction per
+  spec Invariant 12. As a standalone service it goes away; implement-*
+  removes the class and its tag.
+- Error channel: becomes part of `HumanContactError` (closed union on the
+  new abstraction).
+- Touchpoints: `apps/requestPermission` and every handler that currently
+  reaches for `DefaultPermissionServiceTag`.
+
+### 10. `WebhookClient` (adapter) — `packages/server/src/adapters/webhook.ts`
+
+- Current shape: class with methods returning `Effect<T, WebhookError>`
+  (already Effect-shaped); `signWebhookPayload` is a pure function.
+- Target shape: unchanged public surface; resolved via `WebhookClientTag`.
+  `signWebhookPayload` stays a free function.
+- Error channel: `WebhookError` (already a closed tag set — see the
+  `Data.TaggedError` declarations in `webhook.ts`).
+- Touchpoints: `AppHost`, `MessageService` (delivery-webhook path).
+
+### 11. `Broadcaster` — `packages/server/src/ws/broadcaster.ts`
+
+- Current shape: class with `broadcastToConversation` (fan-out + silent
+  `Effect.runFork`) and `sendToAgent` (same shape).
+- Target shape: **removed**. No replacement service; callers use
+  `DeliveryService.send` (arch-G module 2) + `Effect.forEach` for fan-out.
+- Error channel: n/a (module deleted).
+- Touchpoints: every current caller of `Broadcaster.*` — `MessageService`,
+  `AppHost`, `DefaultPermissionService`, `ConversationService.create` (via
+  the subscribe-after-create hook), presence push, delivery-ack push.
+  Implement-* rewrites each call site to `DeliveryService.send` per the
+  fan-out shape. See "Files to remove at implement-* time" in the design
+  doc.
+
+### 12. `ConnectionManager` (WS-only) — `packages/server/src/ws/connection.ts`
+
+- Current shape: class with synchronous `add` / `remove` / `get` / `all`
+  / `getByAgent` / `subscribeAgentsToConversation` / `entries` / `size`.
+- Target shape: **removed**. Replaced by the arch-G
+  `ConnectionManager` (module 1) whose endpoint-oriented surface subsumes
+  connection tracking as a subset (arch-A's `NetworkConnectionManager`
+  read surface + arch-G's `register`/`unregister`/`lookup`/`connectedAgents`).
+- Error channel: n/a (module deleted).
+- Touchpoints: WS upgrade handler, presence, conversation subscriptions,
+  `Broadcaster` callers.
+
+---
+
+## Services NOT migrating in arch-G
+
+- `Logger` — already Context-resolved via `LoggerTag`; no change.
+- `Db` (Kysely handle) — already Context-resolved via `DbTag`; no change.
+- `EnvelopeEncryption` — already a pure data carrier; no change.
+- Everything under `packages/app-sdk/` — SDK-side, not server-side. Arch-G
+  is server-only.
+
+---
+
+## Open-questions bucket (routed to implement-senior)
+
+1. **`AppHost` internal state (`Ref<HashMap<..., Deferred>>`)** — moves to
+   a dedicated `HumanContact` service under arch-B/C. If those slices land
+   after arch-G's implement-* PRs, the `Ref` stays on `AppHost` as a
+   transitional shape. Recommended default: leave the `Ref` on `AppHost`
+   during implement-G; migrate when arch-B/C implementer runs.
+2. **`PresenceService` subscription push path** — currently re-derives
+   connection subscribers on every push. Under arch-G the push goes
+   through `DeliveryService.send`, which resolves via
+   `AgentEndpointResolver`. Recommended default: keep the existing
+   subscriber-set Map in `PresenceService`; just reroute the push call to
+   `send`. Larger presence redesign is out of scope.
+3. **`MessageDeliveryTracker` (renamed `DeliveryService`) — should this
+   move under `task/services/` per the arch-A target layout, or stay under
+   `services/`?** Recommended default: `task/services/` to collocate with
+   `MessageService`; aligns with arch-A implement-* move plan.
+4. **`WebhookUserService` retry + concurrency** — today closes over
+   `WebhookClient.call` with no explicit timeout management. Recommended
+   default: no behavior change in implement-G; surface is Effect-shaped
+   already, and the webhook retry budget is a separate concern.
+
+Each default is non-load-bearing: the implement-senior may pick any of
+the alternatives without returning to arch-G. The recommendations exist so
+the first slice can make forward progress without deadlocking on choices.


### PR DESCRIPTION
Architecture only. Not for merge.

Design doc: https://github.com/chughtapan/moltzap/issues/134#issuecomment-4284298429

Sub-issue: #158

## Scope

5 new stub modules wiring the Effect-native server stack per arch-G spec:

1. `packages/server/src/network/connection-manager.ts` — endpoint registry + `AgentEndpointResolver`
2. `packages/server/src/network/delivery-service.ts` — `send(to, payload)` primitive + `BackpressurePolicy`
3. `packages/server/src/rpc/handler-runtime.ts` — `defineTaskMethod` + `TaskRequiredContext` + `CombinedRegistry`
4. `packages/server/src/services/service-surface.md` — Promise→Effect migration checklist
5. `packages/server/src/runtime/layers.ts` — `NetworkLayerLive`, `TaskLayerLive`, `AppRuntimeLive`

Plus `rpc/handler-runtime.type-test.ts` placeholder for negative type tests.

Every body is `throw new Error("not implemented")` or `declare const`. No logic. No `Promise<T>` on public signatures. No `any` / `Record<string, unknown>`. Every discriminated union closed on `_tag`.

## Not for merge

Replaces (at implement-* time): `ws/broadcaster.ts`, `ws/connection.ts`, `app/layers.ts`, rename of `services/delivery.service.ts`, removal of `DefaultPermissionService`. See "Files to remove at implement-* time" in the design doc.