### PR TITLE
fix: wait for detached runtime groups to exit

### DIFF
--- a/packages/runtimes/src/openclaw-adapter.ts
+++ b/packages/runtimes/src/openclaw-adapter.ts
@@ -15,6 +15,10 @@ import type {
 } from "./runtime.js";
 import { SpawnFailed } from "./errors.js";
 
+const OPENCLAW_TERM_WAIT_MS = 10_000;
+const OPENCLAW_KILL_WAIT_MS = 5_000;
+const PROCESS_GROUP_POLL_INTERVAL_MS = 100;
+
 export interface OpenClawAdapterDeps {
   readonly server: RuntimeServerHandle;
   readonly openclawBin: string;
@@ -175,28 +179,26 @@ export class OpenClawAdapter implements Runtime {
     return "inbound from agent:";
   }
 
-  /** Async teardown: SIGTERM → await exit event (≤10s) → SIGKILL → rm workdir. */
+  /** Async teardown: SIGTERM → await group exit (≤10s) → SIGKILL → rm workdir. */
   // #ignore-sloppy-code-next-line[async-keyword, promise-type]: child_process exit event + fs.rm boundary
   private async doTeardown(): Promise<void> {
     if (!this.state || this.state.tornDown) return;
     this.state.tornDown = true;
 
     const { child, stateDir } = this.state;
+    const groupId = child.pid ?? null;
 
-    this.killGroup(child, "SIGTERM");
-
-    if (child.exitCode === null) {
-      await new Promise<void>((resolve) => {
-        const timer = setTimeout(resolve, 10_000);
-        child.once("exit", () => {
-          clearTimeout(timer);
-          resolve();
-        });
-      });
-    }
-
-    if (child.exitCode === null) {
-      this.killGroup(child, "SIGKILL");
+    if (groupId !== null) {
+      this.killGroup(groupId, "SIGTERM");
+      const exitedAfterTerm = await Effect.runPromise(
+        this.waitForProcessGroupExit(groupId, OPENCLAW_TERM_WAIT_MS),
+      );
+      if (!exitedAfterTerm) {
+        this.killGroup(groupId, "SIGKILL");
+        await Effect.runPromise(
+          this.waitForProcessGroupExit(groupId, OPENCLAW_KILL_WAIT_MS),
+        );
+      }
     }
 
     try {
@@ -207,11 +209,44 @@ export class OpenClawAdapter implements Runtime {
     }
   }
 
-  private killGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  private waitForProcessGroupExit(
+    groupId: number,
+    timeoutMs: number,
+  ): Effect.Effect<boolean, never, never> {
+    const deadline = Date.now() + timeoutMs;
+    const poll = (): Effect.Effect<boolean, never, never> =>
+      Effect.sync(() => this.isProcessGroupAlive(groupId)).pipe(
+        Effect.flatMap((alive) => {
+          if (!alive) {
+            return Effect.succeed(true);
+          }
+          if (Date.now() >= deadline) {
+            return Effect.succeed(false);
+          }
+          return Effect.sleep(`${PROCESS_GROUP_POLL_INTERVAL_MS} millis`).pipe(
+            Effect.flatMap(() => poll()),
+          );
+        }),
+      );
+    return poll();
+  }
+
+  private isProcessGroupAlive(groupId: number): boolean {
     try {
-      if (child.pid != null) {
-        process.kill(-child.pid, signal);
-      }
+      process.kill(-groupId, 0);
+      return true;
+    } catch (error) {
+      return !(
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ESRCH"
+      );
+    }
+  }
+
+  private killGroup(groupId: number, signal: NodeJS.Signals): void {
+    try {
+      process.kill(-groupId, signal);
       // #ignore-sloppy-code-next-line[bare-catch]: ESRCH — process already dead
     } catch (_err) {
       void _err;

--- a/packages/runtimes/src/runtimes.test.ts
+++ b/packages/runtimes/src/runtimes.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { Effect, Exit, Fiber } from "effect";
 
@@ -185,6 +186,79 @@ describe("OpenClawAdapter.teardown", () => {
     const adapter = new OpenClawAdapter(stubDeps());
     await Effect.runPromise(adapter.teardown());
     await Effect.runPromise(adapter.teardown());
+  });
+
+  it("waits for detached process-group exit before returning", async () => {
+    vi.useFakeTimers();
+    const killCalls: Array<{
+      readonly pid: number;
+      readonly signal: NodeJS.Signals | 0;
+    }> = [];
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | 0,
+    ) => {
+      killCalls.push({ pid, signal: signal ?? 0 });
+      if (pid !== -4242) {
+        throw new Error(`Unexpected pid ${pid}`);
+      }
+      if ((signal ?? 0) === 0) {
+        if (groupAlive) {
+          return true;
+        }
+        const err = new Error("ESRCH") as Error & { code?: string };
+        err.code = "ESRCH";
+        throw err;
+      }
+      if (signal === "SIGTERM") {
+        fakeChild.exitCode = 0;
+        queueMicrotask(() => {
+          fakeChild.emit("exit", 0, null);
+        });
+        return true;
+      }
+      if (signal === "SIGKILL") {
+        groupAlive = false;
+        return true;
+      }
+      return true;
+    }) as typeof process.kill);
+    let groupAlive = true;
+    const fakeChild = new EventEmitter() as EventEmitter & {
+      exitCode: number | null;
+      pid: number;
+    };
+    fakeChild.exitCode = null;
+    fakeChild.pid = 4242;
+
+    const adapter = new OpenClawAdapter(stubDeps());
+    (adapter as OpenClawAdapterWithInjectedState).state = {
+      child: fakeChild,
+      stateDir: "/tmp/openclaw-teardown-test",
+      logBuffer: "",
+      spawnInput: stubSpawnInput(),
+      tornDown: false,
+    };
+
+    try {
+      const teardownPromise = Effect.runPromise(adapter.teardown());
+      await vi.advanceTimersByTimeAsync(15_000);
+      await teardownPromise;
+    } finally {
+      vi.useRealTimers();
+      killSpy.mockRestore();
+    }
+
+    expect(killCalls).toEqual(
+      expect.arrayContaining([
+        { pid: -4242, signal: "SIGTERM" },
+        { pid: -4242, signal: "SIGKILL" },
+      ]),
+    );
+    expect(
+      killCalls.filter((call) => call.pid === -4242 && call.signal === 0)
+        .length,
+    ).toBeGreaterThan(0);
   });
 });
 
@@ -419,6 +493,21 @@ interface MockRuntimeHandle {
   readonly stats: MockRuntimeStats;
   readonly waitStarted: Promise<void>;
 }
+
+interface InjectedOpenClawAdapterState {
+  readonly child: EventEmitter & {
+    readonly pid: number;
+    exitCode: number | null;
+  };
+  readonly stateDir: string;
+  readonly logBuffer: string;
+  readonly spawnInput: SpawnInput;
+  tornDown: boolean;
+}
+
+type OpenClawAdapterWithInjectedState = OpenClawAdapter & {
+  state: InjectedOpenClawAdapterState | null;
+};
 
 function stubRuntimeAgentSpec(
   overrides?: Partial<RuntimeAgentSpec>,


### PR DESCRIPTION
## Summary
- wait for detached OpenClaw process groups to fully exit during teardown instead of trusting only the leader exit
- escalate from `SIGTERM` to `SIGKILL` if the detached group stays alive past the grace window
- add a runtimes regression test covering leader-exits-but-group-stays-alive teardown

## Verification
- `pnpm --filter @moltzap/runtimes exec vitest run src/runtimes.test.ts`
- `pnpm --filter @moltzap/runtimes build`
- interrupted live regression via `moltzap-arena` direct harness with the submodule pinned to this branch; OpenClaw process count stayed at the original baseline after shutdown instead of increasing

Closes #194.
