### PR TITLE
Expand executable conformance proof coverage

### DIFF
--- a/packages/protocol/scripts/check-divergence-proofs.sh
+++ b/packages/protocol/scripts/check-divergence-proofs.sh
@@ -31,13 +31,19 @@ fi
 
 required_registrars=(
   registerEventWellFormednessClient
+  registerMalformedFrameHandlingClient
   registerFanOutCardinalityClient
   registerPayloadOpacityClient
+  registerTaskBoundaryIsolationClient
   registerSchemaExhaustiveFuzzClient
   registerModelEquivalenceClient
   registerRequestIdUniquenessClient
+  registerRequestWellFormedness
+  registerRpcMapCoverage
   registerAuthorityNegative
+  registerAuthorityPositive
   registerModelEquivalence
+  registerRequestIdUniqueness
   registerIdempotence
 )
 

--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/client-executable.proofs.test.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/client-executable.proofs.test.ts
@@ -12,10 +12,12 @@ import type { ConformanceArtifact } from "../runner.js";
 import { collectProperties, type PropertyFailure } from "../registry.js";
 import {
   registerEventWellFormednessClient,
+  registerMalformedFrameHandlingClient,
   registerModelEquivalenceClient,
   registerRequestIdUniquenessClient,
   registerFanOutCardinalityClient,
   registerPayloadOpacityClient,
+  registerTaskBoundaryIsolationClient,
   registerSchemaExhaustiveFuzzClient,
 } from "../client/index.js";
 import type {
@@ -39,6 +41,8 @@ type EventBehavior =
   | "scramble-position-index"
   | "strip-required-field"
   | "rewrite-payload"
+  | "rewrite-conversation-id"
+  | "close-on-malformed"
   | "close-on-untagged-fuzz";
 
 type RpcBehavior = "normal" | "non-response-type" | "spurious-id";
@@ -72,6 +76,22 @@ describe("client-side conformance executable divergence proofs", () => {
       eventBehavior: "rewrite-payload",
     });
     expectInvariant(failure, "payload-opacity-client");
+  });
+
+  it("registerMalformedFrameHandlingClient fails when malformed frames poison liveness", async () => {
+    const failure = await runSingleClientProof(
+      registerMalformedFrameHandlingClient,
+      { eventBehavior: "close-on-malformed" },
+    );
+    expectInvariant(failure, "malformed-frame-handling-client");
+  }, 10_000);
+
+  it("registerTaskBoundaryIsolationClient fails when task ids are cross-wired", async () => {
+    const failure = await runSingleClientProof(
+      registerTaskBoundaryIsolationClient,
+      { eventBehavior: "rewrite-conversation-id" },
+    );
+    expectInvariant(failure, "task-boundary-isolation-client");
   });
 
   it("registerSchemaExhaustiveFuzzClient fails when post-fuzz liveness is poisoned", async () => {
@@ -141,6 +161,8 @@ function makeBadClientContext(
     const publishEvent = (frame: EventFrame): Effect.Effect<void> =>
       Effect.gen(function* () {
         const behavior = opts.eventBehavior ?? "normal";
+        const close = yield* Ref.get(closeRef);
+        if (close !== null && behavior === "close-on-malformed") return;
         const data = frame.data as { __emissionTag?: string } | undefined;
         const tag =
           typeof data?.__emissionTag === "string" ? data.__emissionTag : null;
@@ -158,7 +180,11 @@ function makeBadClientContext(
               ? rewriteEventData(frame, { positionIndex: 999 })
               : behavior === "rewrite-payload"
                 ? rewriteEventData(frame, { opaqueToken: "rewritten" })
-                : frame;
+                : behavior === "rewrite-conversation-id"
+                  ? rewriteEventData(frame, {
+                      conversationId: "cross-wired-task",
+                    })
+                  : frame;
         const encoded = new TextEncoder().encode(JSON.stringify(surfaceFrame));
         yield* Ref.update(eventsRef, (events) => [
           ...events,
@@ -197,7 +223,14 @@ function makeBadClientContext(
       inbound,
       emitEvent: (event) => publishEvent(event),
       emitResponse: (response) => resolveResponse(response),
-      emitMalformed: () => Effect.void,
+      emitMalformed: () =>
+        opts.eventBehavior === "close-on-malformed"
+          ? Ref.set(closeRef, {
+              code: 1002,
+              reason: "bad client closed on malformed frame",
+              observedAtMs: Date.now(),
+            })
+          : Effect.void,
       close: (close) =>
         Ref.set(closeRef, {
           code: close.code,

--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
@@ -10,10 +10,16 @@ import type { ConformanceArtifact } from "../runner.js";
 import type { ConformanceRunContext, RealServerHandle } from "../runner.js";
 import { collectProperties, type PropertyFailure } from "../registry.js";
 import {
+  registerAuthorityPositive,
   registerAuthorityNegative,
   registerIdempotence,
   registerModelEquivalence,
+  registerRequestIdUniqueness,
 } from "../rpc-semantics.js";
+import {
+  registerRequestWellFormedness,
+  registerRpcMapCoverage,
+} from "../schema-conformance.js";
 import {
   expectAssertionFailure,
   expectInvariant,
@@ -22,7 +28,11 @@ import {
 
 type BadServerBehavior =
   | "allow-unauthenticated"
+  | "duplicate-response-id"
+  | "drop-contacts-list"
+  | "drop-sampled-response"
   | "reject-confident-model-call"
+  | "reject-authorized"
   | "drift-idempotent-result";
 
 describe("server-side conformance executable divergence proofs", () => {
@@ -40,11 +50,39 @@ describe("server-side conformance executable divergence proofs", () => {
     expectAssertionFailure(failure, "model-equivalence");
   });
 
+  it("registerAuthorityPositive fails when an authorized RPC is denied", async () => {
+    const failure = await runSingleServerProof(registerAuthorityPositive, {
+      behavior: "reject-authorized",
+    });
+    expectInvariant(failure, "authority-positive");
+  });
+
+  it("registerRequestIdUniqueness fails when responses duplicate an id", async () => {
+    const failure = await runSingleServerProof(registerRequestIdUniqueness, {
+      behavior: "duplicate-response-id",
+    });
+    expectAssertionFailure(failure, "request-id-uniqueness");
+  });
+
   it("registerIdempotence fails when list results drift across replays", async () => {
     const failure = await runSingleServerProof(registerIdempotence, {
       behavior: "drift-idempotent-result",
     });
     expectInvariant(failure, "idempotence");
+  });
+
+  it("registerRequestWellFormedness fails when sampled calls receive no reply", async () => {
+    const failure = await runSingleServerProof(registerRequestWellFormedness, {
+      behavior: "drop-sampled-response",
+    });
+    expectAssertionFailure(failure, "request-well-formedness");
+  }, 12_000);
+
+  it("registerRpcMapCoverage fails when a sampled method never responds", async () => {
+    const failure = await runSingleServerProof(registerRpcMapCoverage, {
+      behavior: "drop-contacts-list",
+    });
+    expectInvariant(failure, "rpc-map-coverage");
   });
 });
 
@@ -189,7 +227,14 @@ function makeBadWebSocketServer(
                   behavior,
                   ordinal,
                 );
+                if (response === null) return;
                 yield* writer(encodeFrame(response)).pipe(Effect.orDie);
+                if (
+                  behavior === "duplicate-response-id" &&
+                  decoded.right.method === "conversations/list"
+                ) {
+                  yield* writer(encodeFrame(response)).pipe(Effect.orDie);
+                }
               });
             });
           }),
@@ -211,10 +256,22 @@ function makeBadResponse(
   request: RequestFrame,
   behavior: BadServerBehavior,
   ordinal: number,
-): ResponseFrame {
+): ResponseFrame | null {
+  if (behavior === "drop-contacts-list" && request.method === "contacts/list") {
+    return null;
+  }
   if (
-    behavior === "reject-confident-model-call" &&
-    request.method === "agents/list"
+    behavior === "drop-sampled-response" &&
+    ordinal > 1 &&
+    request.method !== "auth/connect"
+  ) {
+    return null;
+  }
+  if (
+    (behavior === "reject-confident-model-call" &&
+      request.method === "agents/list") ||
+    (behavior === "reject-authorized" &&
+      request.method === "conversations/list")
   ) {
     return {
       jsonrpc: "2.0",

--- a/packages/protocol/src/testing/conformance/client/suite.ts
+++ b/packages/protocol/src/testing/conformance/client/suite.ts
@@ -113,12 +113,12 @@ export function registerAllClientProperties(
   registerFanOutCardinalityClient(ctx);
   registerPayloadOpacityClient(ctx);
   registerTaskBoundaryIsolationClient(ctx);
+  registerSchemaExhaustiveFuzzClient(ctx);
   registerLatencyResilienceClient(ctx);
   registerSlicerFramingClient(ctx);
   registerResetPeerRecoveryClient(ctx);
   registerTimeoutSurfaceClient(ctx);
   registerSlowCloseCleanupClient(ctx);
-  registerSchemaExhaustiveFuzzClient(ctx);
 }
 
 /**
@@ -194,11 +194,6 @@ function allowedClientCoverageGaps(
       },
     );
   }
-  gaps.push({
-    kind: "unavailable",
-    id: "boundary/schema-exhaustive-fuzz-client",
-    reasonIncludes: "real client did not complete handshake",
-  });
   return gaps;
 }
 


### PR DESCRIPTION
## Summary\n\n- expands divergence proof coverage from 9 to 15 executable registrar cases\n- adds bad-client proofs for malformed-frame liveness and task-boundary cross-wiring\n- adds bad-server proofs for request well-formedness, rpc map coverage, authority-positive, and request-id uniqueness\n- removes the allowlisted client schema-fuzz handshake gap by running the boundary fuzz property before destructive client adversity cases\n\nCloses #259.\nUpdates #253 row #5.\n\n## Verification\n\n- `pnpm install --frozen-lockfile`\n- `pnpm -r build`\n- `pnpm format:check`\n- `pnpm lint` (exits 0 with existing warnings)\n- `pnpm typecheck`\n- `pnpm --filter @moltzap/protocol test`\n- `SKIP_TOXIPROXY=1 pnpm -F @moltzap/server-core test:conformance`\n- `pnpm -F @moltzap/client test:conformance`\n- `pnpm -F @moltzap/openclaw-channel test:conformance`\n- `pnpm -F @moltzap/nanoclaw-channel test:conformance`