### PR TITLE
[impl-staff] moltzap runtime cleanup

### DIFF
--- a/docs/architecture/2026-04-22-moltzap-runtime-cleanup-surfaces.md
+++ b/docs/architecture/2026-04-22-moltzap-runtime-cleanup-surfaces.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This slice freezes two upstream `@moltzap/server-core` surfaces and three `@moltzap/evals` surfaces so the implementation pass can remove Effect-version glue, route runtime logging through one shared observability contract, move MoltZap eval scenarios onto data-backed planned-harness staging, and make `cc-judge` the default execution model without touching arena-owned files. The shape is: `server-core` owns normalized process config plus shared request/session/agent/fiber log context, while `evals` owns only MoltZap-specific scenario documents, staging of planned-harness files for the upstream `cc-judge` ingress slice from `#167/#169`, and an explicit execution-mode boundary that demotes local `llm-judge` / `report` / `judgment-bundle` / `nanoclaw-smoke` paths behind opt-in legacy handling.
+This slice freezes two upstream `@moltzap/server-core` surfaces and three `@moltzap/evals` surfaces so the implementation pass can remove Effect-version glue, route runtime logging through one shared observability contract, move MoltZap eval scenarios onto declarative planned-harness staging, and make `cc-judge` the default execution model without touching arena-owned files. The shape is: `server-core` owns normalized process config plus shared request/session/agent/fiber observability where helper combinators are total once bootstrap succeeds, while `evals` owns only MoltZap-specific scenario documents that explicitly mirror current DM, group, and cross-conversation behavior, plus staged planned-harness catalogs whose `pathOrGlob` selection aligns to the upstream `cc-judge run-plans <plan-path-or-glob>` ingress from `#167/#169`.
 
 ## Modules
 
@@ -12,18 +12,18 @@ Public surface: `RuntimeConfigPath`, `RuntimeEnvironment`, `RuntimeLogLevel`, `R
 Dependencies: `../config/effect-config.js`, `../config/loader.js`, `../app/config.js`, `effect`.
 
 2. `packages/server/src/runtime-surface/logging.ts`
-Purpose: upstream a shared observability contract around the existing Pino-plus-Effect logger shape, including typed request/session/agent/fiber annotations.
+Purpose: upstream a shared observability contract around the existing Pino-plus-Effect logger shape, including typed request/session/agent/fiber annotations and a total post-bootstrap helper surface.
 Public surface: `RuntimeRequestId`, `RuntimeSessionId`, `RuntimeAgentId`, `RuntimeFiberId`, `RuntimeSpanName`, `RuntimeLogContext`, `RuntimeTraceSpan`, `RuntimeObservability`, `RuntimeObservabilityError`, `createRuntimeObservability(...)`, `withRuntimeLogContext(...)`, `withRuntimeTraceSpan(...)`.
 Dependencies: `../logger.js`, `./config.js`, `effect`.
 
 3. `packages/evals/src/runtime-surface/types.ts`
 Purpose: define the MoltZap-owned eval contracts that stay local after generic bundle / judge / report ownership moves to `cc-judge`.
-Public surface: `EvalScenarioDocumentPath`, `PlannedHarnessArtifactPath`, `EvalResultsDirectory`, `EvalRunId`, `EvalRuntimeKind`, `EvalConversationMode`, `EvalScenarioAssertion`, `MoltZapEvalScenarioDocument`, `LegacyEvalSurface`, `EvalExecutionMode`, `EvalRunRequest`, `EvalRunReceipt`.
+Public surface: `EvalScenarioDocumentPath`, `PlannedHarnessArtifactPath`, `PlannedHarnessPathOrGlob`, `EvalResultsDirectory`, `EvalRunId`, `EvalRuntimeKind`, `EvalScenarioAssertion`, `DirectMessageConversation`, `GroupConversation`, `CrossConversation`, `EvalScenarioConversation`, `MoltZapEvalScenarioDocument`, `StagedPlannedHarnessArtifact`, `PlannedHarnessExecutionInput`, `StagedPlannedHarnessCatalog`, `LegacyEvalSurface`, `EvalExecutionMode`, `EvalRunRequest`, `EvalRunReceipt`.
 Dependencies: no external libraries beyond TypeScript structural typing; consumed by the other two eval runtime-surface modules.
 
 4. `packages/evals/src/runtime-surface/scenario-source.ts`
-Purpose: load and validate MoltZap scenario YAML/data files, reject remaining TS-only deterministic callback shapes, and stage file-backed planned-harness artifacts for the upstream `cc-judge` runner path.
-Public surface: `LoadedEvalScenarioDocument`, `StagedPlannedHarnessArtifact`, `EvalScenarioSourceError`, `loadEvalScenarioDocuments(...)`, `stagePlannedHarnessArtifacts(...)`.
+Purpose: load and validate MoltZap scenario YAML/data files, reject remaining TS-only deterministic callback shapes, and stage file-backed planned-harness catalogs for the upstream `cc-judge` runner path.
+Public surface: `LoadedEvalScenarioDocument`, `EvalScenarioSourceError`, `loadEvalScenarioDocuments(...)`, `stagePlannedHarnessArtifacts(...)`.
 Dependencies: `./types.js`, `effect`, `yaml` parser chosen to align with `@moltzap/server-core` and avoid keeping `js-yaml` as a second parser stack long-term.
 
 5. `packages/evals/src/runtime-surface/runner.ts`
@@ -160,11 +160,6 @@ export class RuntimeObservabilityError extends Data.TaggedError(
         readonly message: string;
       }
     | {
-        readonly _tag: "AnnotationRejected";
-        readonly field: string;
-        readonly message: string;
-      }
-    | {
         readonly _tag: "FiberSupervisorUnavailable";
         readonly message: string;
       };
@@ -185,7 +180,7 @@ export function withRuntimeTraceSpan<A, E, R>(
 ): Effect.Effect<A, E, R>;
 ```
 
-Intent: `logging.ts` owns the typed observability contract that server boot, RPC handlers, CLI commands, and eval orchestration all share.
+Intent: `logging.ts` owns the typed observability contract that server boot, RPC handlers, CLI commands, and eval orchestration all share. `createRuntimeObservability(...)` is the only fallible boundary; once the service exists, `annotate`, `span`, `withRuntimeLogContext(...)`, and `withRuntimeTraceSpan(...)` are total wrappers over typed context rather than a second runtime-validation layer.
 
 ```ts
 // packages/evals/src/runtime-surface/types.ts
@@ -195,6 +190,10 @@ export type EvalScenarioDocumentPath = string & {
 
 export type PlannedHarnessArtifactPath = string & {
   readonly __brand: "PlannedHarnessArtifactPath";
+};
+
+export type PlannedHarnessPathOrGlob = string & {
+  readonly __brand: "PlannedHarnessPathOrGlob";
 };
 
 export type EvalResultsDirectory = string & {
@@ -207,24 +206,77 @@ export type EvalRunId = string & {
 
 export type EvalRuntimeKind = "openclaw" | "nanoclaw";
 
-export type EvalConversationMode = "dm" | "group" | "cross-conversation";
-
 export type EvalScenarioAssertion =
   | { readonly _tag: "ContainsText"; readonly text: string }
   | { readonly _tag: "OmitsText"; readonly text: string }
   | { readonly _tag: "MaxWordCount"; readonly maxWords: number }
   | { readonly _tag: "MatchesRegex"; readonly pattern: string };
 
+export interface DirectMessageConversation {
+  readonly _tag: "DirectMessage";
+  readonly setupMessage: string;
+  readonly followUpMessages: readonly string[];
+}
+
+export interface GroupConversation {
+  readonly _tag: "GroupConversation";
+  readonly setupMessage: string;
+  readonly followUpMessages: readonly string[];
+  readonly bystanderCount: number;
+  readonly bystanderMessages: readonly string[];
+}
+
+export interface CrossConversation {
+  readonly _tag: "CrossConversation";
+  readonly setupMessage: string;
+  readonly followUpMessages: readonly string[];
+  readonly probeMessage: string;
+}
+
+export type EvalScenarioConversation =
+  | DirectMessageConversation
+  | GroupConversation
+  | CrossConversation;
+
 export interface MoltZapEvalScenarioDocument {
   readonly id: string;
   readonly name: string;
   readonly description: string;
   readonly runtime: EvalRuntimeKind;
-  readonly conversationMode: EvalConversationMode;
-  readonly setupMessages: readonly string[];
+  readonly conversation: EvalScenarioConversation;
   readonly expectedBehavior: string;
   readonly assertions: readonly EvalScenarioAssertion[];
   readonly resultsSubdirectory?: string;
+}
+
+export interface StagedPlannedHarnessArtifact {
+  readonly sourcePath: EvalScenarioDocumentPath;
+  readonly scenarioId: string;
+  readonly plannedHarnessPath: PlannedHarnessArtifactPath;
+}
+
+export type PlannedHarnessExecutionInput =
+  | {
+      readonly _tag: "SingleDocument";
+      readonly pathOrGlob: PlannedHarnessPathOrGlob;
+      readonly matchedDocument: PlannedHarnessArtifactPath;
+    }
+  | {
+      readonly _tag: "DocumentGlob";
+      readonly pathOrGlob: PlannedHarnessPathOrGlob;
+      readonly matchedDocuments: readonly [
+        PlannedHarnessArtifactPath,
+        PlannedHarnessArtifactPath,
+        ...PlannedHarnessArtifactPath[],
+      ];
+    };
+
+export interface StagedPlannedHarnessCatalog {
+  readonly artifacts: readonly [
+    StagedPlannedHarnessArtifact,
+    ...StagedPlannedHarnessArtifact[],
+  ];
+  readonly executionInput: PlannedHarnessExecutionInput;
 }
 
 export type LegacyEvalSurface =
@@ -236,7 +288,7 @@ export type LegacyEvalSurface =
 export type EvalExecutionMode =
   | {
       readonly _tag: "CcJudgeDefault";
-      readonly plannedHarnessPath: PlannedHarnessArtifactPath;
+      readonly plannedHarnessInput: PlannedHarnessExecutionInput;
     }
   | {
       readonly _tag: "LegacyLlmJudgeExplicit";
@@ -245,7 +297,10 @@ export type EvalExecutionMode =
     };
 
 export interface EvalRunRequest {
-  readonly scenarioDocuments: readonly EvalScenarioDocumentPath[];
+  readonly scenarioDocuments: readonly [
+    EvalScenarioDocumentPath,
+    ...EvalScenarioDocumentPath[],
+  ];
   readonly runtime: EvalRuntimeKind;
   readonly resultsDirectory: EvalResultsDirectory;
   readonly retainArtifacts: boolean;
@@ -256,22 +311,17 @@ export interface EvalRunReceipt {
   readonly runId: EvalRunId;
   readonly executionMode: EvalExecutionMode;
   readonly resultsDirectory: EvalResultsDirectory;
-  readonly stagedHarnesses: readonly PlannedHarnessArtifactPath[];
+  readonly stagedHarness: StagedPlannedHarnessCatalog;
 }
 ```
 
-Intent: `types.ts` makes the local MoltZap-owned surface explicit and keeps generic bundle/report ownership out of `@moltzap/evals`.
+Intent: `types.ts` makes the local MoltZap-owned surface explicit and keeps generic bundle/report ownership out of `@moltzap/evals`. The declarative scenario contract now mirrors the real MoltZap catalog directly: DM scenarios use `DirectMessage`, group scenarios map `groupBystanders` and `bystanderMessages` into `GroupConversation`, and cross-conversation scenarios map `crossConversationProbe` into `CrossConversation` without hiding those branches behind a generic `conversationMode` plus loosely-related arrays.
 
 ```ts
 // packages/evals/src/runtime-surface/scenario-source.ts
 export interface LoadedEvalScenarioDocument {
   readonly sourcePath: EvalScenarioDocumentPath;
   readonly document: MoltZapEvalScenarioDocument;
-}
-
-export interface StagedPlannedHarnessArtifact {
-  readonly sourcePath: EvalScenarioDocumentPath;
-  readonly plannedHarnessPath: PlannedHarnessArtifactPath;
 }
 
 export class EvalScenarioSourceError extends Data.TaggedError(
@@ -290,6 +340,15 @@ export class EvalScenarioSourceError extends Data.TaggedError(
     | {
         readonly _tag: "ScenarioSchemaInvalid";
         readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "ConversationDocumentInvalid";
+        readonly path: string;
+        readonly conversationTag:
+          | "DirectMessage"
+          | "GroupConversation"
+          | "CrossConversation";
         readonly message: string;
       }
     | {
@@ -318,14 +377,10 @@ export function loadEvalScenarioDocuments(
 export function stagePlannedHarnessArtifacts(input: {
   readonly documents: readonly LoadedEvalScenarioDocument[];
   readonly resultsDirectory: EvalResultsDirectory;
-}): Effect.Effect<
-  readonly StagedPlannedHarnessArtifact[],
-  EvalScenarioSourceError,
-  never
->;
+}): Effect.Effect<StagedPlannedHarnessCatalog, EvalScenarioSourceError, never>;
 ```
 
-Intent: `scenario-source.ts` is the only local module that reads MoltZap eval scenario data and the only allowed place to reject leftover TS callback semantics.
+Intent: `scenario-source.ts` is the only local module that reads MoltZap eval scenario data and the only allowed place to reject leftover TS callback semantics. It also owns the fan-in from one-or-more scenario YAML files into a single staged harness catalog whose execution input is already frozen in the same `pathOrGlob` terms that `cc-judge` accepts upstream.
 
 ```ts
 // packages/evals/src/runtime-surface/runner.ts
@@ -357,7 +412,10 @@ export class EvalRuntimeSurfaceError extends Data.TaggedError(
 }> {}
 
 export function resolveEvalExecutionMode(
-  request: EvalRunRequest,
+  input: {
+    readonly request: EvalRunRequest;
+    readonly stagedHarness: StagedPlannedHarnessCatalog;
+  },
 ): Effect.Effect<EvalExecutionMode, EvalRuntimeSurfaceError, never>;
 
 export function runEvalCatalog(
@@ -370,16 +428,16 @@ export function runEvalCatalog(
 >;
 ```
 
-Intent: `runner.ts` is the only orchestration boundary that knows how MoltZap stages local scenarios into the upstream `cc-judge` path and when legacy mode is still allowed.
+Intent: `runner.ts` is the only orchestration boundary that knows how MoltZap stages local scenarios into the upstream `cc-judge` path and when legacy mode is still allowed. Mode selection is no longer allowed to invent or infer a plan path; it must consume the staged catalog produced by `stagePlannedHarnessArtifacts(...)`.
 
 ## Data flow
 
 - Server boot or eval CLI enters through `loadRuntimeProcessConfig(...)`, which normalizes file-backed config plus env overlays into one `RuntimeProcessConfig`.
-- `createRuntimeObservability(...)` constructs the shared logger/tracing service from that config and becomes the only supported source of request/session/agent/fiber annotations.
-- `loadEvalScenarioDocuments(...)` reads MoltZap-owned YAML/data scenario files and rejects leftover TS callback fields that block declarative migration.
-- `stagePlannedHarnessArtifacts(...)` translates the validated MoltZap scenario documents into staged file-backed planned-harness inputs for the upstream `cc-judge` ingress slice; generic bundle schema and judge/report ownership do not live here.
-- `resolveEvalExecutionMode(...)` chooses `CcJudgeDefault` when the runtime is supported and the staged harness path is available; otherwise it can only return `LegacyLlmJudgeExplicit` when the caller asked for an explicit fallback.
-- `runEvalCatalog(...)` runs the staged catalog under the shared observability contract, emitting additive structured context and routing default judgment/report ownership to `cc-judge`.
+- `createRuntimeObservability(...)` constructs the shared logger/tracing service from that config; after that bootstrap step, `withRuntimeLogContext(...)` and `withRuntimeTraceSpan(...)` are total wrappers over typed context and never widen the downstream error channel.
+- `loadEvalScenarioDocuments(...)` reads MoltZap-owned YAML/data scenario files into an explicit `DirectMessage | GroupConversation | CrossConversation` union, rejects leftover TS callback fields, and rejects invalid group or cross-conversation document shapes before execution starts.
+- `stagePlannedHarnessArtifacts(...)` translates the validated MoltZap scenario documents into a `StagedPlannedHarnessCatalog` with one staged artifact per source document plus a frozen `PlannedHarnessExecutionInput`: single-document runs pass the staged file path through directly, while multi-document runs stage under one directory and hand `cc-judge` a glob-shaped `pathOrGlob` aligned to `run-plans`.
+- `resolveEvalExecutionMode(...)` receives both the original request and the staged harness catalog, then chooses `CcJudgeDefault` with the already-built `PlannedHarnessExecutionInput` when the runtime is supported; otherwise it can only return `LegacyLlmJudgeExplicit` when the caller asked for an explicit fallback.
+- `runEvalCatalog(...)` runs the staged catalog under the shared observability contract, emits additive structured context, routes default judgment/report ownership to `cc-judge`, and returns the full staged harness catalog in the run receipt for artifact retention and debugging.
 
 ```text
 process boundary
@@ -397,22 +455,22 @@ loadEvalScenarioDocuments(paths)
 stagePlannedHarnessArtifacts(documents, resultsDirectory)
     |-- EvalScenarioSourceError
     v
-resolveEvalExecutionMode(request)
+resolveEvalExecutionMode({ request, stagedHarness })
     |-- EvalRuntimeSurfaceError
     v
 runEvalCatalog(deps, request)
     |-- EvalRuntimeSurfaceError / EvalScenarioSourceError
     v
-cc-judge default run receipt + staged artifact retention
+cc-judge default run receipt + staged harness catalog retention
 ```
 
 ## Errors
 
 - `loadRuntimeProcessConfig(...)` exposes `RuntimeConfigSurfaceError` so boot-path failures stay typed instead of throwing from config reads or deep env lookups.
-- `createRuntimeObservability(...)`, `withRuntimeLogContext(...)`, and `withRuntimeTraceSpan(...)` expose `RuntimeObservabilityError` via the created service boundary and encode logger bootstrap / annotation rejection / supervisor availability explicitly.
-- `loadEvalScenarioDocuments(...)` and `stagePlannedHarnessArtifacts(...)` expose `EvalScenarioSourceError`, including a dedicated `DeterministicCallbackNotSupported` branch so the implementation pass cannot silently preserve TS callback checks.
+- `createRuntimeObservability(...)` exposes `RuntimeObservabilityError` only for logger or fiber-supervisor bootstrap. `annotate`, `span`, `withRuntimeLogContext(...)`, and `withRuntimeTraceSpan(...)` are intentionally total because they operate only on already-typed context and do not perform a second rejectable validation step.
+- `loadEvalScenarioDocuments(...)` and `stagePlannedHarnessArtifacts(...)` expose `EvalScenarioSourceError`, including dedicated `ConversationDocumentInvalid` and `DeterministicCallbackNotSupported` branches so the implementation pass cannot silently preserve malformed group/cross-conversation documents or TS callback checks.
 - `resolveEvalExecutionMode(...)` and `runEvalCatalog(...)` expose `EvalRuntimeSurfaceError`, including `LegacyModeRequiresExplicitOptIn` so local judge/report paths cannot remain the accidental default.
-- `EvalExecutionMode` is a closed discriminated union; downstream implementation must exhaustively handle `CcJudgeDefault` and `LegacyLlmJudgeExplicit` instead of drifting back to boolean flags.
+- `EvalExecutionMode.CcJudgeDefault` carries a `PlannedHarnessExecutionInput` rather than a fake singular plan path, so the implementation must exhaustively handle both `SingleDocument` and `DocumentGlob` staging shapes when multiple scenario documents are present.
 
 ## Dependencies
 
@@ -433,8 +491,8 @@ cc-judge default run receipt + staged artifact retention
 | Goal 5 / AC: remove `winston` from `@moltzap/evals` | direct design anchor | `packages/server/src/runtime-surface/logging.ts`, `packages/evals/src/runtime-surface/runner.ts` |
 | Goals 6 and 8 / AC: nanoclaw spike debt cleaned up behind a real runtime abstraction and local generic eval ownership shrinks | direct | `packages/evals/src/runtime-surface/types.ts`, `packages/evals/src/runtime-surface/runner.ts` |
 | Goals 7 and 8 / AC: `cc-judge` becomes default and local judge/report surfaces are demoted or removed | direct | `packages/evals/src/runtime-surface/types.ts`, `packages/evals/src/runtime-surface/runner.ts` |
-| Goal 11 / AC: MoltZap eval scenarios move from TS catalog callbacks to YAML/data assertions | direct | `packages/evals/src/runtime-surface/types.ts`, `packages/evals/src/runtime-surface/scenario-source.ts` |
-| Goal 13 / AC: planned-harness YAML stays a second path distinct from the simple prompt/workspace schema | direct, depends on `#167/#169` | `packages/evals/src/runtime-surface/scenario-source.ts`, `packages/evals/src/runtime-surface/runner.ts` |
+| Goal 11 / AC: MoltZap eval scenarios move from TS catalog callbacks to YAML/data assertions, including current group and cross-conversation behavior | direct | `packages/evals/src/runtime-surface/types.ts`, `packages/evals/src/runtime-surface/scenario-source.ts` |
+| Goal 13 / AC: planned-harness YAML stays a second path distinct from the simple prompt/workspace schema and flows through the same `pathOrGlob` ingress that `#167/#169` froze | direct, depends on `#167/#169` | `packages/evals/src/runtime-surface/types.ts`, `packages/evals/src/runtime-surface/scenario-source.ts`, `packages/evals/src/runtime-surface/runner.ts` |
 | Goal 17 / AC: no permanent duplicate ownership of generic YAML decode, bundle schema/codec, workspace seeding, or judge/report plumbing | direct | `packages/evals/src/runtime-surface/scenario-source.ts`, `packages/evals/src/runtime-surface/runner.ts` |
 | Non-goals 4, 5, 6 and issue ownership constraint: no arena-specific files or harness work in this slice | preserved by scope | all modules above; no `moltzap-arena` paths and no arena-specific interfaces introduced |
 

--- a/docs/architecture/2026-04-22-moltzap-runtime-cleanup-surfaces.md
+++ b/docs/architecture/2026-04-22-moltzap-runtime-cleanup-surfaces.md
@@ -1,0 +1,453 @@
+# MoltZap Runtime Cleanup Surfaces
+
+## Summary
+
+This slice freezes two upstream `@moltzap/server-core` surfaces and three `@moltzap/evals` surfaces so the implementation pass can remove Effect-version glue, route runtime logging through one shared observability contract, move MoltZap eval scenarios onto data-backed planned-harness staging, and make `cc-judge` the default execution model without touching arena-owned files. The shape is: `server-core` owns normalized process config plus shared request/session/agent/fiber log context, while `evals` owns only MoltZap-specific scenario documents, staging of planned-harness files for the upstream `cc-judge` ingress slice from `#167/#169`, and an explicit execution-mode boundary that demotes local `llm-judge` / `report` / `judgment-bundle` / `nanoclaw-smoke` paths behind opt-in legacy handling.
+
+## Modules
+
+1. `packages/server/src/runtime-surface/config.ts`
+Purpose: normalize file-backed YAML config plus process-env overlays into one typed runtime bootstrap snapshot that downstream server and eval code can share.
+Public surface: `RuntimeConfigPath`, `RuntimeEnvironment`, `RuntimeLogLevel`, `RuntimeLoggingConfig`, `RuntimeTracingConfig`, `LoadRuntimeConfigInput`, `RuntimeProcessConfig`, `RuntimeConfigSurfaceError`, `loadRuntimeProcessConfig(...)`.
+Dependencies: `../config/effect-config.js`, `../config/loader.js`, `../app/config.js`, `effect`.
+
+2. `packages/server/src/runtime-surface/logging.ts`
+Purpose: upstream a shared observability contract around the existing Pino-plus-Effect logger shape, including typed request/session/agent/fiber annotations.
+Public surface: `RuntimeRequestId`, `RuntimeSessionId`, `RuntimeAgentId`, `RuntimeFiberId`, `RuntimeSpanName`, `RuntimeLogContext`, `RuntimeTraceSpan`, `RuntimeObservability`, `RuntimeObservabilityError`, `createRuntimeObservability(...)`, `withRuntimeLogContext(...)`, `withRuntimeTraceSpan(...)`.
+Dependencies: `../logger.js`, `./config.js`, `effect`.
+
+3. `packages/evals/src/runtime-surface/types.ts`
+Purpose: define the MoltZap-owned eval contracts that stay local after generic bundle / judge / report ownership moves to `cc-judge`.
+Public surface: `EvalScenarioDocumentPath`, `PlannedHarnessArtifactPath`, `EvalResultsDirectory`, `EvalRunId`, `EvalRuntimeKind`, `EvalConversationMode`, `EvalScenarioAssertion`, `MoltZapEvalScenarioDocument`, `LegacyEvalSurface`, `EvalExecutionMode`, `EvalRunRequest`, `EvalRunReceipt`.
+Dependencies: no external libraries beyond TypeScript structural typing; consumed by the other two eval runtime-surface modules.
+
+4. `packages/evals/src/runtime-surface/scenario-source.ts`
+Purpose: load and validate MoltZap scenario YAML/data files, reject remaining TS-only deterministic callback shapes, and stage file-backed planned-harness artifacts for the upstream `cc-judge` runner path.
+Public surface: `LoadedEvalScenarioDocument`, `StagedPlannedHarnessArtifact`, `EvalScenarioSourceError`, `loadEvalScenarioDocuments(...)`, `stagePlannedHarnessArtifacts(...)`.
+Dependencies: `./types.js`, `effect`, `yaml` parser chosen to align with `@moltzap/server-core` and avoid keeping `js-yaml` as a second parser stack long-term.
+
+5. `packages/evals/src/runtime-surface/runner.ts`
+Purpose: resolve the default `cc-judge` execution mode versus explicit legacy fallback, and expose one Effect-native entrypoint for running a staged MoltZap eval catalog with shared observability.
+Public surface: `EvalRuntimeDependencies`, `EvalRuntimeSurfaceError`, `resolveEvalExecutionMode(...)`, `runEvalCatalog(...)`.
+Dependencies: `./types.js`, `./scenario-source.js`, `@moltzap/server-core`, `effect`, supported `cc-judge` planned-harness package surface from `#167/#169`.
+
+## Interfaces
+
+```ts
+// packages/server/src/runtime-surface/config.ts
+export type RuntimeConfigPath = string & {
+  readonly __brand: "RuntimeConfigPath";
+};
+
+export type RuntimeEnvironment = "development" | "test" | "production";
+
+export type RuntimeLogLevel = "debug" | "info" | "warn" | "error";
+
+export interface RuntimeLoggingConfig {
+  readonly level: RuntimeLogLevel;
+  readonly preserveLegacyFields: boolean;
+}
+
+export interface RuntimeTracingConfig {
+  readonly serviceName: string;
+  readonly includeFiberIds: boolean;
+  readonly includeRequestContext: boolean;
+}
+
+export interface LoadRuntimeConfigInput {
+  readonly configPath?: RuntimeConfigPath;
+  readonly processEnv?: Readonly<Record<string, string | undefined>>;
+}
+
+export interface RuntimeProcessConfig {
+  readonly configPath: RuntimeConfigPath;
+  readonly configDirectory: string;
+  readonly environment: RuntimeEnvironment;
+  readonly logging: RuntimeLoggingConfig;
+  readonly tracing: RuntimeTracingConfig;
+  readonly app: MoltZapAppConfig;
+  readonly server: LoadedConfig;
+}
+
+export class RuntimeConfigSurfaceError extends Data.TaggedError(
+  "RuntimeConfigSurfaceError",
+)<{
+  readonly cause:
+    | {
+        readonly _tag: "ConfigFileUnreadable";
+        readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "ConfigFileInvalid";
+        readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "EnvironmentInvalid";
+        readonly key: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "DirectoryResolutionFailed";
+        readonly path: string;
+        readonly message: string;
+      };
+}> {}
+
+export function loadRuntimeProcessConfig(
+  input: LoadRuntimeConfigInput,
+): Effect.Effect<RuntimeProcessConfig, RuntimeConfigSurfaceError, never>;
+```
+
+Intent: `config.ts` is the one process-boundary decode surface for shared logging/tracing config and for the normalized server bootstrap snapshot.
+
+```ts
+// packages/server/src/runtime-surface/logging.ts
+export type RuntimeRequestId = string & {
+  readonly __brand: "RuntimeRequestId";
+};
+
+export type RuntimeSessionId = string & {
+  readonly __brand: "RuntimeSessionId";
+};
+
+export type RuntimeAgentId = string & {
+  readonly __brand: "RuntimeAgentId";
+};
+
+export type RuntimeFiberId = string & {
+  readonly __brand: "RuntimeFiberId";
+};
+
+export type RuntimeSpanName = string & {
+  readonly __brand: "RuntimeSpanName";
+};
+
+export interface RuntimeLogContext {
+  readonly requestId?: RuntimeRequestId;
+  readonly sessionId?: RuntimeSessionId;
+  readonly agentId?: RuntimeAgentId;
+  readonly connectionId?: string;
+  readonly workflow?: "rpc" | "session" | "transport" | "eval";
+}
+
+export interface RuntimeTraceSpan {
+  readonly name: RuntimeSpanName;
+  readonly fiberId?: RuntimeFiberId;
+  readonly parentFiberId?: RuntimeFiberId;
+}
+
+export interface RuntimeObservability {
+  readonly logger: Logger;
+  readonly config: RuntimeProcessConfig;
+  readonly annotate: <A, E, R>(
+    context: RuntimeLogContext,
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>;
+  readonly span: <A, E, R>(
+    span: RuntimeTraceSpan,
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>;
+}
+
+export class RuntimeObservabilityError extends Data.TaggedError(
+  "RuntimeObservabilityError",
+)<{
+  readonly cause:
+    | {
+        readonly _tag: "LoggerBootstrapFailed";
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "AnnotationRejected";
+        readonly field: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "FiberSupervisorUnavailable";
+        readonly message: string;
+      };
+}> {}
+
+export function createRuntimeObservability(
+  config: RuntimeProcessConfig,
+): Effect.Effect<RuntimeObservability, RuntimeObservabilityError, never>;
+
+export function withRuntimeLogContext<A, E, R>(
+  context: RuntimeLogContext,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R>;
+
+export function withRuntimeTraceSpan<A, E, R>(
+  span: RuntimeTraceSpan,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R>;
+```
+
+Intent: `logging.ts` owns the typed observability contract that server boot, RPC handlers, CLI commands, and eval orchestration all share.
+
+```ts
+// packages/evals/src/runtime-surface/types.ts
+export type EvalScenarioDocumentPath = string & {
+  readonly __brand: "EvalScenarioDocumentPath";
+};
+
+export type PlannedHarnessArtifactPath = string & {
+  readonly __brand: "PlannedHarnessArtifactPath";
+};
+
+export type EvalResultsDirectory = string & {
+  readonly __brand: "EvalResultsDirectory";
+};
+
+export type EvalRunId = string & {
+  readonly __brand: "EvalRunId";
+};
+
+export type EvalRuntimeKind = "openclaw" | "nanoclaw";
+
+export type EvalConversationMode = "dm" | "group" | "cross-conversation";
+
+export type EvalScenarioAssertion =
+  | { readonly _tag: "ContainsText"; readonly text: string }
+  | { readonly _tag: "OmitsText"; readonly text: string }
+  | { readonly _tag: "MaxWordCount"; readonly maxWords: number }
+  | { readonly _tag: "MatchesRegex"; readonly pattern: string };
+
+export interface MoltZapEvalScenarioDocument {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly runtime: EvalRuntimeKind;
+  readonly conversationMode: EvalConversationMode;
+  readonly setupMessages: readonly string[];
+  readonly expectedBehavior: string;
+  readonly assertions: readonly EvalScenarioAssertion[];
+  readonly resultsSubdirectory?: string;
+}
+
+export type LegacyEvalSurface =
+  | "llm-judge"
+  | "report"
+  | "judgment-bundle"
+  | "nanoclaw-smoke";
+
+export type EvalExecutionMode =
+  | {
+      readonly _tag: "CcJudgeDefault";
+      readonly plannedHarnessPath: PlannedHarnessArtifactPath;
+    }
+  | {
+      readonly _tag: "LegacyLlmJudgeExplicit";
+      readonly requestedBy: "cli-flag" | "unsupported-runtime";
+      readonly surface: LegacyEvalSurface;
+    };
+
+export interface EvalRunRequest {
+  readonly scenarioDocuments: readonly EvalScenarioDocumentPath[];
+  readonly runtime: EvalRuntimeKind;
+  readonly resultsDirectory: EvalResultsDirectory;
+  readonly retainArtifacts: boolean;
+  readonly requestedMode?: "cc-judge" | "legacy-llm-judge";
+}
+
+export interface EvalRunReceipt {
+  readonly runId: EvalRunId;
+  readonly executionMode: EvalExecutionMode;
+  readonly resultsDirectory: EvalResultsDirectory;
+  readonly stagedHarnesses: readonly PlannedHarnessArtifactPath[];
+}
+```
+
+Intent: `types.ts` makes the local MoltZap-owned surface explicit and keeps generic bundle/report ownership out of `@moltzap/evals`.
+
+```ts
+// packages/evals/src/runtime-surface/scenario-source.ts
+export interface LoadedEvalScenarioDocument {
+  readonly sourcePath: EvalScenarioDocumentPath;
+  readonly document: MoltZapEvalScenarioDocument;
+}
+
+export interface StagedPlannedHarnessArtifact {
+  readonly sourcePath: EvalScenarioDocumentPath;
+  readonly plannedHarnessPath: PlannedHarnessArtifactPath;
+}
+
+export class EvalScenarioSourceError extends Data.TaggedError(
+  "EvalScenarioSourceError",
+)<{
+  readonly cause:
+    | {
+        readonly _tag: "ScenarioFileMissing";
+        readonly path: string;
+      }
+    | {
+        readonly _tag: "ScenarioYamlInvalid";
+        readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "ScenarioSchemaInvalid";
+        readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "DeterministicCallbackNotSupported";
+        readonly path: string;
+        readonly field: "deterministicPassCheck" | "deterministicFailCheck";
+      }
+    | {
+        readonly _tag: "DuplicateScenarioId";
+        readonly scenarioId: string;
+        readonly paths: readonly [
+          EvalScenarioDocumentPath,
+          EvalScenarioDocumentPath,
+        ];
+      };
+}> {}
+
+export function loadEvalScenarioDocuments(
+  paths: readonly EvalScenarioDocumentPath[],
+): Effect.Effect<
+  readonly LoadedEvalScenarioDocument[],
+  EvalScenarioSourceError,
+  never
+>;
+
+export function stagePlannedHarnessArtifacts(input: {
+  readonly documents: readonly LoadedEvalScenarioDocument[];
+  readonly resultsDirectory: EvalResultsDirectory;
+}): Effect.Effect<
+  readonly StagedPlannedHarnessArtifact[],
+  EvalScenarioSourceError,
+  never
+>;
+```
+
+Intent: `scenario-source.ts` is the only local module that reads MoltZap eval scenario data and the only allowed place to reject leftover TS callback semantics.
+
+```ts
+// packages/evals/src/runtime-surface/runner.ts
+export interface EvalRuntimeDependencies {
+  readonly runtimeConfig: RuntimeProcessConfig;
+  readonly observability: RuntimeObservability;
+}
+
+export class EvalRuntimeSurfaceError extends Data.TaggedError(
+  "EvalRuntimeSurfaceError",
+)<{
+  readonly cause:
+    | {
+        readonly _tag: "UnsupportedRuntime";
+        readonly runtime: EvalRuntimeKind;
+      }
+    | {
+        readonly _tag: "CcJudgeSurfaceUnavailable";
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "LegacyModeRequiresExplicitOptIn";
+        readonly surface: LegacyEvalSurface;
+      }
+    | {
+        readonly _tag: "ObservabilityUnavailable";
+        readonly message: string;
+      };
+}> {}
+
+export function resolveEvalExecutionMode(
+  request: EvalRunRequest,
+): Effect.Effect<EvalExecutionMode, EvalRuntimeSurfaceError, never>;
+
+export function runEvalCatalog(
+  deps: EvalRuntimeDependencies,
+  request: EvalRunRequest,
+): Effect.Effect<
+  EvalRunReceipt,
+  EvalRuntimeSurfaceError | EvalScenarioSourceError,
+  never
+>;
+```
+
+Intent: `runner.ts` is the only orchestration boundary that knows how MoltZap stages local scenarios into the upstream `cc-judge` path and when legacy mode is still allowed.
+
+## Data flow
+
+- Server boot or eval CLI enters through `loadRuntimeProcessConfig(...)`, which normalizes file-backed config plus env overlays into one `RuntimeProcessConfig`.
+- `createRuntimeObservability(...)` constructs the shared logger/tracing service from that config and becomes the only supported source of request/session/agent/fiber annotations.
+- `loadEvalScenarioDocuments(...)` reads MoltZap-owned YAML/data scenario files and rejects leftover TS callback fields that block declarative migration.
+- `stagePlannedHarnessArtifacts(...)` translates the validated MoltZap scenario documents into staged file-backed planned-harness inputs for the upstream `cc-judge` ingress slice; generic bundle schema and judge/report ownership do not live here.
+- `resolveEvalExecutionMode(...)` chooses `CcJudgeDefault` when the runtime is supported and the staged harness path is available; otherwise it can only return `LegacyLlmJudgeExplicit` when the caller asked for an explicit fallback.
+- `runEvalCatalog(...)` runs the staged catalog under the shared observability contract, emitting additive structured context and routing default judgment/report ownership to `cc-judge`.
+
+```text
+process boundary
+    |
+    v
+loadRuntimeProcessConfig(input)
+    |-- RuntimeConfigSurfaceError
+    v
+createRuntimeObservability(config)
+    |-- RuntimeObservabilityError
+    v
+loadEvalScenarioDocuments(paths)
+    |-- EvalScenarioSourceError
+    v
+stagePlannedHarnessArtifacts(documents, resultsDirectory)
+    |-- EvalScenarioSourceError
+    v
+resolveEvalExecutionMode(request)
+    |-- EvalRuntimeSurfaceError
+    v
+runEvalCatalog(deps, request)
+    |-- EvalRuntimeSurfaceError / EvalScenarioSourceError
+    v
+cc-judge default run receipt + staged artifact retention
+```
+
+## Errors
+
+- `loadRuntimeProcessConfig(...)` exposes `RuntimeConfigSurfaceError` so boot-path failures stay typed instead of throwing from config reads or deep env lookups.
+- `createRuntimeObservability(...)`, `withRuntimeLogContext(...)`, and `withRuntimeTraceSpan(...)` expose `RuntimeObservabilityError` via the created service boundary and encode logger bootstrap / annotation rejection / supervisor availability explicitly.
+- `loadEvalScenarioDocuments(...)` and `stagePlannedHarnessArtifacts(...)` expose `EvalScenarioSourceError`, including a dedicated `DeterministicCallbackNotSupported` branch so the implementation pass cannot silently preserve TS callback checks.
+- `resolveEvalExecutionMode(...)` and `runEvalCatalog(...)` expose `EvalRuntimeSurfaceError`, including `LegacyModeRequiresExplicitOptIn` so local judge/report paths cannot remain the accidental default.
+- `EvalExecutionMode` is a closed discriminated union; downstream implementation must exhaustively handle `CcJudgeDefault` and `LegacyLlmJudgeExplicit` instead of drifting back to boolean flags.
+
+## Dependencies
+
+| library | version | license | why this one |
+|---|---:|---|---|
+| `effect` | `3.21.0` | MIT | Existing runtime substrate across server and evals; this slice freezes typed error and Effect-native orchestration surfaces rather than adding another async/error model. |
+| `@effect/platform-node` | `0.106.0` | MIT | Existing Node process/runtime integration already used in server boot paths; implementation reuses it instead of inventing another process-boundary helper layer. |
+| `pino` | `9.6.0` | MIT | Existing sink for the shared MoltZap logging shape; this slice standardizes around it and removes `winston` as a parallel runtime logger. |
+| `yaml` | `2.8.3` | ISC | Aligns file-backed scenario/config decoding with the parser already present in `@moltzap/server-core`, reducing parser drift during the eval YAML migration. |
+| `yargs` | `17.0.0` | MIT | Existing eval CLI parser; the implementation slice can preserve operator-facing flags while changing the default execution mode to `cc-judge`. |
+
+## Traceability
+
+| spec item | slice coverage | module / file |
+|---|---|---|
+| Goal 2 / AC: shared upstream surfaces for config, logging, and fiber tracing | direct | `packages/server/src/runtime-surface/config.ts`, `packages/server/src/runtime-surface/logging.ts` |
+| Goals 3 and 4 / AC: Effect-native boot paths, CLI/runtime logging routed through shared surface, no ad hoc `console.*` default | direct design anchor | `packages/server/src/runtime-surface/config.ts`, `packages/server/src/runtime-surface/logging.ts`, `packages/evals/src/runtime-surface/runner.ts` |
+| Goal 5 / AC: remove `winston` from `@moltzap/evals` | direct design anchor | `packages/server/src/runtime-surface/logging.ts`, `packages/evals/src/runtime-surface/runner.ts` |
+| Goals 6 and 8 / AC: nanoclaw spike debt cleaned up behind a real runtime abstraction and local generic eval ownership shrinks | direct | `packages/evals/src/runtime-surface/types.ts`, `packages/evals/src/runtime-surface/runner.ts` |
+| Goals 7 and 8 / AC: `cc-judge` becomes default and local judge/report surfaces are demoted or removed | direct | `packages/evals/src/runtime-surface/types.ts`, `packages/evals/src/runtime-surface/runner.ts` |
+| Goal 11 / AC: MoltZap eval scenarios move from TS catalog callbacks to YAML/data assertions | direct | `packages/evals/src/runtime-surface/types.ts`, `packages/evals/src/runtime-surface/scenario-source.ts` |
+| Goal 13 / AC: planned-harness YAML stays a second path distinct from the simple prompt/workspace schema | direct, depends on `#167/#169` | `packages/evals/src/runtime-surface/scenario-source.ts`, `packages/evals/src/runtime-surface/runner.ts` |
+| Goal 17 / AC: no permanent duplicate ownership of generic YAML decode, bundle schema/codec, workspace seeding, or judge/report plumbing | direct | `packages/evals/src/runtime-surface/scenario-source.ts`, `packages/evals/src/runtime-surface/runner.ts` |
+| Non-goals 4, 5, 6 and issue ownership constraint: no arena-specific files or harness work in this slice | preserved by scope | all modules above; no `moltzap-arena` paths and no arena-specific interfaces introduced |
+
+## Open questions
+
+1. Q: Should `@moltzap/evals` publish a new package export for `runtime-surface/*` in the first implementation PR, or stay internal until the legacy `./llm-judge`, `./report`, and `./judgment-bundle` subpaths are removed?
+Recommended default: keep the runtime-surface internal during the first implementation wave and only publish a new package export once `#172` has actually demoted the legacy surfaces.
+Escalation target: `implement-staff` in `#172`.
+
+2. Q: Should `nanoclaw` first-wave support stay behind `LegacyLlmJudgeExplicit`, or must `#172` move it onto `CcJudgeDefault` immediately?
+Recommended default: keep `nanoclaw` behind explicit legacy mode in the first implementation wave unless the runtime adapter can emit the same shared-contract receipt shape without relying on `nanoclaw-smoke`.
+Escalation target: `implement-staff` in `#172`.
+
+3. Q: Should the eval CLI become a new `cc-judge`-first command surface immediately, or preserve the current command while flipping only the default execution mode?
+Recommended default: preserve the current command name and flags for one wave, but make `cc-judge` the default and require an explicit legacy opt-in flag for local judge/report mode.
+Escalation target: `implement-staff` in `#172`.

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -54,11 +54,11 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.101",
     "@sinclair/typebox": "^0.34.0",
+    "cc-judge": "git+https://github.com/chughtapan/cc-judge.git#39debed2606f2da7455e7cdc7ee78e9b46c4e0de",
     "dotenv": "^16.0.0",
-    "effect": "^3.21.0",
-    "js-yaml": "^4.0.0",
+    "effect": "3.21.0",
     "pg": "^8.13.0",
-    "winston": "^3.0.0",
+    "yaml": "2.8.3",
     "yargs": "^17.0.0"
   },
   "devDependencies": {
@@ -68,7 +68,6 @@
     "@moltzap/protocol": "workspace:*",
     "@moltzap/server-core": "workspace:*",
     "@testcontainers/postgresql": "^10.18.0",
-    "@types/js-yaml": "^4.0.0",
     "@types/pg": "^8.11.0",
     "@types/yargs": "^17.0.0",
     "kysely": "^0.28.2",

--- a/packages/evals/src/e2e-infra/judgment-bundle.ts
+++ b/packages/evals/src/e2e-infra/judgment-bundle.ts
@@ -1,8 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as yaml from "js-yaml";
 import { Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
+import { stringify as stringifyYaml } from "yaml";
 import type {
   EvalScenario,
   GeneratedResult,
@@ -443,7 +443,7 @@ export function writeJudgmentBundleArtifacts(
   const yamlPath = path.join(outputDir, `${baseName}.yaml`);
 
   fs.writeFileSync(jsonPath, `${JSON.stringify(bundle, null, 2)}\n`);
-  fs.writeFileSync(yamlPath, `${yaml.dump(bundle, { noRefs: true })}`);
+  fs.writeFileSync(yamlPath, `${stringifyYaml(bundle)}`);
 
   return { jsonPath, yamlPath };
 }

--- a/packages/evals/src/e2e-infra/logger.ts
+++ b/packages/evals/src/e2e-infra/logger.ts
@@ -1,52 +1,116 @@
-/** Winston logger for the E2E eval pipeline. */
-
-import * as winston from "winston";
+import { appendFileSync, mkdirSync } from "node:fs";
 import * as path from "node:path";
+import { logger as sharedLogger } from "@moltzap/server-core";
 
-let fileTransport: winston.transport | null = null;
+type EvalLogLevel = "debug" | "info" | "warn" | "error";
 
-const consoleTransport = new winston.transports.Console({
-  level: "info",
-  format: winston.format.combine(
-    winston.format.colorize(),
-    winston.format.printf(({ timestamp, level, message }) => {
-      return `\r\x1b[K${timestamp} [${level}]: ${message}`;
-    }),
-  ),
-});
+const LEVEL_WEIGHT: Record<EvalLogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
 
-export const logger = winston.createLogger({
-  level: "debug",
-  format: winston.format.combine(
-    winston.format.timestamp(),
-    winston.format.printf(({ timestamp, level, message }) => {
-      return `${timestamp} [${level}]: ${message}`;
-    }),
-  ),
-  transports: [consoleTransport],
-});
+let consoleLevel: EvalLogLevel = "info";
+let outputFilePath: string | undefined;
+
+function normalizeLevel(value: string): EvalLogLevel {
+  switch (value) {
+    case "debug":
+    case "info":
+    case "warn":
+    case "error":
+      return value;
+    default:
+      return "info";
+  }
+}
+
+function shouldWriteConsole(level: EvalLogLevel): boolean {
+  return LEVEL_WEIGHT[level] >= LEVEL_WEIGHT[consoleLevel];
+}
+
+function serialiseLogArgs(level: EvalLogLevel, args: unknown[]): string {
+  const timestamp = new Date().toISOString();
+  if (args.length === 0) {
+    return JSON.stringify({ timestamp, level, message: "" });
+  }
+  const [first, second, ...rest] = args;
+  if (typeof first === "string") {
+    return JSON.stringify({
+      timestamp,
+      level,
+      message: first,
+      args: [second, ...rest].filter((value) => value !== undefined),
+    });
+  }
+  if (typeof second === "string") {
+    return JSON.stringify({
+      timestamp,
+      level,
+      message: second,
+      fields: first,
+      args: rest,
+    });
+  }
+  return JSON.stringify({
+    timestamp,
+    level,
+    args,
+  });
+}
+
+function writeFileLog(level: EvalLogLevel, args: unknown[]): void {
+  if (outputFilePath === undefined) {
+    return;
+  }
+  appendFileSync(outputFilePath, serialiseLogArgs(level, args) + "\n");
+}
+
+function emit(level: EvalLogLevel, args: unknown[]): void {
+  writeFileLog(level, args);
+  if (!shouldWriteConsole(level)) {
+    return;
+  }
+  const method =
+    level === "warn" ? "warn" : level === "error" ? "error" : level;
+  const sink = sharedLogger[method].bind(sharedLogger) as (
+    ...values: unknown[]
+  ) => void;
+  sink(...args);
+}
+
+export const logger = {
+  get level(): EvalLogLevel {
+    return consoleLevel;
+  },
+  set level(value: string) {
+    consoleLevel = normalizeLevel(value);
+  },
+  debug(...args: unknown[]): void {
+    emit("debug", args);
+  },
+  info(...args: unknown[]): void {
+    emit("info", args);
+  },
+  warn(...args: unknown[]): void {
+    emit("warn", args);
+  },
+  error(...args: unknown[]): void {
+    emit("error", args);
+  },
+};
 
 export function setupLogger(
   outputDir: string | undefined,
   logLevel: string,
 ): void {
-  logger.level = "debug";
-  consoleTransport.level = logLevel;
-
-  if (fileTransport) {
-    logger.remove(fileTransport);
-    fileTransport = null;
+  consoleLevel = normalizeLevel(logLevel);
+  sharedLogger.level = consoleLevel;
+  if (outputDir === undefined) {
+    outputFilePath = undefined;
+    return;
   }
-
-  if (outputDir) {
-    fileTransport = new winston.transports.File({
-      filename: path.join(outputDir, "output.log"),
-      level: "debug",
-      format: winston.format.combine(
-        winston.format.timestamp(),
-        winston.format.json(),
-      ),
-    });
-    logger.add(fileTransport);
-  }
+  mkdirSync(outputDir, { recursive: true });
+  outputFilePath = path.join(outputDir, "output.log");
 }

--- a/packages/evals/src/e2e-infra/report.ts
+++ b/packages/evals/src/e2e-infra/report.ts
@@ -6,7 +6,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as yaml from "js-yaml";
+import { stringify as stringifyYaml } from "yaml";
 import type { EvaluatedResult } from "./types.js";
 import { logger } from "./logger.js";
 
@@ -202,7 +202,7 @@ export function generateReport(
 
     fs.writeFileSync(
       path.join(detailsDir, `${baseName}.failed.yaml`),
-      yaml.dump(failureData),
+      stringifyYaml(failureData),
     );
 
     // Write the eval prompt if available
@@ -230,7 +230,7 @@ export function generateReport(
     };
     fs.writeFileSync(
       path.join(detailsDir, `${baseName}.${suffix}.transcript.yaml`),
-      yaml.dump(transcriptData),
+      stringifyYaml(transcriptData),
     );
   }
 

--- a/packages/evals/src/runtime-surface/runner.ts
+++ b/packages/evals/src/runtime-surface/runner.ts
@@ -16,6 +16,7 @@ import type {
   EvalRunRequest,
   EvalRuntimeKind,
   LegacyEvalSurface,
+  StagedPlannedHarnessCatalog,
 } from "./types.js";
 
 export interface EvalRuntimeDependencies {
@@ -46,7 +47,10 @@ export class EvalRuntimeSurfaceError extends Data.TaggedError(
 }> {}
 
 export function resolveEvalExecutionMode(
-  _request: EvalRunRequest,
+  _input: {
+    readonly request: EvalRunRequest;
+    readonly stagedHarness: StagedPlannedHarnessCatalog;
+  },
 ): Effect.Effect<EvalExecutionMode, EvalRuntimeSurfaceError, never> {
   throw new Error("not implemented");
 }

--- a/packages/evals/src/runtime-surface/runner.ts
+++ b/packages/evals/src/runtime-surface/runner.ts
@@ -46,12 +46,10 @@ export class EvalRuntimeSurfaceError extends Data.TaggedError(
       };
 }> {}
 
-export function resolveEvalExecutionMode(
-  _input: {
-    readonly request: EvalRunRequest;
-    readonly stagedHarness: StagedPlannedHarnessCatalog;
-  },
-): Effect.Effect<EvalExecutionMode, EvalRuntimeSurfaceError, never> {
+export function resolveEvalExecutionMode(_input: {
+  readonly request: EvalRunRequest;
+  readonly stagedHarness: StagedPlannedHarnessCatalog;
+}): Effect.Effect<EvalExecutionMode, EvalRuntimeSurfaceError, never> {
   throw new Error("not implemented");
 }
 

--- a/packages/evals/src/runtime-surface/runner.ts
+++ b/packages/evals/src/runtime-surface/runner.ts
@@ -1,0 +1,63 @@
+/**
+ * Architecture-only contract for the MoltZap eval runtime entrypoint.
+ *
+ * Implementers fill this in during the approved runtime cleanup slice.
+ */
+
+import { Data, Effect } from "effect";
+import type {
+  RuntimeObservability,
+  RuntimeProcessConfig,
+} from "@moltzap/server-core";
+import type { EvalScenarioSourceError } from "./scenario-source.js";
+import type {
+  EvalExecutionMode,
+  EvalRunReceipt,
+  EvalRunRequest,
+  EvalRuntimeKind,
+  LegacyEvalSurface,
+} from "./types.js";
+
+export interface EvalRuntimeDependencies {
+  readonly runtimeConfig: RuntimeProcessConfig;
+  readonly observability: RuntimeObservability;
+}
+
+export class EvalRuntimeSurfaceError extends Data.TaggedError(
+  "EvalRuntimeSurfaceError",
+)<{
+  readonly cause:
+    | {
+        readonly _tag: "UnsupportedRuntime";
+        readonly runtime: EvalRuntimeKind;
+      }
+    | {
+        readonly _tag: "CcJudgeSurfaceUnavailable";
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "LegacyModeRequiresExplicitOptIn";
+        readonly surface: LegacyEvalSurface;
+      }
+    | {
+        readonly _tag: "ObservabilityUnavailable";
+        readonly message: string;
+      };
+}> {}
+
+export function resolveEvalExecutionMode(
+  _request: EvalRunRequest,
+): Effect.Effect<EvalExecutionMode, EvalRuntimeSurfaceError, never> {
+  throw new Error("not implemented");
+}
+
+export function runEvalCatalog(
+  _deps: EvalRuntimeDependencies,
+  _request: EvalRunRequest,
+): Effect.Effect<
+  EvalRunReceipt,
+  EvalRuntimeSurfaceError | EvalScenarioSourceError,
+  never
+> {
+  throw new Error("not implemented");
+}

--- a/packages/evals/src/runtime-surface/scenario-source.ts
+++ b/packages/evals/src/runtime-surface/scenario-source.ts
@@ -9,17 +9,12 @@ import type {
   EvalResultsDirectory,
   EvalScenarioDocumentPath,
   MoltZapEvalScenarioDocument,
-  PlannedHarnessArtifactPath,
+  StagedPlannedHarnessCatalog,
 } from "./types.js";
 
 export interface LoadedEvalScenarioDocument {
   readonly sourcePath: EvalScenarioDocumentPath;
   readonly document: MoltZapEvalScenarioDocument;
-}
-
-export interface StagedPlannedHarnessArtifact {
-  readonly sourcePath: EvalScenarioDocumentPath;
-  readonly plannedHarnessPath: PlannedHarnessArtifactPath;
 }
 
 export class EvalScenarioSourceError extends Data.TaggedError(
@@ -38,6 +33,15 @@ export class EvalScenarioSourceError extends Data.TaggedError(
     | {
         readonly _tag: "ScenarioSchemaInvalid";
         readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "ConversationDocumentInvalid";
+        readonly path: string;
+        readonly conversationTag:
+          | "DirectMessage"
+          | "GroupConversation"
+          | "CrossConversation";
         readonly message: string;
       }
     | {
@@ -68,10 +72,6 @@ export function loadEvalScenarioDocuments(
 export function stagePlannedHarnessArtifacts(_input: {
   readonly documents: readonly LoadedEvalScenarioDocument[];
   readonly resultsDirectory: EvalResultsDirectory;
-}): Effect.Effect<
-  readonly StagedPlannedHarnessArtifact[],
-  EvalScenarioSourceError,
-  never
-> {
+}): Effect.Effect<StagedPlannedHarnessCatalog, EvalScenarioSourceError, never> {
   throw new Error("not implemented");
 }

--- a/packages/evals/src/runtime-surface/scenario-source.ts
+++ b/packages/evals/src/runtime-surface/scenario-source.ts
@@ -1,0 +1,77 @@
+/**
+ * Architecture-only contract for MoltZap eval scenario loading and staging.
+ *
+ * Implementers fill this in during the approved runtime cleanup slice.
+ */
+
+import { Data, Effect } from "effect";
+import type {
+  EvalResultsDirectory,
+  EvalScenarioDocumentPath,
+  MoltZapEvalScenarioDocument,
+  PlannedHarnessArtifactPath,
+} from "./types.js";
+
+export interface LoadedEvalScenarioDocument {
+  readonly sourcePath: EvalScenarioDocumentPath;
+  readonly document: MoltZapEvalScenarioDocument;
+}
+
+export interface StagedPlannedHarnessArtifact {
+  readonly sourcePath: EvalScenarioDocumentPath;
+  readonly plannedHarnessPath: PlannedHarnessArtifactPath;
+}
+
+export class EvalScenarioSourceError extends Data.TaggedError(
+  "EvalScenarioSourceError",
+)<{
+  readonly cause:
+    | {
+        readonly _tag: "ScenarioFileMissing";
+        readonly path: string;
+      }
+    | {
+        readonly _tag: "ScenarioYamlInvalid";
+        readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "ScenarioSchemaInvalid";
+        readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "DeterministicCallbackNotSupported";
+        readonly path: string;
+        readonly field: "deterministicPassCheck" | "deterministicFailCheck";
+      }
+    | {
+        readonly _tag: "DuplicateScenarioId";
+        readonly scenarioId: string;
+        readonly paths: readonly [
+          EvalScenarioDocumentPath,
+          EvalScenarioDocumentPath,
+        ];
+      };
+}> {}
+
+export function loadEvalScenarioDocuments(
+  _paths: readonly EvalScenarioDocumentPath[],
+): Effect.Effect<
+  readonly LoadedEvalScenarioDocument[],
+  EvalScenarioSourceError,
+  never
+> {
+  throw new Error("not implemented");
+}
+
+export function stagePlannedHarnessArtifacts(_input: {
+  readonly documents: readonly LoadedEvalScenarioDocument[];
+  readonly resultsDirectory: EvalResultsDirectory;
+}): Effect.Effect<
+  readonly StagedPlannedHarnessArtifact[],
+  EvalScenarioSourceError,
+  never
+> {
+  throw new Error("not implemented");
+}

--- a/packages/evals/src/runtime-surface/types.ts
+++ b/packages/evals/src/runtime-surface/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Architecture-only contracts for MoltZap-owned eval runtime surfaces.
+ *
+ * Implementers fill this in during the approved runtime cleanup slice.
+ */
+
+export type EvalScenarioDocumentPath = string & {
+  readonly __brand: "EvalScenarioDocumentPath";
+};
+
+export type PlannedHarnessArtifactPath = string & {
+  readonly __brand: "PlannedHarnessArtifactPath";
+};
+
+export type EvalResultsDirectory = string & {
+  readonly __brand: "EvalResultsDirectory";
+};
+
+export type EvalRunId = string & {
+  readonly __brand: "EvalRunId";
+};
+
+export type EvalRuntimeKind = "openclaw" | "nanoclaw";
+
+export type EvalConversationMode = "dm" | "group" | "cross-conversation";
+
+export type EvalScenarioAssertion =
+  | { readonly _tag: "ContainsText"; readonly text: string }
+  | { readonly _tag: "OmitsText"; readonly text: string }
+  | { readonly _tag: "MaxWordCount"; readonly maxWords: number }
+  | { readonly _tag: "MatchesRegex"; readonly pattern: string };
+
+export interface MoltZapEvalScenarioDocument {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly runtime: EvalRuntimeKind;
+  readonly conversationMode: EvalConversationMode;
+  readonly setupMessages: readonly string[];
+  readonly expectedBehavior: string;
+  readonly assertions: readonly EvalScenarioAssertion[];
+  readonly resultsSubdirectory?: string;
+}
+
+export type LegacyEvalSurface =
+  | "llm-judge"
+  | "report"
+  | "judgment-bundle"
+  | "nanoclaw-smoke";
+
+export type EvalExecutionMode =
+  | {
+      readonly _tag: "CcJudgeDefault";
+      readonly plannedHarnessPath: PlannedHarnessArtifactPath;
+    }
+  | {
+      readonly _tag: "LegacyLlmJudgeExplicit";
+      readonly requestedBy: "cli-flag" | "unsupported-runtime";
+      readonly surface: LegacyEvalSurface;
+    };
+
+export interface EvalRunRequest {
+  readonly scenarioDocuments: readonly EvalScenarioDocumentPath[];
+  readonly runtime: EvalRuntimeKind;
+  readonly resultsDirectory: EvalResultsDirectory;
+  readonly retainArtifacts: boolean;
+  readonly requestedMode?: "cc-judge" | "legacy-llm-judge";
+}
+
+export interface EvalRunReceipt {
+  readonly runId: EvalRunId;
+  readonly executionMode: EvalExecutionMode;
+  readonly resultsDirectory: EvalResultsDirectory;
+  readonly stagedHarnesses: readonly PlannedHarnessArtifactPath[];
+}

--- a/packages/evals/src/runtime-surface/types.ts
+++ b/packages/evals/src/runtime-surface/types.ts
@@ -12,6 +12,10 @@ export type PlannedHarnessArtifactPath = string & {
   readonly __brand: "PlannedHarnessArtifactPath";
 };
 
+export type PlannedHarnessPathOrGlob = string & {
+  readonly __brand: "PlannedHarnessPathOrGlob";
+};
+
 export type EvalResultsDirectory = string & {
   readonly __brand: "EvalResultsDirectory";
 };
@@ -22,24 +26,77 @@ export type EvalRunId = string & {
 
 export type EvalRuntimeKind = "openclaw" | "nanoclaw";
 
-export type EvalConversationMode = "dm" | "group" | "cross-conversation";
-
 export type EvalScenarioAssertion =
   | { readonly _tag: "ContainsText"; readonly text: string }
   | { readonly _tag: "OmitsText"; readonly text: string }
   | { readonly _tag: "MaxWordCount"; readonly maxWords: number }
   | { readonly _tag: "MatchesRegex"; readonly pattern: string };
 
+export interface DirectMessageConversation {
+  readonly _tag: "DirectMessage";
+  readonly setupMessage: string;
+  readonly followUpMessages: readonly string[];
+}
+
+export interface GroupConversation {
+  readonly _tag: "GroupConversation";
+  readonly setupMessage: string;
+  readonly followUpMessages: readonly string[];
+  readonly bystanderCount: number;
+  readonly bystanderMessages: readonly string[];
+}
+
+export interface CrossConversation {
+  readonly _tag: "CrossConversation";
+  readonly setupMessage: string;
+  readonly followUpMessages: readonly string[];
+  readonly probeMessage: string;
+}
+
+export type EvalScenarioConversation =
+  | DirectMessageConversation
+  | GroupConversation
+  | CrossConversation;
+
 export interface MoltZapEvalScenarioDocument {
   readonly id: string;
   readonly name: string;
   readonly description: string;
   readonly runtime: EvalRuntimeKind;
-  readonly conversationMode: EvalConversationMode;
-  readonly setupMessages: readonly string[];
+  readonly conversation: EvalScenarioConversation;
   readonly expectedBehavior: string;
   readonly assertions: readonly EvalScenarioAssertion[];
   readonly resultsSubdirectory?: string;
+}
+
+export interface StagedPlannedHarnessArtifact {
+  readonly sourcePath: EvalScenarioDocumentPath;
+  readonly scenarioId: string;
+  readonly plannedHarnessPath: PlannedHarnessArtifactPath;
+}
+
+export type PlannedHarnessExecutionInput =
+  | {
+      readonly _tag: "SingleDocument";
+      readonly pathOrGlob: PlannedHarnessPathOrGlob;
+      readonly matchedDocument: PlannedHarnessArtifactPath;
+    }
+  | {
+      readonly _tag: "DocumentGlob";
+      readonly pathOrGlob: PlannedHarnessPathOrGlob;
+      readonly matchedDocuments: readonly [
+        PlannedHarnessArtifactPath,
+        PlannedHarnessArtifactPath,
+        ...PlannedHarnessArtifactPath[],
+      ];
+    };
+
+export interface StagedPlannedHarnessCatalog {
+  readonly artifacts: readonly [
+    StagedPlannedHarnessArtifact,
+    ...StagedPlannedHarnessArtifact[],
+  ];
+  readonly executionInput: PlannedHarnessExecutionInput;
 }
 
 export type LegacyEvalSurface =
@@ -51,7 +108,7 @@ export type LegacyEvalSurface =
 export type EvalExecutionMode =
   | {
       readonly _tag: "CcJudgeDefault";
-      readonly plannedHarnessPath: PlannedHarnessArtifactPath;
+      readonly plannedHarnessInput: PlannedHarnessExecutionInput;
     }
   | {
       readonly _tag: "LegacyLlmJudgeExplicit";
@@ -60,7 +117,10 @@ export type EvalExecutionMode =
     };
 
 export interface EvalRunRequest {
-  readonly scenarioDocuments: readonly EvalScenarioDocumentPath[];
+  readonly scenarioDocuments: readonly [
+    EvalScenarioDocumentPath,
+    ...EvalScenarioDocumentPath[],
+  ];
   readonly runtime: EvalRuntimeKind;
   readonly resultsDirectory: EvalResultsDirectory;
   readonly retainArtifacts: boolean;
@@ -71,5 +131,5 @@ export interface EvalRunReceipt {
   readonly runId: EvalRunId;
   readonly executionMode: EvalExecutionMode;
   readonly resultsDirectory: EvalResultsDirectory;
-  readonly stagedHarnesses: readonly PlannedHarnessArtifactPath[];
+  readonly stagedHarness: StagedPlannedHarnessCatalog;
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
     "@sinclair/typebox": "^0.34.0",
     "ajv": "^8.17.0",
     "ajv-formats": "^3.0.0",
-    "effect": "^3.21.0",
+    "effect": "3.21.0",
     "kysely": "^0.28.2",
     "kysely-pglite": "^0.6.1",
     "pg": "^8.12.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -53,6 +53,35 @@ export {
   MoltZapConfigSchema,
 } from "./config/schema.js";
 export type { MoltZapConfig, ConfigError } from "./config/schema.js";
+export {
+  RuntimeConfigSurfaceError,
+  loadRuntimeProcessConfig,
+} from "./runtime-surface/config.js";
+export type {
+  LoadRuntimeConfigInput,
+  RuntimeConfigPath,
+  RuntimeEnvironment,
+  RuntimeLogLevel,
+  RuntimeLoggingConfig,
+  RuntimeTracingConfig,
+  RuntimeProcessConfig,
+} from "./runtime-surface/config.js";
+export {
+  RuntimeObservabilityError,
+  createRuntimeObservability,
+  withRuntimeLogContext,
+  withRuntimeTraceSpan,
+} from "./runtime-surface/logging.js";
+export type {
+  RuntimeRequestId,
+  RuntimeSessionId,
+  RuntimeAgentId,
+  RuntimeFiberId,
+  RuntimeSpanName,
+  RuntimeLogContext,
+  RuntimeTraceSpan,
+  RuntimeObservability,
+} from "./runtime-surface/logging.js";
 
 // Standalone
 export { startServer } from "./standalone.js";

--- a/packages/server/src/runtime-surface/config.ts
+++ b/packages/server/src/runtime-surface/config.ts
@@ -1,12 +1,23 @@
 /**
- * Architecture-only contract for shared runtime process config.
- *
- * Implementers fill this in during the approved runtime cleanup slice.
+ * Shared runtime process config for server boot and eval orchestration.
  */
 
-import { Data, Effect } from "effect";
+import { dirname } from "node:path";
+import { realpathSync } from "node:fs";
+import {
+  ConfigProvider,
+  Data,
+  Effect,
+  Match,
+} from "effect";
+import type { ConfigError } from "effect/ConfigError";
 import type { LoadedConfig } from "../app/config.js";
+import { ServerConfigLoader } from "../app/config.js";
 import type { MoltZapAppConfig } from "../config/effect-config.js";
+import {
+  ConfigLoadError,
+  loadConfigFromFile,
+} from "../config/loader.js";
 
 export type RuntimeConfigPath = string & {
   readonly __brand: "RuntimeConfigPath";
@@ -68,8 +79,375 @@ export class RuntimeConfigSurfaceError extends Data.TaggedError(
       };
 }> {}
 
+type ProcessEnvSnapshot = Readonly<Record<string, string | undefined>>;
+
+const DEFAULT_RUNTIME_ENVIRONMENT: RuntimeEnvironment = "development";
+const DEFAULT_LOG_LEVEL: RuntimeLogLevel = "info";
+const DEFAULT_SERVICE_NAME = "moltzap-server";
+
+function resolveRuntimeConfigPath(
+  input: LoadRuntimeConfigInput,
+  processEnv: ProcessEnvSnapshot,
+): RuntimeConfigPath {
+  const selected =
+    input.configPath ?? processEnv["MOLTZAP_CONFIG"] ?? "moltzap.yaml";
+  return selected as RuntimeConfigPath;
+}
+
+function replaceProcessEnv(next: ProcessEnvSnapshot): void {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(next)) {
+    if (value !== undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function withPatchedProcessEnv<A, E, R>(
+  processEnv: ProcessEnvSnapshot,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = { ...process.env };
+      replaceProcessEnv(processEnv);
+      return previous;
+    }),
+    () => effect,
+    (previous) =>
+      Effect.sync(() => {
+        replaceProcessEnv(previous);
+      }),
+  );
+}
+
+function mapConfigLoadError(
+  configPath: RuntimeConfigPath,
+  error: ConfigLoadError,
+): RuntimeConfigSurfaceError {
+  switch (error.kind) {
+    case "read":
+      return new RuntimeConfigSurfaceError({
+        cause: {
+          _tag: "ConfigFileUnreadable",
+          path: configPath,
+          message: error.message,
+        },
+      });
+    case "env": {
+      const missingKey = error.message.match(/"([^"]+)"/)?.[1] ?? "unknown";
+      return new RuntimeConfigSurfaceError({
+        cause: {
+          _tag: "EnvironmentInvalid",
+          key: missingKey,
+          message: error.message,
+        },
+      });
+    }
+    case "yaml":
+    case "validation":
+      return new RuntimeConfigSurfaceError({
+        cause: {
+          _tag: "ConfigFileInvalid",
+          path: configPath,
+          message: error.message,
+        },
+      });
+  }
+}
+
+function formatConfigError(error: ConfigError): string {
+  const lines: string[] = [];
+  const pushLeaf = (leaf: { path: ReadonlyArray<string>; message: string }) => {
+    lines.push(`  ${leaf.path.join(".") || "/"}: ${leaf.message}`);
+  };
+  const walk = (current: ConfigError): void =>
+    Match.value(current).pipe(
+      Match.discriminatorsExhaustive("_op")({
+        And: (and) => {
+          walk(and.left);
+          walk(and.right);
+        },
+        Or: (or) => {
+          walk(or.left);
+          walk(or.right);
+        },
+        InvalidData: pushLeaf,
+        MissingData: pushLeaf,
+        Unsupported: pushLeaf,
+        SourceUnavailable: pushLeaf,
+      }),
+    );
+  walk(error);
+  const deduped: string[] = [];
+  const seen = new Set<string>();
+  for (const line of lines) {
+    if (!seen.has(line)) {
+      seen.add(line);
+      deduped.push(line);
+    }
+  }
+  return "\n" + deduped.join("\n");
+}
+
+function resolveRuntimeEnvironment(
+  raw: string | undefined,
+): Effect.Effect<RuntimeEnvironment, RuntimeConfigSurfaceError, never> {
+  if (raw === undefined || raw.length === 0) {
+    return Effect.succeed(DEFAULT_RUNTIME_ENVIRONMENT);
+  }
+  switch (raw) {
+    case "development":
+    case "test":
+    case "production":
+      return Effect.succeed(raw);
+    default:
+      return Effect.fail(
+        new RuntimeConfigSurfaceError({
+          cause: {
+            _tag: "EnvironmentInvalid",
+            key: "NODE_ENV",
+            message: `NODE_ENV must be one of development, test, production; received "${raw}"`,
+          },
+        }),
+      );
+  }
+}
+
+function resolveRuntimeLogLevel(
+  raw: string | undefined,
+): Effect.Effect<RuntimeLogLevel, RuntimeConfigSurfaceError, never> {
+  if (raw === undefined || raw.length === 0) {
+    return Effect.succeed(DEFAULT_LOG_LEVEL);
+  }
+  switch (raw) {
+    case "debug":
+    case "info":
+    case "warn":
+    case "error":
+      return Effect.succeed(raw);
+    default:
+      return Effect.fail(
+        new RuntimeConfigSurfaceError({
+          cause: {
+            _tag: "EnvironmentInvalid",
+            key: "LOG_LEVEL",
+            message: `LOG_LEVEL must be one of debug, info, warn, error; received "${raw}"`,
+          },
+        }),
+      );
+  }
+}
+
+function parseBooleanEnv(
+  raw: string | undefined,
+  key: string,
+  fallback: boolean,
+): Effect.Effect<boolean, RuntimeConfigSurfaceError, never> {
+  if (raw === undefined || raw.length === 0) {
+    return Effect.succeed(fallback);
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (
+    normalized === "true" ||
+    normalized === "1" ||
+    normalized === "yes" ||
+    normalized === "on"
+  ) {
+    return Effect.succeed(true);
+  }
+  if (
+    normalized === "false" ||
+    normalized === "0" ||
+    normalized === "no" ||
+    normalized === "off"
+  ) {
+    return Effect.succeed(false);
+  }
+  return Effect.fail(
+    new RuntimeConfigSurfaceError({
+      cause: {
+        _tag: "EnvironmentInvalid",
+        key,
+        message: `${key} must be a boolean-like value (true/false/1/0/yes/no/on/off); received "${raw}"`,
+      },
+    }),
+  );
+}
+
+function parseIntegerEnv(
+  raw: string | undefined,
+  key: string,
+): Effect.Effect<number | undefined, RuntimeConfigSurfaceError, never> {
+  if (raw === undefined || raw.length === 0) {
+    return Effect.succeed(undefined);
+  }
+  if (!/^-?\d+$/.test(raw.trim())) {
+    return Effect.fail(
+      new RuntimeConfigSurfaceError({
+        cause: {
+          _tag: "EnvironmentInvalid",
+          key,
+          message: `${key} must be an integer; received "${raw}"`,
+        },
+      }),
+    );
+  }
+  return Effect.succeed(Number.parseInt(raw, 10));
+}
+
+function resolveTracingServiceName(
+  raw: string | undefined,
+): Effect.Effect<string, RuntimeConfigSurfaceError, never> {
+  if (raw === undefined) {
+    return Effect.succeed(DEFAULT_SERVICE_NAME);
+  }
+  if (raw.trim().length === 0) {
+    return Effect.fail(
+      new RuntimeConfigSurfaceError({
+        cause: {
+          _tag: "EnvironmentInvalid",
+          key: "OTEL_SERVICE_NAME",
+          message: "OTEL_SERVICE_NAME must be a non-empty string when set",
+        },
+      }),
+    );
+  }
+  return Effect.succeed(raw);
+}
+
+function buildServerConfigProviderInput(
+  appConfig: MoltZapAppConfig,
+  processEnv: ProcessEnvSnapshot,
+): Effect.Effect<Record<string, unknown>, RuntimeConfigSurfaceError, never> {
+  return Effect.gen(function* () {
+    const providerInput: Record<string, unknown> = {};
+
+    if (appConfig.database?.url !== undefined) {
+      providerInput["DATABASE_URL"] = appConfig.database.url;
+    }
+    if (appConfig.encryption?.master_secret !== undefined) {
+      providerInput["ENCRYPTION_MASTER_SECRET"] =
+        appConfig.encryption.master_secret;
+    }
+    if (appConfig.server?.port !== undefined) {
+      providerInput["PORT"] = appConfig.server.port;
+    }
+    if (appConfig.server?.cors_origins !== undefined) {
+      providerInput["CORS_ORIGINS"] = appConfig.server.cors_origins.join(",");
+    }
+    if (appConfig.dev_mode?.enabled !== undefined) {
+      providerInput["MOLTZAP_DEV_MODE"] = appConfig.dev_mode.enabled;
+    }
+
+    if (processEnv["DATABASE_URL"] !== undefined) {
+      providerInput["DATABASE_URL"] = processEnv["DATABASE_URL"];
+    }
+    if (processEnv["ENCRYPTION_MASTER_SECRET"] !== undefined) {
+      providerInput["ENCRYPTION_MASTER_SECRET"] =
+        processEnv["ENCRYPTION_MASTER_SECRET"];
+    }
+    if (processEnv["CORS_ORIGINS"] !== undefined) {
+      providerInput["CORS_ORIGINS"] = processEnv["CORS_ORIGINS"];
+    }
+
+    const port = yield* parseIntegerEnv(processEnv["PORT"], "PORT");
+    if (port !== undefined) {
+      providerInput["PORT"] = port;
+    }
+
+    const devMode = yield* parseBooleanEnv(
+      processEnv["MOLTZAP_DEV_MODE"],
+      "MOLTZAP_DEV_MODE",
+      appConfig.dev_mode?.enabled ?? false,
+    );
+    providerInput["MOLTZAP_DEV_MODE"] = devMode;
+
+    return providerInput;
+  });
+}
+
 export function loadRuntimeProcessConfig(
-  _input: LoadRuntimeConfigInput,
+  input: LoadRuntimeConfigInput,
 ): Effect.Effect<RuntimeProcessConfig, RuntimeConfigSurfaceError, never> {
-  throw new Error("not implemented");
+  return Effect.gen(function* () {
+    const processEnv = input.processEnv ?? process.env;
+    const configPath = resolveRuntimeConfigPath(input, processEnv);
+
+    const loadedAppConfig = yield* withPatchedProcessEnv(
+      processEnv,
+      loadConfigFromFile(configPath),
+    ).pipe(Effect.mapError((error) => mapConfigLoadError(configPath, error)));
+
+    const configDirectory = yield* Effect.try({
+      try: () => dirname(realpathSync(configPath)),
+      catch: (cause) =>
+        new RuntimeConfigSurfaceError({
+          cause: {
+            _tag: "DirectoryResolutionFailed",
+            path: configPath,
+            message: `Failed to resolve config directory for "${configPath}": ${
+              cause instanceof Error ? cause.message : String(cause)
+            }`,
+          },
+        }),
+    });
+
+    const environment = yield* resolveRuntimeEnvironment(processEnv["NODE_ENV"]);
+    const loggingLevel = yield* resolveRuntimeLogLevel(
+      processEnv["LOG_LEVEL"] ?? loadedAppConfig.log_level,
+    );
+    const tracingServiceName = yield* resolveTracingServiceName(
+      processEnv["OTEL_SERVICE_NAME"],
+    );
+    const includeFiberIds = yield* parseBooleanEnv(
+      processEnv["MOLTZAP_INCLUDE_FIBER_IDS"],
+      "MOLTZAP_INCLUDE_FIBER_IDS",
+      true,
+    );
+    const includeRequestContext = yield* parseBooleanEnv(
+      processEnv["MOLTZAP_INCLUDE_REQUEST_CONTEXT"],
+      "MOLTZAP_INCLUDE_REQUEST_CONTEXT",
+      true,
+    );
+
+    const { _configDir, ...app } = loadedAppConfig;
+    void _configDir;
+    const serverProviderInput = yield* buildServerConfigProviderInput(
+      app,
+      processEnv,
+    );
+    const server = yield* ServerConfigLoader.pipe(
+      Effect.withConfigProvider(ConfigProvider.fromJson(serverProviderInput)),
+      Effect.mapError(
+        (configError) =>
+          new RuntimeConfigSurfaceError({
+            cause: {
+              _tag: "ConfigFileInvalid",
+              path: configPath,
+              message: `Invalid runtime config in "${configPath}": ${formatConfigError(configError)}`,
+            },
+          }),
+      ),
+    );
+
+    return {
+      configPath,
+      configDirectory,
+      environment,
+      logging: {
+        level: loggingLevel,
+        preserveLegacyFields: true,
+      },
+      tracing: {
+        serviceName: tracingServiceName,
+        includeFiberIds,
+        includeRequestContext,
+      },
+      app,
+      server,
+    };
+  });
 }

--- a/packages/server/src/runtime-surface/config.ts
+++ b/packages/server/src/runtime-surface/config.ts
@@ -1,0 +1,75 @@
+/**
+ * Architecture-only contract for shared runtime process config.
+ *
+ * Implementers fill this in during the approved runtime cleanup slice.
+ */
+
+import { Data, Effect } from "effect";
+import type { LoadedConfig } from "../app/config.js";
+import type { MoltZapAppConfig } from "../config/effect-config.js";
+
+export type RuntimeConfigPath = string & {
+  readonly __brand: "RuntimeConfigPath";
+};
+
+export type RuntimeEnvironment = "development" | "test" | "production";
+
+export type RuntimeLogLevel = "debug" | "info" | "warn" | "error";
+
+export interface RuntimeLoggingConfig {
+  readonly level: RuntimeLogLevel;
+  readonly preserveLegacyFields: boolean;
+}
+
+export interface RuntimeTracingConfig {
+  readonly serviceName: string;
+  readonly includeFiberIds: boolean;
+  readonly includeRequestContext: boolean;
+}
+
+export interface LoadRuntimeConfigInput {
+  readonly configPath?: RuntimeConfigPath;
+  readonly processEnv?: Readonly<Record<string, string | undefined>>;
+}
+
+export interface RuntimeProcessConfig {
+  readonly configPath: RuntimeConfigPath;
+  readonly configDirectory: string;
+  readonly environment: RuntimeEnvironment;
+  readonly logging: RuntimeLoggingConfig;
+  readonly tracing: RuntimeTracingConfig;
+  readonly app: MoltZapAppConfig;
+  readonly server: LoadedConfig;
+}
+
+export class RuntimeConfigSurfaceError extends Data.TaggedError(
+  "RuntimeConfigSurfaceError",
+)<{
+  readonly cause:
+    | {
+        readonly _tag: "ConfigFileUnreadable";
+        readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "ConfigFileInvalid";
+        readonly path: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "EnvironmentInvalid";
+        readonly key: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "DirectoryResolutionFailed";
+        readonly path: string;
+        readonly message: string;
+      };
+}> {}
+
+export function loadRuntimeProcessConfig(
+  _input: LoadRuntimeConfigInput,
+): Effect.Effect<RuntimeProcessConfig, RuntimeConfigSurfaceError, never> {
+  throw new Error("not implemented");
+}

--- a/packages/server/src/runtime-surface/config.ts
+++ b/packages/server/src/runtime-surface/config.ts
@@ -4,20 +4,12 @@
 
 import { dirname } from "node:path";
 import { realpathSync } from "node:fs";
-import {
-  ConfigProvider,
-  Data,
-  Effect,
-  Match,
-} from "effect";
+import { ConfigProvider, Data, Effect, Match } from "effect";
 import type { ConfigError } from "effect/ConfigError";
 import type { LoadedConfig } from "../app/config.js";
 import { ServerConfigLoader } from "../app/config.js";
 import type { MoltZapAppConfig } from "../config/effect-config.js";
-import {
-  ConfigLoadError,
-  loadConfigFromFile,
-} from "../config/loader.js";
+import { ConfigLoadError, loadConfigFromFile } from "../config/loader.js";
 
 export type RuntimeConfigPath = string & {
   readonly __brand: "RuntimeConfigPath";
@@ -395,7 +387,9 @@ export function loadRuntimeProcessConfig(
         }),
     });
 
-    const environment = yield* resolveRuntimeEnvironment(processEnv["NODE_ENV"]);
+    const environment = yield* resolveRuntimeEnvironment(
+      processEnv["NODE_ENV"],
+    );
     const loggingLevel = yield* resolveRuntimeLogLevel(
       processEnv["LOG_LEVEL"] ?? loadedAppConfig.log_level,
     );

--- a/packages/server/src/runtime-surface/logging.ts
+++ b/packages/server/src/runtime-surface/logging.ts
@@ -1,0 +1,95 @@
+/**
+ * Architecture-only contract for shared runtime observability.
+ *
+ * Implementers fill this in during the approved runtime cleanup slice.
+ */
+
+import { Data, Effect } from "effect";
+import type { Logger } from "../logger.js";
+import type { RuntimeProcessConfig } from "./config.js";
+
+export type RuntimeRequestId = string & {
+  readonly __brand: "RuntimeRequestId";
+};
+
+export type RuntimeSessionId = string & {
+  readonly __brand: "RuntimeSessionId";
+};
+
+export type RuntimeAgentId = string & {
+  readonly __brand: "RuntimeAgentId";
+};
+
+export type RuntimeFiberId = string & {
+  readonly __brand: "RuntimeFiberId";
+};
+
+export type RuntimeSpanName = string & {
+  readonly __brand: "RuntimeSpanName";
+};
+
+export interface RuntimeLogContext {
+  readonly requestId?: RuntimeRequestId;
+  readonly sessionId?: RuntimeSessionId;
+  readonly agentId?: RuntimeAgentId;
+  readonly connectionId?: string;
+  readonly workflow?: "rpc" | "session" | "transport" | "eval";
+}
+
+export interface RuntimeTraceSpan {
+  readonly name: RuntimeSpanName;
+  readonly fiberId?: RuntimeFiberId;
+  readonly parentFiberId?: RuntimeFiberId;
+}
+
+export interface RuntimeObservability {
+  readonly logger: Logger;
+  readonly config: RuntimeProcessConfig;
+  readonly annotate: <A, E, R>(
+    context: RuntimeLogContext,
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>;
+  readonly span: <A, E, R>(
+    span: RuntimeTraceSpan,
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>;
+}
+
+export class RuntimeObservabilityError extends Data.TaggedError(
+  "RuntimeObservabilityError",
+)<{
+  readonly cause:
+    | {
+        readonly _tag: "LoggerBootstrapFailed";
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "AnnotationRejected";
+        readonly field: string;
+        readonly message: string;
+      }
+    | {
+        readonly _tag: "FiberSupervisorUnavailable";
+        readonly message: string;
+      };
+}> {}
+
+export function createRuntimeObservability(
+  _config: RuntimeProcessConfig,
+): Effect.Effect<RuntimeObservability, RuntimeObservabilityError, never> {
+  throw new Error("not implemented");
+}
+
+export function withRuntimeLogContext<A, E, R>(
+  _context: RuntimeLogContext,
+  _effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  throw new Error("not implemented");
+}
+
+export function withRuntimeTraceSpan<A, E, R>(
+  _span: RuntimeTraceSpan,
+  _effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  throw new Error("not implemented");
+}

--- a/packages/server/src/runtime-surface/logging.ts
+++ b/packages/server/src/runtime-surface/logging.ts
@@ -64,11 +64,6 @@ export class RuntimeObservabilityError extends Data.TaggedError(
         readonly message: string;
       }
     | {
-        readonly _tag: "AnnotationRejected";
-        readonly field: string;
-        readonly message: string;
-      }
-    | {
         readonly _tag: "FiberSupervisorUnavailable";
         readonly message: string;
       };

--- a/packages/server/src/runtime-surface/logging.ts
+++ b/packages/server/src/runtime-surface/logging.ts
@@ -1,11 +1,9 @@
 /**
- * Architecture-only contract for shared runtime observability.
- *
- * Implementers fill this in during the approved runtime cleanup slice.
+ * Shared runtime observability for server boot and eval orchestration.
  */
 
 import { Data, Effect } from "effect";
-import type { Logger } from "../logger.js";
+import { getLogger, type Logger } from "../logger.js";
 import type { RuntimeProcessConfig } from "./config.js";
 
 export type RuntimeRequestId = string & {
@@ -69,22 +67,121 @@ export class RuntimeObservabilityError extends Data.TaggedError(
       };
 }> {}
 
+type LogFieldValue = string | number | boolean;
+
+function toLogAnnotations(
+  context: RuntimeLogContext,
+): Record<string, LogFieldValue> {
+  const annotations: Record<string, LogFieldValue> = {};
+  if (context.requestId !== undefined) {
+    annotations["requestId"] = context.requestId;
+  }
+  if (context.sessionId !== undefined) {
+    annotations["sessionId"] = context.sessionId;
+  }
+  if (context.agentId !== undefined) {
+    annotations["agentId"] = context.agentId;
+  }
+  if (context.connectionId !== undefined) {
+    annotations["connectionId"] = context.connectionId;
+  }
+  if (context.workflow !== undefined) {
+    annotations["workflow"] = context.workflow;
+  }
+  return annotations;
+}
+
+function toSpanAttributes(
+  span: RuntimeTraceSpan,
+): Record<string, LogFieldValue> {
+  const attributes: Record<string, LogFieldValue> = {};
+  if (span.fiberId !== undefined) {
+    attributes["runtime.fiberId"] = span.fiberId;
+  }
+  if (span.parentFiberId !== undefined) {
+    attributes["runtime.parentFiberId"] = span.parentFiberId;
+  }
+  return attributes;
+}
+
+function filterContextForConfig(
+  config: RuntimeProcessConfig,
+  context: RuntimeLogContext,
+): RuntimeLogContext {
+  if (config.tracing.includeRequestContext) {
+    return context;
+  }
+  return {};
+}
+
+function filterSpanForConfig(
+  config: RuntimeProcessConfig,
+  span: RuntimeTraceSpan,
+): RuntimeTraceSpan {
+  if (config.tracing.includeFiberIds) {
+    return span;
+  }
+  return {
+    name: span.name,
+  };
+}
+
 export function createRuntimeObservability(
-  _config: RuntimeProcessConfig,
+  config: RuntimeProcessConfig,
 ): Effect.Effect<RuntimeObservability, RuntimeObservabilityError, never> {
-  throw new Error("not implemented");
+  return Effect.try({
+    try: () => {
+      const rootLogger = getLogger();
+      rootLogger.level = config.logging.level;
+      const logger = rootLogger.child({
+        service: config.tracing.serviceName,
+        environment: config.environment,
+      });
+      return {
+        logger,
+        config,
+        annotate: <A, E, R>(
+          context: RuntimeLogContext,
+          effect: Effect.Effect<A, E, R>,
+        ): Effect.Effect<A, E, R> =>
+          withRuntimeLogContext(filterContextForConfig(config, context), effect),
+        span: <A, E, R>(
+          span: RuntimeTraceSpan,
+          effect: Effect.Effect<A, E, R>,
+        ): Effect.Effect<A, E, R> =>
+          withRuntimeTraceSpan(filterSpanForConfig(config, span), effect),
+      };
+    },
+    catch: (cause) =>
+      new RuntimeObservabilityError({
+        cause: {
+          _tag: "LoggerBootstrapFailed",
+          message: cause instanceof Error ? cause.message : String(cause),
+        },
+      }),
+  });
 }
 
 export function withRuntimeLogContext<A, E, R>(
-  _context: RuntimeLogContext,
-  _effect: Effect.Effect<A, E, R>,
+  context: RuntimeLogContext,
+  effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> {
-  throw new Error("not implemented");
+  const annotations = toLogAnnotations(context);
+  if (Object.keys(annotations).length === 0) {
+    return effect;
+  }
+  return effect.pipe(Effect.annotateLogs(annotations));
 }
 
 export function withRuntimeTraceSpan<A, E, R>(
-  _span: RuntimeTraceSpan,
-  _effect: Effect.Effect<A, E, R>,
+  span: RuntimeTraceSpan,
+  effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> {
-  throw new Error("not implemented");
+  const attributes = toSpanAttributes(span);
+  return effect.pipe(
+    Effect.withSpan(span.name, {
+      captureStackTrace: false,
+      attributes,
+    }),
+  );
 }

--- a/packages/server/src/runtime-surface/logging.ts
+++ b/packages/server/src/runtime-surface/logging.ts
@@ -144,7 +144,10 @@ export function createRuntimeObservability(
           context: RuntimeLogContext,
           effect: Effect.Effect<A, E, R>,
         ): Effect.Effect<A, E, R> =>
-          withRuntimeLogContext(filterContextForConfig(config, context), effect),
+          withRuntimeLogContext(
+            filterContextForConfig(config, context),
+            effect,
+          ),
         span: <A, E, R>(
           span: RuntimeTraceSpan,
           effect: Effect.Effect<A, E, R>,

--- a/packages/server/src/standalone.ts
+++ b/packages/server/src/standalone.ts
@@ -327,9 +327,10 @@ export async function startServer(configPath?: string): Promise<{
 
   // Auto-migrate
   await Effect.runPromise(
-    autoMigrateEffect(handle, runtimeConfig.server.encryption.masterSecret).pipe(
-      Effect.provide(NodeFileSystem.layer),
-    ),
+    autoMigrateEffect(
+      handle,
+      runtimeConfig.server.encryption.masterSecret,
+    ).pipe(Effect.provide(NodeFileSystem.layer)),
   );
 
   // Build CoreConfig

--- a/packages/server/src/standalone.ts
+++ b/packages/server/src/standalone.ts
@@ -8,7 +8,6 @@ import { Kysely, PostgresDialect, sql } from "kysely";
 import { Duration, Effect } from "effect";
 import { FileSystem, HttpClient, HttpClientRequest } from "@effect/platform";
 import { NodeFileSystem, NodeHttpClient } from "@effect/platform-node";
-import { loadConfigFromFile } from "./config/loader.js";
 import type { MoltZapAppConfig as MoltZapConfig } from "./config/effect-config.js";
 import { createCoreApp } from "./app/server.js";
 import { seedInitialKek } from "./crypto/key-rotation.js";
@@ -24,6 +23,9 @@ import { WebhookUserService } from "./services/user.service.js";
 import { logger } from "./logger.js";
 import type { CoreApp, CoreConfig } from "./app/types.js";
 import type { Database } from "./db/database.js";
+import { loadRuntimeProcessConfig } from "./runtime-surface/config.js";
+import type { RuntimeConfigPath } from "./runtime-surface/config.js";
+import { createRuntimeObservability } from "./runtime-surface/logging.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -295,23 +297,37 @@ export async function startServer(configPath?: string): Promise<{
   config: MoltZapConfig;
   stop: () => Promise<void>;
 }> {
-  const yamlConfig = await Effect.runPromise(loadConfigFromFile(configPath));
+  const runtimeConfig = await Effect.runPromise(
+    loadRuntimeProcessConfig(
+      configPath === undefined
+        ? {}
+        : { configPath: configPath as RuntimeConfigPath },
+    ),
+  );
+  const observability = await Effect.runPromise(
+    createRuntimeObservability(runtimeConfig),
+  );
+  const log = observability.logger;
+
+  process.env["LOG_LEVEL"] = runtimeConfig.logging.level;
+  process.env["NODE_ENV"] = runtimeConfig.environment;
+  process.env["OTEL_SERVICE_NAME"] = runtimeConfig.tracing.serviceName;
 
   // Create database (PGlite if no URL, Postgres otherwise)
-  // DATABASE_URL env var is a fallback when YAML doesn't specify database.url
-  const databaseUrl = yamlConfig.database?.url || process.env["DATABASE_URL"];
-  const usePgLite = !databaseUrl;
+  const appConfig = runtimeConfig.app;
+  const databaseUrl = runtimeConfig.server.database.url;
+  const usePgLite = databaseUrl.length === 0;
   const handle = usePgLite
-    ? await createPgLiteDb(yamlConfig.database?.data_dir)
-    : await createPostgresDb(databaseUrl!);
+    ? await createPgLiteDb(appConfig.database?.data_dir)
+    : await createPostgresDb(databaseUrl);
 
   if (usePgLite) {
-    logger.info("Using embedded PGlite database (no external Postgres needed)");
+    log.info("Using embedded PGlite database (no external Postgres needed)");
   }
 
   // Auto-migrate
   await Effect.runPromise(
-    autoMigrateEffect(handle, yamlConfig.encryption?.master_secret).pipe(
+    autoMigrateEffect(handle, runtimeConfig.server.encryption.masterSecret).pipe(
       Effect.provide(NodeFileSystem.layer),
     ),
   );
@@ -323,14 +339,14 @@ export async function startServer(configPath?: string): Promise<{
   // after createCoreApp since they gate per-request behavior.
   const webhookClient = new WebhookClient();
 
-  const userServiceCfg = yamlConfig.services?.users;
+  const userServiceCfg = appConfig.services?.users;
   const userService =
     userServiceCfg?.type === "webhook" && userServiceCfg.webhook_url
       ? new WebhookUserService(
           webhookClient,
           userServiceCfg.webhook_url,
           userServiceCfg.timeout_ms ?? 10000,
-          logger,
+          log,
         )
       : undefined;
 
@@ -339,11 +355,11 @@ export async function startServer(configPath?: string): Promise<{
   // "developer at the keyboard". Skips the external-claim handshake so
   // the quickstart can reach the app-session flow without Supabase etc.
   // Production MUST leave `dev_mode.enabled` false (or absent).
-  const devModeUserId = yamlConfig.dev_mode?.enabled
-    ? (yamlConfig.dev_mode.user_id ?? randomUUID())
+  const devModeUserId = appConfig.dev_mode?.enabled
+    ? (appConfig.dev_mode.user_id ?? randomUUID())
     : undefined;
   if (devModeUserId) {
-    logger.warn(
+    log.warn(
       { devModeUserId },
       "dev_mode.enabled=true — registered agents will be auto-owned; do not use in production",
     );
@@ -352,10 +368,11 @@ export async function startServer(configPath?: string): Promise<{
   const coreConfig: CoreConfig = {
     db: handle.db,
     dbCleanup: handle.cleanup,
-    encryptionMasterSecret: yamlConfig.encryption?.master_secret,
-    port: yamlConfig.server?.port ?? 41973,
-    corsOrigins: yamlConfig.server?.cors_origins ?? ["*"],
-    registrationSecret: yamlConfig.registration?.secret,
+    encryptionMasterSecret: runtimeConfig.server.encryption.masterSecret,
+    port: runtimeConfig.server.server.port,
+    corsOrigins: runtimeConfig.server.server.corsOrigins.exact,
+    registrationSecret: appConfig.registration?.secret,
+    devMode: runtimeConfig.server.devMode,
     devModeUserId,
     userService,
     webhookClient,
@@ -364,41 +381,41 @@ export async function startServer(configPath?: string): Promise<{
   const app = createCoreApp(coreConfig);
 
   if (
-    yamlConfig.services?.contacts?.type === "webhook" &&
-    yamlConfig.services.contacts.webhook_url
+    appConfig.services?.contacts?.type === "webhook" &&
+    appConfig.services.contacts.webhook_url
   ) {
     app.setContactService(
       new WebhookContactService(
         webhookClient,
-        yamlConfig.services.contacts.webhook_url,
-        yamlConfig.services.contacts.timeout_ms ?? 10000,
-        logger,
+        appConfig.services.contacts.webhook_url,
+        appConfig.services.contacts.timeout_ms ?? 10000,
+        log,
       ),
     );
   }
 
   if (
-    yamlConfig.services?.permissions?.type === "webhook" &&
-    yamlConfig.services.permissions.webhook_url
+    appConfig.services?.permissions?.type === "webhook" &&
+    appConfig.services.permissions.webhook_url
   ) {
     const adapter = new AsyncWebhookAdapter();
     const token =
-      yamlConfig.services.permissions.callback_token ?? crypto.randomUUID();
+      appConfig.services.permissions.callback_token ?? crypto.randomUUID();
     const callbackBaseUrl = `http://127.0.0.1:${app.port}`;
     const permService = new WebhookPermissionService(
       adapter,
-      yamlConfig.services.permissions.webhook_url,
+      appConfig.services.permissions.webhook_url,
       callbackBaseUrl,
       token,
-      logger,
+      log,
     );
     app.setPermissionService(permService);
     app.setWebhookPermissionCallback(adapter, token);
   }
 
   // Register app manifests (resolve paths relative to config file location)
-  if (yamlConfig.apps) {
-    const configDir = yamlConfig._configDir;
+  if (appConfig.apps) {
+    const configDir = runtimeConfig.configDirectory;
     const fsReadAppManifest = (manifestPath: string) =>
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
@@ -407,7 +424,7 @@ export async function startServer(configPath?: string): Promise<{
           .pipe(Effect.mapError((e) => new Error(e.message)));
       }).pipe(Effect.provide(NodeFileSystem.layer));
 
-    for (const appRef of yamlConfig.apps) {
+    for (const appRef of appConfig.apps) {
       const manifestPath = isAbsolute(appRef.manifest)
         ? appRef.manifest
         : resolve(configDir, appRef.manifest);
@@ -418,7 +435,7 @@ export async function startServer(configPath?: string): Promise<{
         ),
       );
       if (!loadResult.ok) {
-        logger.error(
+        log.error(
           { err: loadResult.err, path: appRef.manifest },
           "Failed to load app manifest",
         );
@@ -427,12 +444,12 @@ export async function startServer(configPath?: string): Promise<{
       try {
         const manifest = JSON.parse(loadResult.json);
         app.registerApp(manifest);
-        logger.info(
+        log.info(
           { appId: manifest.appId, path: appRef.manifest },
           "App manifest registered",
         );
       } catch (err) {
-        logger.error(
+        log.error(
           { err, path: appRef.manifest },
           "Failed to load app manifest",
         );
@@ -441,21 +458,21 @@ export async function startServer(configPath?: string): Promise<{
   }
 
   // Seed agents (after server is listening)
-  if (yamlConfig.seed?.agents?.length) {
+  if (appConfig.seed?.agents?.length) {
     const baseUrl = `http://127.0.0.1:${app.port}`;
     // Wait for the server to be ready, then seed. Fire-and-forget at the
     // process edge; logs are the feedback loop.
     const seedTask = waitForReadyEffect(baseUrl, 10).pipe(
-      Effect.flatMap(() => seedAgentsEffect(yamlConfig, handle.db, baseUrl)),
+      Effect.flatMap(() => seedAgentsEffect(appConfig, handle.db, baseUrl)),
       Effect.provide(NodeHttpClient.layer),
       Effect.catchAll((err) =>
-        Effect.sync(() => logger.error({ err }, "Seed failed")),
+        Effect.sync(() => log.error({ err }, "Seed failed")),
       ),
     );
     Effect.runFork(seedTask);
   }
 
-  logger.info(
+  log.info(
     {
       port: app.port,
       mode: "standalone",
@@ -466,7 +483,7 @@ export async function startServer(configPath?: string): Promise<{
 
   return {
     app,
-    config: yamlConfig,
+    config: appConfig,
     // `app.close()` already returns `Promise<void>` — forward it directly.
     stop: () => app.close(),
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,25 +145,25 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.101
-        version: 0.2.101(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 0.2.101(@cfworker/json-schema@4.1.1)(zod@3.24.0)
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.49
+      cc-judge:
+        specifier: git+https://github.com/chughtapan/cc-judge.git#39debed2606f2da7455e7cdc7ee78e9b46c4e0de
+        version: https://codeload.github.com/chughtapan/cc-judge/tar.gz/39debed2606f2da7455e7cdc7ee78e9b46c4e0de(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vue@3.5.32(typescript@5.9.3))(zod@3.24.0)
       dotenv:
         specifier: ^16.0.0
         version: 16.6.1
       effect:
-        specifier: ^3.21.0
+        specifier: 3.21.0
         version: 3.21.0
-      js-yaml:
-        specifier: ^4.0.0
-        version: 4.1.1
       pg:
         specifier: ^8.13.0
         version: 8.20.0
-      winston:
-        specifier: ^3.0.0
-        version: 3.19.0
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
       yargs:
         specifier: ^17.0.0
         version: 17.7.2
@@ -186,9 +186,6 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^10.18.0
         version: 10.28.0
-      '@types/js-yaml':
-        specifier: ^4.0.0
-        version: 4.0.9
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
@@ -328,7 +325,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.1(ajv@8.18.0)
       effect:
-        specifier: ^3.21.0
+        specifier: 3.21.0
         version: 3.21.0
       kysely:
         specifier: ^0.28.2
@@ -387,6 +384,71 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  '@ai-sdk/provider-utils@1.0.22':
+    resolution: {integrity: sha512-YHK2rpj++wnLVc9vPGzGFP3Pjeld2MwhKinetA0zKXOoHAT/Jit5O8kZsxcSlJPu9wvcGT1UGZEjZrtO7PfFOQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/provider@0.0.26':
+    resolution: {integrity: sha512-dQkfBDs2lTYpKM8389oopPdQgIU007GQyCbuPPrV+K6MtSII3HBfE0stUIMXUb44L+LK1t6GXPP7wjSzjO6uKg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@0.0.70':
+    resolution: {integrity: sha512-GnwbtjW4/4z7MleLiW+TOZC2M29eCg1tOUpuEiYFMmFNZK8mkrqM0PFZMo6UsYeUYMWqEOOcPOU9OQVJMJh7IQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      zod:
+        optional: true
+
+  '@ai-sdk/solid@0.0.54':
+    resolution: {integrity: sha512-96KWTVK+opdFeRubqrgaJXoNiDP89gNxFRWUp0PJOotZW816AbhUf4EnDjBjXTLjXL1n0h8tGSE9sZsRkj9wQQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      solid-js: ^1.7.7
+    peerDependenciesMeta:
+      solid-js:
+        optional: true
+
+  '@ai-sdk/svelte@0.0.57':
+    resolution: {integrity: sha512-SyF9ItIR9ALP9yDNAD+2/5Vl1IT6kchgyDH8xkmhysfJI6WrvJbtO1wdQ0nylvPLcsPoYu+cAlz1krU4lFHcYw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  '@ai-sdk/ui-utils@0.0.50':
+    resolution: {integrity: sha512-Z5QYJVW+5XpSaJ4jYCCAVG7zIAuKOOdikhgpksneNmKvx61ACFaf98pmOd+xnjahl0pIlc/QIe6O4yVaJ1sEaw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/vue@0.0.59':
+    resolution: {integrity: sha512-+ofYlnqdc8c4F6tM0IKF0+7NagZRAiqBJpGDJ+6EYhDW8FHLUP/JFBgu32SjxSxC6IKFZxEnl68ZoP/Z38EMlw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      vue: ^3.3.4
+    peerDependenciesMeta:
+      vue:
+        optional: true
+
   '@alcalzone/ansi-tokenize@0.2.5':
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
     engines: {node: '>=18'}
@@ -394,6 +456,12 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/claude-agent-sdk@0.1.45':
+    resolution: {integrity: sha512-4TE8tp5XFu+4BMphqFhQ8fxW8C9x4bGz8QPC9Up9YUll3nidWOosaNFgTCo+qqbVsOvDXNpHx/S4iEK7ll041A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.24.1
 
   '@anthropic-ai/claude-agent-sdk@0.2.101':
     resolution: {integrity: sha512-LwDQ6ueXnd1EVJbP0XICUO5en4FYJ8Cv/98/+RofoRr4l1cdAdYn1/n758DrTeGkMvTqb4lbdyMNs0RnT7mtoA==}
@@ -427,6 +495,11 @@ packages:
 
   '@ark/util@0.55.0':
     resolution: {integrity: sha512-aWFNK7aqSvqFtVsl1xmbTjGbg91uqtJV7Za76YGNEwIO4qLjMfyY8flmmbhooYMuqPCO2jyxu8hve943D+w3bA==}
+
+  '@asteasolutions/zod-to-openapi@6.4.0':
+    resolution: {integrity: sha512-8cxfF7AHHx2PqnN4Cd8/O8CBu/nVYJP9DpnfVLW3BFb66VJDnqI/CczZnkqMc3SNh6J9GiX7JbJ5T4BSP4HZ2Q==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@asyncapi/parser@3.4.0':
     resolution: {integrity: sha512-Sxn74oHiZSU6+cVeZy62iPZMFMvKp4jupMFHelSICCMw1qELmUHPvuZSr+ZHDmNGgHcEpzJM5HN02kR7T4g+PQ==}
@@ -730,6 +803,9 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@braintrust/core@0.0.74':
+    resolution: {integrity: sha512-k0oojIOC9nM5LG/L0O3PVqCR5T5Fh+Gn56QjyfvQBsP56tAR1TXMYn952xc2wHj5D93GOgmwZ2rEdnud0BADPw==}
+
   '@canvas/image-data@1.1.0':
     resolution: {integrity: sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA==}
 
@@ -741,13 +817,6 @@ packages:
 
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
-
-  '@colors/colors@1.6.0':
-    resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
-    engines: {node: '>=0.1.90'}
-
-  '@dabh/diagnostics@2.0.8':
-    resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
   '@effect/cli@0.73.2':
     resolution: {integrity: sha512-K8IJo81+qa1LU8dhxcDU4QO/bIjL/dPd3zUOSCpLiuUNz8Y3/T+WNs3GqIXEhMfCFMSlRZERN0YgmtRlEZUREA==}
@@ -873,10 +942,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.4':
@@ -885,16 +966,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.4':
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.4':
@@ -903,10 +1002,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.4':
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -915,10 +1026,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.4':
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.4':
@@ -927,10 +1050,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.4':
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.4':
@@ -939,10 +1074,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.4':
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -951,16 +1098,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.4':
     resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.4':
@@ -975,6 +1140,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.4':
     resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
     engines: {node: '>=18'}
@@ -985,6 +1156,12 @@ packages:
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.4':
@@ -999,11 +1176,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.4':
     resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
@@ -1011,10 +1200,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.4':
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.4':
@@ -1653,6 +1854,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -1693,6 +1898,12 @@ packages:
     engines: {node: '>= 10.16.0'}
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -2010,6 +2221,9 @@ packages:
     resolution: {integrity: sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==}
     engines: {node: '>= 10'}
 
+  '@next/env@14.2.35':
+    resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2028,6 +2242,10 @@ packages:
 
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     resolution: {integrity: sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@oxfmt/darwin-arm64@0.7.0':
     resolution: {integrity: sha512-By831Cju71Etl3VetSrL1DrYcUwYIaKlOt0Icss5zUBUMGy8g2/C6iImVTpccDkPDJEsr1N67adhGqUHisBxqA==}
@@ -2617,6 +2835,15 @@ packages:
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
 
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
+
+  '@sinclair/typebox@0.33.22':
+    resolution: {integrity: sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ==}
+
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
@@ -2832,9 +3059,6 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
-  '@so-ric/colorspace@1.1.6':
-    resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
-
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
@@ -2933,6 +3157,11 @@ packages:
   '@stryker-mutator/util@9.6.1':
     resolution: {integrity: sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==}
 
+  '@sveltejs/acorn-typescript@1.0.9':
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
@@ -2971,6 +3200,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/diff-match-patch@1.0.36':
+    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
+
   '@types/docker-modem@3.0.6':
     resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
 
@@ -2994,9 +3226,6 @@ packages:
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -3046,8 +3275,8 @@ packages:
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
-  '@types/triple-beam@1.3.5':
-    resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -3134,6 +3363,15 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vercel/functions@1.6.0':
+    resolution: {integrity: sha512-R6FKQrYT5MZs5IE1SqeCJWxMuBdHawFcCZboKKw8p7s+6/mcd55Gx6tWmyKnQTyrSEA04NH73Tc9CbqpEle8RA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -3162,6 +3400,35 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vue/compiler-core@3.5.32':
+    resolution: {integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==}
+
+  '@vue/compiler-dom@3.5.32':
+    resolution: {integrity: sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==}
+
+  '@vue/compiler-sfc@3.5.32':
+    resolution: {integrity: sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==}
+
+  '@vue/compiler-ssr@3.5.32':
+    resolution: {integrity: sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==}
+
+  '@vue/reactivity@3.5.32':
+    resolution: {integrity: sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==}
+
+  '@vue/runtime-core@3.5.32':
+    resolution: {integrity: sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==}
+
+  '@vue/runtime-dom@3.5.32':
+    resolution: {integrity: sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==}
+
+  '@vue/server-renderer@3.5.32':
+    resolution: {integrity: sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==}
+    peerDependencies:
+      vue: 3.5.32
+
+  '@vue/shared@3.5.32':
+    resolution: {integrity: sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -3205,6 +3472,27 @@ packages:
   aggregate-error@4.0.1:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
     engines: {node: '>=12'}
+
+  ai@3.4.33:
+    resolution: {integrity: sha512-plBlrVZKwPoRTmM8+D1sJac9Bq8eaa2jiZlHLZIWekKWI1yMWYZvCCEezY9ASPwRhULYDJB2VhKOBUUeg3S5JQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      openai: ^4.42.0
+      react: ^18 || ^19 || ^19.0.0-rc
+      sswr: ^2.1.0
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      openai:
+        optional: true
+      react:
+        optional: true
+      sswr:
+        optional: true
+      svelte:
+        optional: true
+      zod:
+        optional: true
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -3308,6 +3596,10 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   arkregex@0.0.3:
     resolution: {integrity: sha512-bU21QJOJEFJK+BPNgv+5bVXkvRxyAvgnon75D92newgHxkBJTgiFwQxusyViYyJkETsddPlHyspshDQcCzmkNg==}
 
@@ -3380,6 +3672,10 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -3505,6 +3801,12 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  braintrust@0.0.180:
+    resolution: {integrity: sha512-PEGdTmO61l6d43riQiNJhOoKqldNsWyLgfvCuNW17SL6ST3ZWUqp3STMv7S2f+7FOEhndn9iSYPq6j2vEyqwGw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.0.0
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -3591,6 +3893,12 @@ packages:
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  cc-judge@https://codeload.github.com/chughtapan/cc-judge/tar.gz/39debed2606f2da7455e7cdc7ee78e9b46c4e0de:
+    resolution: {tarball: https://codeload.github.com/chughtapan/cc-judge/tar.gz/39debed2606f2da7455e7cdc7ee78e9b46c4e0de}
+    version: 0.0.1
+    engines: {node: '>=20.11.0'}
+    hasBin: true
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3687,6 +3995,10 @@ packages:
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
 
+  cli-progress@3.12.0:
+    resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
+    engines: {node: '>=4'}
+
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
@@ -3706,6 +4018,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3724,34 +4040,18 @@ packages:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
-  color-convert@3.1.3:
-    resolution: {integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==}
-    engines: {node: '>=14.6'}
-
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  color-name@2.1.0:
-    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
-    engines: {node: '>=12.20'}
-
   color-string@1.9.1:
     resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color-string@2.1.4:
-    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
-    engines: {node: '>=18'}
 
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
-
-  color@5.0.3:
-    resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
-    engines: {node: '>=18'}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -4014,6 +4314,9 @@ packages:
     resolution: {integrity: sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==}
     hasBin: true
 
+  devalue@5.7.1:
+    resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -4119,9 +4422,6 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  enabled@2.0.0:
-    resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
-
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
@@ -4204,6 +4504,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
@@ -4274,6 +4579,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4286,6 +4594,14 @@ packages:
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
+
+  esrap@2.2.5:
+    resolution: {integrity: sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -4313,6 +4629,9 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -4334,6 +4653,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@1.1.2:
+    resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
+    engines: {node: '>=14.18'}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -4460,9 +4783,6 @@ packages:
       picomatch:
         optional: true
 
-  fecha@4.2.3:
-    resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
-
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -4511,9 +4831,6 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
-
-  fn.name@1.1.0:
-    resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -4698,6 +5015,12 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  glob@11.0.0:
+    resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
+    engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
@@ -5148,6 +5471,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -5211,6 +5537,10 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -5291,6 +5621,9 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -5301,6 +5634,11 @@ packages:
 
   jsonc-parser@2.2.1:
     resolution: {integrity: sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==}
+
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -5346,9 +5684,6 @@ packages:
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
-
-  kuler@2.0.0:
-    resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
   kysely-codegen@0.15.0:
     resolution: {integrity: sha512-LPta2nQOyoEPDQ3w/Gsplc+2iyZPAsGvtWoS21VzOB0NDQ0B38Xy1gS8WlbGef542Zdw2eLJHxekud9DzVdNRw==}
@@ -5472,6 +5807,9 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -5496,10 +5834,6 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
-  logform@2.7.0:
-    resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
-    engines: {node: '>= 12.0.0'}
 
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
@@ -5891,6 +6225,10 @@ packages:
   multipasta@0.2.7:
     resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
 
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
   mutation-server-protocol@0.4.1:
     resolution: {integrity: sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==}
     engines: {node: '>=18'}
@@ -6075,9 +6413,6 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  one-time@1.0.0:
-    resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
-
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -6118,6 +6453,9 @@ packages:
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
 
   openclaw@2026.3.31:
     resolution: {integrity: sha512-+8SIp5dTPftir1s513tT0FumpBgNvhgX+B0tyGUF94Vx9yL8qK6RTwIyiQADgPPUzIH2NVAlgTYFRSz6lxLj4w==}
@@ -6952,6 +7290,9 @@ packages:
     resolution: {integrity: sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==}
     hasBin: true
 
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -7074,6 +7415,9 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
+
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
@@ -7091,6 +7435,10 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  slugify@1.6.9:
+    resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
+    engines: {node: '>=8.0.0'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -7181,8 +7529,10 @@ packages:
     resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
     engines: {node: '>=10.16.0'}
 
-  stack-trace@0.0.10:
-    resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+  sswr@2.2.0:
+    resolution: {integrity: sha512-clTszLPZkmycALTHD1mXGU+mOtA/MIoLgS1KGTTzFNVm9rytQVykgRaP+z1zl572cz0bTqj4rFVoC2N+IGK4Sg==}
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -7303,6 +7653,23 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svelte@5.55.4:
+    resolution: {integrity: sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==}
+    engines: {node: '>=18'}
+
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  swrev@4.0.0:
+    resolution: {integrity: sha512-LqVcOHSB4cPGgitD1riJ1Hh4vdmITOp+BkmfmXRh4hSF/t7EnS4iD+SOTmq7w5pPm/SiPeto4ADbKS6dHUDWFA==}
+
+  swrv@1.2.0:
+    resolution: {integrity: sha512-lH/g4UcNyj+7lzK4eRGT4C68Q4EhQ6JtM9otPRIASfhhzfLWtbZPHcMuhuba7S9YVYuxkMUGImwMyGpfbkH07A==}
+    peerDependencies:
+      vue: '>=3.2.26 < 4'
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -7353,9 +7720,6 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
-  text-hex@1.0.0:
-    resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
-
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -7365,6 +7729,10 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -7425,10 +7793,6 @@ packages:
 
   trim-trailing-lines@2.1.0:
     resolution: {integrity: sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==}
-
-  triple-beam@1.4.1:
-    resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
-    engines: {node: '>= 14.0.0'}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
@@ -7672,6 +8036,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -7788,6 +8157,14 @@ packages:
       jsdom:
         optional: true
 
+  vue@3.5.32:
+    resolution: {integrity: sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   weapon-regex@1.3.6:
     resolution: {integrity: sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==}
 
@@ -7837,14 +8214,6 @@ packages:
   widest-line@5.0.0:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
     engines: {node: '>=18'}
-
-  winston-transport@4.9.0:
-    resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
-    engines: {node: '>= 12.0.0'}
-
-  winston@3.19.0:
-    resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
-    engines: {node: '>= 12.0.0'}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -7939,6 +8308,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.6.1:
+    resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
@@ -7982,6 +8356,9 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
@@ -8017,6 +8394,70 @@ snapshots:
     dependencies:
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@1.0.22(zod@3.24.0)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      eventsource-parser: 1.1.2
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+    optionalDependencies:
+      zod: 3.24.0
+
+  '@ai-sdk/provider@0.0.26':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@0.0.70(react@19.2.3)(zod@3.24.0)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+      swr: 2.4.1(react@19.2.3)
+      throttleit: 2.1.0
+    optionalDependencies:
+      react: 19.2.3
+      zod: 3.24.0
+
+  '@ai-sdk/solid@0.0.54(zod@3.24.0)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/svelte@0.0.57(svelte@5.55.4(@typescript-eslint/types@8.58.2))(zod@3.24.0)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+      sswr: 2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2))
+    optionalDependencies:
+      svelte: 5.55.4(@typescript-eslint/types@8.58.2)
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/ui-utils@0.0.50(zod@3.24.0)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      json-schema: 0.4.0
+      secure-json-parse: 2.7.0
+      zod-to-json-schema: 3.25.2(zod@3.24.0)
+    optionalDependencies:
+      zod: 3.24.0
+
+  '@ai-sdk/vue@0.0.59(vue@3.5.32(typescript@5.9.3))(zod@3.24.0)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+      swrv: 1.2.0(vue@3.5.32(typescript@5.9.3))
+    optionalDependencies:
+      vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - zod
+
   '@alcalzone/ansi-tokenize@0.2.5':
     dependencies:
       ansi-styles: 6.2.3
@@ -8024,11 +8465,22 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.101(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.1.45(zod@3.24.0)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
-      zod: 4.3.6
+      zod: 3.24.0
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
+  '@anthropic-ai/claude-agent-sdk@0.2.101(@cfworker/json-schema@4.1.1)(zod@3.24.0)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.81.0(zod@3.24.0)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.24.0)
+      zod: 3.24.0
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -8048,6 +8500,12 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.3.6
+
+  '@anthropic-ai/sdk@0.81.0(zod@3.24.0)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.24.0
 
   '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
     dependencies:
@@ -8069,6 +8527,11 @@ snapshots:
       '@ark/util': 0.55.0
 
   '@ark/util@0.55.0': {}
+
+  '@asteasolutions/zod-to-openapi@6.4.0(zod@3.24.0)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 3.24.0
 
   '@asyncapi/parser@3.4.0':
     dependencies:
@@ -8696,6 +9159,12 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@braintrust/core@0.0.74':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 6.4.0(zod@3.24.0)
+      uuid: 9.0.1
+      zod: 3.24.0
+
   '@canvas/image-data@1.1.0': {}
 
   '@cfworker/json-schema@4.1.1':
@@ -8712,14 +9181,6 @@ snapshots:
       fast-string-width: 1.1.0
       fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
-
-  '@colors/colors@1.6.0': {}
-
-  '@dabh/diagnostics@2.0.8':
-    dependencies:
-      '@so-ric/colorspace': 1.1.6
-      enabled: 2.0.0
-      kuler: 2.0.0
 
   '@effect/cli@0.73.2(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
@@ -8852,49 +9313,97 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
   '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
     optional: true
 
   '@esbuild/android-arm@0.27.4':
     optional: true
 
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
   '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
     optional: true
 
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
   '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
     optional: true
 
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
@@ -8903,10 +9412,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.4':
@@ -8915,13 +9430,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -9005,7 +9532,7 @@ snapshots:
       protobufjs: 7.5.4
       ws: 8.20.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.24.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9483,6 +10010,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/cliui@9.0.0': {}
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -9519,6 +10048,14 @@ snapshots:
   '@jsep-plugin/ternary@1.1.4(jsep@1.4.0)':
     dependencies:
       jsep: 1.4.0
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -10177,7 +10714,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.24.0)':
     dependencies:
       '@hono/node-server': 1.19.12(hono@4.12.9)
       ajv: 8.18.0
@@ -10194,7 +10731,7 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
+      zod: 3.24.0
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
@@ -10268,6 +10805,8 @@ snapshots:
       '@napi-rs/canvas-win32-arm64-msvc': 0.1.97
       '@napi-rs/canvas-win32-x64-msvc': 0.1.97
 
+  '@next/env@14.2.35': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -10304,6 +10843,8 @@ snapshots:
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     dependencies:
       fast-deep-equal: 3.1.3
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@oxfmt/darwin-arm64@0.7.0':
     optional: true
@@ -10768,6 +11309,14 @@ snapshots:
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
+
+  '@sinclair/typebox@0.33.22': {}
+
   '@sinclair/typebox@0.34.49': {}
 
   '@sindresorhus/is@5.6.0': {}
@@ -11086,11 +11635,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@so-ric/colorspace@1.1.6':
-    dependencies:
-      color: 5.0.3
-      text-hex: 1.0.0
-
   '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -11304,6 +11848,10 @@ snapshots:
 
   '@stryker-mutator/util@9.6.1': {}
 
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
@@ -11352,6 +11900,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/diff-match-patch@1.0.36': {}
+
   '@types/docker-modem@3.0.6':
     dependencies:
       '@types/node': 25.5.0
@@ -11380,8 +11930,6 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/http-cache-semantics@4.2.0': {}
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -11438,7 +11986,7 @@ snapshots:
     dependencies:
       '@types/node': 18.19.130
 
-  '@types/triple-beam@1.3.5': {}
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
 
@@ -11557,6 +12105,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.28)':
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.28
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -11599,6 +12151,60 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@vue/compiler-core@3.5.32':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/shared': 3.5.32
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.32':
+    dependencies:
+      '@vue/compiler-core': 3.5.32
+      '@vue/shared': 3.5.32
+
+  '@vue/compiler-sfc@3.5.32':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/compiler-core': 3.5.32
+      '@vue/compiler-dom': 3.5.32
+      '@vue/compiler-ssr': 3.5.32
+      '@vue/shared': 3.5.32
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.8
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.32':
+    dependencies:
+      '@vue/compiler-dom': 3.5.32
+      '@vue/shared': 3.5.32
+
+  '@vue/reactivity@3.5.32':
+    dependencies:
+      '@vue/shared': 3.5.32
+
+  '@vue/runtime-core@3.5.32':
+    dependencies:
+      '@vue/reactivity': 3.5.32
+      '@vue/shared': 3.5.32
+
+  '@vue/runtime-dom@3.5.32':
+    dependencies:
+      '@vue/reactivity': 3.5.32
+      '@vue/runtime-core': 3.5.32
+      '@vue/shared': 3.5.32
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.32(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.32
+      '@vue/shared': 3.5.32
+      vue: 3.5.32(typescript@5.9.3)
+
+  '@vue/shared@3.5.32': {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -11635,6 +12241,30 @@ snapshots:
     dependencies:
       clean-stack: 4.2.0
       indent-string: 5.0.0
+
+  ai@3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vue@3.5.32(typescript@5.9.3))(zod@3.24.0):
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/react': 0.0.70(react@19.2.3)(zod@3.24.0)
+      '@ai-sdk/solid': 0.0.54(zod@3.24.0)
+      '@ai-sdk/svelte': 0.0.57(svelte@5.55.4(@typescript-eslint/types@8.58.2))(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+      '@ai-sdk/vue': 0.0.59(vue@3.5.32(typescript@5.9.3))(zod@3.24.0)
+      '@opentelemetry/api': 1.9.0
+      eventsource-parser: 1.1.2
+      json-schema: 0.4.0
+      jsondiffpatch: 0.6.0
+      secure-json-parse: 2.7.0
+      zod-to-json-schema: 3.25.2(zod@3.24.0)
+    optionalDependencies:
+      react: 19.2.3
+      sswr: 2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2))
+      svelte: 5.55.4(@typescript-eslint/types@8.58.2)
+      zod: 3.24.0
+    transitivePeerDependencies:
+      - solid-js
+      - vue
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
@@ -11737,6 +12367,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.1: {}
+
   arkregex@0.0.3:
     dependencies:
       '@ark/util': 0.55.0
@@ -11820,6 +12452,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
     optional: true
+
+  axobject-query@4.1.0: {}
 
   b4a@1.8.0: {}
 
@@ -11941,6 +12575,39 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  braintrust@0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vue@3.5.32(typescript@5.9.3))(zod@3.24.0):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@braintrust/core': 0.0.74
+      '@next/env': 14.2.35
+      '@vercel/functions': 1.6.0(@aws-sdk/credential-provider-web-identity@3.972.28)
+      ai: 3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vue@3.5.32(typescript@5.9.3))(zod@3.24.0)
+      argparse: 2.0.1
+      chalk: 4.1.2
+      cli-progress: 3.12.0
+      dotenv: 16.6.1
+      esbuild: 0.18.20
+      eventsource-parser: 1.1.2
+      graceful-fs: 4.2.11
+      minimatch: 9.0.9
+      mustache: 4.2.0
+      pluralize: 8.0.0
+      simple-git: 3.36.0
+      slugify: 1.6.9
+      source-map: 0.7.6
+      uuid: 9.0.1
+      zod: 3.24.0
+      zod-to-json-schema: 3.25.2(zod@3.24.0)
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
+      - openai
+      - react
+      - solid-js
+      - sswr
+      - supports-color
+      - svelte
+      - vue
+
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.20
@@ -12028,6 +12695,27 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001788: {}
+
+  cc-judge@https://codeload.github.com/chughtapan/cc-judge/tar.gz/39debed2606f2da7455e7cdc7ee78e9b46c4e0de(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vue@3.5.32(typescript@5.9.3))(zod@3.24.0):
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk': 0.1.45(zod@3.24.0)
+      '@sinclair/typebox': 0.33.22
+      braintrust: 0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vue@3.5.32(typescript@5.9.3))(zod@3.24.0)
+      effect: 3.21.0
+      glob: 11.0.0
+      proper-lockfile: 4.1.2
+      yaml: 2.6.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
+      - openai
+      - react
+      - solid-js
+      - sswr
+      - supports-color
+      - svelte
+      - vue
+      - zod
 
   ccount@2.0.1: {}
 
@@ -12132,6 +12820,10 @@ snapshots:
       parse5-htmlparser2-tree-adapter: 6.0.1
       yargs: 16.2.0
 
+  cli-progress@3.12.0:
+    dependencies:
+      string-width: 4.2.3
+
   cli-spinners@2.9.2: {}
 
   cli-truncate@4.0.0:
@@ -12153,6 +12845,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   code-excerpt@4.0.0:
     dependencies:
       convert-to-spaces: 2.0.1
@@ -12169,34 +12863,19 @@ snapshots:
     dependencies:
       color-name: 1.1.4
 
-  color-convert@3.1.3:
-    dependencies:
-      color-name: 2.1.0
-
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
-
-  color-name@2.1.0: {}
 
   color-string@1.9.1:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.4
 
-  color-string@2.1.4:
-    dependencies:
-      color-name: 2.1.0
-
   color@4.2.3:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
-
-  color@5.0.3:
-    dependencies:
-      color-convert: 3.1.3
-      color-string: 2.1.4
 
   colorette@2.0.20: {}
 
@@ -12415,6 +13094,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  devalue@5.7.1: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -12524,8 +13205,6 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
-
-  enabled@2.0.0: {}
 
   encodeurl@1.0.2: {}
 
@@ -12675,6 +13354,31 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
   esbuild@0.27.4:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.4
@@ -12800,6 +13504,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.16.0
@@ -12811,6 +13517,12 @@ snapshots:
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@2.2.5(@typescript-eslint/types@8.58.2):
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
+      '@typescript-eslint/types': 8.58.2
 
   esrecurse@4.3.0:
     dependencies:
@@ -12847,6 +13559,8 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -12864,6 +13578,8 @@ snapshots:
       - bare-abort-controller
 
   events@3.3.0: {}
+
+  eventsource-parser@1.1.2: {}
 
   eventsource-parser@3.0.6: {}
 
@@ -13061,8 +13777,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fecha@4.2.3: {}
-
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -13138,8 +13852,6 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
-
-  fn.name@1.1.0: {}
 
   follow-redirects@1.15.11: {}
 
@@ -13349,6 +14061,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@11.0.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -13360,7 +14081,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -13943,6 +14664,10 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -14004,6 +14729,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
   jake@10.9.4:
     dependencies:
       async: 3.2.6
@@ -14064,11 +14793,19 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
 
   jsonc-parser@2.2.1: {}
+
+  jsondiffpatch@0.6.0:
+    dependencies:
+      '@types/diff-match-patch': 1.0.36
+      chalk: 5.6.2
+      diff-match-patch: 1.0.5
 
   jsonfile@6.2.0:
     dependencies:
@@ -14124,8 +14861,6 @@ snapshots:
     optional: true
 
   kubernetes-types@1.30.0: {}
-
-  kuler@2.0.0: {}
 
   kysely-codegen@0.15.0(kysely@0.28.16)(pg@8.20.0):
     dependencies:
@@ -14221,6 +14956,8 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  locate-character@3.0.0: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -14238,15 +14975,6 @@ snapshots:
   lodash@4.17.23: {}
 
   lodash@4.18.1: {}
-
-  logform@2.7.0:
-    dependencies:
-      '@colors/colors': 1.6.0
-      '@types/triple-beam': 1.3.5
-      fecha: 4.2.3
-      ms: 2.1.3
-      safe-stable-stringify: 2.5.0
-      triple-beam: 1.4.1
 
   loglevel@1.9.2: {}
 
@@ -14966,6 +15694,8 @@ snapshots:
 
   multipasta@0.2.7: {}
 
+  mustache@4.2.0: {}
+
   mutation-server-protocol@0.4.1:
     dependencies:
       zod: 4.3.6
@@ -15135,10 +15865,6 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  one-time@1.0.0:
-    dependencies:
-      fn.name: 1.1.0
-
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
@@ -15169,6 +15895,10 @@ snapshots:
 
   openapi-types@12.1.3: {}
 
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.3
+
   openclaw@2026.3.31(@cfworker/json-schema@4.1.1)(@napi-rs/canvas@0.1.97):
     dependencies:
       '@agentclientprotocol/sdk': 0.17.1(zod@4.3.6)
@@ -15182,7 +15912,7 @@ snapshots:
       '@mariozechner/pi-coding-agent': 0.64.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.64.0
       '@matrix-org/matrix-sdk-crypto-wasm': 18.0.0
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.24.0)
       '@mozilla/readability': 0.6.0
       '@napi-rs/canvas': 0.1.97
       '@sinclair/typebox': 0.34.49
@@ -16258,6 +16988,8 @@ snapshots:
 
   sdp-transform@3.0.0: {}
 
+  secure-json-parse@2.7.0: {}
+
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
@@ -16485,6 +17217,16 @@ snapshots:
       simple-concat: 1.0.1
     optional: true
 
+  simple-git@3.36.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   simple-swizzle@0.2.4:
     dependencies:
       is-arrayish: 0.3.4
@@ -16502,6 +17244,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  slugify@1.6.9: {}
 
   smart-buffer@4.2.0: {}
 
@@ -16607,7 +17351,10 @@ snapshots:
       cpu-features: 0.0.10
       nan: 2.26.2
 
-  stack-trace@0.0.10: {}
+  sswr@2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2)):
+    dependencies:
+      svelte: 5.55.4(@typescript-eslint/types@8.58.2)
+      swrev: 4.0.0
 
   stack-utils@2.0.6:
     dependencies:
@@ -16747,6 +17494,39 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svelte@5.55.4(@typescript-eslint/types@8.58.2):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.7.1
+      esm-env: 1.2.2
+      esrap: 2.2.5(@typescript-eslint/types@8.58.2)
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  swr@2.4.1(react@19.2.3):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+
+  swrev@4.0.0: {}
+
+  swrv@1.2.0(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.32(typescript@5.9.3)
 
   tagged-tag@1.0.0: {}
 
@@ -16911,8 +17691,6 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
-  text-hex@1.0.0: {}
-
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -16924,6 +17702,8 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
+
+  throttleit@2.1.0: {}
 
   through@2.3.8: {}
 
@@ -16967,8 +17747,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trim-trailing-lines@2.1.0: {}
-
-  triple-beam@1.4.1: {}
 
   trough@2.2.0: {}
 
@@ -17239,6 +18017,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  use-sync-external-store@1.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   util-deprecate@1.0.2: {}
 
   utility-types@3.11.0: {}
@@ -17353,6 +18135,16 @@ snapshots:
       - tsx
       - yaml
 
+  vue@3.5.32(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.32
+      '@vue/compiler-sfc': 3.5.32
+      '@vue/runtime-dom': 3.5.32
+      '@vue/server-renderer': 3.5.32(vue@3.5.32(typescript@5.9.3))
+      '@vue/shared': 3.5.32
+    optionalDependencies:
+      typescript: 5.9.3
+
   weapon-regex@1.3.6: {}
 
   web-namespaces@2.0.1: {}
@@ -17424,26 +18216,6 @@ snapshots:
     dependencies:
       string-width: 7.2.0
 
-  winston-transport@4.9.0:
-    dependencies:
-      logform: 2.7.0
-      readable-stream: 3.6.2
-      triple-beam: 1.4.1
-
-  winston@3.19.0:
-    dependencies:
-      '@colors/colors': 1.6.0
-      '@dabh/diagnostics': 2.0.8
-      async: 3.2.6
-      is-stream: 2.0.1
-      logform: 2.7.0
-      one-time: 1.0.0
-      readable-stream: 3.6.2
-      safe-stable-stringify: 2.5.0
-      stack-trace: 0.0.10
-      triple-beam: 1.4.1
-      winston-transport: 4.9.0
-
   word-wrap@1.2.5: {}
 
   wordwrap@1.0.0: {}
@@ -17502,6 +18274,8 @@ snapshots:
 
   yallist@5.0.0: {}
 
+  yaml@2.6.1: {}
+
   yaml@2.8.3: {}
 
   yargs-parser@20.2.9: {}
@@ -17551,6 +18325,8 @@ snapshots:
 
   yoga-layout@3.2.1: {}
 
+  zimmerframe@1.1.4: {}
+
   zip-stream@6.0.1:
     dependencies:
       archiver-utils: 5.0.2
@@ -17562,6 +18338,10 @@ snapshots:
       zod: 3.21.4
 
   zod-to-json-schema@3.20.4(zod@3.24.0):
+    dependencies:
+      zod: 3.24.0
+
+  zod-to-json-schema@3.25.2(zod@3.24.0):
     dependencies:
       zod: 3.24.0
 


### PR DESCRIPTION
Part of #174

Follow-on eval/runtime convergence: #177

Design anchor: #175
Spec anchor: #164
Umbrella: #168

## What changed
This PR is the narrowed merge candidate against `main` for the server/runtime slice of row 5.

## This PR lands
- implement `packages/server/src/runtime-surface/config.ts`
- implement `packages/server/src/runtime-surface/logging.ts`
- switch `packages/server/src/standalone.ts` onto the runtime-surface bootstrap
- exact-pin `effect` in `packages/server/package.json` per the approved dependency table
- land the eval/logging/package prework already present on this branch

## Follow-on work moved to #177
- `@moltzap/evals` runtime cleanup slice
- planned-harness staging / `cc-judge` default execution wiring
- legacy `contractMode` removal and runtime-session bring-up replacement

## Verification
- CI green on this PR
- `ci`
- `test-integration`
