### PR TITLE
Add local Toxiproxy conformance runner

### DIFF
--- a/docs/development/testing.mdx
+++ b/docs/development/testing.mdx
@@ -14,6 +14,8 @@ pnpm test                    # all packages
 pnpm --filter @moltzap/protocol test     # protocol only
 pnpm --filter @moltzap/server-core test  # server-core unit tests
 pnpm --filter @moltzap/server-core test:integration  # integration tests (needs Docker)
+pnpm test:conformance:toxiproxy  # protocol conformance with live Toxiproxy
+pnpm test:conformance:stress     # same conformance path with more fast-check runs
 ```
 
 ## Test infrastructure
@@ -58,3 +60,31 @@ Each test file covers a specific feature: registration, DM messaging, group chat
 ## Property-based tests
 
 Protocol schema tests use `fast-check` for property-based testing of schema validation boundaries.
+
+## Protocol conformance
+
+The conformance gate exercises the real server/client surfaces through the protocol testing package. Tier D adversity requires Toxiproxy, so the root command owns the local Docker lifecycle and mirrors the CI setup:
+
+```bash
+pnpm test:conformance:toxiproxy
+```
+
+That command starts `docker-compose.conformance.yml`, waits for `TOXIPROXY_URL` (default `http://127.0.0.1:8474`), then runs conformance for:
+
+- `@moltzap/server-core`
+- `@moltzap/client`
+- `@moltzap/openclaw-channel`
+- `@moltzap/nanoclaw-channel`
+
+For heavier local stress, run:
+
+```bash
+pnpm test:conformance:stress
+```
+
+Stress mode uses the same suites and Toxiproxy path but sets `CONFORMANCE_NUM_RUNS=100` by default. Override it when chasing a flaky boundary:
+
+```bash
+CONFORMANCE_NUM_RUNS=250 pnpm test:conformance:stress
+FC_SEED=12345 pnpm test:conformance:toxiproxy
+```

--- a/docs/development/testing.mdx
+++ b/docs/development/testing.mdx
@@ -82,9 +82,10 @@ For heavier local stress, run:
 pnpm test:conformance:stress
 ```
 
-Stress mode uses the same suites and Toxiproxy path but sets `CONFORMANCE_NUM_RUNS=100` by default. Override it when chasing a flaky boundary:
+Stress mode uses the same suites and Toxiproxy path but sets `CONFORMANCE_NUM_RUNS=100` and `CONFORMANCE_SEED_COUNT=3` by default. That means each package runs three deterministic seed passes, and properties that consume `numRuns` increase their generated samples. Override either knob when chasing a flaky boundary:
 
 ```bash
 CONFORMANCE_NUM_RUNS=250 pnpm test:conformance:stress
+CONFORMANCE_SEED_COUNT=10 pnpm test:conformance:stress
 FC_SEED=12345 pnpm test:conformance:toxiproxy
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "format:check": "oxfmt --check .",
     "typecheck": "pnpm -r exec tsc --noEmit",
     "check": "pnpm lint && pnpm format:check",
+    "test:conformance:toxiproxy": "bash scripts/conformance-toxiproxy.sh",
+    "test:conformance:stress": "CONFORMANCE_STRESS=1 bash scripts/conformance-toxiproxy.sh",
     "docs": "cd docs && mint dev",
     "docs:generate": "cd packages/protocol && npx tsx ../../scripts/generate-protocol-docs.ts",
     "docs:check": "cd docs && mint broken-links",

--- a/packages/protocol/src/testing/conformance/boundary.ts
+++ b/packages/protocol/src/testing/conformance/boundary.ts
@@ -146,10 +146,14 @@ export function registerSchemaExhaustiveFuzz(ctx: ConformanceRunContext): void {
               }),
           ),
         );
+        const samplesPerMethod = ctx.opts.numRuns ?? 1;
         for (const method of allRpcMethods) {
           const callArb = arbitraryCallFor(method);
-          const [sampled] = fc.sample(callArb, { numRuns: 1, seed: ctx.seed });
-          if (sampled === undefined) {
+          const samples = fc.sample(callArb, {
+            numRuns: samplesPerMethod,
+            seed: ctx.seed,
+          });
+          if (samples.length === 0) {
             return yield* Effect.fail(
               new PropertyInvariantViolation({
                 category: CATEGORY,
@@ -158,25 +162,27 @@ export function registerSchemaExhaustiveFuzz(ctx: ConformanceRunContext): void {
               }),
             );
           }
-          yield* client
-            .sendRpc(sampled.method, sampled.params)
-            .pipe(Effect.either);
-          // Post-fuzz liveness: a follow-up RPC must return a typed
-          // response. Accepting any `Left` would let a timeout or
-          // transport-close slip through as "server alive" — which is
-          // exactly what the property must reject. Require the post
-          // call to SUCCEED; timeouts are failures here.
-          const post = yield* client
-            .sendRpc("agents/list", {})
-            .pipe(Effect.either);
-          if (post._tag !== "Right") {
-            return yield* Effect.fail(
-              new PropertyInvariantViolation({
-                category: CATEGORY,
-                name: "schema-exhaustive-fuzz",
-                reason: `server became unresponsive after ${method} (post-call ${post._tag === "Left" ? post.left._tag : "unknown"})`,
-              }),
-            );
+          for (const sampled of samples) {
+            yield* client
+              .sendRpc(sampled.method, sampled.params)
+              .pipe(Effect.either);
+            // Post-fuzz liveness: a follow-up RPC must return a typed
+            // response. Accepting any `Left` would let a timeout or
+            // transport-close slip through as "server alive" — which is
+            // exactly what the property must reject. Require the post
+            // call to SUCCEED; timeouts are failures here.
+            const post = yield* client
+              .sendRpc("agents/list", {})
+              .pipe(Effect.either);
+            if (post._tag !== "Right") {
+              return yield* Effect.fail(
+                new PropertyInvariantViolation({
+                  category: CATEGORY,
+                  name: "schema-exhaustive-fuzz",
+                  reason: `server became unresponsive after ${method} (post-call ${post._tag === "Left" ? post.left._tag : "unknown"})`,
+                }),
+              );
+            }
           }
         }
       }),

--- a/packages/protocol/src/testing/conformance/client/boundary.ts
+++ b/packages/protocol/src/testing/conformance/client/boundary.ts
@@ -47,9 +47,11 @@ export function registerSchemaExhaustiveFuzzClient(
           "schema-exhaustive-fuzz-client",
         );
         yield* subscribeAll(fx.handle);
-        // Fuzz burst: 10 arbitrary EventFrames seeded by ctx.seed.
+        // Fuzz burst: default 10 frames; stress mode scales with
+        // CONFORMANCE_NUM_RUNS through ctx.opts.numRuns.
+        const fuzzRuns = ctx.opts.numRuns ?? 10;
         const burst = fc.sample(arbitraryEventFrame(), {
-          numRuns: 10,
+          numRuns: fuzzRuns,
           seed: ctx.seed,
         });
         for (const frame of burst) {

--- a/packages/protocol/src/testing/conformance/client/runner.ts
+++ b/packages/protocol/src/testing/conformance/client/runner.ts
@@ -32,6 +32,7 @@ import {
   TransportIoError,
   type ToxicControlError,
 } from "../../errors.js";
+import { conformanceNumRunsFromEnv } from "../env.js";
 import type { ConformanceArtifact } from "../runner.js";
 import { PROTOCOL_VERSION } from "../../../version.js";
 
@@ -276,8 +277,13 @@ export function acquireClientRunContext(
   Scope.Scope
 > {
   return Effect.gen(function* () {
+    const effectiveOpts = {
+      ...opts,
+      numRuns: opts.numRuns ?? conformanceNumRunsFromEnv(),
+    };
     const seed =
-      opts.replaySeed ?? Number(process.env.FC_SEED ?? Date.now() & 0x7fffffff);
+      effectiveOpts.replaySeed ??
+      Number(process.env.FC_SEED ?? Date.now() & 0x7fffffff);
     const artifacts = yield* Ref.make<ReadonlyArray<ConformanceArtifact>>([]);
 
     // Bind the TestServer under the ambient Scope. Server-close on teardown.
@@ -297,8 +303,13 @@ export function acquireClientRunContext(
     // Optional Toxiproxy acquisition — matches the server-side runner's
     // contract (only allocate when tier "D" is present).
     let toxiproxy: ToxiproxyClient | null = null;
-    if (opts.tiers.includes("D") && opts.toxiproxyUrl !== undefined) {
-      const tp = yield* makeToxiproxyClient({ apiUrl: opts.toxiproxyUrl });
+    if (
+      effectiveOpts.tiers.includes("D") &&
+      effectiveOpts.toxiproxyUrl !== undefined
+    ) {
+      const tp = yield* makeToxiproxyClient({
+        apiUrl: effectiveOpts.toxiproxyUrl,
+      });
       yield* tp.ping.pipe(Effect.orElseSucceed(() => undefined));
       toxiproxy = tp;
     }
@@ -320,10 +331,10 @@ export function acquireClientRunContext(
 
     return {
       testServer,
-      realClientFactory: opts.realClient,
+      realClientFactory: effectiveOpts.realClient,
       handshakeWindow,
       toxiproxy,
-      opts,
+      opts: effectiveOpts,
       seed,
       artifacts,
     } satisfies ClientConformanceRunContext;

--- a/packages/protocol/src/testing/conformance/client/suite.ts
+++ b/packages/protocol/src/testing/conformance/client/suite.ts
@@ -40,6 +40,7 @@ import type {
   ToxicControlError,
 } from "../../errors.js";
 import type { SuiteResult } from "../suite.js";
+import { conformanceArtifactDirFromEnv } from "../env.js";
 import {
   isAllowedCoverageGap,
   type AllowedCoverageGap,
@@ -134,7 +135,9 @@ export function runClientConformanceSuite(
 > {
   const toxiproxyUrl = opts.toxiproxyUrl ?? null;
   const artifactDir =
-    opts.artifactDir ?? path.resolve(process.cwd(), "conformance-artifacts");
+    opts.artifactDir ??
+    conformanceArtifactDirFromEnv() ??
+    path.resolve(process.cwd(), "conformance-artifacts");
   const tiers: ClientConformanceRunOptions["tiers"] =
     toxiproxyUrl === null ? ["A", "B", "C", "E"] : ["A", "B", "C", "D", "E"];
 

--- a/packages/protocol/src/testing/conformance/env.ts
+++ b/packages/protocol/src/testing/conformance/env.ts
@@ -1,0 +1,13 @@
+export function conformanceNumRunsFromEnv(): number | undefined {
+  const raw = process.env.CONFORMANCE_NUM_RUNS;
+  if (raw === undefined || raw === "") return undefined;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`CONFORMANCE_NUM_RUNS must be a positive integer: ${raw}`);
+  }
+  return parsed;
+}
+
+export function conformanceArtifactDirFromEnv(): string | undefined {
+  return process.env.CONFORMANCE_ARTIFACT_DIR ?? process.env.ARTIFACT_DIR;
+}

--- a/packages/protocol/src/testing/conformance/runner.ts
+++ b/packages/protocol/src/testing/conformance/runner.ts
@@ -15,6 +15,7 @@
 import { Effect, Ref, Scope } from "effect";
 import { makeToxiproxyClient, type ToxiproxyClient } from "../toxics/client.js";
 import { RealServerAcquireError, ToxicControlError } from "../errors.js";
+import { conformanceNumRunsFromEnv } from "./env.js";
 
 /**
  * Opaque handle to a running real MoltZap server. The conformance runner
@@ -80,8 +81,13 @@ export function acquireRunContext(
   Scope.Scope
 > {
   return Effect.gen(function* () {
+    const effectiveOpts = {
+      ...opts,
+      numRuns: opts.numRuns ?? conformanceNumRunsFromEnv(),
+    };
     const seed =
-      opts.replaySeed ?? Number(process.env.FC_SEED ?? Date.now() & 0x7fffffff);
+      effectiveOpts.replaySeed ??
+      Number(process.env.FC_SEED ?? Date.now() & 0x7fffffff);
     const artifacts = yield* Ref.make<ReadonlyArray<ConformanceArtifact>>([]);
 
     const realServer = yield* Effect.acquireRelease(
@@ -100,8 +106,8 @@ export function acquireRunContext(
     );
 
     let toxiproxy: ToxiproxyClient | null = null;
-    if (opts.tiers.includes("D")) {
-      const url = opts.toxiproxyUrl ?? "http://127.0.0.1:8474";
+    if (effectiveOpts.tiers.includes("D")) {
+      const url = effectiveOpts.toxiproxyUrl ?? "http://127.0.0.1:8474";
       toxiproxy = yield* makeToxiproxyClient({ apiUrl: url });
       yield* toxiproxy.ping.pipe(
         Effect.retry({ times: 10, schedule: undefined }),
@@ -111,7 +117,7 @@ export function acquireRunContext(
     return {
       realServer,
       toxiproxy,
-      opts,
+      opts: effectiveOpts,
       seed,
       artifacts,
     } satisfies ConformanceRunContext;

--- a/packages/protocol/src/testing/conformance/suite.ts
+++ b/packages/protocol/src/testing/conformance/suite.ts
@@ -43,6 +43,7 @@ import {
   isAllowedCoverageGap,
   type AllowedCoverageGap,
 } from "./coverage-policy.js";
+import { conformanceArtifactDirFromEnv } from "./env.js";
 
 /**
  * Input shape — consumer names the concrete implementation under test and
@@ -226,7 +227,9 @@ export function runConformanceSuite(
 ): Effect.Effect<SuiteResult, ToxicControlError | RealServerAcquireError> {
   const toxiproxyUrl = opts.toxiproxyUrl ?? null;
   const artifactDir =
-    opts.artifactDir ?? path.resolve(process.cwd(), "conformance-artifacts");
+    opts.artifactDir ??
+    conformanceArtifactDirFromEnv() ??
+    path.resolve(process.cwd(), "conformance-artifacts");
   const categories: ConformanceRunOptions["tiers"] =
     toxiproxyUrl === null ? ["A", "B", "C", "E"] : ["A", "B", "C", "D", "E"];
 

--- a/scripts/conformance-toxiproxy.sh
+++ b/scripts/conformance-toxiproxy.sh
@@ -7,7 +7,9 @@ TOXIPROXY_URL="${TOXIPROXY_URL:-http://127.0.0.1:8474}"
 
 if [[ "${CONFORMANCE_STRESS:-0}" == "1" ]]; then
   export CONFORMANCE_NUM_RUNS="${CONFORMANCE_NUM_RUNS:-100}"
+  CONFORMANCE_SEED_COUNT="${CONFORMANCE_SEED_COUNT:-3}"
 fi
+CONFORMANCE_SEED_COUNT="${CONFORMANCE_SEED_COUNT:-1}"
 
 PACKAGES=("$@")
 if [[ "${#PACKAGES[@]}" -eq 0 ]]; then
@@ -38,6 +40,17 @@ export TOXIPROXY_URL
 export SKIP_DOCKER=1
 export CONFORMANCE_ARTIFACT_DIR="${CONFORMANCE_ARTIFACT_DIR:-conformance-artifacts}"
 
+if ! [[ "$CONFORMANCE_SEED_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+  echo "CONFORMANCE_SEED_COUNT must be a positive integer: $CONFORMANCE_SEED_COUNT" >&2
+  exit 1
+fi
+
+BASE_FC_SEED="${FC_SEED:-$(( $(date +%s) & 0x7fffffff ))}"
+if ! [[ "$BASE_FC_SEED" =~ ^[0-9]+$ ]]; then
+  echo "FC_SEED must be a non-negative integer when set: $BASE_FC_SEED" >&2
+  exit 1
+fi
+
 docker compose -f "$COMPOSE_FILE" up -d
 trap cleanup EXIT
 wait_for_toxiproxy
@@ -46,8 +59,13 @@ echo "Running conformance with Toxiproxy at $TOXIPROXY_URL"
 if [[ -n "${CONFORMANCE_NUM_RUNS:-}" ]]; then
   echo "Stress numRuns override: $CONFORMANCE_NUM_RUNS"
 fi
+echo "Seed passes: $CONFORMANCE_SEED_COUNT (base FC_SEED=$BASE_FC_SEED)"
 
-for pkg in "${PACKAGES[@]}"; do
-  echo "==> $pkg"
-  pnpm -F "$pkg" test:conformance
+for ((seed_index = 0; seed_index < CONFORMANCE_SEED_COUNT; seed_index++)); do
+  export FC_SEED=$((BASE_FC_SEED + seed_index))
+  echo "== seed pass $((seed_index + 1))/$CONFORMANCE_SEED_COUNT: FC_SEED=$FC_SEED"
+  for pkg in "${PACKAGES[@]}"; do
+    echo "==> $pkg"
+    pnpm -F "$pkg" test:conformance
+  done
 done

--- a/scripts/conformance-toxiproxy.sh
+++ b/scripts/conformance-toxiproxy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${CONFORMANCE_COMPOSE_FILE:-$ROOT_DIR/docker-compose.conformance.yml}"
+TOXIPROXY_URL="${TOXIPROXY_URL:-http://127.0.0.1:8474}"
+
+if [[ "${CONFORMANCE_STRESS:-0}" == "1" ]]; then
+  export CONFORMANCE_NUM_RUNS="${CONFORMANCE_NUM_RUNS:-100}"
+fi
+
+PACKAGES=("$@")
+if [[ "${#PACKAGES[@]}" -eq 0 ]]; then
+  PACKAGES=(
+    "@moltzap/server-core"
+    "@moltzap/client"
+    "@moltzap/openclaw-channel"
+    "@moltzap/nanoclaw-channel"
+  )
+fi
+
+cleanup() {
+  docker compose -f "$COMPOSE_FILE" down -v
+}
+
+wait_for_toxiproxy() {
+  for _ in {1..30}; do
+    if curl -sf "$TOXIPROXY_URL/version" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Toxiproxy did not become healthy at $TOXIPROXY_URL" >&2
+  return 1
+}
+
+export TOXIPROXY_URL
+export SKIP_DOCKER=1
+export CONFORMANCE_ARTIFACT_DIR="${CONFORMANCE_ARTIFACT_DIR:-conformance-artifacts}"
+
+docker compose -f "$COMPOSE_FILE" up -d
+trap cleanup EXIT
+wait_for_toxiproxy
+
+echo "Running conformance with Toxiproxy at $TOXIPROXY_URL"
+if [[ -n "${CONFORMANCE_NUM_RUNS:-}" ]]; then
+  echo "Stress numRuns override: $CONFORMANCE_NUM_RUNS"
+fi
+
+for pkg in "${PACKAGES[@]}"; do
+  echo "==> $pkg"
+  pnpm -F "$pkg" test:conformance
+done


### PR DESCRIPTION
## Summary


- add a root Toxiproxy-backed conformance runner mirroring CI\n- expose normal and stress conformance scripts from the workspace root\n- wire CONFORMANCE_NUM_RUNS and artifact-dir env handling into protocol conformance runners\n- document local conformance and stress commands\n\n## Verification\n\n- pnpm -F @moltzap/protocol build\n- pnpm format:check\n- pnpm lint (warnings only, existing repo warnings)\n- CONFORMANCE_NUM_RUNS=1 pnpm test:conformance:toxiproxy\n\nNote: pnpm typecheck / pre-commit currently fails in packages/claude-code-channel because it cannot resolve @moltzap/client, effect, and MCP SDK type deps; this is unrelated to this patch.