### PR TITLE
[impl-senior] fix(conformance): drop 2 vacuous predicates

### DIFF
--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/client-boundary.proofs.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/client-boundary.proofs.ts
@@ -14,14 +14,14 @@ describe.skip("registerSchemaExhaustiveFuzzClient — divergence proofs", () => 
     expect(true).toBe(true);
   });
 
-  it("fails when the real client leaks a fuzzed task-B event into task-A subscriber", () => {
-    // Mutation: in the subscription filter, replace the per-task
-    //   predicate with `() => true` specifically for fuzzed payloads
-    //   (e.g. when `source === "fuzz"`).
-    // Predicate broken: client/boundary.ts — C4-shape post-fuzz
-    //   assertion leg of registerSchemaExhaustiveFuzzClient.
-    // Expected observable: property fails; task-A subscriber
-    //   observes tagged task-B events.
+  it("fails when the real client drops all events after a fuzz burst", () => {
+    // Mutation: in the real client's inbound handler, after receiving any
+    //   frame with an arbitrary-shape payload, set a "fuzz-poisoned" flag
+    //   and silently drop all subsequent frames including the liveness probe.
+    // Predicate broken: client/boundary.ts — liveness probe leg of
+    //   registerSchemaExhaustiveFuzzClient (observed.length === 0 check).
+    // Expected observable: property fails; post-fuzz tagged event never
+    //   surfaces on the subscriber before the budget expires.
     // Last verified: pending real-client mutation.
     expect(true).toBe(true);
   });

--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/client-schema-conformance.proofs.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/client-schema-conformance.proofs.ts
@@ -26,16 +26,14 @@ describe.skip("registerEventWellFormednessClient — divergence proofs", () => {
 });
 
 describe.skip("registerMalformedFrameHandlingClient — divergence proofs", () => {
-  it("fails when the real client crashes the process on a bit-flipped frame", () => {
+  it("fails when the real client crashes and disconnects on a bit-flipped frame", () => {
     // Mutation: in the real client's frame-decode path, remove the
     //   try/catch around `JSON.parse` so a bit-flipped inbound frame
-    //   throws out of the socket read loop.
-    // Predicate broken: client/schema-conformance.ts — "no crash" leg
-    //   of registerMalformedFrameHandlingClient's conjunction
-    //   (observable via `RealClientHandle.closeSignal` firing).
-    // Expected observable: property fails; closeSignal resolves with
-    //   reason matching the decode exception; liveness probe times
-    //   out.
+    //   throws out of the socket read loop, disconnecting the client.
+    // Predicate broken: client/schema-conformance.ts — liveness leg of
+    //   registerMalformedFrameHandlingClient; a disconnected client
+    //   cannot receive the post-malformed tagged event within deadline.
+    // Expected observable: property fails; liveness probe times out.
     // Last verified: pending real-client mutation.
     expect(true).toBe(true);
   });
@@ -44,7 +42,7 @@ describe.skip("registerMalformedFrameHandlingClient — divergence proofs", () =
     // Mutation: in the real client's reader loop, set a "poisoned"
     //   flag after the first malformed frame and return early from
     //   every subsequent decode.
-    // Predicate broken: client/schema-conformance.ts — "liveness" leg
+    // Predicate broken: client/schema-conformance.ts — liveness leg
     //   of registerMalformedFrameHandlingClient.
     // Expected observable: property fails; post-malformed tagged
     //   event never surfaces on the subscriber before deadline.

--- a/packages/protocol/src/testing/conformance/client/boundary.ts
+++ b/packages/protocol/src/testing/conformance/client/boundary.ts
@@ -27,11 +27,9 @@ const PROPERTY_BUDGET_MS = 12_000;
  * many shapes to a real client. Properties interleave with a tagged
  * liveness probe and a task-boundary assertion.
  *
- * Predicate (all three must hold):
+ * Predicate (both must hold):
  *   1. No crash — real client stays `ready`; no spurious closeSignal.
  *   2. Liveness probe — a valid tagged event emitted post-fuzz surfaces.
- *   3. Task-boundary cleanliness — no cross-wiring on the tagged
- *      observation surface.
  */
 export function registerSchemaExhaustiveFuzzClient(
   ctx: ClientConformanceRunContext,
@@ -95,17 +93,6 @@ export function registerSchemaExhaustiveFuzzClient(
               CATEGORY,
               "schema-exhaustive-fuzz-client",
               "liveness probe never surfaced after fuzz burst",
-            ),
-          );
-        }
-        // (3) Task-boundary cleanliness: the liveness probe's surfaced
-        // tag must be exactly the emitted one — no cross-wiring.
-        if (observed[0]!.tag !== tag) {
-          return yield* Effect.fail(
-            invariant(
-              CATEGORY,
-              "schema-exhaustive-fuzz-client",
-              `cross-wired: expected tag ${tag}, got ${observed[0]!.tag}`,
             ),
           );
         }

--- a/packages/protocol/src/testing/conformance/client/schema-conformance.ts
+++ b/packages/protocol/src/testing/conformance/client/schema-conformance.ts
@@ -14,11 +14,10 @@
  *     `emissionTag` via `ClientHandshakeWindow.emitTaggedEvent` — auto-
  *     subscribe / hello / resume frames never satisfy a predicate.
  *   - O6 (#200): when spec names a typed error, assert exact match.
- *     A4 client half: `MalformedFrameError`
- *     (`packages/client/src/runtime/errors.ts`) is the documented type.
- *     Predicate accepts either "silently dropped + liveness probe
- *     surfaces" OR "typed MalformedFrameError fires"; never a generic
- *     error.
+ *     A4 client half: `MalformedFrameError` is documented; the adapter
+ *     exposes no typed error channel, so the predicate checks liveness
+ *     only — a client that crashes on a malformed frame will disconnect,
+ *     preventing the subsequent liveness probe from surfacing.
  */
 import { Effect } from "effect";
 import { Value } from "@sinclair/typebox/value";
@@ -120,16 +119,12 @@ export function registerEventWellFormednessClient(
 
 /**
  * A4 client half — TestServer emits a bit-flipped / truncated /
- * oversized frame tagged with `emissionTag`; real client either (a)
- * drops silently OR (b) surfaces a typed `MalformedFrameError` on its
- * documented error channel. A subsequent tagged valid event still
- * surfaces (liveness proof, mirrors #187 round-5 guard).
+ * oversized frame; real client drops it silently. A subsequent tagged
+ * valid event still surfaces (liveness proof, mirrors #187 round-5
+ * guard). A client that crashes on the malformed frame disconnects,
+ * preventing the liveness probe from surfacing within the deadline.
  *
- * Predicate conjunction (all three must hold):
- *   - no process / fiber crash observable to the suite's Scope
- *   - reaction in {drop, typed MalformedFrameError} — generic
- *     `Error` or untyped disconnect fails
- *   - liveness: next tagged event surfaces within deadline
+ * Predicate: liveness — next tagged event surfaces within deadline.
  */
 export function registerMalformedFrameHandlingClient(
   ctx: ClientConformanceRunContext,
@@ -138,7 +133,7 @@ export function registerMalformedFrameHandlingClient(
     ctx,
     CATEGORY,
     "malformed-frame-handling-client",
-    "malformed TestServer emission drops or surfaces MalformedFrameError; liveness intact",
+    "malformed TestServer emission absorbed silently; liveness intact",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(


### PR DESCRIPTION
## Summary

Closes #223.

Two client-side conformance predicates were vacuously asserted — the code claimed to check something that was structurally impossible to observe:

**E2 leg 3 (`boundary.ts`):** `if (observed[0]!.tag !== tag)` was unreachable. `collectTagged(t => t === tag)` already guarantees every returned item satisfies `t === tag`, so the cross-wiring branch could never fire. Removed the block; updated JSDoc from "all three must hold" → "both must hold".

**V6 A4 (`schema-conformance.ts`):** The docstring claimed the predicate was a 3-leg conjunction (no-crash + typed-error-or-drop + liveness), but the adapter exposes no typed `MalformedFrameError` channel and adding a `closeRace` check introduced a false positive (invalid-UTF-8 bit-flips cause RFC 6455 protocol close, firing `closeSignal` on a compliant client). The code was already liveness-only; aligned the comment and property description string to match.

Also re-aimed the two divergence proof `it()` descriptions to reference the liveness leg that each property actually asserts, so they document real observable failures.

## Before / After

| | Before | After |
|---|---|---|
| E2 leg 3 predicate | `observed[0]!.tag !== tag` (unreachable) | removed |
| A4 predicate description | "3-leg conjunction: no-crash + typed-error-or-drop + liveness" | "liveness — next tagged event surfaces within deadline" |
| A4 property string | `"...drops or surfaces MalformedFrameError; liveness intact"` | `"...absorbed silently; liveness intact"` |
| E2 proof test 2 | "leaks fuzzed task-B into task-A subscriber" | "drops all events after fuzz burst" |
| A4 proof test 1 | "crashes the process on a bit-flipped frame" (ref'd non-existent no-crash leg) | "crashes and disconnects on bit-flipped frame" (refs liveness leg) |

## Verification

- `bash packages/protocol/scripts/check-divergence-proofs.sh` → **OK (1 tombstoned, all live registrars have proofs)**
- `pnpm -F @moltzap/protocol build` → clean
- `SKIP_DOCKER=1 pnpm -F @moltzap/server-core test:conformance` → **1 passed / 45 skipped / 0 failed**
- Pre-commit hook (oxfmt + lint + typecheck + sloppy-code-guard) → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)