### PR TITLE
[impl-senior] conversations/list cursor validation

### DIFF
--- a/packages/server/src/services/conversation.service.ts
+++ b/packages/server/src/services/conversation.service.ts
@@ -226,7 +226,16 @@ export class ConversationService {
   > {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
-        const cursorParam = cursor ?? null;
+        let cursorParam: string | null = null;
+        if (cursor != null) {
+          const parsed = new Date(cursor);
+          if (isNaN(parsed.getTime()) || parsed.toISOString() !== cursor) {
+            return yield* Effect.fail(
+              invalidParams("Cursor must be an ISO-8601 timestamp"),
+            );
+          }
+          cursorParam = cursor;
+        }
         const archivedFilter =
           archived === "only"
             ? sql`AND c.archived_at IS NOT NULL`


### PR DESCRIPTION
## Summary

Fixes `conversations/list` cursor injection into Postgres `timestamptz` without validation (issue #225).

### Before

```ts
const cursorParam = cursor ?? null;
// ...
${cursorParam ? sql`AND c.updated_at < ${cursorParam}` : sql``}
```

Passing `cursor: " "` or `cursor: "not a date"` reached Postgres directly →
`ERROR: invalid input syntax for type timestamp with time zone` → `SqlError` → wire-level `InternalError` (-32603).

### After

```ts
let cursorParam: string | null = null;
if (cursor != null) {
  const parsed = new Date(cursor);
  if (isNaN(parsed.getTime()) || parsed.toISOString() !== cursor) {
    return yield* Effect.fail(
      invalidParams("Cursor must be an ISO-8601 timestamp"),
    );
  }
  cursorParam = cursor;
}
```

Invalid cursors (including whitespace-only strings) now return typed `InvalidParams` (-32602) before touching the database.
The round-trip check (`toISOString() === cursor`) also rejects valid ISO dates that aren't in the server's own `YYYY-MM-DDTHH:mm:ss.sssZ` format, which is the only format cursors can legitimately arrive in (they are values the server previously returned via `.toISOString()`).

### Typed-error evidence

| Input | Before | After |
|-------|--------|-------|
| `cursor: " "` | `InternalError (-32603)` via SqlError | `InvalidParams (-32602)` |
| `cursor: "not a date"` | `InternalError (-32603)` via SqlError | `InvalidParams (-32602)` |
| `cursor: "2024-01-15T10:30:00.000Z"` | ✅ succeeds | ✅ succeeds |
| no cursor | ✅ succeeds | ✅ succeeds |

### Diff stat

```
packages/server/src/services/conversation.service.ts | 11 ++++++++++-
 1 file changed, 10 insertions(+), 1 deletion(-)
```

### /simplify log

Three agents reviewed the diff (reuse, quality, efficiency):
- **Reuse**: No existing ISO-8601 validator found; inline approach is correct.
- **Quality**: Capitalized error message for consistency with other `invalidParams` calls (`"Cursor must be..."` → fixed).
- **Efficiency**: Round-trip check over `!isNaN` alone is intentionally strict — cursors are server-emitted values; no unnecessary work on valid paths.

Closes #225