### PR TITLE
fix: expose signal-aware runtime fleet startup

### DIFF
--- a/packages/runtimes/src/fleet.ts
+++ b/packages/runtimes/src/fleet.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit } from "effect";
+import { Effect, Exit, Fiber } from "effect";
 import {
   RuntimeExitedBeforeReady,
   RuntimeReadyTimedOut,
@@ -51,6 +51,11 @@ export interface RuntimeFleetLaunchOptions {
   readonly nanoclaw?: Omit<NanoclawAdapterDeps, "server">;
 }
 
+export interface RuntimeFleetProcessSignalOptions
+  extends RuntimeFleetLaunchOptions {
+  readonly signals?: ReadonlyArray<NodeJS.Signals>;
+}
+
 export interface RuntimeFleetAgent {
   readonly name: string;
   readonly agentId: string;
@@ -60,6 +65,14 @@ export interface RuntimeFleet {
   readonly agents: ReadonlyArray<RuntimeFleetAgent>;
   stopAll(): Effect.Effect<void, never, never>;
   getLogs(name: string): string;
+}
+
+export class RuntimeFleetStartupInterrupted extends Error {
+  readonly _tag = "RuntimeFleetStartupInterrupted" as const;
+
+  constructor(readonly signal: NodeJS.Signals) {
+    super(`Runtime fleet startup interrupted by ${signal}`);
+  }
 }
 
 interface StartedRuntimeAgent {
@@ -236,4 +249,57 @@ export function launchRuntimeFleet(
       } satisfies RuntimeFleet;
     }),
   );
+}
+
+export function launchRuntimeFleetWithProcessSignals(
+  options: RuntimeFleetProcessSignalOptions,
+): Effect.Effect<
+  RuntimeFleet,
+  RuntimeLaunchFailed | RuntimeFleetStartupInterrupted,
+  never
+> {
+  const signals = options.signals ?? ["SIGINT", "SIGTERM"];
+  return Effect.async<
+    RuntimeFleet,
+    RuntimeLaunchFailed | RuntimeFleetStartupInterrupted
+  >((resume) => {
+    const fiber = Effect.runFork(launchRuntimeFleet(options));
+    let shutdownSignal: NodeJS.Signals | null = null;
+
+    const handlers = signals.map((signal) => {
+      const handler = (): void => {
+        if (shutdownSignal !== null) {
+          return;
+        }
+        shutdownSignal = signal;
+        Effect.runFork(Fiber.interrupt(fiber));
+      };
+      process.on(signal, handler);
+      return { signal, handler };
+    });
+
+    const cleanup = (): void => {
+      for (const { signal, handler } of handlers) {
+        process.off(signal, handler);
+      }
+    };
+
+    fiber.addObserver((exit) => {
+      cleanup();
+      if (Exit.isSuccess(exit)) {
+        resume(Effect.succeed(exit.value));
+        return;
+      }
+      if (shutdownSignal !== null && Exit.isInterrupted(exit)) {
+        resume(Effect.fail(new RuntimeFleetStartupInterrupted(shutdownSignal)));
+        return;
+      }
+      resume(Effect.failCause(exit.cause));
+    });
+
+    return Effect.sync(() => {
+      cleanup();
+      Effect.runFork(Fiber.interrupt(fiber));
+    });
+  });
 }

--- a/packages/runtimes/src/index.ts
+++ b/packages/runtimes/src/index.ts
@@ -25,7 +25,10 @@ export {
   type RuntimeFleet,
   type RuntimeFleetAgent,
   type RuntimeFleetLaunchOptions,
+  type RuntimeFleetProcessSignalOptions,
   type RuntimeStartOptions,
+  RuntimeFleetStartupInterrupted,
   startRuntimeAgent,
   launchRuntimeFleet,
+  launchRuntimeFleetWithProcessSignals,
 } from "./fleet.js";

--- a/packages/runtimes/src/runtimes.test.ts
+++ b/packages/runtimes/src/runtimes.test.ts
@@ -8,6 +8,8 @@ import {
 } from "./openclaw-adapter.js";
 import {
   launchRuntimeFleet,
+  launchRuntimeFleetWithProcessSignals,
+  RuntimeFleetStartupInterrupted,
   startRuntimeAgent,
   type RuntimeAgentSpec,
 } from "./fleet.js";
@@ -441,6 +443,43 @@ describe("runtime fleet lifecycle", () => {
     const exit = await Effect.runPromise(Fiber.await(fiber));
 
     expect(Exit.isInterrupted(exit)).toBe(true);
+    expect(first.stats.teardownCalls).toBe(1);
+    expect(second.stats.teardownCalls).toBe(1);
+  });
+
+  it("tears down an in-flight fleet when a configured process signal arrives", async () => {
+    const first = createMockRuntime({
+      readyEffect: Effect.succeed({ _tag: "Ready" }),
+    });
+    const second = createMockRuntime({
+      readyEffect: Effect.never,
+    });
+    setMockFleetRuntimes(first.runtime, second.runtime);
+
+    const fiber = Effect.runFork(
+      Effect.either(
+        launchRuntimeFleetWithProcessSignals({
+          kind: "openclaw",
+          server: stubServer(),
+          agents: [
+            stubRuntimeAgentSpec({ agentName: "alpha", agentId: "agent-001" }),
+            stubRuntimeAgentSpec({ agentName: "beta", agentId: "agent-002" }),
+          ],
+          readyTimeoutMs: 60_000,
+          signals: ["SIGUSR2"],
+        }),
+      ),
+    );
+
+    await second.waitStarted;
+    process.emit("SIGUSR2");
+    const result = await Effect.runPromise(Fiber.join(fiber));
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(RuntimeFleetStartupInterrupted);
+      expect(result.left.signal).toBe("SIGUSR2");
+    }
     expect(first.stats.teardownCalls).toBe(1);
     expect(second.stats.teardownCalls).toBe(1);
   });


### PR DESCRIPTION
## Summary
- add `launchRuntimeFleetWithProcessSignals(...)` for CLI/operator code that needs process `SIGINT`/`SIGTERM` to interrupt an in-flight fleet launch
- expose `RuntimeFleetStartupInterrupted` so downstream operators can report startup cancellation without treating it as a runtime crash
- add a regression test that emits a configured process signal while a second runtime is still starting and verifies both ready and in-flight runtimes are torn down

## Verification
- `pnpm --filter @moltzap/runtimes exec vitest run src/runtimes.test.ts`
- `pnpm --filter @moltzap/runtimes build`
- commit hook: `pnpm check`, `pnpm typecheck` with existing warning baseline

Related to #194 and #198.
