### PR TITLE
[impl-senior] make runtime fleet launch interruption-safe

### DIFF
--- a/packages/runtimes/src/fleet.ts
+++ b/packages/runtimes/src/fleet.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
 import {
   RuntimeExitedBeforeReady,
   RuntimeReadyTimedOut,
@@ -67,6 +67,24 @@ interface StartedRuntimeAgent {
   readonly runtime: Runtime;
 }
 
+interface PendingRuntimeAgent {
+  readonly runtime: Runtime;
+  readonly releaseStartupCleanup: Effect.Effect<void, never, never>;
+}
+
+class UnknownRuntimeAgent extends Error {
+  readonly _tag = "UnknownRuntimeAgent" as const;
+
+  constructor(
+    readonly agentName: string,
+    readonly knownAgents: ReadonlyArray<string>,
+  ) {
+    super(
+      `Unknown runtime agent "${agentName}". Known agents: ${knownAgents.join(", ")}`,
+    );
+  }
+}
+
 function createRuntime(options: RuntimeStartOptions): Runtime {
   if (options.kind === "openclaw") {
     return createWorkspaceOpenClawAdapter({
@@ -103,16 +121,32 @@ function teardownStartedAgents(
   );
 }
 
-export function startRuntimeAgent(
-  options: RuntimeStartOptions,
-): Effect.Effect<Runtime, RuntimeLaunchFailed, never> {
+function startPendingRuntimeAgent(options: RuntimeStartOptions) {
   const runtime = createRuntime(options);
+  const spawnInput = toSpawnInput(options.agent);
   return Effect.gen(function* () {
-    yield* runtime.spawn(toSpawnInput(options.agent));
+    let cleanupArmed = true;
+    const [closeStartupScope] = yield* Effect.withEarlyRelease(
+      Effect.gen(function* () {
+        yield* Effect.addFinalizer(() =>
+          cleanupArmed ? runtime.teardown() : Effect.void,
+        );
+        yield* runtime.spawn(spawnInput);
+      }),
+    );
+    const releaseStartupCleanup = Effect.uninterruptible(
+      Effect.sync(() => {
+        cleanupArmed = false;
+      }).pipe(Effect.zipRight(closeStartupScope)),
+    );
+
     const ready = yield* runtime.waitUntilReady(options.readyTimeoutMs);
     switch (ready._tag) {
       case "Ready":
-        return runtime;
+        return {
+          runtime,
+          releaseStartupCleanup,
+        } satisfies PendingRuntimeAgent;
       case "Timeout":
         return yield* Effect.fail(
           new RuntimeReadyTimedOut(options.agent.agentName, ready.timeoutMs),
@@ -129,61 +163,77 @@ export function startRuntimeAgent(
   });
 }
 
+export function startRuntimeAgent(
+  options: RuntimeStartOptions,
+): Effect.Effect<Runtime, RuntimeLaunchFailed, never> {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const pending = yield* startPendingRuntimeAgent(options);
+      yield* pending.releaseStartupCleanup;
+      return pending.runtime;
+    }),
+  );
+}
+
 export function launchRuntimeFleet(
   options: RuntimeFleetLaunchOptions,
 ): Effect.Effect<RuntimeFleet, RuntimeLaunchFailed, never> {
-  return Effect.gen(function* () {
-    const startedAgents: StartedRuntimeAgent[] = [];
-    const launchOne = (agent: RuntimeAgentSpec) =>
-      startRuntimeAgent({
-        kind: options.kind,
-        server: options.server,
-        agent,
-        readyTimeoutMs: options.readyTimeoutMs,
-        ...(options.openclaw !== undefined
-          ? { openclaw: options.openclaw }
-          : {}),
-        ...(options.nanoclaw !== undefined
-          ? { nanoclaw: options.nanoclaw }
-          : {}),
-      }).pipe(
-        Effect.map((runtime) => {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const startedAgents: StartedRuntimeAgent[] = [];
+      const launchOne = (agent: RuntimeAgentSpec) =>
+        Effect.gen(function* () {
+          const pending = yield* startPendingRuntimeAgent({
+            kind: options.kind,
+            server: options.server,
+            agent,
+            readyTimeoutMs: options.readyTimeoutMs,
+            ...(options.openclaw !== undefined
+              ? { openclaw: options.openclaw }
+              : {}),
+            ...(options.nanoclaw !== undefined
+              ? { nanoclaw: options.nanoclaw }
+              : {}),
+          });
           const startedAgent = {
             spec: agent,
-            runtime,
+            runtime: pending.runtime,
           } satisfies StartedRuntimeAgent;
           startedAgents.push(startedAgent);
+          yield* pending.releaseStartupCleanup;
           return startedAgent;
-        }),
+        });
+
+      const started = yield* Effect.forEach(options.agents, launchOne, {
+        concurrency: 1,
+      }).pipe(
+        Effect.onExit((exit) =>
+          Exit.isSuccess(exit)
+            ? Effect.void
+            : teardownStartedAgents(startedAgents),
+        ),
       );
 
-    const started = yield* Effect.catchAll(
-      Effect.forEach(options.agents, launchOne, { concurrency: 1 }),
-      (error) =>
-        teardownStartedAgents(startedAgents).pipe(
-          Effect.zipRight(Effect.fail(error)),
-        ),
-    );
-
-    return {
-      agents: started.map((startedAgent) => ({
-        name: startedAgent.spec.agentName,
-        agentId: startedAgent.spec.agentId,
-      })),
-      stopAll: () => teardownStartedAgents(started),
-      getLogs(name: string): string {
-        const startedAgent = started.find(
-          (candidate) => candidate.spec.agentName === name,
-        );
-        if (startedAgent === undefined) {
-          throw new Error(
-            `Unknown runtime agent "${name}". Known agents: ${started
-              .map((candidate) => candidate.spec.agentName)
-              .join(", ")}`,
+      return {
+        agents: started.map((startedAgent) => ({
+          name: startedAgent.spec.agentName,
+          agentId: startedAgent.spec.agentId,
+        })),
+        stopAll: () => teardownStartedAgents(started),
+        getLogs(name: string): string {
+          const startedAgent = started.find(
+            (candidate) => candidate.spec.agentName === name,
           );
-        }
-        return startedAgent.runtime.getLogs(0).text;
-      },
-    } satisfies RuntimeFleet;
-  });
+          if (startedAgent === undefined) {
+            throw new UnknownRuntimeAgent(
+              name,
+              started.map((candidate) => candidate.spec.agentName),
+            );
+          }
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- log reads always start at offset 0 for fleet snapshots
+          return startedAgent.runtime.getLogs(0).text;
+        },
+      } satisfies RuntimeFleet;
+    }),
+  );
 }

--- a/packages/runtimes/src/runtimes.test.ts
+++ b/packages/runtimes/src/runtimes.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { Effect } from "effect";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Effect, Exit, Fiber } from "effect";
 
 import {
   OpenClawAdapter,
   type OpenClawAdapterDeps,
 } from "./openclaw-adapter.js";
+import {
+  launchRuntimeFleet,
+  startRuntimeAgent,
+  type RuntimeAgentSpec,
+} from "./fleet.js";
 import {
   NanoclawAdapter,
   type NanoclawAdapterDeps,
@@ -17,6 +22,28 @@ import type {
   ReadyOutcome,
 } from "./runtime.js";
 import { SpawnFailed } from "./errors.js";
+
+const fleetRuntimeFactoryState = vi.hoisted(() => ({
+  nextRuntime: null as null | (() => Runtime),
+}));
+
+vi.mock("./openclaw-adapter.js", async () => {
+  const actual = await vi.importActual<typeof import("./openclaw-adapter.js")>(
+    "./openclaw-adapter.js",
+  );
+  return {
+    ...actual,
+    createWorkspaceOpenClawAdapter: vi.fn(() => {
+      const factory = fleetRuntimeFactoryState.nextRuntime;
+      if (factory === null) {
+        throw new Error(
+          "Expected a configured runtime factory for fleet tests",
+        );
+      }
+      return factory();
+    }),
+  };
+});
 
 // Minimal stub for the live server surface the adapters poll for readiness.
 function stubServer(): RuntimeServerHandle {
@@ -52,6 +79,10 @@ function stubSpawnInput(overrides?: Partial<SpawnInput>): SpawnInput {
     ...overrides,
   };
 }
+
+afterEach(() => {
+  fleetRuntimeFactoryState.nextRuntime = null;
+});
 
 // ---------------------------------------------------------------------------
 // Runtime interface contract
@@ -281,8 +312,176 @@ describe("NanoclawAdapter", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Fleet lifecycle cleanup
+// ---------------------------------------------------------------------------
+
+describe("runtime fleet lifecycle", () => {
+  it("tears down an in-flight runtime when startRuntimeAgent is interrupted", async () => {
+    const blocked = createMockRuntime({
+      readyEffect: Effect.never,
+    });
+    setMockFleetRuntimes(blocked.runtime);
+
+    const fiber = Effect.runFork(
+      startRuntimeAgent({
+        kind: "openclaw",
+        server: stubServer(),
+        agent: stubRuntimeAgentSpec(),
+        readyTimeoutMs: 60_000,
+      }),
+    );
+
+    await blocked.waitStarted;
+    await Effect.runPromise(Fiber.interrupt(fiber));
+    const exit = await Effect.runPromise(Fiber.await(fiber));
+
+    expect(Exit.isInterrupted(exit)).toBe(true);
+    expect(blocked.stats.spawnCalls).toBe(1);
+    expect(blocked.stats.waitCalls).toBe(1);
+    expect(blocked.stats.teardownCalls).toBe(1);
+  });
+
+  it("tears down ready and in-flight runtimes when launchRuntimeFleet is interrupted mid-startup", async () => {
+    const first = createMockRuntime({
+      readyEffect: Effect.succeed({ _tag: "Ready" }),
+    });
+    const second = createMockRuntime({
+      readyEffect: Effect.never,
+    });
+    setMockFleetRuntimes(first.runtime, second.runtime);
+
+    const fiber = Effect.runFork(
+      launchRuntimeFleet({
+        kind: "openclaw",
+        server: stubServer(),
+        agents: [
+          stubRuntimeAgentSpec({ agentName: "alpha", agentId: "agent-001" }),
+          stubRuntimeAgentSpec({ agentName: "beta", agentId: "agent-002" }),
+        ],
+        readyTimeoutMs: 60_000,
+      }),
+    );
+
+    await second.waitStarted;
+    await Effect.runPromise(Fiber.interrupt(fiber));
+    const exit = await Effect.runPromise(Fiber.await(fiber));
+
+    expect(Exit.isInterrupted(exit)).toBe(true);
+    expect(first.stats.teardownCalls).toBe(1);
+    expect(second.stats.teardownCalls).toBe(1);
+  });
+
+  it("tears down previously started and failing runtimes before fleet launch returns an error", async () => {
+    const first = createMockRuntime({
+      readyEffect: Effect.succeed({ _tag: "Ready" }),
+    });
+    const second = createMockRuntime({
+      readyEffect: Effect.succeed({ _tag: "Timeout", timeoutMs: 250 }),
+    });
+    setMockFleetRuntimes(first.runtime, second.runtime);
+
+    const result = await Effect.runPromise(
+      Effect.either(
+        launchRuntimeFleet({
+          kind: "openclaw",
+          server: stubServer(),
+          agents: [
+            stubRuntimeAgentSpec({ agentName: "alpha", agentId: "agent-001" }),
+            stubRuntimeAgentSpec({ agentName: "beta", agentId: "agent-002" }),
+          ],
+          readyTimeoutMs: 250,
+        }),
+      ),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("RuntimeReadyTimedOut");
+      expect(result.left.agentName).toBe("beta");
+    }
+    expect(first.stats.teardownCalls).toBe(1);
+    expect(second.stats.teardownCalls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+interface MockRuntimeStats {
+  spawnCalls: number;
+  waitCalls: number;
+  teardownCalls: number;
+}
+
+interface MockRuntimeHandle {
+  readonly runtime: Runtime;
+  readonly stats: MockRuntimeStats;
+  readonly waitStarted: Promise<void>;
+}
+
+function stubRuntimeAgentSpec(
+  overrides?: Partial<RuntimeAgentSpec>,
+): RuntimeAgentSpec {
+  return {
+    agentName: "test-agent",
+    apiKey: "test-api-key",
+    agentId: "agent-001",
+    serverUrl: "ws://localhost:9999/ws",
+    ...overrides,
+  };
+}
+
+function setMockFleetRuntimes(...runtimes: ReadonlyArray<Runtime>): void {
+  const queue = [...runtimes];
+  fleetRuntimeFactoryState.nextRuntime = () => {
+    const runtime = queue.shift();
+    if (runtime === undefined) {
+      throw new Error("No mocked runtime remaining for fleet test");
+    }
+    return runtime;
+  };
+}
+
+function createMockRuntime(options: {
+  readonly readyEffect: Effect.Effect<ReadyOutcome, never, never>;
+}): MockRuntimeHandle {
+  const stats: MockRuntimeStats = {
+    spawnCalls: 0,
+    waitCalls: 0,
+    teardownCalls: 0,
+  };
+
+  let resolveWaitStarted: (() => void) | null = null;
+  const waitStarted = new Promise<void>((resolve) => {
+    resolveWaitStarted = resolve;
+  });
+
+  const runtime: Runtime = {
+    spawn: () =>
+      Effect.sync(() => {
+        stats.spawnCalls += 1;
+      }),
+    waitUntilReady: () =>
+      Effect.sync(() => {
+        stats.waitCalls += 1;
+        resolveWaitStarted?.();
+        resolveWaitStarted = null;
+      }).pipe(Effect.zipRight(options.readyEffect)),
+    teardown: () =>
+      Effect.sync(() => {
+        stats.teardownCalls += 1;
+      }),
+    getLogs: () => ({ text: "", nextOffset: 0 }),
+    getInboundMarker: () => "inbound from agent:",
+  };
+
+  return {
+    runtime,
+    stats,
+    waitStarted,
+  };
+}
 
 function absurd(x: never): never {
   throw new Error(`unreachable: ${JSON.stringify(x)}`);


### PR DESCRIPTION
Closes #192
Investigation: https://github.com/chughtapan/moltzap/issues/189#issuecomment-4310458455

## What changed
`@moltzap/runtimes` now keeps startup teardown armed until a runtime has both spawned and been safely handed off to its caller. `startRuntimeAgent()` uses a scoped startup helper so interruption or readiness failure tears down the in-flight runtime, and `launchRuntimeFleet()` tears down already-started agents on any non-success exit before returning a fleet object.

The regression coverage stays in `packages/runtimes/src/runtimes.test.ts` and exercises three paths with mocked runtimes: interrupting `startRuntimeAgent()` mid-startup, interrupting `launchRuntimeFleet()` after one runtime is ready and another is still booting, and failing a later runtime startup after an earlier runtime is already ready.

## Plan anchors
| Change | Plan anchor |
| --- | --- |
| Hold startup teardown ownership until readiness succeeds in `startRuntimeAgent()` | #192 acceptance: upstream `@moltzap/runtimes` cleans up partially started detached runtimes on failure or interruption |
| Extend fleet launch cleanup to interruption and ready-agent rollback before returning the fleet | #189 root cause + #192 acceptance: partially started and already-started runtimes must be cleaned before the fleet object is returned |
| Add focused regression coverage for interrupted and failed startup lifecycle paths | #192 acceptance: focused tests cover the leak path |

## Verification
- `pnpm exec eslint packages/runtimes/src/fleet.ts packages/runtimes/src/runtimes.test.ts`
- `pnpm --filter @moltzap/runtimes exec tsc --noEmit`
- `pnpm --filter @moltzap/runtimes test`
- `pnpm --filter @moltzap/runtimes build`
- `git commit` pre-commit hook (`pnpm check`, repo typecheck, guardrails) passed
