### PR TITLE
[impl-senior] fix: TransportDecodeError + process hang on direct WS commands (sbd#198)

### DIFF
--- a/packages/client/src/cli/transport.test.ts
+++ b/packages/client/src/cli/transport.test.ts
@@ -8,6 +8,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   decideTransport,
   resolveTransportInputs,
+  tagWsError,
+  TransportDecodeError,
+  TransportRpcError,
+  ServiceUnreachableError,
+  TransportTimeoutError,
   type TransportOptions,
 } from "./transport.js";
 
@@ -94,6 +99,62 @@ describe("decideTransport", () => {
       ),
     );
     expect(invocations).toBe(0);
+  });
+});
+
+/**
+ * Regression guard for sbd#198: `Effect.runPromise` wrapping of `sendRpc`
+ * produced `FiberFailureImpl` (with `_tag = undefined`), causing `tagWsError`'s
+ * default branch to emit `TransportDecodeError` for every ws error. `tagWsError`
+ * is `@internal`-exported so this suite can reach it without a mock WS server.
+ */
+describe("tagWsError — maps ws-client error tags to TransportError variants", () => {
+  it("RpcServerError maps to TransportRpcError (not TransportDecodeError)", () => {
+    const err = tagWsError("apps/listSessions", {
+      _tag: "RpcServerError",
+      code: -32001,
+      message: "session not found",
+    });
+    expect(err).toBeInstanceOf(TransportRpcError);
+    expect(err._tag).toBe("TransportRpcError");
+    if (err instanceof TransportRpcError) {
+      expect(err.code).toBe(-32001);
+      expect(err.message).toBe("session not found");
+    }
+  });
+
+  it("NotConnectedError maps to ServiceUnreachableError", () => {
+    const err = tagWsError("apps/listSessions", { _tag: "NotConnectedError" });
+    expect(err).toBeInstanceOf(ServiceUnreachableError);
+    expect(err._tag).toBe("ServiceUnreachableError");
+  });
+
+  it("RpcTimeoutError maps to TransportTimeoutError with timeoutMs forwarded", () => {
+    const err = tagWsError("apps/listSessions", {
+      _tag: "RpcTimeoutError",
+      timeoutMs: 15_000,
+    });
+    expect(err).toBeInstanceOf(TransportTimeoutError);
+    if (err instanceof TransportTimeoutError) {
+      expect(err.timeoutMs).toBe(15_000);
+    }
+  });
+
+  it("default branch (unknown _tag) maps to TransportDecodeError", () => {
+    const err = tagWsError("apps/listSessions", {
+      _tag: "SomeUnknownError",
+    });
+    expect(err).toBeInstanceOf(TransportDecodeError);
+  });
+
+  it("FiberFailureImpl-shaped error (no _tag) maps to TransportDecodeError — not to TransportRpcError", () => {
+    // Simulates FiberFailureImpl (_tag absent): pre-fix behaviour hit the
+    // default branch and emitted TransportDecodeError for every server error.
+    const err = tagWsError("apps/listSessions", {
+      message: "some unknown error",
+    });
+    expect(err).toBeInstanceOf(TransportDecodeError);
+    expect(err._tag).toBe("TransportDecodeError");
   });
 });
 

--- a/packages/client/src/cli/transport.test.ts
+++ b/packages/client/src/cli/transport.test.ts
@@ -3,18 +3,45 @@
  * boundary checks. Integration coverage of the direct-WS branch lives in
  * the E2E fixture (`__tests__/cli-multi-agent.int.test.ts`).
  */
-import { Effect } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Cause, Effect, Exit, Option } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RpcServerError } from "../runtime/errors.js";
 import {
   decideTransport,
+  makeTransportLayer,
   resolveTransportInputs,
   tagWsError,
+  Transport,
   TransportDecodeError,
   TransportRpcError,
   ServiceUnreachableError,
   TransportTimeoutError,
   type TransportOptions,
 } from "./transport.js";
+
+/**
+ * Module-level mock so transport.ts's `new MoltZapWsClient(...)` call is
+ * intercepted for the composed-rpc test below. Existing tests (decideTransport,
+ * tagWsError, resolveTransportInputs) do not exercise the ws-client path, so
+ * the mock is a no-op for them.
+ */
+vi.mock("../ws-client.js", async () => {
+  const effect = await import("effect");
+  const errors = await import("../runtime/errors.js");
+  return {
+    MoltZapWsClient: vi.fn().mockImplementation(() => ({
+      connect: () => effect.Effect.void,
+      sendRpc: (_method: string, _params: unknown) =>
+        effect.Effect.fail(
+          new errors.RpcServerError({
+            code: -32001,
+            message: "item not found",
+          }),
+        ),
+      close: () => effect.Effect.void,
+    })),
+  };
+});
 
 const makeOpts = (over: Partial<TransportOptions> = {}): TransportOptions => ({
   serverUrl: "wss://example.test",
@@ -103,10 +130,15 @@ describe("decideTransport", () => {
 });
 
 /**
- * Regression guard for sbd#198: `Effect.runPromise` wrapping of `sendRpc`
- * produced `FiberFailureImpl` (with `_tag = undefined`), causing `tagWsError`'s
- * default branch to emit `TransportDecodeError` for every ws error. `tagWsError`
- * is `@internal`-exported so this suite can reach it without a mock WS server.
+ * Regression guard for sbd#198: the original v2 implementation at 069135d
+ * used `Effect.runPromise(sendRpc)` inside `Effect.tryPromise`. In Effect 3.21,
+ * `runPromise` wraps typed failures in `FiberFailureImpl` (no `_tag`), so
+ * `tagWsError`'s switch hit the default branch and emitted `TransportDecodeError`
+ * for every ws error. Fixed by code-guard commit ff2de0d; these tests guard
+ * against regression to that pattern.
+ *
+ * `tagWsError` is `@internal`-exported so this suite can reach it directly
+ * without a mock WS server.
  */
 describe("tagWsError — maps ws-client error tags to TransportError variants", () => {
   it("RpcServerError maps to TransportRpcError (not TransportDecodeError)", () => {
@@ -140,16 +172,10 @@ describe("tagWsError — maps ws-client error tags to TransportError variants", 
     }
   });
 
-  it("default branch (unknown _tag) maps to TransportDecodeError", () => {
-    const err = tagWsError("apps/listSessions", {
-      _tag: "SomeUnknownError",
-    });
-    expect(err).toBeInstanceOf(TransportDecodeError);
-  });
-
   it("FiberFailureImpl-shaped error (no _tag) maps to TransportDecodeError — not to TransportRpcError", () => {
-    // Simulates FiberFailureImpl (_tag absent): pre-fix behaviour hit the
-    // default branch and emitted TransportDecodeError for every server error.
+    // Guards the regression: a future runPromise bridge would produce an object
+    // with no _tag (FiberFailureImpl shape). This pins the default branch to
+    // TransportDecodeError so the error is observable, not silently swallowed.
     const err = tagWsError("apps/listSessions", {
       message: "some unknown error",
     });
@@ -192,5 +218,41 @@ describe("resolveTransportInputs (composition-boundary gate)", () => {
     expect(opts.impersonateKey).toBeUndefined();
     expect(opts.profileKey).toBeUndefined();
     expect(opts.socketPath).toBeDefined();
+  });
+});
+
+/**
+ * Composed rpc() failure path — pins the full call chain so a future
+ * regression to `Effect.runPromise(sendRpc)` inside `Effect.tryPromise`
+ * is caught here, not just in the isolated `tagWsError` suite above.
+ *
+ * The ws-client mock (module-level `vi.mock("../ws-client.js")`) makes
+ * `sendRpc` return `Effect.fail(new RpcServerError(...))` so the test
+ * exercises: connect (success) → sendRpc (RpcServerError) → tagWsError
+ * → TransportRpcError. A runPromise bridge would wrap RpcServerError in
+ * FiberFailureImpl (no _tag) and the result would be TransportDecodeError.
+ */
+describe("makeDirectTransport — composed rpc() failure path", () => {
+  it("RpcServerError from sendRpc propagates as TransportRpcError through tagWsError", async () => {
+    const opts: TransportOptions = {
+      impersonateKey: "test-key",
+      serverUrl: "wss://test.example",
+    };
+    const exit = await Effect.runPromise(
+      Transport.pipe(
+        Effect.flatMap((t) => t.rpc("apps/listSessions", {})),
+        Effect.exit,
+        Effect.provide(makeTransportLayer(opts)),
+      ),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure)).toBe(true);
+      if (Option.isSome(failure)) {
+        expect(failure.value).toBeInstanceOf(TransportRpcError);
+        expect(failure.value._tag).toBe("TransportRpcError");
+      }
+    }
   });
 });

--- a/packages/client/src/cli/transport.ts
+++ b/packages/client/src/cli/transport.ts
@@ -253,20 +253,19 @@ export const tagWsError = (
 /**
  * Build a direct-WebSocket transport. Requires `Scope` so `Layer.scoped`
  * can install a finalizer via `Effect.addFinalizer`. The finalizer fires on
- * fiber interruption (SIGINT/SIGTERM), closing the ws-client and its internal
- * ManagedRuntime + reader fiber. Normal command exits call `process.exit`
- * explicitly via `runHandler`, which preempts the finalizer but terminates
- * the process anyway (see `runHandler` below). This replaces the fragile
- * `process.once("beforeExit", ...)` hook which never fired because the reader
- * fiber kept the event loop non-empty.
+ * fiber interruption (SIGINT/SIGTERM) — closing the ws-client and its internal
+ * ManagedRuntime — and also runs on normal completion so the event loop drains
+ * naturally without a forced `process.exit`. This replaces the fragile
+ * `process.once("beforeExit", ...)` hook that never fired because the reader
+ * fiber kept the event loop non-empty (sbd#198 Bug-2 / moltzap#228).
+ *
+ * `MoltZapWsClient` is constructed lazily inside `Effect.cached` so commands
+ * that never reach the wire (e.g. help-text display, input validation failure)
+ * do not pay for a ManagedRuntime spin-up.
  *
  * `sendRpc` is composed entirely in Effect-land — no `Effect.runPromise`
  * bridge — so typed errors (`NotConnectedError`, `RpcTimeoutError`,
- * `RpcServerError`) flow through `tagWsError` without being wrapped in
- * `FiberFailureImpl` (the root cause of sbd#198 / moltzap#228).
- *
- * `Effect.cached` memoises the connect handshake so a command that issues
- * multiple RPCs (e.g. `apps list` then `apps get`) only opens one socket.
+ * `RpcServerError`) flow through `tagWsError` with their `_tag` intact.
  */
 const makeDirectTransport = (
   serverUrl: string,
@@ -288,17 +287,25 @@ const makeDirectTransport = (
       );
     }
 
-    const client = new MoltZapWsClient({ serverUrl, agentKey });
-
-    // Finalizer fires on SIGINT/SIGTERM (fiber interrupt). On normal exits,
-    // runHandler calls process.exit which preempts this, but the client is
-    // terminated by the OS regardless.
-    yield* Effect.addFinalizer(() => client.close());
+    // Lazily-created client: null until the first rpc() call fires connectOnce.
+    // The finalizer checks the current value at scope-close time so help/
+    // validation paths that never open a socket incur no cleanup cost.
+    let client: MoltZapWsClient | null = null;
+    yield* Effect.addFinalizer(() =>
+      client !== null ? client.close() : Effect.void,
+    );
 
     // Memoize the connect handshake: only one round-trip per invocation,
     // cached for the lifetime of this scope.
     const connectOnce = yield* Effect.cached(
-      client.connect().pipe(Effect.mapError((e) => tagWsError("connect", e))),
+      Effect.gen(function* () {
+        const c = new MoltZapWsClient({ serverUrl, agentKey });
+        client = c;
+        yield* c
+          .connect()
+          .pipe(Effect.mapError((e) => tagWsError("connect", e)));
+        return c;
+      }),
     );
 
     return {
@@ -308,8 +315,8 @@ const makeDirectTransport = (
         params: Record<string, unknown>,
       ): Effect.Effect<Result, TransportError> =>
         connectOnce.pipe(
-          Effect.flatMap(() =>
-            client
+          Effect.flatMap((c) =>
+            c
               .sendRpc(method, params)
               .pipe(Effect.mapError((e) => tagWsError(method, e))),
           ),
@@ -395,10 +402,10 @@ export const rpc = <Result>(
  * a generic fallback. Shared across every v2 subcommand wrapper so the
  * exit-code contract (Invariant §4.6) has a single implementation.
  *
- * Both branches call `process.exit` explicitly. On success, `exit(0)` flushes
- * any lingering event-loop handles (e.g. the ws-client's ManagedRuntime
- * dispose) that would otherwise prevent the one-shot CLI process from
- * terminating naturally (sbd#198 / moltzap#228 Bug-2 fix).
+ * On success, this returns normally and relies on the `Layer.scoped`
+ * finalizer in `makeDirectTransport` to close the ws-client and drain
+ * the event loop (sbd#198 / moltzap#228 Bug-2 fix). No forced
+ * `process.exit(0)` — that would truncate piped stdout on large payloads.
  */
 export const runHandler = <
   E extends { readonly message?: string; readonly _tag?: string },
@@ -416,7 +423,6 @@ export const runHandler = <
         process.exit(1);
       }),
     ),
-    Effect.zipRight(Effect.sync(() => process.exit(0))),
   );
 
 /**

--- a/packages/client/src/cli/transport.ts
+++ b/packages/client/src/cli/transport.ts
@@ -14,7 +14,7 @@
  * directly via `Effect.provideService`.
  */
 import * as net from "node:net";
-import { Context, Data, Effect, Layer } from "effect";
+import { Context, Data, Effect, Layer, Scope } from "effect";
 import { MoltZapService } from "../service.js";
 import { MoltZapWsClient } from "../ws-client.js";
 import { request as daemonRequest } from "./socket-client.js";
@@ -216,7 +216,8 @@ const makeDaemonTransport = (socketPath: string): Transport => ({
 // Map ws-client errors (NotConnectedError | RpcTimeoutError | RpcServerError)
 // to TransportError tags. Names are matched via _tag rather than instanceof
 // to avoid a circular import chain through runtime/errors.
-const tagWsError = (
+/** @internal exported for decoder-fixture tests only (sbd#198). */
+export const tagWsError = (
   method: string,
   err: {
     readonly _tag?: string;
@@ -249,10 +250,28 @@ const tagWsError = (
   }
 };
 
+/**
+ * Build a direct-WebSocket transport. Requires `Scope` so `Layer.scoped`
+ * can install a finalizer via `Effect.addFinalizer`. The finalizer fires on
+ * fiber interruption (SIGINT/SIGTERM), closing the ws-client and its internal
+ * ManagedRuntime + reader fiber. Normal command exits call `process.exit`
+ * explicitly via `runHandler`, which preempts the finalizer but terminates
+ * the process anyway (see `runHandler` below). This replaces the fragile
+ * `process.once("beforeExit", ...)` hook which never fired because the reader
+ * fiber kept the event loop non-empty.
+ *
+ * `sendRpc` is composed entirely in Effect-land — no `Effect.runPromise`
+ * bridge — so typed errors (`NotConnectedError`, `RpcTimeoutError`,
+ * `RpcServerError`) flow through `tagWsError` without being wrapped in
+ * `FiberFailureImpl` (the root cause of sbd#198 / moltzap#228).
+ *
+ * `Effect.cached` memoises the connect handshake so a command that issues
+ * multiple RPCs (e.g. `apps list` then `apps get`) only opens one socket.
+ */
 const makeDirectTransport = (
   serverUrl: string,
   agentKey: string,
-): Effect.Effect<Transport, TransportConfigError> =>
+): Effect.Effect<Transport, TransportConfigError, Scope.Scope> =>
   Effect.gen(function* () {
     if (!serverUrl) {
       return yield* Effect.fail(
@@ -268,32 +287,34 @@ const makeDirectTransport = (
         }),
       );
     }
-    // Construct lazily on first RPC so commands that never reach the
-    // wire (e.g. help text, input validation failure) don't pay for a
-    // WebSocket open. Register a process-exit hook so one-shot CLI
-    // invocations don't hang on the ws-client's ManagedRuntime and the
-    // socket's keepalive timers.
-    const ensureConnected = yield* Effect.cached(
-      Effect.gen(function* () {
-        const c = new MoltZapWsClient({ serverUrl, agentKey });
-        const closeSync = (): void => {
-          void Effect.runPromise(c.close());
-        };
-        process.once("beforeExit", closeSync);
-        yield* c.connect();
-        return c;
-      }),
+
+    const client = new MoltZapWsClient({ serverUrl, agentKey });
+
+    // Finalizer fires on SIGINT/SIGTERM (fiber interrupt). On normal exits,
+    // runHandler calls process.exit which preempts this, but the client is
+    // terminated by the OS regardless.
+    yield* Effect.addFinalizer(() => client.close());
+
+    // Memoize the connect handshake: only one round-trip per invocation,
+    // cached for the lifetime of this scope.
+    const connectOnce = yield* Effect.cached(
+      client.connect().pipe(Effect.mapError((e) => tagWsError("connect", e))),
     );
+
     return {
-      kind: "direct",
-      rpc: <Result>(method: string, params: Record<string, unknown>) =>
-        ensureConnected.pipe(
-          Effect.flatMap((c) => c.sendRpc(method, params)),
-          Effect.map((result) => result as Result),
-          Effect.mapError((e) =>
-            tagWsError(method, e as { readonly _tag?: string }),
+      kind: "direct" as const,
+      rpc: <Result>(
+        method: string,
+        params: Record<string, unknown>,
+      ): Effect.Effect<Result, TransportError> =>
+        connectOnce.pipe(
+          Effect.flatMap(() =>
+            client
+              .sendRpc(method, params)
+              .pipe(Effect.mapError((e) => tagWsError(method, e))),
           ),
-        ) as Effect.Effect<Result, TransportError>,
+          Effect.map((v) => v as Result),
+        ),
     };
   });
 
@@ -314,7 +335,7 @@ const makeDirectTransport = (
 export const makeTransportLayer = (
   options: TransportOptions,
 ): Layer.Layer<Transport, TransportConfigError> =>
-  Layer.effect(
+  Layer.scoped(
     Transport,
     Effect.gen(function* () {
       const decision = yield* decideTransport(options);
@@ -373,6 +394,11 @@ export const rpc = <Result>(
  * tagged-error `message` field if present, otherwise the `_tag`, otherwise
  * a generic fallback. Shared across every v2 subcommand wrapper so the
  * exit-code contract (Invariant §4.6) has a single implementation.
+ *
+ * Both branches call `process.exit` explicitly. On success, `exit(0)` flushes
+ * any lingering event-loop handles (e.g. the ws-client's ManagedRuntime
+ * dispose) that would otherwise prevent the one-shot CLI process from
+ * terminating naturally (sbd#198 / moltzap#228 Bug-2 fix).
  */
 export const runHandler = <
   E extends { readonly message?: string; readonly _tag?: string },
@@ -390,6 +416,7 @@ export const runHandler = <
         process.exit(1);
       }),
     ),
+    Effect.zipRight(Effect.sync(() => process.exit(0))),
   );
 
 /**


### PR DESCRIPTION
Closes #228

## What changed

Two bugs in `makeDirectTransport` that together made every `moltzap --as <apiKey> <v2-command>` invocation unreliable:

**Bug 1 — TransportDecodeError on every RPC failure (root cause of moltzap#228):**
The original v2 implementation at `069135d` used `Effect.runPromise(sendRpc)` inside `Effect.tryPromise`. In Effect 3.21, `runPromise` wraps typed failures in `FiberFailureImpl` (which has `_tag = undefined`), so `tagWsError`'s switch always fell through to the default branch and produced `TransportDecodeError` instead of the correct `TransportRpcError` / `ServiceUnreachableError` / `TransportTimeoutError`.

**Note on diagnosis:** Bug 1 was already fixed by the code-guard commit `ff2de0d` (which converted the Promise-based `ensureConnected` to pure `Effect.cached` + `Effect.flatMap` composition) before this PR was created. This PR adds formal regression test coverage for that fix — the `tagWsError` decoder-fixture tests and the composed rpc() failure-path test.

**Bug 2 — CLI hangs after a successful one-shot command:**
The ws-client's internal `ManagedRuntime` + reader fiber kept the event loop non-empty, so `NodeRuntime.runMain` never reached its "no pending handles" exit. The old `process.once("beforeExit", closeSync)` hook never fired because the reader fiber prevents the `beforeExit` event.

Fix: `Layer.effect → Layer.scoped` opens the `Scope` needed for `Effect.addFinalizer(() => client.close())`. On normal completion, the Layer scope closes, the finalizer disposes the ws-client's ManagedRuntime, and the event loop drains naturally. No forced `process.exit(0)` — that would truncate piped stdout on large payloads (`apps get --json | jq` regression risk).

`MoltZapWsClient` is constructed lazily inside `Effect.cached` (was accidentally made eager in the first version of this fix) so help/validation paths do not pay for a ManagedRuntime spin-up.

**Regression guard:** `tagWsError` is exported as `@internal` so decoder-fixture tests can reach it without a mock WS server. Four decoder-fixture tests cover all `_tag` branches including the FiberFailureImpl-shaped no-`_tag` case. One composed rpc() test mocks `MoltZapWsClient.sendRpc` to return `Effect.fail(new RpcServerError(...))` and asserts the transport's `rpc()` produces `TransportRpcError` — this pins the full Effect composition chain.

## Plan anchors

| Change | Plan anchor |
|---|---|
| Pure Effect composition in `makeDirectTransport.rpc` | sbd#198 fix: pure Effect composition (ff2de0d fixed Bug-1; this PR formalizes it) |
| `Layer.effect` → `Layer.scoped` + `Effect.addFinalizer` | sbd#198 Bug-2 fix: scope-based ws-client cleanup |
| Lazy `MoltZapWsClient` construction inside `Effect.cached` | sbd#198 fix: preserve lazy-construction invariant |
| No `process.exit(0)` on success path | sbd#198 Bug-2 fix: event loop drains naturally via finalizer |
| Export `tagWsError` as `@internal` | sbd#198 regression guard: decoder-fixture tests |
| 4 decoder-fixture + 1 composed-rpc unit tests | sbd#198 regression guard |

## Scope

- Modules touched: `packages/client/src/cli/transport.ts`, `packages/client/src/cli/transport.test.ts`
- Tier (from safer-diff-scope): senior
- New modules: 0
- New public signatures outside the plan: 0 (`tagWsError` export is `@internal`)
- New deps: 0

## Tests

- 4 decoder-fixture tests in `describe("tagWsError...")`: RpcServerError → TransportRpcError, NotConnectedError → ServiceUnreachableError, RpcTimeoutError → TransportTimeoutError (timeoutMs forwarded), FiberFailureImpl-shaped no-`_tag` → TransportDecodeError
- 1 composed rpc() test: mocks `MoltZapWsClient.sendRpc` via `vi.mock`, asserts `transport.rpc()` → `TransportRpcError` (pins full Effect composition)
- All 14 transport unit tests pass (9 existing + 5 new)
- All 225 client unit tests pass (previously-reported integration test timeouts resolved by ws-client close PR #234)
- Smoke: success path exits cleanly without hang; stdout not truncated

## Confidence

HIGH — root cause confirmed via git archaeology (069135d → ff2de0d → this PR); regression tests pin the exact `_tag = undefined` failure path; success-path drain verified empirically (no hang, full stdout output).

## Simplify pass

Run before PR. One finding: comments about `Effect.addFinalizer` inaccurately stated it fires on all exits. Updated to accurately state: fires on fiber interruption (SIGINT/SIGTERM) and also on normal scope close (which is how Bug-2 is fixed). No logic changes from simplify.

/safer:review-senior is mandatory before this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)