### PR TITLE
[impl-junior] conversations/list cursor validation

### DIFF
--- a/packages/server/src/services/conversation.service.ts
+++ b/packages/server/src/services/conversation.service.ts
@@ -226,7 +226,20 @@ export class ConversationService {
   > {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
-        const cursorParam = cursor ?? null;
+        // Validate cursor as ISO-8601 timestamp before interpolation
+        let cursorParam: string | null = null;
+        if (cursor) {
+          const parsed = new Date(cursor);
+          if (
+            isNaN(parsed.getTime()) ||
+            parsed.toISOString() !== cursor
+          ) {
+            return yield* Effect.fail(
+              invalidParams(`cursor must be a valid ISO-8601 timestamp`),
+            );
+          }
+          cursorParam = cursor;
+        }
         const archivedFilter =
           archived === "only"
             ? sql`AND c.archived_at IS NOT NULL`


### PR DESCRIPTION
## Summary

Fix pathological cursor handling in conversations/list. Invalid cursors (e.g., " " or "not a date") now return typed InvalidParams (-32602) instead of Postgres SqlError wrapped as InternalError (-32603).

**Before:** cursor interpolated directly into SQL template without validation  
**After:** parse cursor as ISO-8601 timestamp; fail fast with InvalidParams

## Changes

- Single-file change: packages/server/src/services/conversation.service.ts:229
- Validate cursor as ISO-8601 before interpolation into SQL template
- Return InvalidParams (-32602) for invalid cursors
- Validation at service boundary preserves public contract—schema unchanged

## Testing

Validation logic verified against test cases:
- " " (whitespace) → Invalid
- "not a date" → Invalid
- "2024-04-24T21:00:00.000Z" → Valid
- null/undefined → Valid

## Status

- [x] Fix implemented
- [x] TypeScript compilation verified
- [ ] Ready for review

Fixes #225

---
Generated with Claude Code