### PR TITLE
fix(protocol): stop flat-barrel branded id exports

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -37,7 +37,7 @@
     "@sinclair/typebox": "^0.34.0",
     "ajv": "^8.17.0",
     "ajv-formats": "^3.0.0",
-    "effect": "^3.21.0"
+    "effect": "3.21.0"
   },
   "devDependencies": {
     "@effect/platform": "^0.96.0",

--- a/packages/protocol/src/schema/index.ts
+++ b/packages/protocol/src/schema/index.ts
@@ -1,4 +1,9 @@
-export * from "./primitives.js";
+export {
+  ConversationId,
+  MessageId,
+  ContactId,
+  InviteToken,
+} from "./primitives.js";
 export * from "./identity.js";
 export * from "./contacts.js";
 export * from "./conversations.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,7 +209,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.1(ajv@8.18.0)
       effect:
-        specifier: ^3.21.0
+        specifier: 3.21.0
         version: 3.21.0
     devDependencies:
       '@effect/platform':


### PR DESCRIPTION
## Summary

- stop exporting TypeBox `UserId` / `AgentId` schema values through the flat `@moltzap/protocol` barrel by making the schema barrel explicit
- keep the branded-id canary behavior from #161 intact: callers must use subpaths instead of the flat barrel for these names
- pin `packages/protocol` to the exact workspace `effect` version (`3.21.0`) instead of a caret range as part of the #164 cleanup bar

Closes #161.
Part of #164.

## Issue disposition

- #149 / #151: current `main` has already superseded the old eval-package implementation shape. `packages/evals` is no longer a workspace package and now contains only YAML scenarios plus docs; there is no local eval CLI, judge stack, or bundle pipeline left in MoltZap.
- #164 remains open as the umbrella cleanup issue. This PR only lands the protocol/export and exact-pin slice.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm check`
- `pnpm --filter @moltzap/protocol test`
- negative canary: importing `{ UserId, AgentId }` from `@moltzap/protocol` fails with no-export diagnostics
