### PR TITLE
Publish with explicit npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -134,6 +134,6 @@ jobs:
             echo "Publishing ${NAME}@${VER}..."
             (
               cd "packages/$pkg"
-              npm publish --access public
+              npm publish --access public --provenance
             )
           done


### PR DESCRIPTION
## Summary
- add explicit `--provenance` to npm publish while keeping Node 24 and OIDC setup

## Validation
- pnpm format:check .github/workflows/publish.yml
- npm publish --dry-run --access public --provenance from packages/protocol

Follow-up to publish auth investigation after #264.