### PR TITLE
Align npm trusted publishing authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   publish:
     # Skip if this push is a version commit from a previous run
@@ -36,6 +40,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
 
@@ -109,14 +114,12 @@ jobs:
         run: pnpm -r build
 
       - name: Publish packages
-        env:
-          # Trusted publishing must use GitHub Actions OIDC, not a
-          # long-lived npm token. Keep this unset even if repository-level
-          # secrets or npmrc files are added later.
-          NODE_AUTH_TOKEN: ""
         run: |
           echo "npm version: $(npm --version)"
-          npm config delete //registry.npmjs.org/:_authToken || true
+          test -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" || {
+            echo "ERROR: GitHub OIDC token request env is missing; check id-token: write permissions"
+            exit 1
+          }
           # Publish any package whose local version is not yet on npm. This
           # covers both newly bumped versions and versions from prior runs
           # where the bump committed but the publish failed.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chughtapan/moltzap"
+    "url": "git+https://github.com/chughtapan/moltzap.git"
   },
   "type": "module",
   "files": [

--- a/packages/openclaw-channel/package.json
+++ b/packages/openclaw-channel/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chughtapan/moltzap"
+    "url": "git+https://github.com/chughtapan/moltzap.git"
   },
   "type": "module",
   "files": [

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chughtapan/moltzap"
+    "url": "git+https://github.com/chughtapan/moltzap.git"
   },
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- align publish workflow with current npm trusted-publishing guidance for Node 24 and registry-url
- fail fast if GitHub OIDC request env is unavailable
- normalize repository URLs for published packages so npm does not auto-correct metadata during trusted publish

## Context
The publish run from PR #263 still failed with ENEEDAUTH on @moltzap/protocol. The failed log showed npm auto-correcting protocol repository metadata immediately before auth fallback. npm docs list exact workflow filename/id-token permissions and exact repository URL as ENEEDAUTH troubleshooting points.

## Validation
- pnpm format:check .github/workflows/publish.yml packages/protocol/package.json packages/client/package.json packages/openclaw-channel/package.json packages/server/package.json
- npm publish --dry-run --access public from packages/protocol
- pre-commit check/typecheck/guardrails passed