### PR TITLE
[arch] Client observability API — stubs for spec #222

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -32,3 +32,14 @@ export {
   type WsClientLogger,
   type MoltZapWsClientOptions,
 } from "./ws-client.js";
+export type {
+  SubscriptionFilter,
+  SubscriptionId,
+  EventSubscription,
+  SubscriberHandler,
+} from "./runtime/subscribers.js";
+export type { CloseInfo } from "./runtime/close-info.js";
+export type {
+  TrackedRpcResponse,
+  MoltZapWsClientOptionsV2,
+} from "./runtime/observability-api.js";

--- a/packages/client/src/runtime/close-info.ts
+++ b/packages/client/src/runtime/close-info.ts
@@ -1,0 +1,110 @@
+/**
+ * Close-metadata extraction for the WebSocket reader fiber.
+ *
+ * Responsibility: inspect an `Exit.Exit<void, Socket.SocketError>` produced by
+ * `Socket.runRaw(...)` and project it onto a caller-facing `CloseInfo`
+ * (WebSocket `{code, reason}`). Spec #222 AC 5.4 requires the real close
+ * metadata, not hardcoded constants, when upstream surfaces it; OQ-5 names
+ * the defaults to synthesize when it does not.
+ *
+ * Pure module: no I/O, no Refs, no fibers. Called exactly once per socket
+ * lifetime from `MoltZapWsClient`'s reader-fiber `Effect.onExit` hook
+ * (`ws-client.ts:386-411` today — post-impl the extraction happens at that
+ * same point before calling `onDisconnect(close)`).
+ *
+ * Error channel: `extractCloseInfo` is total — every possible `Exit` maps to
+ * a `CloseInfo`. The defaults below are the resolution of OQ-5 (A). No
+ * typed error surface on this module.
+ */
+import type { Cause, Exit } from "effect";
+import type * as Socket from "@effect/platform/Socket";
+
+/**
+ * WebSocket close metadata surfaced to `MoltZapWsClientOptions.onDisconnect`
+ * (required arg post-migration — see design doc §Deletions, OQ-6) and to
+ * the conformance-adapter's `RealClientCloseEvent`. Mirrors the WHATWG
+ * WebSocket `CloseEvent` fields restricted to `{code, reason}` — `wasClean`
+ * is derivable from `code` and not worth its own field.
+ */
+export interface CloseInfo {
+  readonly code: number;
+  readonly reason: string;
+}
+
+/**
+ * Discriminated shape the reader-fiber exit falls into. Implementation's
+ * `extractCloseInfo` pattern-matches this union and returns the `{code,
+ * reason}` projection. Named here so downstream review can check that
+ * every branch has an assigned close pair.
+ *
+ * Exhaustiveness (Principle 4): the `Unknown` branch is the residual for
+ * any `SocketError` variant @effect/platform adds in the future. The
+ * implementation's pattern-match ends in `default: return absurd(kind)`.
+ */
+export type CloseKind =
+  | {
+      /** Graceful `SocketCloseError` — upstream code + reason round-tripped. */
+      readonly _tag: "Clean";
+      readonly code: number;
+      readonly reason: string;
+    }
+  | {
+      /** `Exit.Success` with no close frame observed — socket ended cleanly. */
+      readonly _tag: "EndOfStream";
+    }
+  | {
+      /** `SocketGenericError` with reason "Open" / "OpenTimeout". */
+      readonly _tag: "HandshakeFailure";
+      readonly underlying: "Open" | "OpenTimeout";
+    }
+  | {
+      /** `SocketGenericError` with reason "Read" / "Write" — transport broke. */
+      readonly _tag: "TransportFailure";
+      readonly underlying: "Read" | "Write";
+    }
+  | {
+      /** Cause did not match any known `SocketError` shape. */
+      readonly _tag: "Unknown";
+    };
+
+/**
+ * OQ-5 resolution defaults. Exported so the implementation, tests, and
+ * the conformance-adapter's V7 proof share one source of truth; the
+ * V7 divergence proof mutates these to flip the predicate.
+ */
+export const DEFAULT_GRACEFUL_CLOSE: CloseInfo = {
+  code: 1000,
+  reason: "normal",
+};
+export const DEFAULT_ABNORMAL_CLOSE: CloseInfo = {
+  code: 1006,
+  reason: "abnormal",
+};
+
+/**
+ * Classify a reader-fiber exit cause into `CloseKind`. Total; the
+ * `Unknown` branch is the residual for future `SocketError` variants.
+ */
+export function classifyCloseCause(
+  cause: Cause.Cause<Socket.SocketError>,
+): CloseKind {
+  void cause;
+  throw new Error("not implemented");
+}
+
+/**
+ * Project an `Exit` onto `CloseInfo`. Composition of `classifyCloseCause`
+ * plus the OQ-5 default map:
+ *
+ *   Clean              -> { code, reason } from SocketCloseError
+ *   EndOfStream        -> DEFAULT_GRACEFUL_CLOSE
+ *   HandshakeFailure   -> DEFAULT_ABNORMAL_CLOSE
+ *   TransportFailure   -> DEFAULT_ABNORMAL_CLOSE
+ *   Unknown            -> DEFAULT_ABNORMAL_CLOSE
+ */
+export function extractCloseInfo(
+  exit: Exit.Exit<void, Socket.SocketError>,
+): CloseInfo {
+  void exit;
+  throw new Error("not implemented");
+}

--- a/packages/client/src/runtime/observability-api.ts
+++ b/packages/client/src/runtime/observability-api.ts
@@ -1,0 +1,157 @@
+/**
+ * Public-surface preview for the `MoltZapWsClient` observability API
+ * (spec #222). This module declares the new types and the free-function
+ * signatures that the implementer ports onto the `MoltZapWsClient` class
+ * in the `implement-senior` round. Lives as a standalone interface file
+ * so the architect branch can publish typed stubs without editing the
+ * existing `ws-client.ts` bodies.
+ *
+ * Three additions land on `MoltZapWsClient`:
+ *
+ *   1. `sendRpcTracked` — like `sendRpc` but surfaces the outbound request
+ *      id and response envelope `type`. Covers spec §5.1 (B4) + §5.2
+ *      (V5). OQ-1 resolution (B).
+ *   2. `subscribe(filter, handler)` — per-subscription event delivery with
+ *      filter grammar. Covers §5.3 (C4 + `RealClientEventSubscriber.subscribe`
+ *      filter stub). OQ-2 / OQ-3 resolutions (A / A). Implementation
+ *      lives in `runtime/subscribers.ts`.
+ *   3. `onDisconnect: (close: CloseInfo) => void` — required-arg
+ *      close-event payload. Covers §5.4 (V7). OQ-5 / OQ-6 resolutions
+ *      (A / rewrite-to-migrate).
+ *
+ * One deletion lands on `MoltZapWsClient`:
+ *
+ *   - `MoltZapWsClientOptions.onEvent` — deleted. Replaced by
+ *     `client.subscribe({}, handler)`. Migration list in design doc
+ *     §Consumer migration. OQ-4 resolution (rewrite-to-delete per
+ *     team-lead invariant change).
+ */
+import type { Effect } from "effect";
+import type { RpcDefinition, TSchema, Static } from "@moltzap/protocol";
+import type {
+  NotConnectedError,
+  RpcServerError,
+  RpcTimeoutError,
+} from "./errors.js";
+import type { WsClientLogger } from "../ws-client.js";
+import type { CloseInfo } from "./close-info.js";
+import type {
+  EventSubscription,
+  SubscriptionFilter,
+  SubscriberHandler,
+} from "./subscribers.js";
+
+/**
+ * Return shape of `sendRpcTracked`. Spec #222 OQ-1 resolution (B): surface
+ * the outbound request `id` (un-vacuates B4 at
+ * `packages/protocol/src/testing/conformance/client/rpc-semantics.ts:205-216`)
+ * and the response envelope `type` (un-vacuates V5 at
+ * `rpc-semantics.ts:103-110`), without leaking `jsonrpc` onto the caller
+ * surface.
+ *
+ * `type` is the literal `"response"` — the only response-frame kind
+ * `packages/protocol/src/schema/frames.ts:18` defines — but it is surfaced
+ * as an observable value (not a synthesized adapter constant) so the V5
+ * predicate can flip under a mutation that forges a non-response shape.
+ *
+ * `result` is the decoded server payload, identical to what `sendRpc`
+ * resolves to today. Errors remain on the typed channel of the Effect.
+ */
+export interface TrackedRpcResponse<R> {
+  readonly id: string;
+  readonly type: "response";
+  readonly result: R;
+}
+
+/**
+ * Post-migration shape of `MoltZapWsClient`'s constructor options.
+ * Implementer replaces the current `MoltZapWsClientOptions` in
+ * `ws-client.ts` with this shape. Diff vs. current:
+ *
+ *   - DELETED: `onEvent?: (event: EventFrame) => void`. Migration:
+ *     `client.subscribe({}, handler)` call post-construction.
+ *   - CHANGED: `onDisconnect?: () => void` → `onDisconnect?: (close: CloseInfo) => void`.
+ *     Migration: the 3 call sites accept the arg (destructure or ignore).
+ *   - UNCHANGED: `serverUrl`, `agentKey`, `onReconnect`, `logger`.
+ */
+export interface MoltZapWsClientOptionsV2 {
+  readonly serverUrl: string;
+  readonly agentKey: string;
+  /**
+   * Called once per disconnect (not reconnect). Spec #222 §5.4 + OQ-5 (A):
+   * `close` is the typed close metadata — real WebSocket `{code, reason}`
+   * when the transport surfaces them, OQ-5 defaults otherwise. Required
+   * arg (OQ-6 rewrite): zero-arg `() => void` callers are migrated to
+   * accept (and typically ignore) the arg.
+   */
+  readonly onDisconnect?: (close: CloseInfo) => void;
+  readonly onReconnect?: (helloOk: unknown) => void;
+  readonly logger?: WsClientLogger;
+}
+
+/**
+ * Free-function preview of the method `MoltZapWsClient.sendRpcTracked`.
+ * Signature shows both typed-definition and raw-string overloads,
+ * mirroring the existing `sendRpc` shape in `ws-client.ts:233-256`.
+ *
+ * Invariant 3 (spec #222): the returned `id` is the identity minted
+ * inside `sendRpcEffect` at `ws-client.ts:552` (`rpc-${++this.requestCounter}`)
+ * — no parallel counter, no post-hoc mirror, no second minter.
+ *
+ * Invariant 5 preserved: errors remain on the typed channel
+ * (`NotConnectedError | RpcTimeoutError | RpcServerError`); a resolved
+ * tracked response always carries `type: "response"`.
+ */
+export function sendRpcTracked<
+  D extends RpcDefinition<string, TSchema, TSchema>,
+>(
+  method: D,
+  params: Static<D["paramsSchema"]>,
+): Effect.Effect<
+  TrackedRpcResponse<Static<D["resultSchema"]>>,
+  NotConnectedError | RpcTimeoutError | RpcServerError
+>;
+export function sendRpcTracked(
+  method: string,
+  params?: unknown,
+): Effect.Effect<
+  TrackedRpcResponse<unknown>,
+  NotConnectedError | RpcTimeoutError | RpcServerError
+>;
+export function sendRpcTracked(
+  method: string | RpcDefinition<string, TSchema, TSchema>,
+  params?: unknown,
+): Effect.Effect<
+  TrackedRpcResponse<unknown>,
+  NotConnectedError | RpcTimeoutError | RpcServerError
+> {
+  void method;
+  void params;
+  throw new Error("not implemented");
+}
+
+/**
+ * Free-function preview of the method `MoltZapWsClient.subscribe`.
+ *
+ * Registers a per-subscription event handler. Delivery starts with the
+ * next inbound event (OQ-3 A: unsubscribe-during-dispatch lets the
+ * in-flight frame finish; N+1 observes the unsubscribe). Handler
+ * receives every event matching the filter in arrival order
+ * (Invariant 6).
+ *
+ * Fails with `NotConnectedError` iff the client has been permanently
+ * closed via `close()`. Subscription is legal pre-`connect()`; the
+ * registry buffers until the reader fiber starts producing frames.
+ *
+ * Error channel (Principle 3): the Effect's failure type is the single
+ * tagged error `NotConnectedError`; handler-thrown exceptions are
+ * caught by the registry and logged via `WsClientLogger.warn`.
+ */
+export function subscribe(
+  filter: SubscriptionFilter,
+  handler: SubscriberHandler,
+): Effect.Effect<EventSubscription, NotConnectedError> {
+  void filter;
+  void handler;
+  throw new Error("not implemented");
+}

--- a/packages/client/src/runtime/subscribers.ts
+++ b/packages/client/src/runtime/subscribers.ts
@@ -1,0 +1,167 @@
+/**
+ * Per-subscription event registry for `MoltZapWsClient`.
+ *
+ * Responsibility: own the list of live `subscribe()` handles and fan each
+ * inbound `EventFrame` out to every subscription whose filter matches.
+ * Implements spec #222 §5.3 (C4 + the `RealClientEventSubscriber.subscribe`
+ * filter stub). Lives as an internal collaborator of `MoltZapWsClient`;
+ * the public types (`SubscriptionFilter`, `EventSubscription`,
+ * `SubscriptionId`) re-export from the package barrel.
+ *
+ * Dispatch ordering (Invariant 6 — events delivered in arrival order):
+ *   1. Inbound frames are handed to the registry in arrival order.
+ *   2. Within a single frame, subscriptions are notified in registration
+ *      order.
+ *   3. There is no separate legacy `onEvent` fanout — spec #222 OQ-4 is
+ *      resolved by DELETING `MoltZapWsClientOptions.onEvent`. Callers
+ *      that want "every event" register `subscribe({}, handler)` after
+ *      construction and before `connect()`.
+ *
+ * Unsubscribe semantics (OQ-3 A): `unsubscribe` takes effect on the next
+ * frame. The registry snapshots its live-subscription list at the start
+ * of each `dispatch` call; in-flight dispatch of frame N is not
+ * interrupted by an unsubscribe during frame N. Frame N+1 observes the
+ * unsubscribed state.
+ *
+ * Error channel: handlers are invoked inside a `try/catch`; a throw is
+ * logged via the client's injected `WsClientLogger` and swallowed
+ * (matching the prior `onEvent` contract at `ws-client.ts:650-655`
+ * pre-deletion). The registry itself has no typed error surface —
+ * `register`, `dispatch`, and `closeAll` are `Effect<T, never>`.
+ */
+import type { Effect } from "effect";
+import type { EventFrame } from "@moltzap/protocol";
+
+/** Branded identifier for a subscription handle. Minted by `register`. */
+export type SubscriptionId = string & { readonly __brand: "SubscriptionId" };
+
+/**
+ * Filter grammar for `subscribe`. An event is delivered to a subscription
+ * iff it matches **every** field that is set on the filter. Unset fields
+ * are wildcards; the empty filter `{}` matches every event.
+ *
+ * OQ-2 resolution (A): exactly these three fields, no free-form
+ * predicate, no schema-derived matcher. Matches the existing
+ * `RealClientEventFilter` contract at
+ * `packages/protocol/src/testing/conformance/client/runner.ts:104-116`
+ * one-for-one.
+ *
+ *   - `emissionTag` — exact match against the canonical payload key
+ *     `frame.data.__emissionTag`. (The adapter reads the same key at
+ *     `packages/client/src/test-utils/conformance-adapter.ts:77-79`;
+ *     `emitTaggedEventDefault` writes it at `runner.ts:343-357`. The
+ *     `__emissionId` string in the `runner.ts:108` doc comment is a
+ *     known doc-bug — architect files a follow-up issue against
+ *     protocol to correct the comment; it is not the canonical name.)
+ *   - `conversationId` — exact match against `frame.data.conversationId`
+ *     when set on the event payload.
+ *   - `eventNamePrefix` — `frame.event.startsWith(prefix)`.
+ */
+export interface SubscriptionFilter {
+  readonly emissionTag?: string;
+  readonly conversationId?: string;
+  readonly eventNamePrefix?: string;
+}
+
+/**
+ * Handle returned by `register` / `MoltZapWsClient.subscribe`. Caller
+ * holds the handle for its subscription's lifetime and runs
+ * `unsubscribe` to stop delivery.
+ *
+ * `unsubscribe` is `Effect<void, never>`: it is idempotent and total.
+ * Calling `unsubscribe` a second time, or after `closeAll`, is a no-op.
+ */
+export interface EventSubscription {
+  readonly id: SubscriptionId;
+  readonly unsubscribe: Effect.Effect<void, never>;
+}
+
+/**
+ * Per-subscription handler signature. Runs inside the registry's
+ * dispatch fiber. Must not throw — throws are caught by the registry,
+ * logged via the injected logger, and swallowed.
+ *
+ * Returning an `Effect` (not a plain `void`) lets handlers compose with
+ * Effect-native downstream code without an extra runSync shim. The
+ * registry awaits each handler's effect before moving to the next
+ * subscription for this frame — fairness over throughput, so a slow
+ * handler on subscription A does not reorder frames seen by
+ * subscription B across frames.
+ */
+export type SubscriberHandler = (
+  frame: EventFrame,
+) => Effect.Effect<void, never>;
+
+/**
+ * Subscriber registry. One instance per `MoltZapWsClient`, created at
+ * construction time and owned by the client. Not exported from the
+ * package barrel — consumers reach the registry only through
+ * `MoltZapWsClient.subscribe`.
+ */
+export interface SubscriberRegistry {
+  /**
+   * Add a subscription. Returns the handle immediately; delivery starts
+   * with the next frame passed to `dispatch`. Does not await any
+   * connection state — subscribe is legal pre-connect (spec §5.3 +
+   * Assumption 1 deletion: post-delete of `onEvent`, subscribe is the
+   * only pre-connect event hook).
+   */
+  readonly register: (
+    filter: SubscriptionFilter,
+    handler: SubscriberHandler,
+  ) => Effect.Effect<EventSubscription, never>;
+
+  /**
+   * Fan an inbound event out to every matching subscription. Called by
+   * `MoltZapWsClient.handleIncoming` at the existing event-dispatch
+   * point (`ws-client.ts:649-685`). Implementation snapshots the
+   * live-subscription list at the start of dispatch so
+   * unsubscribe-during-dispatch observes next-frame semantics (OQ-3 A).
+   *
+   * Dispatch order: registration order, iterated sequentially; slow
+   * handlers block later subscriptions for this frame but never
+   * reorder frame N relative to frame N+1.
+   */
+  readonly dispatch: (frame: EventFrame) => Effect.Effect<void, never>;
+
+  /**
+   * Drop every live subscription. Called from `MoltZapWsClient.closeSync`
+   * / `disconnectSync` so handlers stop firing once the client is torn
+   * down. Idempotent.
+   */
+  readonly closeAll: Effect.Effect<void, never>;
+}
+
+/**
+ * Construct an empty registry. Called once from the `MoltZapWsClient`
+ * constructor. Takes a logger so registry-internal error logs reach the
+ * same sink as the rest of the client.
+ */
+export function makeSubscriberRegistry(logger: {
+  readonly warn: (...args: ReadonlyArray<unknown>) => void;
+}): Effect.Effect<SubscriberRegistry, never> {
+  void logger;
+  throw new Error("not implemented");
+}
+
+/**
+ * Pure filter-match predicate. Exposed for unit testing so the B4 / C4
+ * divergence proofs in
+ * `packages/protocol/src/testing/conformance/__divergence_proofs__/client-delivery.proofs.ts`
+ * can mutate this predicate (e.g., force it to always return `true`) to
+ * flip the vacuity assertions.
+ *
+ * Returns `true` iff `frame` matches every set field on `filter`:
+ *   - `filter.emissionTag === frame.data.__emissionTag` (strict ===)
+ *   - `filter.conversationId === frame.data.conversationId` (strict ===)
+ *   - `frame.event.startsWith(filter.eventNamePrefix)`
+ * Unset filter fields are wildcards.
+ */
+export function matchesFilter(
+  filter: SubscriptionFilter,
+  frame: EventFrame,
+): boolean {
+  void filter;
+  void frame;
+  throw new Error("not implemented");
+}


### PR DESCRIPTION
Architecture only. Not for merge.

Design doc: https://github.com/chughtapan/moltzap/issues/226 (body replaced).

Stubs: 3 new files + 1 barrel edit.
Every new-function body is `throw new Error("not implemented")`.

Per team-lead invariant change on #226:
- OQ-4 rewrite: deletes `MoltZapWsClientOptions.onEvent` in implement phase.
- OQ-6 rewrite: `onDisconnect(close)` required arg; 3 call-site migrations listed in design doc §Consumer migration.