### PR TITLE
[arch] @moltzap/claude-code-channel v1 module layout

### DIFF
--- a/packages/claude-code-channel/package.json
+++ b/packages/claude-code-channel/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@moltzap/claude-code-channel",
+  "version": "0.1.0",
+  "description": "Claude Code channel plugin for MoltZap messaging (conforms to Anthropic's official channel contract)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chughtapan/moltzap"
+  },
+  "type": "module",
+  "files": [
+    "dist",
+    "!dist/__tests__"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
+  },
+  "dependencies": {
+    "@moltzap/client": "workspace:*",
+    "@moltzap/protocol": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.20.2",
+    "effect": "^3.21.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/claude-code-channel/src/__tests__/echo.integration.test.ts
+++ b/packages/claude-code-channel/src/__tests__/echo.integration.test.ts
@@ -1,0 +1,30 @@
+/**
+ * E2E echo integration test (spec A11).
+ *
+ * Pattern: `packages/openclaw-channel/src/__tests__/echo-server.test.ts` +
+ * `vitest.integration.globalSetup.ts`. Agent SDK spike #182 (sbd#182) pattern
+ * uses PGlite / npx-spawn server for a faster CI fixture; this test's
+ * global-setup will follow that pattern (spawn `@moltzap/server` as a
+ * subprocess — see adjacent `vitest.integration.globalSetup.ts` stub).
+ *
+ * What the integration test proves (once implemented):
+ *   - `bootClaudeCodeChannel` returns Ok against a real MoltZap server.
+ *   - A round-trip message from peer agent renders with contract-correct
+ *     meta keys (`chat_id`, `message_id`, `user`, `ts`).
+ *   - The MCP server's capability declaration matches spec A14.
+ *   - Clean shutdown on `handle.stop` — no lingering sockets, no open fibers.
+ *
+ * Architect stage: skeleton only.
+ */
+
+import { describe, it } from "vitest";
+
+describe("echo integration — @moltzap/claude-code-channel", () => {
+  it.todo(
+    "boot → peer sends 'ping' → notification emitted with contract meta keys",
+  );
+  it.todo("reply (no reply_to) routes to last-active chat");
+  it.todo("reply (reply_to = known message_id) routes to that chat");
+  it.todo("reply (reply_to unknown) returns tool error (isError: true)");
+  it.todo("handle.stop closes WS and MCP transport cleanly");
+});

--- a/packages/claude-code-channel/src/__tests__/echo.integration.test.ts
+++ b/packages/claude-code-channel/src/__tests__/echo.integration.test.ts
@@ -1,30 +1,297 @@
 /**
  * E2E echo integration test (spec A11).
  *
- * Pattern: `packages/openclaw-channel/src/__tests__/echo-server.test.ts` +
- * `vitest.integration.globalSetup.ts`. Agent SDK spike #182 (sbd#182) pattern
- * uses PGlite / npx-spawn server for a faster CI fixture; this test's
- * global-setup will follow that pattern (spawn `@moltzap/server` as a
- * subprocess — see adjacent `vitest.integration.globalSetup.ts` stub).
+ * Pattern:
+ *   - globalSetup spawns a real `@moltzap/server` standalone via spike-182's
+ *     PGlite subprocess pattern; registers two agents (`A` for the channel,
+ *     `B` for the peer).
+ *   - Test boots the channel plumbing against agent A, connects an in-process
+ *     MCP client to the channel's stdio server via `InMemoryTransport`, and
+ *     uses an in-process `MoltZapService` as agent B to drive inbound traffic.
  *
- * What the integration test proves (once implemented):
- *   - `bootClaudeCodeChannel` returns Ok against a real MoltZap server.
- *   - A round-trip message from peer agent renders with contract-correct
- *     meta keys (`chat_id`, `message_id`, `user`, `ts`).
- *   - The MCP server's capability declaration matches spec A14.
- *   - Clean shutdown on `handle.stop` — no lingering sockets, no open fibers.
- *
- * Architect stage: skeleton only.
+ * Notes:
+ *   - We wire `bootChannelMcpServer` directly rather than through
+ *     `bootClaudeCodeChannel` because the only way to attach the in-process
+ *     MCP client is via `transportFactory` (internal seam). The wiring
+ *     mirrors `entry.ts` so changes there must stay in sync.
+ *   - Every meta assertion pins the contract key names (`chat_id`, `user`,
+ *     `message_id`, `ts`) per spec A5, A6, A14.
  */
 
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, inject } from "vitest";
+import { Effect } from "effect";
+import {
+  MoltZapChannelCore,
+  MoltZapService,
+  type EnrichedInboundMessage,
+} from "@moltzap/client";
+import type { Message } from "@moltzap/protocol";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Notification } from "@modelcontextprotocol/sdk/types.js";
+import { bootChannelMcpServer } from "../server.js";
+import { createRoutingState } from "../routing.js";
+import { toClaudeChannelNotification } from "../event.js";
+import type { ReplyError } from "../errors.js";
+
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+interface Harness {
+  channelService: MoltZapService;
+  channelCore: MoltZapChannelCore;
+  peerService: MoltZapService;
+  mcpClient: Client;
+  channelAgentId: string;
+  peerAgentId: string;
+  notifications: Notification[];
+  peerInbox: Message[];
+  conversationId: string;
+  stop: () => Promise<void>;
+}
+
+async function bootHarness(): Promise<Harness> {
+  const wsUrl = inject("moltzapWsUrl");
+  const agentAApiKey = inject("agentAApiKey");
+  const agentBApiKey = inject("agentBApiKey");
+  const channelAgentId = inject("agentAAgentId");
+  const peerAgentId = inject("agentBAgentId");
+
+  const notifications: Notification[] = [];
+
+  const [serverTransport, clientTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const channelService = new MoltZapService({
+    serverUrl: wsUrl,
+    agentKey: agentAApiKey,
+    logger: silentLogger,
+  });
+  const channelCore = new MoltZapChannelCore({
+    service: channelService,
+    logger: silentLogger,
+  });
+  const routing = createRoutingState();
+
+  const sendReply = (chatId: string, text: string) =>
+    channelCore.sendReply(chatId, text).pipe(
+      Effect.mapError(
+        (cause): ReplyError => ({
+          _tag: "SendFailed",
+          cause: cause instanceof Error ? cause.message : String(cause),
+        }),
+      ),
+    );
+
+  const boot = await bootChannelMcpServer(
+    {
+      serverName: "test-claude-code-channel",
+      instructions: "integration test",
+    },
+    {
+      sendReply,
+      routing,
+      logger: silentLogger,
+      transportFactory: () => serverTransport,
+    },
+  );
+  if (boot._tag === "Err") {
+    throw new Error(
+      `server boot failed: ${boot.error._tag}: ${boot.error.cause}`,
+    );
+  }
+  const serverHandle = boot.value;
+
+  const mcpClient = new Client(
+    { name: "integration-test", version: "0.1.0" },
+    { capabilities: {} },
+  );
+  mcpClient.fallbackNotificationHandler = async (
+    notification: Notification,
+  ) => {
+    notifications.push(notification);
+  };
+  await mcpClient.connect(clientTransport);
+
+  // Mirror entry.ts wiring: gate → translate → record → push.
+  channelCore.onInbound((enriched: EnrichedInboundMessage) =>
+    Effect.gen(function* () {
+      const translated = toClaudeChannelNotification(enriched);
+      if (translated._tag === "Err") return;
+      routing.recordInbound(
+        translated.value.params.meta.message_id,
+        translated.value.params.meta.chat_id,
+      );
+      yield* serverHandle
+        .push(translated.value)
+        .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+    }),
+  );
+
+  // Connect channel (agent A) + peer (agent B).
+  await Effect.runPromise(channelService.connect());
+
+  const peerService = new MoltZapService({
+    serverUrl: wsUrl,
+    agentKey: agentBApiKey,
+    logger: silentLogger,
+  });
+  const peerInbox: Message[] = [];
+  peerService.on("message", (msg) => {
+    peerInbox.push(msg);
+  });
+  await Effect.runPromise(peerService.connect());
+
+  // Peer creates a DM with channel-agent-A.
+  const convResponse = (await Effect.runPromise(
+    peerService.sendRpc("conversations/create", {
+      type: "dm",
+      participants: [{ type: "agent", id: channelAgentId }],
+    }),
+  )) as { conversation: { id: string } };
+  const conversationId = convResponse.conversation.id;
+
+  return {
+    channelService,
+    channelCore,
+    peerService,
+    mcpClient,
+    channelAgentId,
+    peerAgentId,
+    notifications,
+    peerInbox,
+    conversationId,
+    stop: async () => {
+      try {
+        await mcpClient.close();
+      } catch {
+        // best effort
+      }
+      try {
+        await Effect.runPromise(serverHandle.stop());
+      } catch {
+        // best effort
+      }
+      try {
+        await Effect.runPromise(channelCore.disconnect());
+      } catch {
+        // best effort
+      }
+      peerService.close();
+    },
+  };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 10_000,
+  tickMs = 25,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await new Promise((r) => setTimeout(r, tickMs));
+  }
+  throw new Error("waitFor: condition not met within timeout");
+}
 
 describe("echo integration — @moltzap/claude-code-channel", () => {
-  it.todo(
-    "boot → peer sends 'ping' → notification emitted with contract meta keys",
-  );
-  it.todo("reply (no reply_to) routes to last-active chat");
-  it.todo("reply (reply_to = known message_id) routes to that chat");
-  it.todo("reply (reply_to unknown) returns tool error (isError: true)");
-  it.todo("handle.stop closes WS and MCP transport cleanly");
+  let h: Harness;
+
+  beforeAll(async () => {
+    h = await bootHarness();
+  }, 120_000);
+
+  afterAll(async () => {
+    await h.stop();
+  });
+
+  it("peer sends 'ping' → channel emits notification with contract meta keys", async () => {
+    await Effect.runPromise(h.peerService.send(h.conversationId, "ping-one"));
+    await waitFor(
+      () =>
+        h.notifications.some(
+          (n) =>
+            n.method === "notifications/claude/channel" &&
+            (n.params as { content?: string }).content === "ping-one",
+        ),
+      15_000,
+    );
+    const n = h.notifications.find(
+      (nn) =>
+        nn.method === "notifications/claude/channel" &&
+        (nn.params as { content?: string }).content === "ping-one",
+    );
+    expect(n).toBeDefined();
+    const meta = (n!.params as { meta: Record<string, unknown> }).meta;
+    expect(Object.keys(meta).sort()).toEqual(
+      ["chat_id", "message_id", "ts", "user"].sort(),
+    );
+    expect(meta.chat_id).toBe(h.conversationId);
+    expect(meta.user).toBe(h.peerAgentId);
+    expect(typeof meta.message_id).toBe("string");
+    expect(typeof meta.ts).toBe("string");
+    // No zapbot-era invented keys.
+    expect("conversation_id" in meta).toBe(false);
+    expect("sender_id" in meta).toBe(false);
+    expect("received_at_ms" in meta).toBe(false);
+  });
+
+  it("every emitted notification method equals 'notifications/claude/channel' (spec A6)", () => {
+    const methods = new Set(h.notifications.map((n) => n.method));
+    expect(methods).toEqual(new Set(["notifications/claude/channel"]));
+  });
+
+  it("reply tool (no reply_to) routes to last-active chat and reaches the peer", async () => {
+    const inboxBefore = h.peerInbox.length;
+
+    const result = await h.mcpClient.callTool({
+      name: "reply",
+      arguments: { text: "pong-one" },
+    });
+    expect(result.isError).not.toBe(true);
+
+    await waitFor(() => h.peerInbox.length > inboxBefore, 10_000);
+    const newMsg = h.peerInbox[h.peerInbox.length - 1];
+    expect(newMsg?.conversationId).toBe(h.conversationId);
+    const text = newMsg?.parts.find(
+      (p): p is { type: "text"; text: string } => p.type === "text",
+    )?.text;
+    expect(text).toBe("pong-one");
+  });
+
+  it("reply tool with reply_to = known message_id routes to that chat", async () => {
+    // The only known message_id is from the first inbound. Use it.
+    const firstInbound = h.notifications.find(
+      (n) => n.method === "notifications/claude/channel",
+    );
+    expect(firstInbound).toBeDefined();
+    const meta = (firstInbound!.params as { meta: { message_id: string } })
+      .meta;
+
+    const inboxBefore = h.peerInbox.length;
+    const result = await h.mcpClient.callTool({
+      name: "reply",
+      arguments: { text: "pong-two", reply_to: meta.message_id },
+    });
+    expect(result.isError).not.toBe(true);
+
+    await waitFor(() => h.peerInbox.length > inboxBefore, 10_000);
+    const newMsg = h.peerInbox[h.peerInbox.length - 1];
+    const text = newMsg?.parts.find(
+      (p): p is { type: "text"; text: string } => p.type === "text",
+    )?.text;
+    expect(text).toBe("pong-two");
+  });
+
+  it("reply tool with unknown reply_to returns tool error (isError: true)", async () => {
+    const result = await h.mcpClient.callTool({
+      name: "reply",
+      arguments: { text: "should-error", reply_to: "unknown-message-id-xyz" },
+    });
+    expect(result.isError).toBe(true);
+  });
 });

--- a/packages/claude-code-channel/src/__tests__/server.test.ts
+++ b/packages/claude-code-channel/src/__tests__/server.test.ts
@@ -1,57 +1,426 @@
 /**
- * Unit tests for `server.ts` (MCP stdio server — capability handshake, tool
- * registry, notification shape, routing).
+ * Unit tests for `server.ts` — MCP stdio server behavior exercised through
+ * the SDK's `InMemoryTransport` pair. Covers capability handshake (A14),
+ * tool registry (A4, A7), notification shape (A5, A6), routing (OQ5), and
+ * boundary validation (Principle 2).
  *
  * Transplanted from zapbot `test/claude-channel-server.test.ts` (verdict
- * §(b) MOVE row 4). Tests are updated for the pruned tool set (reply only
- * in v1; no send_direct_message, no edit_message) and the fixed capability
- * declaration per spec A4 / A6 / A7 / A14.
- *
- * Architect stage: test skeletons only.
+ * §(b) MOVE row 4). Tests updated for the pruned tool set (reply only;
+ * send_direct_message and edit_message deleted / omitted).
  */
 
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { Effect } from "effect";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Notification } from "@modelcontextprotocol/sdk/types.js";
+import {
+  bootChannelMcpServer,
+  CHANNEL_CAPABILITIES,
+  decodeReplyArgs,
+  REPLY_TOOL_INPUT_SCHEMA,
+} from "../server.js";
+import { createRoutingState } from "../routing.js";
+import type { ChatId, ClaudeChannelNotification, MessageId } from "../types.js";
+import type { ReplyError } from "../errors.js";
+
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+async function setup(opts?: {
+  onSendReply?: (
+    chatId: string,
+    text: string,
+  ) => Effect.Effect<void, ReplyError>;
+}) {
+  const [serverTransport, clientTransport] =
+    InMemoryTransport.createLinkedPair();
+  const routing = createRoutingState();
+
+  const sendReply =
+    opts?.onSendReply ??
+    ((_chatId: string, _text: string) => Effect.succeed(undefined as void));
+
+  const boot = await bootChannelMcpServer(
+    {
+      serverName: "test-channel",
+      instructions: "test-instructions",
+    },
+    {
+      sendReply,
+      routing,
+      logger: silentLogger,
+      transportFactory: () => serverTransport,
+    },
+  );
+  if (boot._tag === "Err") {
+    throw new Error(`boot failed: ${boot.error._tag}`);
+  }
+  const serverHandle = boot.value;
+
+  const client = new Client(
+    { name: "test-client", version: "0.1.0" },
+    { capabilities: {} },
+  );
+
+  const notifications: Notification[] = [];
+  client.fallbackNotificationHandler = async (notification: Notification) => {
+    notifications.push(notification);
+  };
+
+  await client.connect(clientTransport);
+
+  return {
+    serverHandle,
+    client,
+    routing,
+    notifications,
+    cleanup: async () => {
+      await client.close();
+      await Effect.runPromise(serverHandle.stop());
+    },
+  };
+}
 
 describe("bootChannelMcpServer — capability handshake (spec A14)", () => {
-  it.todo(
-    "advertises capabilities { tools: {}, experimental: { 'claude/channel': {} } } at connect",
-  );
-  it.todo("does NOT advertise experimental['claude/channel/permission']");
+  it("advertises capabilities { tools: {}, experimental: { 'claude/channel': {} } }", async () => {
+    const { client, cleanup } = await setup();
+    try {
+      const caps = client.getServerCapabilities();
+      expect(caps).toBeDefined();
+      expect(caps?.tools).toEqual({});
+      expect(caps?.experimental).toEqual({ "claude/channel": {} });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does NOT advertise experimental['claude/channel/permission']", async () => {
+    const { client, cleanup } = await setup();
+    try {
+      const caps = client.getServerCapabilities();
+      expect(caps?.experimental).not.toHaveProperty(
+        "claude/channel/permission",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("CHANNEL_CAPABILITIES constant is the contract shape (pins string literal)", () => {
+    expect(CHANNEL_CAPABILITIES).toEqual({
+      tools: {},
+      experimental: { "claude/channel": {} },
+    });
+  });
 });
 
 describe("bootChannelMcpServer — tool registry (spec A4, A7)", () => {
-  it.todo("registers exactly one tool: reply");
-  it.todo("reply.inputSchema matches contract: text required, reply_to? files?");
-  it.todo("does NOT register send_direct_message");
-  it.todo("does NOT register edit_message (v1 — OQ4 default B)");
-  it.todo("does NOT accept caller-injected tool definitions");
+  it("registers exactly one tool: reply", async () => {
+    const { client, cleanup } = await setup();
+    try {
+      const result = await client.listTools();
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools[0]?.name).toBe("reply");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("reply.inputSchema matches contract: text required, reply_to? files?", async () => {
+    const { client, cleanup } = await setup();
+    try {
+      const result = await client.listTools();
+      const reply = result.tools.find((t) => t.name === "reply");
+      expect(reply).toBeDefined();
+      expect(reply?.inputSchema).toMatchObject({
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          reply_to: { type: "string" },
+          files: { type: "array", items: { type: "string" } },
+        },
+        required: ["text"],
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does NOT register send_direct_message", async () => {
+    const { client, cleanup } = await setup();
+    try {
+      const result = await client.listTools();
+      expect(result.tools.map((t) => t.name)).not.toContain(
+        "send_direct_message",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does NOT register edit_message (v1 — OQ4 default B)", async () => {
+    const { client, cleanup } = await setup();
+    try {
+      const result = await client.listTools();
+      expect(result.tools.map((t) => t.name)).not.toContain("edit_message");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("REPLY_TOOL_INPUT_SCHEMA is the exported contract shape", () => {
+    expect(REPLY_TOOL_INPUT_SCHEMA).toMatchObject({
+      type: "object",
+      properties: {
+        text: { type: "string" },
+        reply_to: { type: "string" },
+        files: { type: "array", items: { type: "string" } },
+      },
+      required: ["text"],
+    });
+  });
 });
 
 describe("notification emission (spec A5, A6)", () => {
-  it.todo(
-    "Handle.push emits method exactly 'notifications/claude/channel' with contract meta",
-  );
-  it.todo(
-    "does NOT emit notifications/claude/channel/permission_request or /permission",
-  );
-  it.todo("queues notifications until MCP initialized, flushes once ready");
+  function makeNotification(
+    chatId: string,
+    messageId: string,
+  ): ClaudeChannelNotification {
+    return {
+      method: "notifications/claude/channel",
+      params: {
+        content: "ping",
+        meta: {
+          chat_id: chatId as ChatId,
+          message_id: messageId as MessageId,
+          user: "peer" as never,
+          ts: "2026-04-24T00:00:00Z" as never,
+        },
+      },
+    };
+  }
+
+  it("Handle.push emits method 'notifications/claude/channel' with contract meta", async () => {
+    const { serverHandle, notifications, cleanup } = await setup();
+    try {
+      await Effect.runPromise(serverHandle.push(makeNotification("C1", "M1")));
+      // Give the transport a tick to deliver.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(notifications).toHaveLength(1);
+      const n = notifications[0];
+      expect(n?.method).toBe("notifications/claude/channel");
+      const meta = (n?.params as { meta: Record<string, unknown> }).meta;
+      expect(meta).toMatchObject({
+        chat_id: "C1",
+        message_id: "M1",
+        user: "peer",
+        ts: "2026-04-24T00:00:00Z",
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("notification method set under push equals exactly {'notifications/claude/channel'}", async () => {
+    const { serverHandle, notifications, cleanup } = await setup();
+    try {
+      await Effect.runPromise(serverHandle.push(makeNotification("C1", "M1")));
+      await Effect.runPromise(serverHandle.push(makeNotification("C2", "M2")));
+      await new Promise((r) => setTimeout(r, 10));
+      const methods = new Set(notifications.map((n) => n.method));
+      expect(methods).toEqual(new Set(["notifications/claude/channel"]));
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 describe("reply tool routing (spec OQ5)", () => {
-  it.todo("resolves reply_to present + known → that message's chat_id");
-  it.todo("resolves reply_to absent → last-active chat_id");
-  it.todo(
-    "returns ReplyError.NoActiveChat when reply_to absent and no inbound observed",
-  );
-  it.todo(
-    "returns ReplyError.ReplyToUnknown when reply_to does not map to a known message_id",
-  );
-  it.todo("never silently drops — every call either delivers or errors");
+  it("resolves reply_to present + known → sends to that message's chat_id", async () => {
+    const sent: Array<{ chatId: string; text: string }> = [];
+    const { client, routing, cleanup } = await setup({
+      onSendReply: (chatId, text) =>
+        Effect.sync(() => {
+          sent.push({ chatId, text });
+        }),
+    });
+    try {
+      routing.recordInbound("M-a" as MessageId, "C-a" as ChatId);
+      routing.recordInbound("M-b" as MessageId, "C-b" as ChatId);
+
+      const result = await client.callTool({
+        name: "reply",
+        arguments: { text: "hi", reply_to: "M-a" },
+      });
+      expect(result.isError).not.toBe(true);
+      expect(sent).toEqual([{ chatId: "C-a", text: "hi" }]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("resolves reply_to absent → last-active chat_id", async () => {
+    const sent: Array<{ chatId: string; text: string }> = [];
+    const { client, routing, cleanup } = await setup({
+      onSendReply: (chatId, text) =>
+        Effect.sync(() => {
+          sent.push({ chatId, text });
+        }),
+    });
+    try {
+      routing.recordInbound("M-a" as MessageId, "C-a" as ChatId);
+      routing.recordInbound("M-b" as MessageId, "C-b" as ChatId);
+
+      const result = await client.callTool({
+        name: "reply",
+        arguments: { text: "hi" },
+      });
+      expect(result.isError).not.toBe(true);
+      expect(sent).toEqual([{ chatId: "C-b", text: "hi" }]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns tool error when reply_to absent and no inbound observed (NoActiveChat)", async () => {
+    const { client, cleanup } = await setup();
+    try {
+      const result = await client.callTool({
+        name: "reply",
+        arguments: { text: "hi" },
+      });
+      expect(result.isError).toBe(true);
+      const content = Array.isArray(result.content) ? result.content : [];
+      expect(JSON.stringify(content)).toMatch(/no active chat/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns tool error when reply_to unknown (ReplyToUnknown)", async () => {
+    const { client, routing, cleanup } = await setup();
+    try {
+      routing.recordInbound("M-known" as MessageId, "C-known" as ChatId);
+      const result = await client.callTool({
+        name: "reply",
+        arguments: { text: "hi", reply_to: "M-missing" },
+      });
+      expect(result.isError).toBe(true);
+      const content = Array.isArray(result.content) ? result.content : [];
+      expect(JSON.stringify(content)).toMatch(/M-missing/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("never silently drops — every call delivers or returns isError", async () => {
+    // Covered by the above four cases in aggregate. This test pins that the
+    // default (no routing state, no arguments) returns isError:true rather
+    // than a no-op Ok result.
+    const { client, cleanup } = await setup();
+    try {
+      const result = await client.callTool({ name: "reply", arguments: {} });
+      expect(result.isError).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("surfaces ReplyError.SendFailed as tool error (isError: true)", async () => {
+    const { client, routing, cleanup } = await setup({
+      onSendReply: () =>
+        Effect.fail<ReplyError>({
+          _tag: "SendFailed",
+          cause: "ws dropped",
+        }),
+    });
+    try {
+      routing.recordInbound("M-x" as MessageId, "C-x" as ChatId);
+      const result = await client.callTool({
+        name: "reply",
+        arguments: { text: "hi" },
+      });
+      expect(result.isError).toBe(true);
+      const content = Array.isArray(result.content) ? result.content : [];
+      expect(JSON.stringify(content)).toMatch(/ws dropped/);
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 describe("decodeReplyArgs — boundary validation (Principle 2)", () => {
-  it.todo("accepts {text: 'hi'}");
-  it.todo("accepts {text, reply_to, files}");
-  it.todo("rejects {text: 42} with ReplyArgsInvalid");
-  it.todo("rejects missing text with ReplyArgsInvalid");
+  it("accepts {text: 'hi'}", () => {
+    const r = decodeReplyArgs({ text: "hi" });
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    expect(r.value.text).toBe("hi");
+    expect(r.value.replyTo).toBeUndefined();
+    expect(r.value.files).toBeUndefined();
+  });
+
+  it("accepts {text, reply_to, files}", () => {
+    const r = decodeReplyArgs({ text: "hi", reply_to: "M1", files: ["a.png"] });
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    expect(r.value.text).toBe("hi");
+    expect(r.value.replyTo).toBe("M1");
+    expect(r.value.files).toEqual(["a.png"]);
+  });
+
+  it("rejects {text: 42} with ReplyArgsInvalid", () => {
+    const r = decodeReplyArgs({ text: 42 });
+    expect(r._tag).toBe("Err");
+  });
+
+  it("rejects missing text", () => {
+    const r = decodeReplyArgs({});
+    expect(r._tag).toBe("Err");
+  });
+
+  it("rejects non-string element in files", () => {
+    const r = decodeReplyArgs({ text: "hi", files: ["a", 1] });
+    expect(r._tag).toBe("Err");
+  });
+
+  it("rejects non-object input", () => {
+    const r = decodeReplyArgs(null);
+    expect(r._tag).toBe("Err");
+  });
+
+  it("rejects empty-string text", () => {
+    const r = decodeReplyArgs({ text: "   " });
+    expect(r._tag).toBe("Err");
+  });
+
+  it("rejects empty reply_to", () => {
+    const r = decodeReplyArgs({ text: "hi", reply_to: "" });
+    expect(r._tag).toBe("Err");
+  });
+});
+
+describe("unknown tool name", () => {
+  it("returns tool error for unknown tool name", async () => {
+    const { client, cleanup } = await setup();
+    try {
+      const result = await client.callTool({
+        name: "edit_message",
+        arguments: { message_id: "M1", text: "hi" },
+      });
+      // The SDK may reject before our handler if tool is unknown to listTools;
+      // accept either SDK-level rejection or our tool error.
+      if ("isError" in result) {
+        expect(result.isError).toBe(true);
+      }
+    } catch (err) {
+      // SDK throws "Tool edit_message not found" — acceptable.
+      expect(String(err)).toMatch(/edit_message|not found|unknown/i);
+    } finally {
+      await cleanup();
+    }
+  });
 });

--- a/packages/claude-code-channel/src/__tests__/server.test.ts
+++ b/packages/claude-code-channel/src/__tests__/server.test.ts
@@ -330,6 +330,52 @@ describe("reply tool routing (spec OQ5)", () => {
     }
   });
 
+  it("rejects reply with non-empty files with FilesUnsupported tool error (v1, reviewer-187)", async () => {
+    const sent: Array<{ chatId: string; text: string }> = [];
+    const { client, routing, cleanup } = await setup({
+      onSendReply: (chatId, text) =>
+        Effect.sync(() => {
+          sent.push({ chatId, text });
+        }),
+    });
+    try {
+      routing.recordInbound("M-a" as MessageId, "C-a" as ChatId);
+      const result = await client.callTool({
+        name: "reply",
+        arguments: { text: "hi", reply_to: "M-a", files: ["a.png", "b.png"] },
+      });
+      expect(result.isError).toBe(true);
+      const content = Array.isArray(result.content) ? result.content : [];
+      expect(JSON.stringify(content)).toMatch(/FilesUnsupported/);
+      expect(JSON.stringify(content)).toMatch(/2 file\(s\)/);
+      // Critical: the send side-effect MUST NOT fire when files are rejected.
+      expect(sent).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("accepts reply with empty files array (equivalent to omitted)", async () => {
+    const sent: Array<{ chatId: string; text: string }> = [];
+    const { client, routing, cleanup } = await setup({
+      onSendReply: (chatId, text) =>
+        Effect.sync(() => {
+          sent.push({ chatId, text });
+        }),
+    });
+    try {
+      routing.recordInbound("M-a" as MessageId, "C-a" as ChatId);
+      const result = await client.callTool({
+        name: "reply",
+        arguments: { text: "hi", reply_to: "M-a", files: [] },
+      });
+      expect(result.isError).not.toBe(true);
+      expect(sent).toEqual([{ chatId: "C-a", text: "hi" }]);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("surfaces ReplyError.SendFailed as tool error (isError: true)", async () => {
     const { client, routing, cleanup } = await setup({
       onSendReply: () =>
@@ -363,7 +409,9 @@ describe("decodeReplyArgs — boundary validation (Principle 2)", () => {
     expect(r.value.files).toBeUndefined();
   });
 
-  it("accepts {text, reply_to, files}", () => {
+  it("decodes {text, reply_to, files} — rejection happens at handler, not decoder", () => {
+    // Decoder preserves the `files` field so the handler can emit a tagged
+    // FilesUnsupported tool error. Contract surface stays intact (spec A4).
     const r = decodeReplyArgs({ text: "hi", reply_to: "M1", files: ["a.png"] });
     expect(r._tag).toBe("Ok");
     if (r._tag !== "Ok") return;

--- a/packages/claude-code-channel/src/__tests__/server.test.ts
+++ b/packages/claude-code-channel/src/__tests__/server.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for `server.ts` (MCP stdio server — capability handshake, tool
+ * registry, notification shape, routing).
+ *
+ * Transplanted from zapbot `test/claude-channel-server.test.ts` (verdict
+ * §(b) MOVE row 4). Tests are updated for the pruned tool set (reply only
+ * in v1; no send_direct_message, no edit_message) and the fixed capability
+ * declaration per spec A4 / A6 / A7 / A14.
+ *
+ * Architect stage: test skeletons only.
+ */
+
+import { describe, it } from "vitest";
+
+describe("bootChannelMcpServer — capability handshake (spec A14)", () => {
+  it.todo(
+    "advertises capabilities { tools: {}, experimental: { 'claude/channel': {} } } at connect",
+  );
+  it.todo("does NOT advertise experimental['claude/channel/permission']");
+});
+
+describe("bootChannelMcpServer — tool registry (spec A4, A7)", () => {
+  it.todo("registers exactly one tool: reply");
+  it.todo("reply.inputSchema matches contract: text required, reply_to? files?");
+  it.todo("does NOT register send_direct_message");
+  it.todo("does NOT register edit_message (v1 — OQ4 default B)");
+  it.todo("does NOT accept caller-injected tool definitions");
+});
+
+describe("notification emission (spec A5, A6)", () => {
+  it.todo(
+    "Handle.push emits method exactly 'notifications/claude/channel' with contract meta",
+  );
+  it.todo(
+    "does NOT emit notifications/claude/channel/permission_request or /permission",
+  );
+  it.todo("queues notifications until MCP initialized, flushes once ready");
+});
+
+describe("reply tool routing (spec OQ5)", () => {
+  it.todo("resolves reply_to present + known → that message's chat_id");
+  it.todo("resolves reply_to absent → last-active chat_id");
+  it.todo(
+    "returns ReplyError.NoActiveChat when reply_to absent and no inbound observed",
+  );
+  it.todo(
+    "returns ReplyError.ReplyToUnknown when reply_to does not map to a known message_id",
+  );
+  it.todo("never silently drops — every call either delivers or errors");
+});
+
+describe("decodeReplyArgs — boundary validation (Principle 2)", () => {
+  it.todo("accepts {text: 'hi'}");
+  it.todo("accepts {text, reply_to, files}");
+  it.todo("rejects {text: 42} with ReplyArgsInvalid");
+  it.todo("rejects missing text with ReplyArgsInvalid");
+});

--- a/packages/claude-code-channel/src/__tests__/vitest-provided.d.ts
+++ b/packages/claude-code-channel/src/__tests__/vitest-provided.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Vitest `ProvidedContext` keys published by `vitest.integration.globalSetup.ts`.
+ * Kept alongside the integration tests so `inject(...)` has typed keys.
+ */
+
+import "vitest";
+
+declare module "vitest" {
+  interface ProvidedContext {
+    moltzapBaseUrl: string;
+    moltzapWsUrl: string;
+    agentAAgentId: string;
+    agentAApiKey: string;
+    agentBAgentId: string;
+    agentBApiKey: string;
+  }
+}

--- a/packages/claude-code-channel/src/entry.ts
+++ b/packages/claude-code-channel/src/entry.ts
@@ -6,50 +6,169 @@
  * as the precedent for "wrap client primitives + host plugin shape."
  *
  * Spec A2: `bootClaudeCodeChannel(opts: BootOptions): Promise<Result<Handle, BootError>>`.
- *
- * Lifecycle (linear, no nontrivial state machine):
- *   1. Validate options; fail fast with `AgentKeyInvalid` if `agentKey` is
- *      absent/empty.
- *   2. Construct `MoltZapService` from `{serverUrl, agentKey, logger}`.
- *   3. Construct `MoltZapChannelCore` over that service.
- *   4. Construct `RoutingState` (fresh, per-boot).
- *   5. Boot the MCP stdio server (`bootChannelMcpServer`) with bound
- *      `sendReply` (capture `core.sendReply` + `RoutingState.resolveTarget`)
- *      and `routing`.
- *   6. Register inbound handler on `core.onInbound`: apply `gateInbound?`
- *      (Principle 4 — handle both Success / Failure branches); on Success
- *      translate via `toClaudeChannelNotification`, update `RoutingState`,
- *      push through the server handle.
- *   7. `core.connect()` — any `ServiceRpcError` maps to
- *      `ServiceConnectFailed`.
- *   8. Return `Handle`.
- *
- * Shutdown path (`Handle.stop`): `core.disconnect()` → `serverHandle.stop()`.
- * Both swallow downstream errors into `logger.error` per spec I8; the public
- * `stop` is `Effect<void>` with no error channel because no caller can
- * meaningfully react to teardown failures.
- *
- * No `Promise<T>` on internal plumbing — the spec fixes `Promise<Result<...>>`
- * only at the public boot boundary (A2); everything downstream stays in
- * Effect (Principle 3). The single `runPromise` tax lives inside this file.
  */
 
+import {
+  MoltZapChannelCore,
+  MoltZapService,
+  type EnrichedInboundMessage,
+} from "@moltzap/client";
+import { Effect } from "effect";
+import { toClaudeChannelNotification } from "./event.js";
+import { createRoutingState } from "./routing.js";
+import { bootChannelMcpServer, type ServerHandle } from "./server.js";
 import type { BootOptions, Handle } from "./types.js";
-import type { BootError } from "./errors.js";
+import type { BootError, ReplyError } from "./errors.js";
 
 export type BootResult =
   | { readonly _tag: "Ok"; readonly value: Handle }
   | { readonly _tag: "Err"; readonly error: BootError };
 
+const DEFAULT_SERVER_NAME = "@moltzap/claude-code-channel";
+const DEFAULT_INSTRUCTIONS =
+  'MoltZap messages arrive as <channel source="moltzap" chat_id="..." message_id="..." user="..." ts="...">. ' +
+  "Reply with the reply tool. Pass reply_to=<message_id> to target a specific conversation; omit to reply to the most recent inbound.";
+
+function stringifyCause(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  try {
+    return JSON.stringify(cause);
+  } catch {
+    return String(cause);
+  }
+}
+
 /**
  * Boot a Claude Code channel. Single public entry point of the package.
  *
- * Returns `Promise<BootResult>` — the `Promise` is a concession to callers
- * that have not adopted Effect (zapbot today). Internals are Effect; the
- * error channel stays tagged (Principle 3, not `Promise<Handle>` throws).
+ * Error channel is tagged (Principle 3). Internals run on Effect; the
+ * `Promise` wrapper lives only at this boundary.
  */
-export function bootClaudeCodeChannel(
+export async function bootClaudeCodeChannel(
   opts: BootOptions,
 ): Promise<BootResult> {
-  throw new Error("not implemented");
+  if (typeof opts.agentKey !== "string" || opts.agentKey.trim().length === 0) {
+    return {
+      _tag: "Err",
+      error: {
+        _tag: "AgentKeyInvalid",
+        cause: "agentKey must be a non-empty string",
+      },
+    };
+  }
+  if (
+    typeof opts.serverUrl !== "string" ||
+    opts.serverUrl.trim().length === 0
+  ) {
+    return {
+      _tag: "Err",
+      error: {
+        _tag: "AgentKeyInvalid",
+        cause: "serverUrl must be a non-empty string",
+      },
+    };
+  }
+
+  const logger = opts.logger;
+  const service = new MoltZapService({
+    serverUrl: opts.serverUrl,
+    agentKey: opts.agentKey,
+    logger,
+  });
+
+  const core = new MoltZapChannelCore({ service, logger });
+  const routing = createRoutingState();
+
+  const sendReply = (chatId: string, text: string) =>
+    core.sendReply(chatId, text).pipe(
+      Effect.mapError(
+        (cause): ReplyError => ({
+          _tag: "SendFailed",
+          cause: stringifyCause(cause),
+        }),
+      ),
+    );
+
+  const serverBoot = await bootChannelMcpServer(
+    {
+      serverName: opts.serverName ?? DEFAULT_SERVER_NAME,
+      instructions: opts.instructions ?? DEFAULT_INSTRUCTIONS,
+    },
+    { sendReply, routing, logger },
+  );
+  if (serverBoot._tag === "Err") {
+    return {
+      _tag: "Err",
+      error: {
+        _tag: "McpTransportFailed",
+        cause: `${serverBoot.error._tag}: ${serverBoot.error.cause}`,
+      },
+    };
+  }
+  const serverHandle: ServerHandle = serverBoot.value;
+
+  // Inbound: gate → translate → record → push. Failures log and drop —
+  // spec I5 (pure, drop on failure) + A3.
+  core.onInbound((enriched: EnrichedInboundMessage) =>
+    Effect.gen(function* () {
+      const gated = opts.gateInbound
+        ? opts.gateInbound(enriched)
+        : ({ _tag: "Success", value: enriched } as const);
+      if (gated._tag === "Failure") {
+        logger.info?.(
+          { error: gated.error },
+          "claude-code-channel: gateInbound dropped event",
+        );
+        return;
+      }
+      const translated = toClaudeChannelNotification(gated.value);
+      if (translated._tag === "Err") {
+        logger.warn?.(
+          { error: translated.error, messageId: enriched.id },
+          "claude-code-channel: translation failed, dropping event",
+        );
+        return;
+      }
+      routing.recordInbound(
+        translated.value.params.meta.message_id,
+        translated.value.params.meta.chat_id,
+      );
+      yield* serverHandle
+        .push(translated.value)
+        .pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() =>
+              logger.error?.(
+                { err, messageId: enriched.id },
+                "claude-code-channel: notification push failed",
+              ),
+            ),
+          ),
+        );
+    }),
+  );
+
+  const connectResult = await Effect.runPromise(Effect.either(core.connect()));
+  if (connectResult._tag === "Left") {
+    // Best-effort: tear down MCP transport before reporting to the caller.
+    await Effect.runPromise(serverHandle.stop());
+    return {
+      _tag: "Err",
+      error: {
+        _tag: "ServiceConnectFailed",
+        cause: stringifyCause(connectResult.left),
+      },
+    };
+  }
+
+  const handle: Handle = {
+    push: serverHandle.push,
+    stop: () =>
+      Effect.gen(function* () {
+        yield* core.disconnect();
+        yield* serverHandle.stop();
+      }),
+  };
+
+  return { _tag: "Ok", value: handle };
 }

--- a/packages/claude-code-channel/src/entry.ts
+++ b/packages/claude-code-channel/src/entry.ts
@@ -1,0 +1,55 @@
+/**
+ * entry — public boot entry point for `@moltzap/claude-code-channel`.
+ *
+ * Wires `MoltZapService` + `MoltZapChannelCore` + the MCP stdio server into
+ * a single `Handle`. Mirrors `~/moltzap/packages/openclaw-channel/src/openclaw-entry.ts`
+ * as the precedent for "wrap client primitives + host plugin shape."
+ *
+ * Spec A2: `bootClaudeCodeChannel(opts: BootOptions): Promise<Result<Handle, BootError>>`.
+ *
+ * Lifecycle (linear, no nontrivial state machine):
+ *   1. Validate options; fail fast with `AgentKeyInvalid` if `agentKey` is
+ *      absent/empty.
+ *   2. Construct `MoltZapService` from `{serverUrl, agentKey, logger}`.
+ *   3. Construct `MoltZapChannelCore` over that service.
+ *   4. Construct `RoutingState` (fresh, per-boot).
+ *   5. Boot the MCP stdio server (`bootChannelMcpServer`) with bound
+ *      `sendReply` (capture `core.sendReply` + `RoutingState.resolveTarget`)
+ *      and `routing`.
+ *   6. Register inbound handler on `core.onInbound`: apply `gateInbound?`
+ *      (Principle 4 — handle both Success / Failure branches); on Success
+ *      translate via `toClaudeChannelNotification`, update `RoutingState`,
+ *      push through the server handle.
+ *   7. `core.connect()` — any `ServiceRpcError` maps to
+ *      `ServiceConnectFailed`.
+ *   8. Return `Handle`.
+ *
+ * Shutdown path (`Handle.stop`): `core.disconnect()` → `serverHandle.stop()`.
+ * Both swallow downstream errors into `logger.error` per spec I8; the public
+ * `stop` is `Effect<void>` with no error channel because no caller can
+ * meaningfully react to teardown failures.
+ *
+ * No `Promise<T>` on internal plumbing — the spec fixes `Promise<Result<...>>`
+ * only at the public boot boundary (A2); everything downstream stays in
+ * Effect (Principle 3). The single `runPromise` tax lives inside this file.
+ */
+
+import type { BootOptions, Handle } from "./types.js";
+import type { BootError } from "./errors.js";
+
+export type BootResult =
+  | { readonly _tag: "Ok"; readonly value: Handle }
+  | { readonly _tag: "Err"; readonly error: BootError };
+
+/**
+ * Boot a Claude Code channel. Single public entry point of the package.
+ *
+ * Returns `Promise<BootResult>` — the `Promise` is a concession to callers
+ * that have not adopted Effect (zapbot today). Internals are Effect; the
+ * error channel stays tagged (Principle 3, not `Promise<Handle>` throws).
+ */
+export function bootClaudeCodeChannel(
+  opts: BootOptions,
+): Promise<BootResult> {
+  throw new Error("not implemented");
+}

--- a/packages/claude-code-channel/src/errors.ts
+++ b/packages/claude-code-channel/src/errors.ts
@@ -73,6 +73,12 @@ export type AllowlistError =
 /**
  * Returned by the `reply` tool handler when a call cannot be routed or sent.
  * Surfaces as an MCP tool error (isError: true) to Claude Code.
+ *
+ * `FilesUnsupported` is returned for `reply` calls that include a non-empty
+ * `files` array. v1 ships contract-shaped decode for `files` (so Claude Code
+ * can preview the argument surface) but does NOT ship attachment upload; a
+ * v1.1 follow-up will wire `files` through the client attachments path. This
+ * tagged error replaces the silent drop behavior reviewer-187 called out.
  */
 export type ReplyError =
   | {
@@ -88,6 +94,11 @@ export type ReplyError =
   | {
       readonly _tag: "SendFailed";
       readonly cause: string;
+    }
+  | {
+      readonly _tag: "FilesUnsupported";
+      /** Count of files the caller tried to attach; for operator diagnostics. */
+      readonly fileCount: number;
     };
 
 /**

--- a/packages/claude-code-channel/src/errors.ts
+++ b/packages/claude-code-channel/src/errors.ts
@@ -1,0 +1,99 @@
+/**
+ * errors — tagged error unions.
+ *
+ * Principle 3 (typed errors) + Principle 4 (exhaustiveness over optionality).
+ *
+ * OQ3 resolution: `BootError` minimum tag set is
+ *   { ServiceConnectFailed, McpTransportFailed, AgentKeyInvalid }
+ * — architect-extensible (spec OQ3 default B). Additional tags added here
+ * must be handled exhaustively at every call site; there is no open-ended
+ * `Other` tag.
+ */
+
+/**
+ * Returned by `bootClaudeCodeChannel` when boot cannot proceed.
+ */
+export type BootError =
+  | {
+      readonly _tag: "ServiceConnectFailed";
+      /** MoltZap WS `connect()` failed. */
+      readonly cause: string;
+    }
+  | {
+      readonly _tag: "McpTransportFailed";
+      /** Stdio transport attach or MCP `server.connect` failed. */
+      readonly cause: string;
+    }
+  | {
+      readonly _tag: "AgentKeyInvalid";
+      /** `agentKey` was missing, malformed, or rejected by the server. */
+      readonly cause: string;
+    }
+  | {
+      readonly _tag: "SchemaDecodeFailed";
+      /** A WS or MCP boundary payload failed schema decode at boot. */
+      readonly cause: string;
+      /** The boundary that produced the decode failure. */
+      readonly at: "ws" | "mcp";
+    };
+
+/**
+ * Returned by `Handle.push` when the MCP notification cannot be emitted.
+ */
+export type PushError =
+  | {
+      readonly _tag: "EmitFailed";
+      readonly cause: string;
+    }
+  | {
+      readonly _tag: "NotConnected";
+      /** Transport dropped between boot and this push. */
+      readonly cause: string;
+    };
+
+/**
+ * Returned by `gateInbound` when the inbound event fails consumer policy.
+ *
+ * The upstream package ships no allowlist set; zapbot (and any other
+ * consumer) supplies the predicate. Tag set is intentionally minimal so the
+ * consumer can map its own policy outcomes here without shape negotiation.
+ */
+export type AllowlistError =
+  | {
+      readonly _tag: "SenderNotAllowed";
+      readonly senderId: string;
+      readonly reason: string;
+    }
+  | {
+      readonly _tag: "ConversationNotAllowed";
+      readonly conversationId: string;
+      readonly reason: string;
+    };
+
+/**
+ * Returned by the `reply` tool handler when a call cannot be routed or sent.
+ * Surfaces as an MCP tool error (isError: true) to Claude Code.
+ */
+export type ReplyError =
+  | {
+      readonly _tag: "NoActiveChat";
+      /** `reply_to` was absent and no inbound has been observed yet. */
+      readonly cause: string;
+    }
+  | {
+      readonly _tag: "ReplyToUnknown";
+      /** `reply_to` did not resolve to a known message_id. */
+      readonly replyTo: string;
+    }
+  | {
+      readonly _tag: "SendFailed";
+      readonly cause: string;
+    };
+
+/**
+ * Returned by the `event.ts` translator when an inbound message cannot be
+ * shaped into a contract-conformant notification.
+ */
+export type EventShapeError =
+  | { readonly _tag: "ContentEmpty" }
+  | { readonly _tag: "MetaInvalid"; readonly reason: string };

--- a/packages/claude-code-channel/src/event.test.ts
+++ b/packages/claude-code-channel/src/event.test.ts
@@ -2,28 +2,157 @@
  * Unit tests for `event.ts` (meta-key mapping).
  *
  * Transplanted from zapbot `test/claude-channel-event.test.ts` (verdict
- * §(b) MOVE row 3). Tests are updated to assert the contract-correct meta
- * keys (`chat_id`, `user`, `message_id`, `ts`) per spec A12; behavioral
- * assertions otherwise unchanged.
- *
- * Architect stage: test skeletons only (`it.todo`). implement-staff fills
- * in bodies.
+ * §(b) MOVE row 3). Tests assert the contract-correct meta keys (`chat_id`,
+ * `user`, `message_id`, `ts`) per spec A12.
  */
 
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import type { EnrichedInboundMessage } from "@moltzap/client";
+import {
+  brandChatId,
+  brandIsoTimestamp,
+  brandMessageId,
+  brandUserId,
+  toClaudeChannelNotification,
+} from "./event.js";
 
-describe("toClaudeChannelNotification — meta-key mapping", () => {
-  it.todo("maps conversationId → chat_id verbatim");
-  it.todo("maps sender.id → user verbatim");
-  it.todo("maps inbound .id → message_id verbatim");
-  it.todo("maps createdAt (ISO string) → ts verbatim");
-  it.todo("emits method exactly 'notifications/claude/channel'");
-  it.todo("rejects with ContentEmpty when text is blank-only");
-  it.todo("passes file_path through when present, omits key when absent");
-  it.todo("does not emit zapbot's invented keys (conversation_id, sender_id, received_at_ms)");
+function makeEvent(
+  overrides: Partial<EnrichedInboundMessage> = {},
+): EnrichedInboundMessage {
+  return {
+    id: "msg-01",
+    conversationId: "conv-01",
+    sender: { id: "agent-alice", name: "Alice" },
+    text: "hello world",
+    isFromMe: false,
+    createdAt: "2026-04-24T12:00:00.000Z",
+    contextBlocks: {},
+    ...overrides,
+  };
+}
+
+describe("toClaudeChannelNotification — meta-key mapping (spec A5, A12)", () => {
+  it("maps conversationId → chat_id verbatim", () => {
+    const r = toClaudeChannelNotification(makeEvent({ conversationId: "C42" }));
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    expect(r.value.params.meta.chat_id).toBe("C42");
+  });
+
+  it("maps sender.id → user verbatim", () => {
+    const r = toClaudeChannelNotification(
+      makeEvent({ sender: { id: "agent-bob", name: "Bob" } }),
+    );
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    expect(r.value.params.meta.user).toBe("agent-bob");
+  });
+
+  it("maps inbound .id → message_id verbatim", () => {
+    const r = toClaudeChannelNotification(makeEvent({ id: "M-42" }));
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    expect(r.value.params.meta.message_id).toBe("M-42");
+  });
+
+  it("maps createdAt (ISO string) → ts verbatim", () => {
+    const ts = "2026-04-24T09:00:00.123Z";
+    const r = toClaudeChannelNotification(makeEvent({ createdAt: ts }));
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    expect(r.value.params.meta.ts).toBe(ts);
+  });
+
+  it("emits method exactly 'notifications/claude/channel'", () => {
+    const r = toClaudeChannelNotification(makeEvent());
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    expect(r.value.method).toBe("notifications/claude/channel");
+  });
+
+  it("passes content through verbatim (no transform)", () => {
+    const r = toClaudeChannelNotification(makeEvent({ text: "ping!" }));
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    expect(r.value.params.content).toBe("ping!");
+  });
+
+  it("rejects with ContentEmpty when text is blank-only", () => {
+    const r = toClaudeChannelNotification(makeEvent({ text: "   \n\t" }));
+    expect(r._tag).toBe("Err");
+    if (r._tag !== "Err") return;
+    expect(r.error._tag).toBe("ContentEmpty");
+  });
+
+  it("rejects with ContentEmpty when text is empty string", () => {
+    const r = toClaudeChannelNotification(makeEvent({ text: "" }));
+    expect(r._tag).toBe("Err");
+    if (r._tag !== "Err") return;
+    expect(r.error._tag).toBe("ContentEmpty");
+  });
+
+  it("omits file_path key in v1", () => {
+    const r = toClaudeChannelNotification(makeEvent());
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    expect("file_path" in r.value.params.meta).toBe(false);
+  });
+
+  it("does not emit zapbot's invented keys (conversation_id, sender_id, received_at_ms)", () => {
+    const r = toClaudeChannelNotification(makeEvent());
+    expect(r._tag).toBe("Ok");
+    if (r._tag !== "Ok") return;
+    const meta = r.value.params.meta as unknown as Record<string, unknown>;
+    expect("conversation_id" in meta).toBe(false);
+    expect("sender_id" in meta).toBe(false);
+    expect("received_at_ms" in meta).toBe(false);
+  });
+
+  it("rejects with MetaInvalid when conversationId is empty", () => {
+    const r = toClaudeChannelNotification(makeEvent({ conversationId: "" }));
+    expect(r._tag).toBe("Err");
+    if (r._tag !== "Err") return;
+    expect(r.error._tag).toBe("MetaInvalid");
+  });
+
+  it("rejects with MetaInvalid when createdAt is not ISO", () => {
+    const r = toClaudeChannelNotification(
+      makeEvent({ createdAt: "not a date" }),
+    );
+    expect(r._tag).toBe("Err");
+    if (r._tag !== "Err") return;
+    expect(r.error._tag).toBe("MetaInvalid");
+  });
 });
 
-describe("branded-type narrowers", () => {
-  it.todo("brandChatId rejects empty string");
-  it.todo("brandIsoTimestamp rejects non-ISO strings");
+describe("branded-type narrowers (Principle 1)", () => {
+  it("brandChatId accepts non-empty string", () => {
+    expect(brandChatId("abc")).toBe("abc");
+  });
+
+  it("brandChatId rejects empty string", () => {
+    expect(() => brandChatId("")).toThrow(/non-empty/);
+  });
+
+  it("brandMessageId rejects whitespace-only", () => {
+    expect(() => brandMessageId("   ")).toThrow(/non-empty/);
+  });
+
+  it("brandUserId rejects empty", () => {
+    expect(() => brandUserId("")).toThrow(/non-empty/);
+  });
+
+  it("brandIsoTimestamp accepts valid ISO", () => {
+    expect(brandIsoTimestamp("2026-04-24T00:00:00Z")).toBe(
+      "2026-04-24T00:00:00Z",
+    );
+  });
+
+  it("brandIsoTimestamp rejects non-ISO strings", () => {
+    expect(() => brandIsoTimestamp("not-a-date")).toThrow();
+  });
+
+  it("brandIsoTimestamp rejects year-only input", () => {
+    expect(() => brandIsoTimestamp("2026")).toThrow();
+  });
 });

--- a/packages/claude-code-channel/src/event.test.ts
+++ b/packages/claude-code-channel/src/event.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Unit tests for `event.ts` (meta-key mapping).
+ *
+ * Transplanted from zapbot `test/claude-channel-event.test.ts` (verdict
+ * §(b) MOVE row 3). Tests are updated to assert the contract-correct meta
+ * keys (`chat_id`, `user`, `message_id`, `ts`) per spec A12; behavioral
+ * assertions otherwise unchanged.
+ *
+ * Architect stage: test skeletons only (`it.todo`). implement-staff fills
+ * in bodies.
+ */
+
+import { describe, it } from "vitest";
+
+describe("toClaudeChannelNotification — meta-key mapping", () => {
+  it.todo("maps conversationId → chat_id verbatim");
+  it.todo("maps sender.id → user verbatim");
+  it.todo("maps inbound .id → message_id verbatim");
+  it.todo("maps createdAt (ISO string) → ts verbatim");
+  it.todo("emits method exactly 'notifications/claude/channel'");
+  it.todo("rejects with ContentEmpty when text is blank-only");
+  it.todo("passes file_path through when present, omits key when absent");
+  it.todo("does not emit zapbot's invented keys (conversation_id, sender_id, received_at_ms)");
+});
+
+describe("branded-type narrowers", () => {
+  it.todo("brandChatId rejects empty string");
+  it.todo("brandIsoTimestamp rejects non-ISO strings");
+});

--- a/packages/claude-code-channel/src/event.ts
+++ b/packages/claude-code-channel/src/event.ts
@@ -16,8 +16,6 @@
  *   EnrichedInboundMessage.createdAt (ISO)  → meta.ts
  *
  * Reference: fakechat/server.ts:135-148 (contract meta shape).
- *
- * Stubs only. Bodies fill in implement-staff.
  */
 
 import type { EnrichedInboundMessage } from "@moltzap/client";
@@ -35,6 +33,86 @@ export type EventShapeResult =
   | { readonly _tag: "Ok"; readonly value: ClaudeChannelNotification }
   | { readonly _tag: "Err"; readonly error: EventShapeError };
 
+type BrandResult<T> =
+  | { readonly _tag: "Ok"; readonly value: T }
+  | { readonly _tag: "Err"; readonly reason: string };
+
+function brandChatIdSafe(raw: string): BrandResult<ChatId> {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return { _tag: "Err", reason: "chat_id must be a non-empty string" };
+  }
+  return { _tag: "Ok", value: raw as ChatId };
+}
+
+function brandMessageIdSafe(raw: string): BrandResult<MessageId> {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return { _tag: "Err", reason: "message_id must be a non-empty string" };
+  }
+  return { _tag: "Ok", value: raw as MessageId };
+}
+
+function brandUserIdSafe(raw: string): BrandResult<UserId> {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return { _tag: "Err", reason: "user must be a non-empty string" };
+  }
+  return { _tag: "Ok", value: raw as UserId };
+}
+
+// Loose ISO-8601 shape: date-only or date + T + time + optional tz.
+const ISO_SHAPE =
+  /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?([+-]\d{2}:?\d{2}|Z)?)?$/;
+
+function brandIsoTimestampSafe(raw: string): BrandResult<IsoTimestamp> {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return { _tag: "Err", reason: "ts must be a non-empty string" };
+  }
+  if (!ISO_SHAPE.test(raw)) {
+    return { _tag: "Err", reason: `ts must be an ISO-8601 timestamp: ${raw}` };
+  }
+  const parsed = Date.parse(raw);
+  if (Number.isNaN(parsed)) {
+    return { _tag: "Err", reason: `ts could not be parsed as a date: ${raw}` };
+  }
+  return { _tag: "Ok", value: raw as IsoTimestamp };
+}
+
+/**
+ * Narrow a raw string into the branded `ChatId`. Throws on empty input.
+ * For boundary validation, `toClaudeChannelNotification` returns a tagged
+ * result; this helper is for callers that have already validated upstream.
+ */
+export function brandChatId(raw: string): ChatId {
+  const r = brandChatIdSafe(raw);
+  if (r._tag === "Err") {
+    throw new Error(`brandChatId: ${r.reason}`);
+  }
+  return r.value;
+}
+
+export function brandMessageId(raw: string): MessageId {
+  const r = brandMessageIdSafe(raw);
+  if (r._tag === "Err") {
+    throw new Error(`brandMessageId: ${r.reason}`);
+  }
+  return r.value;
+}
+
+export function brandUserId(raw: string): UserId {
+  const r = brandUserIdSafe(raw);
+  if (r._tag === "Err") {
+    throw new Error(`brandUserId: ${r.reason}`);
+  }
+  return r.value;
+}
+
+export function brandIsoTimestamp(raw: string): IsoTimestamp {
+  const r = brandIsoTimestampSafe(raw);
+  if (r._tag === "Err") {
+    throw new Error(`brandIsoTimestamp: ${r.reason}`);
+  }
+  return r.value;
+}
+
 /**
  * Convert a `MoltZapChannelCore`-delivered enriched inbound message into the
  * contract-conformant notification payload. Pure function; no I/O.
@@ -42,28 +120,55 @@ export type EventShapeResult =
 export function toClaudeChannelNotification(
   event: EnrichedInboundMessage,
 ): EventShapeResult {
-  throw new Error("not implemented");
-}
+  const content = typeof event.text === "string" ? event.text : "";
+  if (content.trim().length === 0) {
+    return { _tag: "Err", error: { _tag: "ContentEmpty" } };
+  }
 
-/**
- * Narrow a raw string into the branded `ChatId`. Runs at the mapping
- * boundary so the rest of the module can trust the type.
- */
-export function brandChatId(raw: string): ChatId {
-  throw new Error("not implemented");
-}
+  const chatIdR = brandChatIdSafe(event.conversationId);
+  if (chatIdR._tag === "Err") {
+    return {
+      _tag: "Err",
+      error: { _tag: "MetaInvalid", reason: chatIdR.reason },
+    };
+  }
+  const messageIdR = brandMessageIdSafe(event.id);
+  if (messageIdR._tag === "Err") {
+    return {
+      _tag: "Err",
+      error: { _tag: "MetaInvalid", reason: messageIdR.reason },
+    };
+  }
+  const senderId =
+    event.sender && typeof event.sender.id === "string" ? event.sender.id : "";
+  const userR = brandUserIdSafe(senderId);
+  if (userR._tag === "Err") {
+    return {
+      _tag: "Err",
+      error: { _tag: "MetaInvalid", reason: userR.reason },
+    };
+  }
+  const tsR = brandIsoTimestampSafe(event.createdAt);
+  if (tsR._tag === "Err") {
+    return {
+      _tag: "Err",
+      error: { _tag: "MetaInvalid", reason: tsR.reason },
+    };
+  }
 
-/** Narrow a raw string into the branded `MessageId`. */
-export function brandMessageId(raw: string): MessageId {
-  throw new Error("not implemented");
-}
-
-/** Narrow a raw string into the branded `UserId`. */
-export function brandUserId(raw: string): UserId {
-  throw new Error("not implemented");
-}
-
-/** Narrow a raw ISO-8601 string into the branded `IsoTimestamp`. */
-export function brandIsoTimestamp(raw: string): IsoTimestamp {
-  throw new Error("not implemented");
+  return {
+    _tag: "Ok",
+    value: {
+      method: "notifications/claude/channel",
+      params: {
+        content,
+        meta: {
+          chat_id: chatIdR.value,
+          message_id: messageIdR.value,
+          user: userR.value,
+          ts: tsR.value,
+        },
+      },
+    },
+  };
 }

--- a/packages/claude-code-channel/src/event.ts
+++ b/packages/claude-code-channel/src/event.ts
@@ -1,0 +1,69 @@
+/**
+ * event — MoltZap inbound → Claude Code channel notification translator.
+ *
+ * Transplanted from zapbot `src/claude-channel/event.ts` (verdict §(b) MOVE
+ * row 1). Adapted:
+ *   - Drops `MoltzapInbound` branded IDs; consumes `EnrichedInboundMessage`
+ *     from `@moltzap/client`.
+ *   - Corrects meta-key divergence from zapbot's invented names to the
+ *     official channel contract names (spec Goal 4, A5).
+ *
+ * Meta-key mapping (from `EnrichedInboundMessage` to contract meta shape):
+ *
+ *   EnrichedInboundMessage.conversationId   → meta.chat_id
+ *   EnrichedInboundMessage.sender.id        → meta.user
+ *   EnrichedInboundMessage.id               → meta.message_id
+ *   EnrichedInboundMessage.createdAt (ISO)  → meta.ts
+ *
+ * Reference: fakechat/server.ts:135-148 (contract meta shape).
+ *
+ * Stubs only. Bodies fill in implement-staff.
+ */
+
+import type { EnrichedInboundMessage } from "@moltzap/client";
+import type {
+  ClaudeChannelNotification,
+  ChatId,
+  IsoTimestamp,
+  MessageId,
+  UserId,
+} from "./types.js";
+import type { EventShapeError } from "./errors.js";
+
+/** Discriminated result — deliberately narrow, no generic `Result` dep. */
+export type EventShapeResult =
+  | { readonly _tag: "Ok"; readonly value: ClaudeChannelNotification }
+  | { readonly _tag: "Err"; readonly error: EventShapeError };
+
+/**
+ * Convert a `MoltZapChannelCore`-delivered enriched inbound message into the
+ * contract-conformant notification payload. Pure function; no I/O.
+ */
+export function toClaudeChannelNotification(
+  event: EnrichedInboundMessage,
+): EventShapeResult {
+  throw new Error("not implemented");
+}
+
+/**
+ * Narrow a raw string into the branded `ChatId`. Runs at the mapping
+ * boundary so the rest of the module can trust the type.
+ */
+export function brandChatId(raw: string): ChatId {
+  throw new Error("not implemented");
+}
+
+/** Narrow a raw string into the branded `MessageId`. */
+export function brandMessageId(raw: string): MessageId {
+  throw new Error("not implemented");
+}
+
+/** Narrow a raw string into the branded `UserId`. */
+export function brandUserId(raw: string): UserId {
+  throw new Error("not implemented");
+}
+
+/** Narrow a raw ISO-8601 string into the branded `IsoTimestamp`. */
+export function brandIsoTimestamp(raw: string): IsoTimestamp {
+  throw new Error("not implemented");
+}

--- a/packages/claude-code-channel/src/index.ts
+++ b/packages/claude-code-channel/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Public entry barrel for `@moltzap/claude-code-channel`.
+ *
+ * Only names listed here are part of the public surface.
+ */
+
+export { bootClaudeCodeChannel, type BootResult } from "./entry.js";
+export type {
+  BootOptions,
+  Handle,
+  ClaudeChannelNotification,
+  GateInbound,
+  ChatId,
+  MessageId,
+  UserId,
+  IsoTimestamp,
+} from "./types.js";
+export type {
+  BootError,
+  PushError,
+  AllowlistError,
+  ReplyError,
+  EventShapeError,
+} from "./errors.js";

--- a/packages/claude-code-channel/src/routing.ts
+++ b/packages/claude-code-channel/src/routing.ts
@@ -1,0 +1,60 @@
+/**
+ * routing — internal tracker for the `reply` tool's routing decision.
+ *
+ * OQ5 resolution (spec OQ5 default A): the contract's `reply` tool takes
+ * `{text, reply_to?, files?}` with no `chat_id`. MoltZap sessions can span
+ * multiple conversations, so the package must resolve which conversation a
+ * `reply` call targets:
+ *
+ *   1. If `reply_to` is provided and resolves to a known `message_id` → its
+ *      originating `chat_id`.
+ *   2. Else → the chat_id of the most recently observed inbound.
+ *   3. Else (no inbound yet) → `ReplyError.NoActiveChat`.
+ *
+ * Contract invariant: `reply` always delivers to a real conversation. Never
+ * silently drop (spec OQ5).
+ *
+ * State is internal to one `bootClaudeCodeChannel` boot; no cross-boot
+ * persistence, no globals.
+ *
+ * Map bound: a small ring-buffer cap (implementer picks the size; named in
+ * the design doc as "bounded LRU — recent 256 message_ids"). Exceeding the
+ * cap evicts the oldest entry; `ReplyToUnknown` fires at the boundary when
+ * the caller references a message beyond the window.
+ */
+
+import type { ChatId, MessageId } from "./types.js";
+
+export interface RoutingState {
+  /**
+   * Record an inbound message. Advances the "last active chat" pointer and
+   * adds the `(message_id, chat_id)` pair to the bounded map.
+   */
+  readonly recordInbound: (messageId: MessageId, chatId: ChatId) => void;
+
+  /**
+   * Resolve a `reply` call to a target chat_id.
+   * - `replyTo` present & known → that message's chat_id.
+   * - `replyTo` present & unknown → `{ _tag: "ReplyToUnknown" }`.
+   * - `replyTo` absent, last-active present → last-active chat_id.
+   * - `replyTo` absent, no inbound yet → `{ _tag: "NoActiveChat" }`.
+   */
+  readonly resolveTarget: (
+    replyTo: MessageId | undefined,
+  ) => RoutingResolution;
+}
+
+export type RoutingResolution =
+  | { readonly _tag: "Resolved"; readonly chatId: ChatId }
+  | { readonly _tag: "NoActiveChat" }
+  | { readonly _tag: "ReplyToUnknown"; readonly replyTo: MessageId };
+
+/**
+ * Construct a fresh routing state. One instance per boot.
+ *
+ * @param capacity bounded LRU size (default chosen by implementer, named
+ *        "recent 256 message_ids" in the design doc).
+ */
+export function createRoutingState(capacity?: number): RoutingState {
+  throw new Error("not implemented");
+}

--- a/packages/claude-code-channel/src/routing.ts
+++ b/packages/claude-code-channel/src/routing.ts
@@ -39,9 +39,7 @@ export interface RoutingState {
    * - `replyTo` absent, last-active present → last-active chat_id.
    * - `replyTo` absent, no inbound yet → `{ _tag: "NoActiveChat" }`.
    */
-  readonly resolveTarget: (
-    replyTo: MessageId | undefined,
-  ) => RoutingResolution;
+  readonly resolveTarget: (replyTo: MessageId | undefined) => RoutingResolution;
 }
 
 export type RoutingResolution =
@@ -49,12 +47,56 @@ export type RoutingResolution =
   | { readonly _tag: "NoActiveChat" }
   | { readonly _tag: "ReplyToUnknown"; readonly replyTo: MessageId };
 
+const DEFAULT_CAPACITY = 256;
+
 /**
  * Construct a fresh routing state. One instance per boot.
  *
- * @param capacity bounded LRU size (default chosen by implementer, named
- *        "recent 256 message_ids" in the design doc).
+ * @param capacity bounded LRU size (default 256 recent message_ids, per
+ *        architect design doc §2.4). Exceeding the cap evicts the oldest
+ *        (FIFO) — relying on JavaScript `Map` preserving insertion order.
  */
-export function createRoutingState(capacity?: number): RoutingState {
-  throw new Error("not implemented");
+export function createRoutingState(
+  capacity: number = DEFAULT_CAPACITY,
+): RoutingState {
+  if (!Number.isFinite(capacity) || capacity <= 0) {
+    throw new Error(
+      `createRoutingState: capacity must be a positive finite number, got ${capacity}`,
+    );
+  }
+  const cap = Math.floor(capacity);
+  const map = new Map<MessageId, ChatId>();
+  let lastActive: ChatId | undefined = undefined;
+
+  function recordInbound(messageId: MessageId, chatId: ChatId): void {
+    // Refresh the LRU position if present.
+    if (map.has(messageId)) {
+      map.delete(messageId);
+    }
+    map.set(messageId, chatId);
+    while (map.size > cap) {
+      const oldest = map.keys().next();
+      if (oldest.done === true) {
+        break;
+      }
+      map.delete(oldest.value);
+    }
+    lastActive = chatId;
+  }
+
+  function resolveTarget(replyTo: MessageId | undefined): RoutingResolution {
+    if (replyTo !== undefined) {
+      const hit = map.get(replyTo);
+      if (hit !== undefined) {
+        return { _tag: "Resolved", chatId: hit };
+      }
+      return { _tag: "ReplyToUnknown", replyTo };
+    }
+    if (lastActive !== undefined) {
+      return { _tag: "Resolved", chatId: lastActive };
+    }
+    return { _tag: "NoActiveChat" };
+  }
+
+  return { recordInbound, resolveTarget };
 }

--- a/packages/claude-code-channel/src/server.ts
+++ b/packages/claude-code-channel/src/server.ts
@@ -18,35 +18,43 @@
  *
  * Reference: fakechat/server.ts:59-66 (capability), 67-92 (tool list),
  * 135-148 (notification shape).
- *
- * Stubs only.
  */
 
-import type { Effect } from "effect";
+import { Effect } from "effect";
 import type { WsClientLogger } from "@moltzap/client";
-import type {
-  ClaudeChannelNotification,
-  MessageId,
-} from "./types.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+  type ListToolsResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { ClaudeChannelNotification, MessageId } from "./types.js";
 import type { PushError, ReplyError } from "./errors.js";
 import type { RoutingState } from "./routing.js";
+
+const REPLY_TOOL_NAME = "reply";
 
 /**
  * Dependencies the server receives from `entry.ts`. The server does not
  * instantiate `MoltZapChannelCore`; the entry module does, and injects the
  * narrow capabilities the server actually uses.
+ *
+ * `transportFactory` is optional and internal — defaulting to a real
+ * `StdioServerTransport`. Tests inject an in-memory transport to exercise
+ * handshake and tool-call behavior without spawning subprocesses.
  */
 export interface ServerDeps {
-  /**
-   * Bound delivery callback. Given resolved chat_id and text, sends via
-   * `MoltZapChannelCore.sendReply`. Error surfaces as `ReplyError.SendFailed`.
-   */
   readonly sendReply: (
     chatId: string,
     text: string,
   ) => Effect.Effect<void, ReplyError>;
   readonly routing: RoutingState;
   readonly logger: WsClientLogger;
+  /** Internal test seam; production defaults to `new StdioServerTransport()`. */
+  readonly transportFactory?: () => Transport;
 }
 
 export interface ServerConfig {
@@ -55,15 +63,9 @@ export interface ServerConfig {
 }
 
 export interface ServerHandle {
-  /** Push a `notifications/claude/channel` notification over stdio. */
   readonly push: (
     notification: ClaudeChannelNotification,
   ) => Effect.Effect<void, PushError>;
-
-  /**
-   * Shut down MCP transport. Infallible by design — teardown failures log
-   * and swallow per spec I8.
-   */
   readonly stop: () => Effect.Effect<void>;
 }
 
@@ -76,33 +78,8 @@ export type ServerBootResult =
   | { readonly _tag: "Err"; readonly error: ServerBootError };
 
 /**
- * Boot the Claude Code channel MCP stdio server.
- *
- * Advertises the fixed capability declaration:
- *   `{ tools: {}, experimental: { "claude/channel": {} } }`
- *
- * Registers exactly one tool: `reply`.
- *
- * Does NOT:
- *   - emit any notification method other than `notifications/claude/channel`
- *     (spec A6);
- *   - register `send_direct_message` (spec A7, non-goal §3.1);
- *   - register `edit_message` in v1 (OQ4 default B);
- *   - accept a caller-injected tool list (spec A4 "no caller-injected tool
- *     definitions").
- */
-export function bootChannelMcpServer(
-  config: ServerConfig,
-  deps: ServerDeps,
-): Promise<ServerBootResult> {
-  throw new Error("not implemented");
-}
-
-/**
- * Schema for the `reply` tool's inputSchema field. Exported so the server
- * and unit tests can share a single source. Matches contract verbatim
- * (fakechat/server.ts:75-86). Required: `text`. Optional: `reply_to`,
- * `files`.
+ * Schema for the `reply` tool's inputSchema field. Matches contract verbatim
+ * (fakechat/server.ts:75-86). Required: `text`. Optional: `reply_to`, `files`.
  */
 export const REPLY_TOOL_INPUT_SCHEMA = {
   type: "object" as const,
@@ -114,10 +91,36 @@ export const REPLY_TOOL_INPUT_SCHEMA = {
   required: ["text"] as const,
 };
 
-/**
- * Decoded shape of an inbound `reply` tool call's arguments. Validated at
- * the MCP boundary (Principle 2).
- */
+/** Fixed MCP server capabilities. Misspelling breaks Claude Code rendering. */
+export const CHANNEL_CAPABILITIES = {
+  tools: {},
+  experimental: { "claude/channel": {} },
+} as const;
+
+// The MCP SDK's ListTools `inputSchema` field wants a mutable `required:
+// string[]`. `as const` on the literal above would narrow it to `readonly`
+// and break assignment. `REPLY_TOOL_INPUT_SCHEMA_MUTABLE` is the handler
+// copy; tests assert deep equality against the frozen literal.
+function buildReplyInputSchema(): {
+  type: "object";
+  properties: {
+    text: { type: "string" };
+    reply_to: { type: "string" };
+    files: { type: "array"; items: { type: "string" } };
+  };
+  required: string[];
+} {
+  return {
+    type: "object",
+    properties: {
+      text: { type: "string" },
+      reply_to: { type: "string" },
+      files: { type: "array", items: { type: "string" } },
+    },
+    required: ["text"],
+  };
+}
+
 export interface DecodedReplyArgs {
   readonly text: string;
   readonly replyTo?: MessageId;
@@ -128,13 +131,266 @@ export type ReplyArgsDecodeResult =
   | { readonly _tag: "Ok"; readonly value: DecodedReplyArgs }
   | {
       readonly _tag: "Err";
-      readonly error: { readonly _tag: "ReplyArgsInvalid"; readonly reason: string };
+      readonly error: {
+        readonly _tag: "ReplyArgsInvalid";
+        readonly reason: string;
+      };
     };
 
 /**
- * Decode and validate a raw `reply` tool-call `arguments` object.
- * Called inside the MCP `CallToolRequestSchema` handler.
+ * Decode and validate a raw `reply` tool-call `arguments` object at the MCP
+ * boundary (Principle 2). No `as` casts across this seam.
  */
 export function decodeReplyArgs(raw: unknown): ReplyArgsDecodeResult {
-  throw new Error("not implemented");
+  if (raw === undefined || raw === null || typeof raw !== "object") {
+    return {
+      _tag: "Err",
+      error: {
+        _tag: "ReplyArgsInvalid",
+        reason: "arguments must be an object",
+      },
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.text !== "string") {
+    return {
+      _tag: "Err",
+      error: { _tag: "ReplyArgsInvalid", reason: "text must be a string" },
+    };
+  }
+  const text = obj.text;
+  if (text.trim().length === 0) {
+    return {
+      _tag: "Err",
+      error: { _tag: "ReplyArgsInvalid", reason: "text must be non-empty" },
+    };
+  }
+
+  let replyTo: MessageId | undefined;
+  if (obj.reply_to !== undefined) {
+    if (typeof obj.reply_to !== "string" || obj.reply_to.trim().length === 0) {
+      return {
+        _tag: "Err",
+        error: {
+          _tag: "ReplyArgsInvalid",
+          reason: "reply_to must be a non-empty string",
+        },
+      };
+    }
+    replyTo = obj.reply_to as MessageId;
+  }
+
+  let files: ReadonlyArray<string> | undefined;
+  if (obj.files !== undefined) {
+    if (!Array.isArray(obj.files)) {
+      return {
+        _tag: "Err",
+        error: { _tag: "ReplyArgsInvalid", reason: "files must be an array" },
+      };
+    }
+    for (const f of obj.files) {
+      if (typeof f !== "string") {
+        return {
+          _tag: "Err",
+          error: {
+            _tag: "ReplyArgsInvalid",
+            reason: "files must be an array of strings",
+          },
+        };
+      }
+    }
+    files = obj.files as ReadonlyArray<string>;
+  }
+
+  return {
+    _tag: "Ok",
+    value:
+      files !== undefined
+        ? { text, replyTo, files }
+        : replyTo !== undefined
+          ? { text, replyTo }
+          : { text },
+  };
+}
+
+function toolErrorResult(message: string): CallToolResult {
+  return { isError: true, content: [{ type: "text", text: message }] };
+}
+
+function toolOkResult(message: string): CallToolResult {
+  return { content: [{ type: "text", text: message }] };
+}
+
+function stringifyCause(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  try {
+    return JSON.stringify(cause);
+  } catch {
+    return String(cause);
+  }
+}
+
+/**
+ * Boot the Claude Code channel MCP stdio server.
+ *
+ * Advertises capabilities `{ tools: {}, experimental: { "claude/channel": {} } }`.
+ * Registers exactly one tool: `reply`. No other notification methods, no
+ * `send_direct_message`, no `edit_message`, no caller-injected tools.
+ */
+export async function bootChannelMcpServer(
+  config: ServerConfig,
+  deps: ServerDeps,
+): Promise<ServerBootResult> {
+  const server = new Server(
+    { name: config.serverName, version: "0.1.0" },
+    {
+      capabilities: CHANNEL_CAPABILITIES,
+      instructions: config.instructions,
+    },
+  );
+
+  // Pending-notification queue for pre-initialization push calls.
+  let initialized = false;
+  const pending: ClaudeChannelNotification[] = [];
+  server.oninitialized = () => {
+    initialized = true;
+    // Best-effort flush; failures log and continue so one bad push doesn't
+    // hide the rest from the client.
+    void (async () => {
+      while (pending.length > 0) {
+        const n = pending.shift();
+        if (n === undefined) break;
+        try {
+          await server.notification({
+            method: n.method,
+            params: n.params as unknown as Record<string, unknown>,
+          });
+        } catch (err) {
+          deps.logger.error(
+            { err },
+            "claude-code-channel: queued notification emit failed",
+          );
+        }
+      }
+    })();
+  };
+
+  try {
+    const toolList: ListToolsResult = {
+      tools: [
+        {
+          name: REPLY_TOOL_NAME,
+          description:
+            "Send a message back through the MoltZap channel. Pass reply_to (a message_id from the channel) to target a specific conversation; omit to reply to the most recent inbound.",
+          inputSchema: buildReplyInputSchema(),
+        },
+      ],
+    };
+    server.setRequestHandler(ListToolsRequestSchema, async () => toolList);
+
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      if (request.params.name !== REPLY_TOOL_NAME) {
+        return toolErrorResult(`unknown tool: ${request.params.name}`);
+      }
+      const decoded = decodeReplyArgs(request.params.arguments);
+      if (decoded._tag === "Err") {
+        return toolErrorResult(decoded.error.reason);
+      }
+      const resolution = deps.routing.resolveTarget(decoded.value.replyTo);
+      switch (resolution._tag) {
+        case "Resolved": {
+          const sendResult = await Effect.runPromise(
+            Effect.either(
+              deps.sendReply(resolution.chatId, decoded.value.text),
+            ),
+          );
+          if (sendResult._tag === "Left") {
+            const e = sendResult.left;
+            return toolErrorResult(
+              e._tag === "SendFailed"
+                ? `send failed: ${e.cause}`
+                : `reply error: ${e._tag}`,
+            );
+          }
+          return toolOkResult(`Reply sent to ${resolution.chatId as string}.`);
+        }
+        case "NoActiveChat":
+          return toolErrorResult(
+            "no active chat: no inbound message has been observed yet; pass reply_to after an inbound arrives",
+          );
+        case "ReplyToUnknown":
+          return toolErrorResult(
+            `reply_to does not match a known message_id: ${resolution.replyTo as string}`,
+          );
+        default: {
+          // Principle 4: exhaustiveness. Reach here only if RoutingResolution adds a tag.
+          const _exhaustive: never = resolution;
+          return toolErrorResult(
+            `unreachable routing: ${JSON.stringify(_exhaustive)}`,
+          );
+        }
+      }
+    });
+  } catch (cause) {
+    return {
+      _tag: "Err",
+      error: {
+        _tag: "ToolRegistrationFailed",
+        cause: stringifyCause(cause),
+      },
+    };
+  }
+
+  const transport = deps.transportFactory
+    ? deps.transportFactory()
+    : new StdioServerTransport();
+  try {
+    await server.connect(transport);
+  } catch (cause) {
+    return {
+      _tag: "Err",
+      error: { _tag: "StdioConnectFailed", cause: stringifyCause(cause) },
+    };
+  }
+
+  const handle: ServerHandle = {
+    push: (notification) =>
+      Effect.gen(function* () {
+        if (!initialized) {
+          pending.push(notification);
+          return;
+        }
+        yield* Effect.tryPromise({
+          try: () =>
+            server.notification({
+              method: notification.method,
+              params: notification.params as unknown as Record<string, unknown>,
+            }),
+          catch: (cause): PushError => ({
+            _tag: "EmitFailed",
+            cause: stringifyCause(cause),
+          }),
+        });
+      }),
+    stop: () =>
+      Effect.gen(function* () {
+        yield* Effect.tryPromise({
+          try: () => server.close(),
+          catch: (cause): Error =>
+            cause instanceof Error ? cause : new Error(stringifyCause(cause)),
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              deps.logger.error(
+                { err },
+                "claude-code-channel: MCP close failed (swallowed per I8)",
+              );
+            }),
+          ),
+        );
+      }),
+  };
+
+  return { _tag: "Ok", value: handle };
 }

--- a/packages/claude-code-channel/src/server.ts
+++ b/packages/claude-code-channel/src/server.ts
@@ -1,0 +1,140 @@
+/**
+ * server — MCP stdio server that fronts the Claude Code channel contract.
+ *
+ * Transplanted from zapbot `src/claude-channel/server.ts` (verdict §(b) MOVE
+ * row 2). Adapted:
+ *   - Capability declaration is FIXED to
+ *       `{ tools: {}, experimental: { "claude/channel": {} } }`
+ *     (spec I3, A14). Zapbot's conditional `enableReplyTool` / permission-
+ *     relay branches are removed — reply is mandatory, permission-relay
+ *     does not ship (non-goal §3.2, A6).
+ *   - Tool set reduced to `reply` only (spec A4, A7). `send_direct_message`
+ *     DELETED (non-goal §3.1). `edit_message` OMITTED in v1 (OQ4 default B;
+ *     `~/moltzap/packages/protocol/` has no edit-message RPC as of
+ *     commit 025ba58 — verified via `grep -rn "edit|update" packages/protocol/src`).
+ *   - `reply` tool resolves target chat via `RoutingState` (OQ5). Tool's
+ *     inputSchema is `{text, reply_to?, files?}` exactly per contract; NO
+ *     `conversationId` required param.
+ *
+ * Reference: fakechat/server.ts:59-66 (capability), 67-92 (tool list),
+ * 135-148 (notification shape).
+ *
+ * Stubs only.
+ */
+
+import type { Effect } from "effect";
+import type { WsClientLogger } from "@moltzap/client";
+import type {
+  ClaudeChannelNotification,
+  MessageId,
+} from "./types.js";
+import type { PushError, ReplyError } from "./errors.js";
+import type { RoutingState } from "./routing.js";
+
+/**
+ * Dependencies the server receives from `entry.ts`. The server does not
+ * instantiate `MoltZapChannelCore`; the entry module does, and injects the
+ * narrow capabilities the server actually uses.
+ */
+export interface ServerDeps {
+  /**
+   * Bound delivery callback. Given resolved chat_id and text, sends via
+   * `MoltZapChannelCore.sendReply`. Error surfaces as `ReplyError.SendFailed`.
+   */
+  readonly sendReply: (
+    chatId: string,
+    text: string,
+  ) => Effect.Effect<void, ReplyError>;
+  readonly routing: RoutingState;
+  readonly logger: WsClientLogger;
+}
+
+export interface ServerConfig {
+  readonly serverName: string;
+  readonly instructions: string;
+}
+
+export interface ServerHandle {
+  /** Push a `notifications/claude/channel` notification over stdio. */
+  readonly push: (
+    notification: ClaudeChannelNotification,
+  ) => Effect.Effect<void, PushError>;
+
+  /**
+   * Shut down MCP transport. Infallible by design — teardown failures log
+   * and swallow per spec I8.
+   */
+  readonly stop: () => Effect.Effect<void>;
+}
+
+export type ServerBootError =
+  | { readonly _tag: "StdioConnectFailed"; readonly cause: string }
+  | { readonly _tag: "ToolRegistrationFailed"; readonly cause: string };
+
+export type ServerBootResult =
+  | { readonly _tag: "Ok"; readonly value: ServerHandle }
+  | { readonly _tag: "Err"; readonly error: ServerBootError };
+
+/**
+ * Boot the Claude Code channel MCP stdio server.
+ *
+ * Advertises the fixed capability declaration:
+ *   `{ tools: {}, experimental: { "claude/channel": {} } }`
+ *
+ * Registers exactly one tool: `reply`.
+ *
+ * Does NOT:
+ *   - emit any notification method other than `notifications/claude/channel`
+ *     (spec A6);
+ *   - register `send_direct_message` (spec A7, non-goal §3.1);
+ *   - register `edit_message` in v1 (OQ4 default B);
+ *   - accept a caller-injected tool list (spec A4 "no caller-injected tool
+ *     definitions").
+ */
+export function bootChannelMcpServer(
+  config: ServerConfig,
+  deps: ServerDeps,
+): Promise<ServerBootResult> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Schema for the `reply` tool's inputSchema field. Exported so the server
+ * and unit tests can share a single source. Matches contract verbatim
+ * (fakechat/server.ts:75-86). Required: `text`. Optional: `reply_to`,
+ * `files`.
+ */
+export const REPLY_TOOL_INPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    text: { type: "string" as const },
+    reply_to: { type: "string" as const },
+    files: { type: "array" as const, items: { type: "string" as const } },
+  },
+  required: ["text"] as const,
+};
+
+/**
+ * Decoded shape of an inbound `reply` tool call's arguments. Validated at
+ * the MCP boundary (Principle 2).
+ */
+export interface DecodedReplyArgs {
+  readonly text: string;
+  readonly replyTo?: MessageId;
+  readonly files?: ReadonlyArray<string>;
+}
+
+export type ReplyArgsDecodeResult =
+  | { readonly _tag: "Ok"; readonly value: DecodedReplyArgs }
+  | {
+      readonly _tag: "Err";
+      readonly error: { readonly _tag: "ReplyArgsInvalid"; readonly reason: string };
+    };
+
+/**
+ * Decode and validate a raw `reply` tool-call `arguments` object.
+ * Called inside the MCP `CallToolRequestSchema` handler.
+ */
+export function decodeReplyArgs(raw: unknown): ReplyArgsDecodeResult {
+  throw new Error("not implemented");
+}

--- a/packages/claude-code-channel/src/server.ts
+++ b/packages/claude-code-channel/src/server.ts
@@ -297,6 +297,14 @@ export async function bootChannelMcpServer(
       if (decoded._tag === "Err") {
         return toolErrorResult(decoded.error.reason);
       }
+      // v1 ships the contract-shaped `files` input (spec A4, fakechat parity),
+      // but attachment upload is a v1.1 follow-up. Reject explicitly with a
+      // tagged error rather than silently dropping the files (reviewer-187).
+      if (decoded.value.files !== undefined && decoded.value.files.length > 0) {
+        return toolErrorResult(
+          `FilesUnsupported: reply.files is not supported in v1 (${decoded.value.files.length.toString()} file(s) rejected). Tracked as v1.1 follow-up.`,
+        );
+      }
       const resolution = deps.routing.resolveTarget(decoded.value.replyTo);
       switch (resolution._tag) {
         case "Resolved": {

--- a/packages/claude-code-channel/src/types.ts
+++ b/packages/claude-code-channel/src/types.ts
@@ -1,0 +1,116 @@
+/**
+ * types — public types for @moltzap/claude-code-channel.
+ *
+ * Principle 2: the values that cross the channel boundary have declared
+ * shapes. Principle 3: error channels are typed unions, not thrown strings.
+ * Principle 4: every union discriminates on `_tag`.
+ *
+ * Interfaces only. No function bodies beyond `throw new Error("not implemented")`.
+ */
+
+import type { Effect } from "effect";
+import type { EnrichedInboundMessage, WsClientLogger } from "@moltzap/client";
+import type {
+  AllowlistError,
+  BootError,
+  PushError,
+} from "./errors.js";
+
+/**
+ * Branded chat id — corresponds to MoltZap's `conversationId` on the wire,
+ * rendered to Claude Code as the contract-meta key `chat_id`.
+ * Principle 1: preventing accidental confusion with `MessageId` at call sites.
+ */
+export type ChatId = string & { readonly __brand: "ChatId" };
+
+/**
+ * Branded message id — corresponds to MoltZap's `id`, rendered as
+ * contract-meta `message_id`.
+ */
+export type MessageId = string & { readonly __brand: "MessageId" };
+
+/**
+ * Branded user id — corresponds to MoltZap's `sender.id`, rendered as
+ * contract-meta `user`.
+ */
+export type UserId = string & { readonly __brand: "UserId" };
+
+/**
+ * ISO-8601 timestamp — corresponds to MoltZap's `createdAt` (already ISO),
+ * rendered as contract-meta `ts`.
+ */
+export type IsoTimestamp = string & { readonly __brand: "IsoTimestamp" };
+
+/**
+ * Claude Code channel notification shape.
+ *
+ * The meta keys are FIXED by Anthropic's channel contract (fakechat
+ * reference, server.ts:135-148). Divergence breaks the `<channel>` tag
+ * renderer inside Claude Code.
+ */
+export interface ClaudeChannelNotification {
+  readonly method: "notifications/claude/channel";
+  readonly params: {
+    readonly content: string;
+    readonly meta: {
+      readonly chat_id: ChatId;
+      readonly message_id: MessageId;
+      readonly user: UserId;
+      readonly ts: IsoTimestamp;
+      readonly file_path?: string;
+    };
+  };
+}
+
+/**
+ * `gateInbound` hook — zapbot-parity allowlist seam.
+ *
+ * Must be pure and synchronous (spec I5). Returning a failure drops the
+ * event; no downstream notification is emitted. No I/O, no mutation.
+ */
+export type GateInbound = (
+  event: EnrichedInboundMessage,
+) =>
+  | { readonly _tag: "Success"; readonly value: EnrichedInboundMessage }
+  | { readonly _tag: "Failure"; readonly error: AllowlistError };
+
+/**
+ * Boot options — one struct per caller.
+ *
+ * No `Record<string, unknown>`, no `any`. Logger is the same shape the rest
+ * of `@moltzap/client` uses.
+ */
+export interface BootOptions {
+  readonly serverUrl: string;
+  readonly agentKey: string;
+  readonly logger: WsClientLogger;
+  readonly gateInbound?: GateInbound;
+  /**
+   * Override the MCP server's advertised name. Defaults to
+   * `"@moltzap/claude-code-channel"`.
+   */
+  readonly serverName?: string;
+  /**
+   * Override the MCP server's `instructions` string delivered at handshake.
+   * Defaults to a contract-conformant default describing the `<channel>` tag
+   * shape and the `reply` tool.
+   */
+  readonly instructions?: string;
+}
+
+/**
+ * Lifecycle handle returned by `bootClaudeCodeChannel`.
+ *
+ * Principle 3: every operation has a typed error channel. `push` uses
+ * `Effect<void, PushError>` so the MCP emit failure surfaces as a tag, not a
+ * rejected Promise. `stop` is infallible-by-design (teardown swallows
+ * downstream errors into logs per spec I8).
+ */
+export interface Handle {
+  readonly push: (
+    notification: ClaudeChannelNotification,
+  ) => Effect.Effect<void, PushError>;
+  readonly stop: () => Effect.Effect<void>;
+}
+
+export type { AllowlistError, BootError, PushError } from "./errors.js";

--- a/packages/claude-code-channel/src/types.ts
+++ b/packages/claude-code-channel/src/types.ts
@@ -10,11 +10,7 @@
 
 import type { Effect } from "effect";
 import type { EnrichedInboundMessage, WsClientLogger } from "@moltzap/client";
-import type {
-  AllowlistError,
-  BootError,
-  PushError,
-} from "./errors.js";
+import type { AllowlistError, BootError, PushError } from "./errors.js";
 
 /**
  * Branded chat id — corresponds to MoltZap's `conversationId` on the wire,

--- a/packages/claude-code-channel/tsconfig.json
+++ b/packages/claude-code-channel/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/packages/claude-code-channel/vitest.config.ts
+++ b/packages/claude-code-channel/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    exclude: ["src/**/*.integration.test.ts"],
+  },
+});

--- a/packages/claude-code-channel/vitest.integration.config.ts
+++ b/packages/claude-code-channel/vitest.integration.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.integration.test.ts"],
+    globalSetup: ["vitest.integration.globalSetup.ts"],
+    fileParallelism: false,
+    testTimeout: 90_000,
+    hookTimeout: 300_000,
+    globalSetupTimeout: 300_000,
+  },
+});

--- a/packages/claude-code-channel/vitest.integration.globalSetup.ts
+++ b/packages/claude-code-channel/vitest.integration.globalSetup.ts
@@ -1,0 +1,14 @@
+/**
+ * Global setup for integration tests.
+ *
+ * Architect stage: signature only. implement-staff wires up the real
+ * `@moltzap/server` subprocess spawn (per sbd#182 spike pattern: PGlite +
+ * `npx @moltzap/server`) and a peer agent registration, providing
+ * coordinates to the echo integration test.
+ */
+
+import type { GlobalSetupContext } from "vitest/node";
+
+export default async function ({ provide: _provide }: GlobalSetupContext) {
+  throw new Error("not implemented");
+}

--- a/packages/claude-code-channel/vitest.integration.globalSetup.ts
+++ b/packages/claude-code-channel/vitest.integration.globalSetup.ts
@@ -1,14 +1,151 @@
 /**
  * Global setup for integration tests.
  *
- * Architect stage: signature only. implement-staff wires up the real
- * `@moltzap/server` subprocess spawn (per sbd#182 spike pattern: PGlite +
- * `npx @moltzap/server`) and a peer agent registration, providing
- * coordinates to the echo integration test.
+ * Pattern: sbd#182 spike (evidence in
+ * `safer-by-default/spike/moltzap-headless-ci-fixture/probe.mjs`).
+ * Spawns `packages/server/dist/standalone.js` with PGlite (no external
+ * Postgres, no docker). Registers two agents so the echo test can boot a
+ * channel as agent A and drive inbound traffic via an in-process MoltZap
+ * client as agent B. Provides WS URL + per-agent API keys + agent IDs to
+ * the test via vitest `provide()`.
  */
 
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import { setTimeout as delay } from "node:timers/promises";
 import type { GlobalSetupContext } from "vitest/node";
 
-export default async function ({ provide: _provide }: GlobalSetupContext) {
-  throw new Error("not implemented");
+let child: ChildProcess | null = null;
+let tempDir: string | null = null;
+
+function pickPort(): number {
+  // 41990-42240 band per spike-182.
+  return 41990 + Math.floor(Math.random() * 250);
+}
+
+async function registerAgent(
+  baseUrl: string,
+  name: string,
+): Promise<{ agentId: string; apiKey: string }> {
+  const r = await fetch(`${baseUrl}/api/v1/auth/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  const text = await r.text();
+  if (!r.ok) {
+    throw new Error(`register ${name}: ${r.status} ${text}`);
+  }
+  const json = JSON.parse(text) as { agentId: string; apiKey: string };
+  if (!json.agentId || !json.apiKey) {
+    throw new Error(`register ${name}: missing agentId/apiKey in ${text}`);
+  }
+  return json;
+}
+
+export default async function ({ provide }: GlobalSetupContext) {
+  // Locate the built standalone.js relative to this package.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const moltzapRoot = resolve(here, "..", "..");
+  const standalone = join(
+    moltzapRoot,
+    "packages",
+    "server",
+    "dist",
+    "standalone.js",
+  );
+
+  tempDir = mkdtempSync(join(tmpdir(), "ccc-integration-"));
+  const configPath = join(tempDir, "moltzap.yaml");
+  const port = pickPort();
+  writeFileSync(
+    configPath,
+    `server:\n  port: ${port}\n  cors_origins: ["*"]\nlog_level: warn\n`,
+    "utf8",
+  );
+
+  const baseUrl = `http://localhost:${port}`;
+  const wsUrl = `ws://localhost:${port}`;
+
+  let stderr = "";
+  child = spawn("node", [standalone], {
+    cwd: moltzapRoot,
+    env: {
+      ...process.env,
+      MOLTZAP_CONFIG: configPath,
+      // `MOLTZAP_DEV_MODE=true` makes `DATABASE_URL` optional; empty URL
+      // triggers embedded PGlite (standalone.ts:319). Required because
+      // DATABASE_URL is otherwise mandatory outside dev-mode and we have
+      // no external Postgres in CI.
+      MOLTZAP_DEV_MODE: "true",
+      PORT: String(port),
+      ENCRYPTION_MASTER_SECRET: "a".repeat(44),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (d: Buffer) => {
+    stderr += d.toString();
+  });
+
+  // Poll `/api/v1/auth/register` with OPTIONS until ≥200 < 500 (server up).
+  const t0 = performance.now();
+  const deadline = t0 + 60_000;
+  let ready = false;
+  while (performance.now() < deadline) {
+    try {
+      const probe = await fetch(`${baseUrl}/api/v1/auth/register`, {
+        method: "OPTIONS",
+        signal: AbortSignal.timeout(500),
+      });
+      if (probe.status < 500) {
+        ready = true;
+        break;
+      }
+    } catch {
+      // not yet
+    }
+    await delay(50);
+  }
+  if (!ready) {
+    child.kill("SIGKILL");
+    throw new Error(
+      `moltzap standalone did not become ready within 60s. stderr tail:\n${stderr.split("\n").slice(-20).join("\n")}`,
+    );
+  }
+
+  const agentA = await registerAgent(baseUrl, "channel-agent-a");
+  const agentB = await registerAgent(baseUrl, "peer-agent-b");
+
+  provide("moltzapBaseUrl", baseUrl);
+  provide("moltzapWsUrl", wsUrl);
+  provide("agentAAgentId", agentA.agentId);
+  provide("agentAApiKey", agentA.apiKey);
+  provide("agentBAgentId", agentB.agentId);
+  provide("agentBApiKey", agentB.apiKey);
+
+  return async () => {
+    const p = child;
+    if (p !== null) {
+      p.kill("SIGTERM");
+      await new Promise<void>((resolveStop) => {
+        const t = setTimeout(() => {
+          p.kill("SIGKILL");
+          resolveStop();
+        }, 5000);
+        p.on("exit", () => {
+          clearTimeout(t);
+          resolveStop();
+        });
+      });
+      child = null;
+    }
+    if (tempDir !== null) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,28 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/claude-code-channel:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.20.2
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@moltzap/client':
+        specifier: workspace:*
+        version: link:../client
+      '@moltzap/protocol':
+        specifier: workspace:*
+        version: link:../protocol
+      effect:
+        specifier: ^3.21.0
+        version: 3.21.0
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/client:
     dependencies:
       '@effect/cli':


### PR DESCRIPTION
Architecture only. **Not for merge.**

Spec: [sbd#174 rev 2](https://github.com/chughtapan/safer-by-default/issues/172#issuecomment-4311624057)
Sub-issue: https://github.com/chughtapan/safer-by-default/issues/184
Design doc: (to be pasted on parent epic sbd#172 as architect comment)

## Scope

Interface stubs for `@moltzap/claude-code-channel` v1. Public surface, branded types, tagged error unions, MCP capability declaration shape, meta-key mapping, and routing seam — all typed, no bodies beyond `throw new Error("not implemented")`.

## Contents

- `packages/claude-code-channel/src/{entry,event,server,routing,errors,types,index}.ts`
- Test skeletons (`it.todo`) for unit + integration.
- `package.json` (dependency list; install happens in the implement-staff PR).
- `tsconfig.json`, `vitest.config.ts`, `vitest.integration.config.ts`, `vitest.integration.globalSetup.ts`.

Every body is `throw new Error("not implemented")`. No control flow, no inline logic.

## Traceability

See the full design doc published on sbd#172 for the acceptance-criterion ↔ module map, the capability-handshake shape, the transplant table adaptation notes (event.ts, server.ts), and the 3 OQ resolutions.