### PR TITLE
Fix trusted publish and server-core npx bin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,17 +108,18 @@ jobs:
       - name: Build all packages
         run: pnpm -r build
 
-      - name: Pack and publish
+      - name: Publish packages
         env:
-          # Clear any residual NODE_AUTH_TOKEN so npm uses OIDC trusted
-          # publishing via id-token: write. See:
-          # https://github.com/orgs/community/discussions/176761
+          # Trusted publishing must use GitHub Actions OIDC, not a
+          # long-lived npm token. Keep this unset even if repository-level
+          # secrets or npmrc files are added later.
           NODE_AUTH_TOKEN: ""
         run: |
           echo "npm version: $(npm --version)"
-          # Publish any package whose local version is not yet on npm.
-          # This covers both newly bumped versions AND versions from prior
-          # runs where the bump committed but the publish failed.
+          npm config delete //registry.npmjs.org/:_authToken || true
+          # Publish any package whose local version is not yet on npm. This
+          # covers both newly bumped versions and versions from prior runs
+          # where the bump committed but the publish failed.
           for pkg in protocol server client openclaw-channel; do
             PKG_JSON="./packages/$pkg/package.json"
             VER=$(node -p "require('$PKG_JSON').version")
@@ -130,8 +131,6 @@ jobs:
             echo "Publishing ${NAME}@${VER}..."
             (
               cd "packages/$pkg"
-              TARBALL=$(pnpm pack --pack-gzip-level 9 | tail -1)
-              [ -f "$TARBALL" ] || { echo "ERROR: pack failed, tarball not found"; exit 1; }
-              npm publish "$TARBALL" --access public --provenance
+              npm publish --access public
             )
           done

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,14 +5,14 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chughtapan/moltzap"
+    "url": "git+https://github.com/chughtapan/moltzap.git"
   },
   "files": [
     "dist",
     "bin"
   ],
   "bin": {
-    "moltzap-server": "./bin/moltzap-server"
+    "moltzap-server": "bin/moltzap-server"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/package-metadata.test.ts
+++ b/packages/server/src/package-metadata.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { access, readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(here, "..");
+const packageJsonPath = path.join(packageRoot, "package.json");
+
+describe("@moltzap/server-core package metadata", () => {
+  it("publishes a single executable bin for npx invocation", async () => {
+    const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+      bin?: Record<string, string>;
+      files?: string[];
+    };
+
+    expect(packageJson.files).toContain("bin");
+    expect(packageJson.bin).toEqual({
+      "moltzap-server": "bin/moltzap-server",
+    });
+
+    await access(path.join(packageRoot, "bin/moltzap-server"), constants.X_OK);
+  });
+});


### PR DESCRIPTION
## Summary
- publish packages directly from their package directories so npm trusted publishing can use GitHub Actions OIDC under Node 24
- normalize @moltzap/server-core package metadata so npm keeps the moltzap-server bin entry
- add a package metadata test for the server bin contract

Fixes #261

## Validation
- pnpm -r build
- pnpm -F @moltzap/server-core test -- package-metadata.test.ts
- pnpm format:check .github/workflows/publish.yml packages/server/package.json packages/server/src/package-metadata.test.ts
- npm publish --dry-run --access public from packages/server
- pre-commit check/typecheck/guardrails passed