### PR TITLE
[impl-senior] moltzap CLI — add apps attest-skill subcommand (sbd#189)

### DIFF
--- a/packages/client/src/cli/commands/apps.test.ts
+++ b/packages/client/src/cli/commands/apps.test.ts
@@ -21,6 +21,7 @@ import {
 } from "vitest";
 import {
   AppsInputError,
+  appsAttestSkillHandler,
   appsCloseHandler,
   appsCreateHandler,
   appsGetHandler,
@@ -273,10 +274,44 @@ describe("apps close", () => {
   });
 });
 
-describe("apps attest-skill (ESCALATED Q-AS-1)", () => {
-  it("AppsInputError class is exported for downstream escalation tracking", () => {
-    const err = new AppsInputError("test");
-    expect(err._tag).toBe("AppsInputError");
-    expect(err.reason).toBe("test");
+describe("apps attest-skill", () => {
+  let stdout: MockInstance;
+  beforeEach(() => {
+    stdout = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+  afterEach(() => stdout.mockRestore());
+
+  it("calls apps/attestSkill with challengeId, skillUrl, version and emits no stdout", async () => {
+    const { calls, transport } = makeFakeTransport(() => ({}));
+    await Effect.runPromise(
+      appsAttestSkillHandler({
+        challengeId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        skillUrl: "https://example.com/skills/my-skill",
+        version: "1.0.0",
+      }).pipe(Effect.provideService(Transport, transport)),
+    );
+    expect(calls).toEqual([
+      {
+        method: "apps/attestSkill",
+        params: {
+          challengeId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          skillUrl: "https://example.com/skills/my-skill",
+          version: "1.0.0",
+        },
+      },
+    ]);
+    expect(stdout).not.toHaveBeenCalled();
+  });
+
+  it("surfaces TransportRpcError on RPC failure", async () => {
+    const { transport } = makeFakeTransport(() => new Error("attestation rejected"));
+    const result = await Effect.runPromiseExit(
+      appsAttestSkillHandler({
+        challengeId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        skillUrl: "https://example.com/skills/my-skill",
+        version: "1.0.0",
+      }).pipe(Effect.provideService(Transport, transport)),
+    );
+    expect(result._tag).toBe("Failure");
   });
 });

--- a/packages/client/src/cli/commands/apps.ts
+++ b/packages/client/src/cli/commands/apps.ts
@@ -200,20 +200,19 @@ export const appsCloseHandler = (
   });
 
 /**
- * Wraps `apps/attestSkill`. ESCALATED (Q-AS-1, spec rev 4).
+ * Wraps `apps/attestSkill` — spec rev 4 addendum §3 (Q-AS-1 resolved).
  *
- * Stub retained for type-level completeness; NOT wired into the CLI
- * Command tree in v1. Spec rev 4 must resolve: `--session → challengeId`
- * rename, `--version` flag, or drop required `version` from the RPC.
+ * All three flags are required; the RPC result is `{}`.
+ * Exit 0 on success with no stdout payload (Invariant §4.6; result is void).
  */
 export const appsAttestSkillHandler = (
-  _args: AppsAttestSkillArgs,
+  args: AppsAttestSkillArgs,
 ): Effect.Effect<void, AppsCommandError, Transport> =>
-  Effect.fail(
-    new AppsInputError(
-      "apps attest-skill is ESCALATED to spec rev 4 (Q-AS-1) and not wired in v1",
-    ),
-  );
+  rpc<Record<string, never>>("apps/attestSkill", {
+    challengeId: args.challengeId,
+    skillUrl: args.skillUrl,
+    version: args.version,
+  }).pipe(Effect.asVoid);
 
 // ─── CLI commands ──────────────────────────────────────────────────────────
 
@@ -318,14 +317,43 @@ const appsCloseCommand = Command.make(
   ({ sessionId }) => runHandler(appsCloseHandler({ sessionId })),
 ).pipe(Command.withDescription("Close an app session"));
 
+const challengeIdOption = Options.text("challenge-id").pipe(
+  Options.withDescription("Challenge id (UUID) from the attestation challenge"),
+);
+const skillUrlOption = Options.text("skill-url").pipe(
+  Options.withDescription("Skill URL being attested"),
+);
+const versionOption = Options.text("version").pipe(
+  Options.withDescription("Skill version string"),
+);
+
 /**
- * `moltzap apps [register|create|list|get|close]` — subcommand group.
- * `apps attest-skill` is NOT wired (Q-AS-1 ESCALATED to spec rev 4).
+ * `moltzap apps attest-skill --challenge-id <id> --skill-url <url> --version <v>`
+ *
+ * Wraps `apps/attestSkill`. All three flags required.
+ * Exits 0 on success with no stdout; error to stderr with non-zero exit
+ * (spec rev 4 addendum §3 Q-AS-1; Invariant §4.6).
  */
+const appsAttestSkillCommand = Command.make(
+  "attest-skill",
+  {
+    challengeId: challengeIdOption,
+    skillUrl: skillUrlOption,
+    version: versionOption,
+  },
+  ({ challengeId, skillUrl, version }) =>
+    runHandler(appsAttestSkillHandler({ challengeId, skillUrl, version })),
+).pipe(
+  Command.withDescription(
+    "Attest a skill for a session. All three flags are required.",
+  ),
+);
+
+/** `moltzap apps [register|create|list|get|close|attest-skill]` — subcommand group. */
 export const appsCommand = Command.make("apps", {}, () =>
   Effect.sync(() => {
     console.log(
-      "Usage: moltzap apps <register|create|list|get|close> [options]",
+      "Usage: moltzap apps <register|create|list|get|close|attest-skill> [options]",
     );
   }),
 ).pipe(
@@ -341,5 +369,6 @@ export const appsCommand = Command.make("apps", {}, () =>
     appsListCommand,
     appsGetCommand,
     appsCloseCommand,
+    appsAttestSkillCommand,
   ]),
 );


### PR DESCRIPTION
Closes #191 (sbd)
Spec rev 4 addendum (binding): https://github.com/chughtapan/safer-by-default/issues/177#issuecomment-4311863836
Architect doc: https://github.com/chughtapan/safer-by-default/issues/177#issuecomment-4311825849

## What changed

Single subcommand addition to the already-merged `packages/client/src/cli/commands/apps.ts`. Fills the Q-AS-1 escalation stub with a real implementation: `appsAttestSkillHandler` now calls `apps/attestSkill` and exits cleanly (no stdout on success per spec rev 4 addendum §3). Wires `appsAttestSkillCommand` into the `apps` group. Tests replace the escalation placeholder with success + RPC-failure paths.

## Plan anchors

| Change | Plan anchor |
|---|---|
| Replace stub `appsAttestSkillHandler` with `rpc("apps/attestSkill", ...).pipe(Effect.asVoid)` | Spec rev 4 addendum §3 Q-AS-1 — exit 0, no stdout, params `{challengeId, skillUrl, version}` |
| Add `appsAttestSkillCommand` with `--challenge-id`, `--skill-url`, `--version` options | Spec rev 4 addendum §3 — "flags verbatim per spec rev 4"; Architect doc §5 |
| Wire into `appsCommand.withSubcommands(...)` | Architect doc — "register in apps command group" |
| Update `appsCommand` usage string | Consistency with attest-skill addition |
| Replace ESCALATED stub test with success + RPC-failure tests | Cross-cutting floor — "success path + RPC-failure path per handler" |

## Scope

- Modules touched: `packages/client/src/cli/commands/apps.ts`, `packages/client/src/cli/commands/apps.test.ts`
- Tier (from safer-diff-scope): senior
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Tests

- `apps attest-skill` success: asserts `apps/attestSkill` called with `{challengeId, skillUrl, version}`, no stdout emitted
- `apps attest-skill` RPC failure: asserts `Effect` resolves as `Failure`
- All 14 tests pass (`pnpm --filter @moltzap/client test`)

## Simplify pass

One finding applied: `Effect.gen(function*() { yield* rpc(...) })` collapsed to `rpc(...).pipe(Effect.asVoid)` (efficiency — drops unnecessary generator wrapper).
Skip: `makeFakeTransport` duplication across 4 test files is pre-existing, out of scope for this diff.

## Codex verdict

`GATE: PASS` — "No actionable regressions were found in the changed handler, CLI wiring, or focused tests."

## Pre-commit hook note

Hook bypass used: `core.hooksPath=/dev/null` per dispatch brief (moltzap#208/#213 still unresolved).

## Confidence

HIGH — spec rev 4 addendum is unambiguous on flag names, exit behavior, and RPC params. Protocol schema at `packages/protocol/src/schema/methods/apps.ts:38-48` confirms `{challengeId, skillUrl, version}`. Build and tests green.

---

`/safer:review-senior` is mandatory before this PR merges.