### PR TITLE
[impl-staff] cc-channel followups: conformance wrapper + runtime adapter + echo test fix (#254 #255 #256)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -10,6 +10,7 @@ on:
       - "packages/client/**"
       - "packages/openclaw-channel/**"
       - "packages/nanoclaw-channel/**"
+      - "packages/claude-code-channel/**"
       - "docker-compose.conformance.yml"
       - ".github/workflows/conformance.yml"
 
@@ -56,6 +57,9 @@ jobs:
       - name: Run Nanoclaw channel conformance suite
         run: pnpm -F @moltzap/nanoclaw-channel test:conformance
 
+      - name: Run Claude Code channel conformance suite
+        run: pnpm -F @moltzap/claude-code-channel test:conformance
+
       - name: Stop Toxiproxy
         if: always()
         run: docker compose -f docker-compose.conformance.yml down -v
@@ -70,4 +74,5 @@ jobs:
             packages/client/conformance-artifacts
             packages/openclaw-channel/conformance-artifacts
             packages/nanoclaw-channel/conformance-artifacts
+            packages/claude-code-channel/conformance-artifacts
           if-no-files-found: ignore

--- a/packages/claude-code-channel/package.json
+++ b/packages/claude-code-channel/package.json
@@ -14,13 +14,21 @@
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "moltzap-claude-code-channel": "./dist/bin.js"
+  },
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./test-support": {
+      "import": "./dist/test-support.js",
+      "types": "./dist/test-support.d.ts"
+    }
   },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "test:integration": "vitest run --config vitest.integration.config.ts"
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:conformance": "bash ../protocol/scripts/check-divergence-proofs.sh && vitest run -c vitest.conformance.config.ts"
   },
   "dependencies": {
     "@moltzap/client": "workspace:*",

--- a/packages/claude-code-channel/src/__tests__/conformance/suite.test.ts
+++ b/packages/claude-code-channel/src/__tests__/conformance/suite.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @moltzap/claude-code-channel — client-side conformance wrapper (issue #254).
+ *
+ * Invokes `clientConformance.runClientConformanceSuite` with the
+ * MoltZap WS client factory re-exported by the channel package's
+ * `test-support` subpath. Mirrors `packages/{client,openclaw-channel,
+ * nanoclaw-channel}/src/__tests__/conformance/suite.test.ts` exactly —
+ * cc-channel is the 4th client-side wrapper alongside the existing three.
+ */
+import { describe, expect, it } from "vitest";
+import { Effect, Exit } from "effect";
+import { clientConformance } from "@moltzap/protocol/testing";
+import { createMoltZapRealClientFactory } from "../../test-support.js";
+
+const TOXIPROXY_URL = process.env.TOXIPROXY_URL ?? null;
+
+describe("@moltzap/claude-code-channel client-side conformance", () => {
+  it("client-side properties pass against the claude-code-channel real client", async () => {
+    const factory = createMoltZapRealClientFactory({
+      agentKey: "claude-code-test-agent-key",
+      agentId: "claude-code-test-agent-id",
+    });
+    const exit = await Effect.runPromiseExit(
+      clientConformance.runClientConformanceSuite({
+        realClient: factory,
+        toxiproxyUrl: TOXIPROXY_URL,
+      }),
+    );
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (!Exit.isSuccess(exit)) return;
+    const result = exit.value;
+    console.log(
+      `[claude-code-conformance] seed=${result.seed} passed=${result.passed.length} unavailable=${result.unavailable.length} failed=${result.failed.length}`,
+    );
+    if (result.failed.length > 0) {
+      const summary = result.failed
+        .map((f) => {
+          const tag = "_tag" in f.failure ? f.failure._tag : "unknown";
+          return `${f.name}: ${tag}`;
+        })
+        .join("; ");
+      throw new Error(
+        `${result.failed.length} claude-code-channel properties failed: ${summary}`,
+      );
+    }
+  }, 600_000);
+});

--- a/packages/claude-code-channel/src/__tests__/echo.integration.test.ts
+++ b/packages/claude-code-channel/src/__tests__/echo.integration.test.ts
@@ -5,34 +5,31 @@
  *   - globalSetup spawns a real `@moltzap/server` standalone via spike-182's
  *     PGlite subprocess pattern; registers two agents (`A` for the channel,
  *     `B` for the peer).
- *   - Test boots the channel plumbing against agent A, connects an in-process
- *     MCP client to the channel's stdio server via `InMemoryTransport`, and
- *     uses an in-process `MoltZapService` as agent B to drive inbound traffic.
+ *   - Test boots the channel via the public `bootClaudeCodeChannel` entry
+ *     against agent A, connects an in-process MCP client to the channel's
+ *     stdio server via `InMemoryTransport` (injected through the
+ *     `_testTransportFactory` test seam — issue #256), and uses an in-process
+ *     `MoltZapService` as agent B to drive inbound traffic.
  *
  * Notes:
- *   - We wire `bootChannelMcpServer` directly rather than through
- *     `bootClaudeCodeChannel` because the only way to attach the in-process
- *     MCP client is via `transportFactory` (internal seam). The wiring
- *     mirrors `entry.ts` so changes there must stay in sync.
+ *   - We route through `bootClaudeCodeChannel` rather than reproducing
+ *     `entry.ts:106-143` inline. The `_testTransportFactory` field on
+ *     `BootOptions` is the only addition to the public surface; underscore-
+ *     prefixed and tagged "tests-only" so production callers do not reach
+ *     for it (reviewer-256, option (a)).
  *   - Every meta assertion pins the contract key names (`chat_id`, `user`,
  *     `message_id`, `ts`) per spec A5, A6, A14.
  */
 
 import { describe, it, expect, beforeAll, afterAll, inject } from "vitest";
 import { Effect } from "effect";
-import {
-  MoltZapChannelCore,
-  MoltZapService,
-  type EnrichedInboundMessage,
-} from "@moltzap/client";
+import { MoltZapService } from "@moltzap/client";
 import type { Message } from "@moltzap/protocol";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { Notification } from "@modelcontextprotocol/sdk/types.js";
-import { bootChannelMcpServer } from "../server.js";
-import { createRoutingState } from "../routing.js";
-import { toClaudeChannelNotification } from "../event.js";
-import type { ReplyError } from "../errors.js";
+import { bootClaudeCodeChannel } from "../entry.js";
+import type { Handle } from "../types.js";
 
 const silentLogger = {
   info: () => {},
@@ -41,8 +38,7 @@ const silentLogger = {
 };
 
 interface Harness {
-  channelService: MoltZapService;
-  channelCore: MoltZapChannelCore;
+  channelHandle: Handle;
   peerService: MoltZapService;
   mcpClient: Client;
   channelAgentId: string;
@@ -65,45 +61,20 @@ async function bootHarness(): Promise<Harness> {
   const [serverTransport, clientTransport] =
     InMemoryTransport.createLinkedPair();
 
-  const channelService = new MoltZapService({
+  const boot = await bootClaudeCodeChannel({
     serverUrl: wsUrl,
     agentKey: agentAApiKey,
     logger: silentLogger,
+    serverName: "test-claude-code-channel",
+    instructions: "integration test",
+    _testTransportFactory: () => serverTransport,
   });
-  const channelCore = new MoltZapChannelCore({
-    service: channelService,
-    logger: silentLogger,
-  });
-  const routing = createRoutingState();
-
-  const sendReply = (chatId: string, text: string) =>
-    channelCore.sendReply(chatId, text).pipe(
-      Effect.mapError(
-        (cause): ReplyError => ({
-          _tag: "SendFailed",
-          cause: cause instanceof Error ? cause.message : String(cause),
-        }),
-      ),
-    );
-
-  const boot = await bootChannelMcpServer(
-    {
-      serverName: "test-claude-code-channel",
-      instructions: "integration test",
-    },
-    {
-      sendReply,
-      routing,
-      logger: silentLogger,
-      transportFactory: () => serverTransport,
-    },
-  );
   if (boot._tag === "Err") {
     throw new Error(
-      `server boot failed: ${boot.error._tag}: ${boot.error.cause}`,
+      `bootClaudeCodeChannel failed: ${boot.error._tag}: ${boot.error.cause}`,
     );
   }
-  const serverHandle = boot.value;
+  const channelHandle = boot.value;
 
   const mcpClient = new Client(
     { name: "integration-test", version: "0.1.0" },
@@ -116,24 +87,7 @@ async function bootHarness(): Promise<Harness> {
   };
   await mcpClient.connect(clientTransport);
 
-  // Mirror entry.ts wiring: gate → translate → record → push.
-  channelCore.onInbound((enriched: EnrichedInboundMessage) =>
-    Effect.gen(function* () {
-      const translated = toClaudeChannelNotification(enriched);
-      if (translated._tag === "Err") return;
-      routing.recordInbound(
-        translated.value.params.meta.message_id,
-        translated.value.params.meta.chat_id,
-      );
-      yield* serverHandle
-        .push(translated.value)
-        .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
-    }),
-  );
-
-  // Connect channel (agent A) + peer (agent B).
-  await Effect.runPromise(channelService.connect());
-
+  // Peer (agent B) is a separate MoltZapService used to drive inbound traffic.
   const peerService = new MoltZapService({
     serverUrl: wsUrl,
     agentKey: agentBApiKey,
@@ -155,8 +109,7 @@ async function bootHarness(): Promise<Harness> {
   const conversationId = convResponse.conversation.id;
 
   return {
-    channelService,
-    channelCore,
+    channelHandle,
     peerService,
     mcpClient,
     channelAgentId,
@@ -171,12 +124,7 @@ async function bootHarness(): Promise<Harness> {
         // best effort
       }
       try {
-        await Effect.runPromise(serverHandle.stop());
-      } catch {
-        // best effort
-      }
-      try {
-        await Effect.runPromise(channelCore.disconnect());
+        await Effect.runPromise(channelHandle.stop());
       } catch {
         // best effort
       }

--- a/packages/claude-code-channel/src/bin.ts
+++ b/packages/claude-code-channel/src/bin.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Stdio MCP-server entry — what Claude Code (`claude --mcp-config ...`)
+ * subprocess-spawns to bring this channel online.
+ *
+ * Reads the moltzap connection config from environment variables (the
+ * MCP config's `env:` block sets these), calls `bootClaudeCodeChannel`,
+ * and holds the process open. stdin/stdout speak MCP JSON-RPC for the
+ * `claude` parent; stderr carries diagnostic logs so the parent's stdout
+ * isn't corrupted.
+ *
+ * Environment contract:
+ *   MOLTZAP_API_KEY    — agent api key (required)
+ *   MOLTZAP_SERVER_URL — moltzap server url (required, http(s)://host[:port] form)
+ *   MOLTZAP_SERVER_NAME — optional MCP server name override (defaults to package default)
+ *
+ * Failure modes exit with code 1 and a diagnostic line on stderr.
+ */
+import { bootClaudeCodeChannel } from "./entry.js";
+
+// #ignore-sloppy-code-next-line[async-keyword, promise-type]: top-level subprocess entry — main wraps the boot Promise behind a single error boundary
+async function main(): Promise<void> {
+  const apiKey = process.env.MOLTZAP_API_KEY;
+  const serverUrl = process.env.MOLTZAP_SERVER_URL;
+  if (apiKey === undefined || apiKey.length === 0) {
+    process.stderr.write(
+      "moltzap-claude-code-channel: MOLTZAP_API_KEY env var is required\n",
+    );
+    process.exit(1);
+  }
+  if (serverUrl === undefined || serverUrl.length === 0) {
+    process.stderr.write(
+      "moltzap-claude-code-channel: MOLTZAP_SERVER_URL env var is required\n",
+    );
+    process.exit(1);
+  }
+
+  // Logger writes to stderr — stdout is reserved for MCP JSON-RPC framing.
+  // Variadic `unknown[]` matches @moltzap/client's `WsClientLogger` shape
+  // (ws-client.ts:110).
+  const logger = {
+    info: (...args: unknown[]): void => {
+      process.stderr.write(`[info] ${formatLogArgs(args)}\n`);
+    },
+    warn: (...args: unknown[]): void => {
+      process.stderr.write(`[warn] ${formatLogArgs(args)}\n`);
+    },
+    error: (...args: unknown[]): void => {
+      process.stderr.write(`[error] ${formatLogArgs(args)}\n`);
+    },
+  };
+
+  const opts: Parameters<typeof bootClaudeCodeChannel>[0] = {
+    serverUrl,
+    agentKey: apiKey,
+    logger,
+  };
+  if (
+    typeof process.env.MOLTZAP_SERVER_NAME === "string" &&
+    process.env.MOLTZAP_SERVER_NAME.length > 0
+  ) {
+    Object.assign(opts, { serverName: process.env.MOLTZAP_SERVER_NAME });
+  }
+
+  const result = await bootClaudeCodeChannel(opts);
+  if (result._tag === "Err") {
+    process.stderr.write(
+      `[error] moltzap-claude-code-channel: bootClaudeCodeChannel failed: ${result.error._tag}: ${result.error.cause}\n`,
+    );
+    process.exit(1);
+  }
+
+  // Adapter readiness is observed by the moltzap server's ConnectionManager
+  // once the WS auth completes. The MCP stdio server stays alive driving the
+  // `notifications/claude/channel` and `reply` tool calls; teardown is
+  // signal-driven (SIGTERM from the parent runtime adapter).
+  process.stderr.write("[info] moltzap-claude-code-channel: ready\n");
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+    // #ignore-sloppy-code-next-line[bare-catch]: log formatting fallback — circular refs etc. are not actionable here
+  } catch (_err) {
+    void _err;
+    return String(value);
+  }
+}
+
+function formatLogArgs(args: ReadonlyArray<unknown>): string {
+  return args.map((a) => (typeof a === "string" ? a : safeJson(a))).join(" ");
+}
+
+void main().catch((err: unknown) => {
+  process.stderr.write(
+    `[error] moltzap-claude-code-channel: uncaught ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/packages/claude-code-channel/src/bin.ts
+++ b/packages/claude-code-channel/src/bin.ts
@@ -50,19 +50,15 @@ async function main(): Promise<void> {
     },
   };
 
-  const opts: Parameters<typeof bootClaudeCodeChannel>[0] = {
+  const serverName = process.env.MOLTZAP_SERVER_NAME;
+  const result = await bootClaudeCodeChannel({
     serverUrl,
     agentKey: apiKey,
     logger,
-  };
-  if (
-    typeof process.env.MOLTZAP_SERVER_NAME === "string" &&
-    process.env.MOLTZAP_SERVER_NAME.length > 0
-  ) {
-    Object.assign(opts, { serverName: process.env.MOLTZAP_SERVER_NAME });
-  }
-
-  const result = await bootClaudeCodeChannel(opts);
+    ...(typeof serverName === "string" && serverName.length > 0
+      ? { serverName }
+      : {}),
+  });
   if (result._tag === "Err") {
     process.stderr.write(
       `[error] moltzap-claude-code-channel: bootClaudeCodeChannel failed: ${result.error._tag}: ${result.error.cause}\n`,

--- a/packages/claude-code-channel/src/entry.ts
+++ b/packages/claude-code-channel/src/entry.ts
@@ -88,7 +88,14 @@ export async function bootClaudeCodeChannel(
       serverName: opts.serverName ?? DEFAULT_SERVER_NAME,
       instructions: opts.instructions ?? DEFAULT_INSTRUCTIONS,
     },
-    { sendReply, routing, logger },
+    {
+      sendReply,
+      routing,
+      logger,
+      ...(opts._testTransportFactory !== undefined
+        ? { transportFactory: opts._testTransportFactory }
+        : {}),
+    },
   );
   if (serverBoot._tag === "Err") {
     return {

--- a/packages/claude-code-channel/src/test-support.ts
+++ b/packages/claude-code-channel/src/test-support.ts
@@ -1,0 +1,16 @@
+/**
+ * `@moltzap/claude-code-channel/test-support` — narrow public subpath
+ * export so the protocol conformance suite can instantiate a real
+ * MoltZap WS client in the shape this channel ships (issue #254 / AC15-AC17
+ * pattern from architect-201 §8 O5).
+ *
+ * The Claude Code channel embeds `MoltZapChannelCore` + `MoltZapService`
+ * inside `bootClaudeCodeChannel`'s entry, exactly like the openclaw and
+ * nanoclaw channel wrappers. The conformance suite exercises the transport
+ * core via `@moltzap/client/test-utils` rather than reshaping the plugin's
+ * public contract — same factory, same shape as the sibling wrappers.
+ */
+export {
+  createMoltZapRealClientFactory,
+  type RealClientFactoryOptions,
+} from "@moltzap/client/test-utils";

--- a/packages/claude-code-channel/src/types.ts
+++ b/packages/claude-code-channel/src/types.ts
@@ -10,6 +10,7 @@
 
 import type { Effect } from "effect";
 import type { EnrichedInboundMessage, WsClientLogger } from "@moltzap/client";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { AllowlistError, BootError, PushError } from "./errors.js";
 
 /**
@@ -92,6 +93,17 @@ export interface BootOptions {
    * shape and the `reply` tool.
    */
   readonly instructions?: string;
+  /**
+   * Internal test seam. When present, replaces the default
+   * `StdioServerTransport` with an injected `Transport` (e.g.
+   * `InMemoryTransport`) so integration tests can drive the real
+   * `bootClaudeCodeChannel` boot path end-to-end without a subprocess.
+   *
+   * Field is prefixed `_` and explicitly tagged "tests-only" because no
+   * production caller has reason to override the transport — production
+   * always uses stdio. Reviewer #256: keep this seam narrow.
+   */
+  readonly _testTransportFactory?: () => Transport;
 }
 
 /**

--- a/packages/claude-code-channel/vitest.conformance.config.ts
+++ b/packages/claude-code-channel/vitest.conformance.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Claude Code channel client-side conformance vitest config (issue #254).
+ * Scoped to the `src/__tests__/conformance/**` tree; reuses the
+ * protocol package's divergence-proof glob so import drift surfaces.
+ */
+export default defineConfig({
+  test: {
+    include: [
+      "src/__tests__/conformance/**/*.test.ts",
+      "../protocol/src/testing/conformance/__divergence_proofs__/client-*.proofs.ts",
+    ],
+    testTimeout: 120_000,
+    hookTimeout: 90_000,
+    fileParallelism: false,
+    passWithNoTests: false,
+  },
+});

--- a/packages/openclaw-channel/package.json
+++ b/packages/openclaw-channel/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^10.18.0",
+    "@types/node": "^25.5.0",
     "@types/pg": "^8.11.0",
     "openai": "^6.26.0",
     "pg": "^8.13.0",

--- a/packages/runtimes/package.json
+++ b/packages/runtimes/package.json
@@ -20,12 +20,18 @@
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
+    "@effect/platform": "^0.96.0",
+    "@effect/platform-node": "^0.106.0",
+    "@moltzap/claude-code-channel": "workspace:*",
     "effect": "3.21.0",
     "openclaw": "2026.3.31"
   },
   "devDependencies": {
-    "@types/node": "^24.7.2",
+    "@anthropic-ai/claude-code": "^2.1.119",
     "@effect/vitest": "^0.29.0",
+    "@moltzap/client": "workspace:*",
+    "@moltzap/server-core": "workspace:*",
+    "@types/node": "^24.7.2",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/packages/runtimes/package.json
+++ b/packages/runtimes/package.json
@@ -31,7 +31,7 @@
     "@effect/vitest": "^0.29.0",
     "@moltzap/client": "workspace:*",
     "@moltzap/server-core": "workspace:*",
-    "@types/node": "^24.7.2",
+    "@types/node": "^25.5.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/packages/runtimes/src/channel-plugin-install.ts
+++ b/packages/runtimes/src/channel-plugin-install.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared plugin-install + workspace-seed helpers consumed by every
+ * runtime adapter that needs to drop a moltzap channel package onto disk
+ * for an external agent runtime to load (issue #272 item 8).
+ *
+ * Both `openclaw-adapter` and `claude-code-adapter` install a channel
+ * package into a per-agent state dir, then either copy or symlink the
+ * runtime imports the package resolves at load time. The two adapters
+ * differ only in:
+ *   - The extension subdirectory name (`openclaw-channel` vs
+ *     `claude-code-channel`).
+ *   - Whether the channel package ships an additional manifest file
+ *     (`openclaw.plugin.json` for openclaw; cc-channel ships none).
+ *   - Which runtime modules need to resolve from the plugin's local
+ *     `node_modules` (openclaw symlinks `effect`; cc-channel additionally
+ *     symlinks `@modelcontextprotocol/sdk`).
+ *
+ * Per the "minimize tech debt" team memory: factor the shared shape out
+ * now that two live adapters consume it.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { SpawnInput } from "./runtime.js";
+
+export interface PluginSymlinkSpec {
+  /** Path inside the plugin's `node_modules/` (e.g. `effect`, `@x/y`). */
+  readonly linkPath: string;
+  /**
+   * Ordered candidate source paths. The first existing candidate is used.
+   * Throws if none exist — surface the missing dep as a config error
+   * rather than a runtime ENOENT inside the spawned subprocess.
+   */
+  readonly candidates: ReadonlyArray<string>;
+}
+
+export interface InstallChannelPluginOpts {
+  readonly stateDir: string;
+  readonly channelDistDir: string;
+  readonly repoRoot: string;
+  /** Subdirectory under `<stateDir>/extensions/`. */
+  readonly extName: string;
+  /**
+   * Extra files copied verbatim from the channel package root into the
+   * installed extension dir. Each entry is a basename (e.g.
+   * `openclaw.plugin.json`); silently skipped if not present.
+   */
+  readonly extraPackageFiles?: ReadonlyArray<string>;
+  /**
+   * Extra symlinks to create under `<extDir>/node_modules/`. Each is
+   * tried against an ordered list of candidate sources; first hit wins.
+   */
+  readonly extraSymlinks?: ReadonlyArray<PluginSymlinkSpec>;
+}
+
+/**
+ * Install a moltzap channel package into a per-agent state dir.
+ *
+ * Standard layout produced:
+ *   <stateDir>/extensions/<extName>/dist/...      ← copied from channelDistDir
+ *   <stateDir>/extensions/<extName>/package.json  ← copied from channel pkg root
+ *   <stateDir>/extensions/<extName>/node_modules/@moltzap/protocol → repoRoot/packages/protocol
+ *   <stateDir>/extensions/<extName>/node_modules/@moltzap/client   → repoRoot/packages/client
+ *   <stateDir>/extensions/<extName>/<extraPackageFiles[i]>         (when present)
+ *   <stateDir>/extensions/<extName>/node_modules/<extraSymlinks[i].linkPath> → first existing candidate
+ *
+ * Returns the absolute path to the installed extension dir.
+ */
+export function installChannelPlugin(opts: InstallChannelPluginOpts): string {
+  const extDir = path.join(opts.stateDir, "extensions", opts.extName);
+  const channelPackageDir = path.dirname(opts.channelDistDir);
+
+  // `recursive: true` creates parent dirs as needed — one mkdir is enough.
+  fs.mkdirSync(extDir, { recursive: true });
+
+  // Copy the plugin's `dist/` (skip nested node_modules + src so the copy
+  // stays small and the runtime resolves through the symlinks below).
+  fs.cpSync(opts.channelDistDir, path.join(extDir, "dist"), {
+    recursive: true,
+    dereference: true,
+    filter: (src) => {
+      const rel = path.relative(opts.channelDistDir, src);
+      return !rel.startsWith("node_modules") && !rel.startsWith("src");
+    },
+  });
+
+  // Copy package.json + any extra package-level manifests (e.g. openclaw's
+  // plugin manifest). Missing extras are silently skipped — this is a
+  // best-effort copy, not a hard requirement.
+  const packageJsonPath = path.join(channelPackageDir, "package.json");
+  if (fs.existsSync(packageJsonPath)) {
+    fs.copyFileSync(packageJsonPath, path.join(extDir, "package.json"));
+  }
+  for (const extra of opts.extraPackageFiles ?? []) {
+    const src = path.join(channelPackageDir, extra);
+    if (fs.existsSync(src)) {
+      fs.copyFileSync(src, path.join(extDir, extra));
+    }
+  }
+
+  // Standard workspace symlinks: every channel resolves @moltzap/protocol
+  // and @moltzap/client at runtime. (The protocol + client packages are
+  // workspace siblings; symlinking lets the plugin pick them up without
+  // a redundant copy.)
+  const pluginNm = path.join(extDir, "node_modules");
+  fs.mkdirSync(path.join(pluginNm, "@moltzap"), { recursive: true });
+  fs.symlinkSync(
+    path.join(opts.repoRoot, "packages/protocol"),
+    path.join(pluginNm, "@moltzap/protocol"),
+    "dir",
+  );
+  fs.symlinkSync(
+    path.join(opts.repoRoot, "packages/client"),
+    path.join(pluginNm, "@moltzap/client"),
+    "dir",
+  );
+
+  for (const spec of opts.extraSymlinks ?? []) {
+    const linkTarget = path.join(pluginNm, spec.linkPath);
+    fs.mkdirSync(path.dirname(linkTarget), { recursive: true });
+    symlinkPreferring(spec.candidates, linkTarget);
+  }
+
+  return extDir;
+}
+
+/**
+ * Drop SpawnInput.workspaceFiles into `<stateDir>/workspace/`. Identical
+ * shape between adapters; lifted here so they share one implementation.
+ */
+export function seedWorkspaceFiles(
+  stateDir: string,
+  workspaceFiles: SpawnInput["workspaceFiles"],
+): void {
+  if (workspaceFiles === undefined) {
+    return;
+  }
+  const workspaceDir = path.join(stateDir, "workspace");
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  for (const file of workspaceFiles) {
+    const destination = path.join(workspaceDir, file.relativePath);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.writeFileSync(destination, file.content);
+  }
+}
+
+function symlinkPreferring(
+  candidates: ReadonlyArray<string>,
+  target: string,
+): void {
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      fs.symlinkSync(candidate, target, "dir");
+      return;
+    }
+  }
+  throw new Error(
+    `channel-plugin-install: none of the candidate paths exist for ${target}: ${candidates.join(", ")}`,
+  );
+}

--- a/packages/runtimes/src/claude-code-adapter.integration.test.ts
+++ b/packages/runtimes/src/claude-code-adapter.integration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Integration test for `ClaudeCodeAdapter` (issue #255).
+ *
+ * Spawns the real Anthropic `claude` CLI (installed as a devDep of
+ * `@moltzap/runtimes`) configured via `--mcp-config` to load the
+ * `@moltzap/claude-code-channel` plugin from a per-agent state dir.
+ * Asserts the adapter's spawn → ready → teardown cycle:
+ *   - The channel's MCP stdio server boots inside `claude`.
+ *   - cc-channel's `MoltZapService.connect()` authenticates against the
+ *     in-process moltzap core test server.
+ *   - The server's `ConnectionManager` records the auth, which
+ *     `waitUntilReady` polls (auth-on-connection — same signal openclaw
+ *     and nanoclaw use).
+ *   - Teardown reaps the detached process group.
+ *
+ * Skips with a logged note when the test environment lacks an Anthropic
+ * API key (CI without `ANTHROPIC_API_KEY` cannot start `claude` past its
+ * auth gate). The skip path mirrors how nanoclaw integration tests
+ * abstain in environments without Docker.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Effect } from "effect";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+import {
+  startCoreTestServer,
+  stopCoreTestServer,
+  type CoreTestServer,
+} from "@moltzap/server-core/test-utils";
+import { registerAgent, stripWsPath } from "@moltzap/client/test";
+
+import { createWorkspaceClaudeCodeAdapter } from "./claude-code-adapter.js";
+import { AgentName, ApiKey, ServerUrl } from "./runtime.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(here, "..", "..", "..");
+const CC_CHANNEL_DIST = join(
+  REPO_ROOT,
+  "packages",
+  "claude-code-channel",
+  "dist",
+);
+const CLAUDE_BIN_CANDIDATES = [
+  join(REPO_ROOT, "packages", "runtimes", "node_modules", ".bin", "claude"),
+  join(REPO_ROOT, "node_modules", ".bin", "claude"),
+];
+
+function findClaudeBin(): string | null {
+  for (const candidate of CLAUDE_BIN_CANDIDATES) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+const CLAUDE_BIN = findClaudeBin();
+// Auth: claude authenticates via whichever path the host has set up —
+// `ANTHROPIC_API_KEY`, OAuth credentials in the host's claude config, or
+// a keychain credential. We don't gate on `ANTHROPIC_API_KEY` because
+// OAuth-only setups are common (and the spawn-side `--bare` flag that
+// would force env-only auth is intentionally NOT passed by the adapter).
+// If claude can't auth at runtime, the subprocess exits and
+// `waitUntilReady` returns `ProcessExited` with the auth error in stderr
+// — which is informative enough.
+if (CLAUDE_BIN === null) {
+  describe.skip("ClaudeCodeAdapter (integration) — skipped (claude bin not installed)", () => {
+    it("requires claude CLI on disk", () => {
+      expect(CLAUDE_BIN).not.toBeNull();
+    });
+  });
+} else {
+  describe("ClaudeCodeAdapter (integration)", () => {
+    let server: CoreTestServer;
+
+    beforeAll(async () => {
+      server = await startCoreTestServer();
+    }, 60_000);
+
+    afterAll(async () => {
+      await stopCoreTestServer();
+    });
+
+    it("spawn → ready → teardown completes against the real claude CLI + cc-channel MCP plugin", async () => {
+      const reg = await Effect.runPromise(
+        registerAgent(server.baseUrl, "claude-code-runtime-it"),
+      );
+
+      const adapter = createWorkspaceClaudeCodeAdapter({
+        server: { connections: server.coreApp.connections },
+        claudeBin: CLAUDE_BIN,
+        channelDistDir: CC_CHANNEL_DIST,
+        repoRoot: REPO_ROOT,
+      });
+
+      const spawnResult = await Effect.runPromise(
+        Effect.either(
+          adapter.spawn({
+            agentName: AgentName("claude-code-runtime-it"),
+            apiKey: ApiKey(reg.apiKey),
+            agentId: reg.agentId,
+            serverUrl: ServerUrl(stripWsPath(server.wsUrl)),
+          }),
+        ),
+      );
+      expect(spawnResult._tag).toBe("Right");
+
+      const ready = await Effect.runPromise(adapter.waitUntilReady(120_000));
+      if (ready._tag !== "Ready") {
+        const logs = adapter.getLogs(0).text;
+        throw new Error(
+          `expected Ready, got ${ready._tag}. claude+cc-channel logs:\n${logs}`,
+        );
+      }
+      expect(ready._tag).toBe("Ready");
+
+      // `getLogs` returns a `LogSlice` shape regardless of whether the
+      // stream-consumer fibers have flushed yet — assert shape, not size.
+      const slice = adapter.getLogs(0);
+      expect(typeof slice.text).toBe("string");
+      expect(slice.nextOffset).toBe(slice.text.length);
+
+      await Effect.runPromise(adapter.teardown());
+
+      // Idempotent — second teardown is a no-op.
+      await Effect.runPromise(adapter.teardown());
+    }, 180_000);
+  });
+}

--- a/packages/runtimes/src/claude-code-adapter.ts
+++ b/packages/runtimes/src/claude-code-adapter.ts
@@ -27,7 +27,7 @@
  */
 import { Command } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { Effect, Exit, Scope, Stream, pipe } from "effect";
+import { Effect, Exit, Fiber, Option, Scope, Stream, pipe } from "effect";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -44,8 +44,8 @@ import { SpawnFailed } from "./errors.js";
 import {
   installChannelPlugin,
   seedWorkspaceFiles,
-  writeClaudeCodeMcpConfig,
-} from "./claude-code-process.js";
+} from "./channel-plugin-install.js";
+import { writeClaudeCodeMcpConfig } from "./claude-code-process.js";
 
 export interface ClaudeCodeAdapterDeps {
   readonly server: RuntimeServerHandle;
@@ -77,10 +77,14 @@ export interface WorkspaceClaudeCodeAdapterInput {
 }
 
 interface SpawnedProcess {
-  readonly exitCode: Effect.Effect<number, never, never>;
+  /**
+   * Long-running fiber that resolves with the exit code (or -1 if the
+   * underlying `Process.exitCode` errors). Polled synchronously by
+   * `waitUntilReady` and `doTeardown` via `Fiber.poll` rather than a
+   * side-channel mutable.
+   */
+  readonly exitFiber: Fiber.RuntimeFiber<number, never>;
   readonly kill: (signal: NodeJS.Signals) => Effect.Effect<void, never, never>;
-  readonly isExited: () => boolean;
-  readonly currentExitCode: () => number | null;
   /**
    * Long-lived `Scope` that carries `Command.start`'s finalizer (which
    * kills the process). The adapter closes this scope on teardown.
@@ -101,12 +105,9 @@ const TERM_WAIT_MS = 10_000;
 
 /**
  * Spawn `claude` via @effect/platform's Command, layering the Node
- * platform context so PlatformError fans out to never. Returns a
- * `SpawnedProcess` with synchronous helpers (`isExited`,
- * `currentExitCode`) in addition to the Effect-native ones — the
- * adapter's `waitUntilReady` is an `Effect.iterate` polling loop that
- * only needs a sync probe per tick, so we keep a sync mirror of the
- * exit code populated by a forked observer fiber.
+ * platform context so PlatformError fans out to never. The returned
+ * `SpawnedProcess` exposes the exit fiber for callers that need to
+ * `Fiber.poll` synchronously inside an `Effect.gen` polling loop.
  */
 function spawnClaudeProcess(opts: {
   readonly claudeBin: string;
@@ -131,28 +132,15 @@ function spawnClaudeProcess(opts: {
     const scope = yield* Scope.make();
     const proc = yield* Command.start(command).pipe(Scope.extend(scope));
 
-    let resolvedExit: number | null = null;
-    const exitObserver = pipe(
-      proc.exitCode,
-      Effect.tap((code) =>
-        Effect.sync(() => {
-          resolvedExit = code;
-        }),
-      ),
-      // PlatformError on the exit channel collapses to "treat as exit -1
-      // with reason in logs"; the adapter only consumes a number.
-      Effect.catchAll(() =>
-        Effect.sync(() => {
-          resolvedExit = -1;
-          return -1;
-        }),
-      ),
-    );
-    const exitFiber = yield* Effect.fork(exitObserver);
-    const exitCodeEffect = pipe(
-      exitFiber,
-      (fiber) => fiber.await,
-      Effect.map((exit) => (exit._tag === "Success" ? exit.value : -1)),
+    // PlatformError on the exit channel collapses to "treat as exit -1
+    // with reason in logs"; the adapter consumes a plain number.
+    // `Effect.forkIn(scope)` (NOT `Effect.fork`) ties the observer's
+    // lifetime to the process scope rather than this gen's scope —
+    // otherwise the fiber gets interrupted the moment spawn returns and
+    // every later `Fiber.poll` reports the interrupt as exit.
+    const exitFiber = yield* proc.exitCode.pipe(
+      Effect.catchAll(() => Effect.succeed(-1)),
+      Effect.forkIn(scope),
     );
 
     const consumeStream = (
@@ -168,8 +156,10 @@ function spawnClaudeProcess(opts: {
         Effect.catchAll(() => Effect.void),
       );
 
-    yield* Effect.fork(consumeStream(proc.stdout));
-    yield* Effect.fork(consumeStream(proc.stderr));
+    // Stream consumers also live in the process scope so they keep
+    // appending logs until the subprocess closes its stdout/stderr.
+    yield* consumeStream(proc.stdout).pipe(Effect.forkIn(scope));
+    yield* consumeStream(proc.stderr).pipe(Effect.forkIn(scope));
 
     const kill = (signal: NodeJS.Signals): Effect.Effect<void, never, never> =>
       pipe(
@@ -178,10 +168,8 @@ function spawnClaudeProcess(opts: {
       );
 
     return {
-      exitCode: exitCodeEffect,
+      exitFiber,
       kill,
-      isExited: () => resolvedExit !== null,
-      currentExitCode: () => resolvedExit,
       scope,
     } satisfies SpawnedProcess;
   }).pipe(
@@ -192,65 +180,103 @@ function spawnClaudeProcess(opts: {
   );
 }
 
+/**
+ * `Fiber.poll` returns `Effect<Option<Exit<A, E>>>` — None while running,
+ * Some(Exit) once resolved. We project to `Option<number>` so callers
+ * stay in plain-number land (matching the underlying exit-code surface).
+ */
+function pollExitCode(
+  fiber: Fiber.RuntimeFiber<number, never>,
+): Effect.Effect<Option.Option<number>, never, never> {
+  return pipe(
+    Fiber.poll(fiber),
+    Effect.map(
+      Option.match({
+        onNone: () => Option.none<number>(),
+        onSome: (exit: Exit.Exit<number, never>): Option.Option<number> =>
+          Exit.match(exit, {
+            onSuccess: (code) => Option.some(code),
+            // Defects (incl. fiber interrupt on scope close) collapse to
+            // -1 — same shape `proc.exitCode.pipe(catchAll → -1)` produces
+            // for PlatformError, so callers see one consistent number.
+            onFailure: () => Option.some(-1),
+          }),
+      }),
+    ),
+  );
+}
+
 export class ClaudeCodeAdapter implements Runtime {
   private state: AdapterState | null = null;
 
   constructor(private readonly deps: ClaudeCodeAdapterDeps) {}
 
   spawn(input: SpawnInput): Effect.Effect<void, SpawnFailed, never> {
+    // Wrap each fs/spawn step in an `Effect.try` that maps the cause to
+    // `SpawnFailed(agentName, ...)`. Hoisted to a single helper so the
+    // four sequential steps don't repeat the same boilerplate (issue
+    // #272 item 4).
+    const tryStep = <A>(fn: () => A): Effect.Effect<A, SpawnFailed, never> =>
+      Effect.try({
+        try: fn,
+        catch: (cause) =>
+          new SpawnFailed(
+            input.agentName,
+            cause instanceof Error ? cause : new Error(String(cause)),
+          ),
+      });
+
     return Effect.gen(this, function* () {
-      const stateDir = yield* Effect.try({
-        try: () =>
-          fs.mkdtempSync(
-            path.join(os.tmpdir(), `claude-code-${input.agentName}-`),
-          ),
-        catch: (cause) =>
-          new SpawnFailed(
-            input.agentName,
-            cause instanceof Error ? cause : new Error(String(cause)),
-          ),
-      });
+      const stateDir = yield* tryStep(() =>
+        fs.mkdtempSync(
+          path.join(os.tmpdir(), `claude-code-${input.agentName}-`),
+        ),
+      );
 
-      yield* Effect.try({
-        try: () => {
-          seedWorkspaceFiles(stateDir, input.workspaceFiles);
-        },
-        catch: (cause) =>
-          new SpawnFailed(
-            input.agentName,
-            cause instanceof Error ? cause : new Error(String(cause)),
-          ),
-      });
+      yield* tryStep(() => seedWorkspaceFiles(stateDir, input.workspaceFiles));
 
-      const extDir = yield* Effect.try({
-        try: () =>
-          installChannelPlugin(
-            stateDir,
-            this.deps.channelDistDir,
-            this.deps.repoRoot,
-          ),
-        catch: (cause) =>
-          new SpawnFailed(
-            input.agentName,
-            cause instanceof Error ? cause : new Error(String(cause)),
-          ),
-      });
+      const extDir = yield* tryStep(() =>
+        installChannelPlugin({
+          stateDir,
+          channelDistDir: this.deps.channelDistDir,
+          repoRoot: this.deps.repoRoot,
+          extName: "claude-code-channel",
+          // cc-channel resolves @modelcontextprotocol/sdk + effect at
+          // MCP-load time; symlink them into the per-agent ext dir.
+          extraSymlinks: [
+            {
+              linkPath: "@modelcontextprotocol/sdk",
+              candidates: [
+                path.join(
+                  this.deps.channelDistDir,
+                  "../node_modules/@modelcontextprotocol/sdk",
+                ),
+                path.join(
+                  this.deps.repoRoot,
+                  "node_modules/@modelcontextprotocol/sdk",
+                ),
+              ],
+            },
+            {
+              linkPath: "effect",
+              candidates: [
+                path.join(this.deps.channelDistDir, "../node_modules/effect"),
+                path.join(this.deps.repoRoot, "node_modules/effect"),
+              ],
+            },
+          ],
+        }),
+      );
 
-      const mcpConfigPath = yield* Effect.try({
-        try: () =>
-          writeClaudeCodeMcpConfig({
-            stateDir,
-            extDir,
-            serverUrl: input.serverUrl,
-            apiKey: input.apiKey,
-            agentName: input.agentName,
-          }),
-        catch: (cause) =>
-          new SpawnFailed(
-            input.agentName,
-            cause instanceof Error ? cause : new Error(String(cause)),
-          ),
-      });
+      const mcpConfigPath = yield* tryStep(() =>
+        writeClaudeCodeMcpConfig({
+          stateDir,
+          extDir,
+          serverUrl: input.serverUrl,
+          apiKey: input.apiKey,
+          agentName: input.agentName,
+        }),
+      );
 
       // `--strict-mcp-config` ensures only adapter-provided MCP servers
       // load (no leakage from host claude config).
@@ -258,6 +284,13 @@ export class ClaudeCodeAdapter implements Runtime {
       // is the long-running streaming mode the agent SDK uses; without
       // it, `claude` either drops into interactive (TTY-bound) or
       // one-shots and exits.
+      // `--dangerously-skip-permissions` is needed because `claude` in
+      // `--print` mode otherwise blocks on permission prompts the moment
+      // a tool is invoked, and there is no TTY to answer them. Long-term
+      // a per-session permission-mode = "bypassPermissions" via
+      // `--permission-mode` would be tighter, but the sandbox boundary
+      // is the per-agent state dir + MoltZap auth, so the looser flag is
+      // acceptable here.
       // We omit `--bare`: bare-mode auth is strictly ANTHROPIC_API_KEY
       // and skips OAuth/keychain. Host environments where the user has
       // logged into `claude` (OAuth) should not be forced to set an API
@@ -285,10 +318,12 @@ export class ClaudeCodeAdapter implements Runtime {
         claudeBin: this.deps.claudeBin,
         args: claudeArgs,
         cwd: stateDir,
-        env: {
-          ...(globalThis.process.env as Record<string, string>),
+        // `process.env` values are `string | undefined`; filter to
+        // string-only to satisfy `Command.env`'s `Record<string, string>`
+        // contract without a wholesale `as` cast (issue #272 item 7).
+        env: filterDefinedEnv(globalThis.process.env, {
           CLAUDE_CODE_HOME: stateDir,
-        },
+        }),
         logBuffer,
       }).pipe(
         Effect.mapError((cause) => new SpawnFailed(input.agentName, cause)),
@@ -311,17 +346,18 @@ export class ClaudeCodeAdapter implements Runtime {
     const { process: proc, spawnInput, logBuffer } = this.state;
     const agentId = spawnInput.agentId;
 
-    // One synchronous probe: returns a `ReadyOutcome` once the agent is
-    // authenticated or the subprocess has exited; returns `null` to signal
-    // "keep polling." `Effect.repeat` with `Schedule.spaced(500ms)` and a
-    // `while` predicate replaces the prior `setTimeout` recursion.
-    const tick: Effect.Effect<ReadyOutcome | null, never, never> = Effect.sync(
-      () => {
-        const exitCode = proc.currentExitCode();
-        if (exitCode !== null) {
+    // One probe per tick: returns a `ReadyOutcome` once the agent is
+    // authenticated or the subprocess has exited; returns `null` to
+    // signal "keep polling." The exit check uses `Fiber.poll` (no
+    // side-channel mutable — issue #272 item 5).
+    const tick: Effect.Effect<ReadyOutcome | null, never, never> = Effect.gen(
+      this,
+      function* () {
+        const exitOpt = yield* pollExitCode(proc.exitFiber);
+        if (Option.isSome(exitOpt)) {
           return {
             _tag: "ProcessExited" as const,
-            exitCode,
+            exitCode: exitOpt.value,
             stderr: logBuffer.value,
           };
         }
@@ -403,23 +439,29 @@ export class ClaudeCodeAdapter implements Runtime {
     // SIGTERM with a timeout; escalate to SIGKILL if SIGTERM doesn't
     // reap. Closing `proc.scope` afterward runs Command.start's kill
     // finalizer + the stream-consumer fiber finalizers.
-    const killAndWait = proc.isExited()
-      ? Effect.void
-      : pipe(
-          proc.kill("SIGTERM"),
-          Effect.flatMap(() =>
-            proc.exitCode.pipe(
-              Effect.timeout(`${TERM_WAIT_MS} millis`),
-              Effect.catchAll(() =>
-                pipe(
-                  proc.kill("SIGKILL"),
-                  Effect.flatMap(() => proc.exitCode),
+    const exitCodeEffect = Fiber.join(proc.exitFiber);
+    const killAndWait = pipe(
+      pollExitCode(proc.exitFiber),
+      Effect.flatMap((exitOpt) =>
+        Option.isSome(exitOpt)
+          ? Effect.void
+          : pipe(
+              proc.kill("SIGTERM"),
+              Effect.flatMap(() =>
+                exitCodeEffect.pipe(
+                  Effect.timeout(`${TERM_WAIT_MS} millis`),
+                  Effect.catchAll(() =>
+                    pipe(
+                      proc.kill("SIGKILL"),
+                      Effect.flatMap(() => exitCodeEffect),
+                    ),
+                  ),
                 ),
               ),
+              Effect.asVoid,
             ),
-          ),
-          Effect.asVoid,
-        );
+      ),
+    );
 
     return pipe(
       killAndWait,
@@ -467,4 +509,26 @@ function resolveWorkspaceClaudeBin(
     return packageBin;
   }
   return path.join(repoRoot, "node_modules/.bin/claude");
+}
+
+/**
+ * Project `process.env` (`Record<string, string | undefined>`) onto a
+ * strict `Record<string, string>` so it slots into `Command.env` without
+ * a wholesale `as` cast (issue #272 item 7). Also folds in adapter-set
+ * extras (`CLAUDE_CODE_HOME` etc.) on top.
+ */
+function filterDefinedEnv(
+  source: NodeJS.ProcessEnv,
+  extras: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value === "string") {
+      out[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(extras)) {
+    out[key] = value;
+  }
+  return out;
 }

--- a/packages/runtimes/src/claude-code-adapter.ts
+++ b/packages/runtimes/src/claude-code-adapter.ts
@@ -1,0 +1,470 @@
+/**
+ * Claude Code runtime adapter (issue #255).
+ *
+ * Mirrors `openclaw-adapter.ts`'s shape: the agent runtime binary is
+ * Anthropic's `claude` CLI; the channel plugin is `@moltzap/claude-code-
+ * channel`, installed into a per-agent state dir and wired in via
+ * `claude --strict-mcp-config --mcp-config <path>`. The cc-channel's MCP
+ * stdio server connects to moltzap, the moltzap server's
+ * `ConnectionManager` records the auth, and `waitUntilReady` resolves —
+ * same auth-on-connection signal openclaw and nanoclaw use.
+ *
+ * Subprocess lifecycle is Effect-native via `@effect/platform`'s
+ * `Command` API: spawn returns a `Process` whose `kill`, `exitCode`,
+ * `stdout`, and `stderr` are typed Effects/Streams. We do NOT spawn with
+ * `detached: true` because cc-channel runs as `claude`'s direct child
+ * (claude --mcp-config spawns the MCP server itself), so a SIGTERM on
+ * `claude` propagates naturally to cc-channel — no group-kill required,
+ * unlike openclaw whose gateway children sit outside the openclaw bin's
+ * own process tree.
+ *
+ * Auth gate: cc-channel needs only the moltzap api key (env-injected via
+ * the MCP config). Claude Code itself authenticates against Anthropic via
+ * whichever path the host has set up — `ANTHROPIC_API_KEY`, OAuth, or a
+ * keychain credential. We do not pin the strategy; if auth fails the
+ * subprocess exits with an error and `waitUntilReady` surfaces it as a
+ * `ProcessExited` outcome.
+ */
+import { Command } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Effect, Exit, Scope, Stream, pipe } from "effect";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type {
+  Runtime,
+  RuntimeServerHandle,
+  SpawnInput,
+  LogSlice,
+  ReadyOutcome,
+} from "./runtime.js";
+import { SpawnFailed } from "./errors.js";
+import {
+  installChannelPlugin,
+  seedWorkspaceFiles,
+  writeClaudeCodeMcpConfig,
+} from "./claude-code-process.js";
+
+export interface ClaudeCodeAdapterDeps {
+  readonly server: RuntimeServerHandle;
+  /**
+   * Absolute path to the `claude` CLI bin. Production callers pass the
+   * workspace `node_modules/.bin/claude` (resolved by
+   * `createWorkspaceClaudeCodeAdapter`).
+   */
+  readonly claudeBin: string;
+  /**
+   * Absolute path to `@moltzap/claude-code-channel`'s built `dist/` dir.
+   * The adapter copies this into the per-agent state dir and points the
+   * MCP config at the copied bin.
+   */
+  readonly channelDistDir: string;
+  /**
+   * Absolute path to the moltzap repo root — used to symlink workspace
+   * deps (`@moltzap/protocol`, `@moltzap/client`, etc.) into the plugin
+   * state dir's `node_modules`.
+   */
+  readonly repoRoot: string;
+}
+
+export interface WorkspaceClaudeCodeAdapterInput {
+  readonly server: RuntimeServerHandle;
+  readonly claudeBin?: string;
+  readonly channelDistDir?: string;
+  readonly repoRoot?: string;
+}
+
+interface SpawnedProcess {
+  readonly exitCode: Effect.Effect<number, never, never>;
+  readonly kill: (signal: NodeJS.Signals) => Effect.Effect<void, never, never>;
+  readonly isExited: () => boolean;
+  readonly currentExitCode: () => number | null;
+  /**
+   * Long-lived `Scope` that carries `Command.start`'s finalizer (which
+   * kills the process). The adapter closes this scope on teardown.
+   */
+  readonly scope: Scope.CloseableScope;
+}
+
+interface AdapterState {
+  process: SpawnedProcess;
+  stateDir: string;
+  spawnInput: SpawnInput;
+  // Mutable string buffer; the stdout/stderr fibers append to it.
+  logBuffer: { value: string };
+  tornDown: boolean;
+}
+
+const TERM_WAIT_MS = 10_000;
+
+/**
+ * Spawn `claude` via @effect/platform's Command, layering the Node
+ * platform context so PlatformError fans out to never. Returns a
+ * `SpawnedProcess` with synchronous helpers (`isExited`,
+ * `currentExitCode`) in addition to the Effect-native ones — the
+ * adapter's `waitUntilReady` is an `Effect.iterate` polling loop that
+ * only needs a sync probe per tick, so we keep a sync mirror of the
+ * exit code populated by a forked observer fiber.
+ */
+function spawnClaudeProcess(opts: {
+  readonly claudeBin: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd: string;
+  readonly env: Readonly<Record<string, string>>;
+  readonly logBuffer: { value: string };
+}): Effect.Effect<SpawnedProcess, Error, never> {
+  const command = pipe(
+    Command.make(opts.claudeBin, ...opts.args),
+    Command.workingDirectory(opts.cwd),
+    Command.env(opts.env),
+    Command.stdin("inherit"),
+  );
+
+  return Effect.gen(function* () {
+    // `Command.start` allocates the child and yields a `Process`, plus
+    // registers a finalizer in the current scope that kills the process.
+    // We allocate our own long-lived `Scope` and extend the start-effect
+    // into it so the process outlives the spawn-effect — the adapter
+    // closes the scope on teardown, which runs the kill finalizer.
+    const scope = yield* Scope.make();
+    const proc = yield* Command.start(command).pipe(Scope.extend(scope));
+
+    let resolvedExit: number | null = null;
+    const exitObserver = pipe(
+      proc.exitCode,
+      Effect.tap((code) =>
+        Effect.sync(() => {
+          resolvedExit = code;
+        }),
+      ),
+      // PlatformError on the exit channel collapses to "treat as exit -1
+      // with reason in logs"; the adapter only consumes a number.
+      Effect.catchAll(() =>
+        Effect.sync(() => {
+          resolvedExit = -1;
+          return -1;
+        }),
+      ),
+    );
+    const exitFiber = yield* Effect.fork(exitObserver);
+    const exitCodeEffect = pipe(
+      exitFiber,
+      (fiber) => fiber.await,
+      Effect.map((exit) => (exit._tag === "Success" ? exit.value : -1)),
+    );
+
+    const consumeStream = (
+      stream: Stream.Stream<Uint8Array, unknown>,
+    ): Effect.Effect<void, never, never> =>
+      pipe(
+        stream,
+        Stream.runForEach((chunk) =>
+          Effect.sync(() => {
+            opts.logBuffer.value += Buffer.from(chunk).toString("utf8");
+          }),
+        ),
+        Effect.catchAll(() => Effect.void),
+      );
+
+    yield* Effect.fork(consumeStream(proc.stdout));
+    yield* Effect.fork(consumeStream(proc.stderr));
+
+    const kill = (signal: NodeJS.Signals): Effect.Effect<void, never, never> =>
+      pipe(
+        proc.kill(signal),
+        Effect.catchAll(() => Effect.void),
+      );
+
+    return {
+      exitCode: exitCodeEffect,
+      kill,
+      isExited: () => resolvedExit !== null,
+      currentExitCode: () => resolvedExit,
+      scope,
+    } satisfies SpawnedProcess;
+  }).pipe(
+    Effect.provide(NodeContext.layer),
+    Effect.mapError((cause) =>
+      cause instanceof Error ? cause : new Error(String(cause)),
+    ),
+  );
+}
+
+export class ClaudeCodeAdapter implements Runtime {
+  private state: AdapterState | null = null;
+
+  constructor(private readonly deps: ClaudeCodeAdapterDeps) {}
+
+  spawn(input: SpawnInput): Effect.Effect<void, SpawnFailed, never> {
+    return Effect.gen(this, function* () {
+      const stateDir = yield* Effect.try({
+        try: () =>
+          fs.mkdtempSync(
+            path.join(os.tmpdir(), `claude-code-${input.agentName}-`),
+          ),
+        catch: (cause) =>
+          new SpawnFailed(
+            input.agentName,
+            cause instanceof Error ? cause : new Error(String(cause)),
+          ),
+      });
+
+      yield* Effect.try({
+        try: () => {
+          seedWorkspaceFiles(stateDir, input.workspaceFiles);
+        },
+        catch: (cause) =>
+          new SpawnFailed(
+            input.agentName,
+            cause instanceof Error ? cause : new Error(String(cause)),
+          ),
+      });
+
+      const extDir = yield* Effect.try({
+        try: () =>
+          installChannelPlugin(
+            stateDir,
+            this.deps.channelDistDir,
+            this.deps.repoRoot,
+          ),
+        catch: (cause) =>
+          new SpawnFailed(
+            input.agentName,
+            cause instanceof Error ? cause : new Error(String(cause)),
+          ),
+      });
+
+      const mcpConfigPath = yield* Effect.try({
+        try: () =>
+          writeClaudeCodeMcpConfig({
+            stateDir,
+            extDir,
+            serverUrl: input.serverUrl,
+            apiKey: input.apiKey,
+            agentName: input.agentName,
+          }),
+        catch: (cause) =>
+          new SpawnFailed(
+            input.agentName,
+            cause instanceof Error ? cause : new Error(String(cause)),
+          ),
+      });
+
+      // `--strict-mcp-config` ensures only adapter-provided MCP servers
+      // load (no leakage from host claude config).
+      // `--print --input-format stream-json --output-format stream-json`
+      // is the long-running streaming mode the agent SDK uses; without
+      // it, `claude` either drops into interactive (TTY-bound) or
+      // one-shots and exits.
+      // We omit `--bare`: bare-mode auth is strictly ANTHROPIC_API_KEY
+      // and skips OAuth/keychain. Host environments where the user has
+      // logged into `claude` (OAuth) should not be forced to set an API
+      // key just for a runtime spawn. `--strict-mcp-config` is the only
+      // isolation we need for the channel; CLAUDE.md / hooks remain
+      // host-controlled.
+      const claudeArgs: ReadonlyArray<string> = [
+        "--strict-mcp-config",
+        "--mcp-config",
+        mcpConfigPath,
+        "--print",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--dangerously-skip-permissions",
+        "--add-dir",
+        path.join(stateDir, "workspace"),
+      ];
+
+      const logBuffer = { value: "" };
+
+      const child = yield* spawnClaudeProcess({
+        claudeBin: this.deps.claudeBin,
+        args: claudeArgs,
+        cwd: stateDir,
+        env: {
+          ...(globalThis.process.env as Record<string, string>),
+          CLAUDE_CODE_HOME: stateDir,
+        },
+        logBuffer,
+      }).pipe(
+        Effect.mapError((cause) => new SpawnFailed(input.agentName, cause)),
+      );
+
+      this.state = {
+        process: child,
+        stateDir,
+        spawnInput: input,
+        logBuffer,
+        tornDown: false,
+      };
+    });
+  }
+
+  waitUntilReady(timeoutMs: number): Effect.Effect<ReadyOutcome, never, never> {
+    if (!this.state) {
+      return Effect.succeed({ _tag: "Ready" as const });
+    }
+    const { process: proc, spawnInput, logBuffer } = this.state;
+    const agentId = spawnInput.agentId;
+
+    // One synchronous probe: returns a `ReadyOutcome` once the agent is
+    // authenticated or the subprocess has exited; returns `null` to signal
+    // "keep polling." `Effect.repeat` with `Schedule.spaced(500ms)` and a
+    // `while` predicate replaces the prior `setTimeout` recursion.
+    const tick: Effect.Effect<ReadyOutcome | null, never, never> = Effect.sync(
+      () => {
+        const exitCode = proc.currentExitCode();
+        if (exitCode !== null) {
+          return {
+            _tag: "ProcessExited" as const,
+            exitCode,
+            stderr: logBuffer.value,
+          };
+        }
+        const connections = this.deps.server.connections.getByAgent(agentId);
+        if (connections.length > 0 && connections[0]!.auth !== null) {
+          return { _tag: "Ready" as const };
+        }
+        return null;
+      },
+    );
+
+    // Probe once, then iterate-with-sleep until probe yields a non-null
+    // outcome. `Effect.iterate` is the Effect-native equivalent of a
+    // `while (state === null) { sleep; state = probe(); }` loop and
+    // returns the final state.
+    const pollLoop = pipe(
+      tick,
+      Effect.flatMap((initial) =>
+        Effect.iterate(initial, {
+          while: (state) => state === null,
+          body: () => Effect.sleep("500 millis").pipe(Effect.zipRight(tick)),
+        }),
+      ),
+    );
+
+    return pipe(
+      pollLoop,
+      // Timeout fans the never-ready case into a `Timeout` outcome and
+      // hands the rest of the pipeline a uniform `ReadyOutcome` value.
+      Effect.timeoutTo({
+        duration: `${timeoutMs} millis`,
+        onSuccess: (outcome): ReadyOutcome =>
+          outcome ?? { _tag: "Ready" as const },
+        onTimeout: (): ReadyOutcome => ({
+          _tag: "Timeout" as const,
+          timeoutMs,
+        }),
+      }),
+      // Failure outcomes (Timeout, ProcessExited) tear down before returning
+      // — keeps the Runtime contract that the adapter cleans up after itself.
+      Effect.tap((outcome) =>
+        outcome._tag === "Ready" ? Effect.void : this.doTeardown(),
+      ),
+    );
+  }
+
+  teardown(): Effect.Effect<void, never, never> {
+    return Effect.suspend(() => this.doTeardown());
+  }
+
+  getLogs(offset: number): LogSlice {
+    if (!this.state) return { text: "", nextOffset: 0 };
+    const full = this.state.logBuffer.value;
+    return { text: full.slice(offset), nextOffset: full.length };
+  }
+
+  getInboundMarker(): string {
+    // The cc-channel pushes an MCP `notifications/claude/channel` to claude
+    // for every inbound; that method name appears in `--verbose` stream-json
+    // output. Used by trace-capture as a coarse "did inbound reach the
+    // agent" signal.
+    return "notifications/claude/channel";
+  }
+
+  private doTeardown(): Effect.Effect<void, never, never> {
+    if (!this.state || this.state.tornDown) return Effect.void;
+    this.state.tornDown = true;
+    const { process: proc, stateDir } = this.state;
+
+    const removeStateDir = Effect.sync(() => {
+      try {
+        fs.rmSync(stateDir, { recursive: true, force: true });
+        // #ignore-sloppy-code-next-line[bare-catch]: teardown cleanup — nothing actionable on rm failure
+      } catch (_err) {
+        void _err;
+      }
+    });
+
+    // SIGTERM with a timeout; escalate to SIGKILL if SIGTERM doesn't
+    // reap. Closing `proc.scope` afterward runs Command.start's kill
+    // finalizer + the stream-consumer fiber finalizers.
+    const killAndWait = proc.isExited()
+      ? Effect.void
+      : pipe(
+          proc.kill("SIGTERM"),
+          Effect.flatMap(() =>
+            proc.exitCode.pipe(
+              Effect.timeout(`${TERM_WAIT_MS} millis`),
+              Effect.catchAll(() =>
+                pipe(
+                  proc.kill("SIGKILL"),
+                  Effect.flatMap(() => proc.exitCode),
+                ),
+              ),
+            ),
+          ),
+          Effect.asVoid,
+        );
+
+    return pipe(
+      killAndWait,
+      Effect.zipRight(Scope.close(proc.scope, Exit.succeed(undefined))),
+      Effect.zipRight(removeStateDir),
+    );
+  }
+}
+
+export function createWorkspaceClaudeCodeAdapter(
+  input: WorkspaceClaudeCodeAdapterInput,
+): ClaudeCodeAdapter {
+  const packageRoot = resolveWorkspacePackageRoot();
+  const repoRoot = input.repoRoot ?? path.dirname(path.dirname(packageRoot));
+  return new ClaudeCodeAdapter({
+    server: input.server,
+    claudeBin:
+      input.claudeBin ?? resolveWorkspaceClaudeBin(packageRoot, repoRoot),
+    channelDistDir:
+      input.channelDistDir ??
+      path.join(repoRoot, "packages/claude-code-channel/dist"),
+    repoRoot,
+  });
+}
+
+// --- Module-private helpers ---
+
+function resolveWorkspacePackageRoot(): string {
+  let current = path.dirname(fileURLToPath(import.meta.url));
+  while (current !== path.parse(current).root) {
+    if (path.basename(current) === "packages") {
+      return path.join(current, "runtimes");
+    }
+    current = path.dirname(current);
+  }
+  throw new Error("Unable to resolve packages/runtimes workspace root");
+}
+
+function resolveWorkspaceClaudeBin(
+  packageRoot: string,
+  repoRoot: string,
+): string {
+  const packageBin = path.join(packageRoot, "node_modules/.bin/claude");
+  if (fs.existsSync(packageBin)) {
+    return packageBin;
+  }
+  return path.join(repoRoot, "node_modules/.bin/claude");
+}

--- a/packages/runtimes/src/claude-code-process.ts
+++ b/packages/runtimes/src/claude-code-process.ts
@@ -1,21 +1,13 @@
 /**
- * Internal config + plugin-install helpers for the Claude Code runtime
- * adapter (issue #255).
+ * Claude-Code-specific config helpers (issue #255).
  *
- * Mirrors `openclaw-adapter.ts`'s module-private `writeOpenClawConfig` /
- * `installChannelPlugin` shape, projected onto Claude Code's spawn surface:
- *   - `writeClaudeCodeMcpConfig` — emits the `claude --mcp-config` JSON
- *     pointing at the disk-installed channel plugin's `bin` script.
- *   - `installChannelPlugin` — copies cc-channel's `dist/` + `package.json`
- *     into the agent state dir, then symlinks `@moltzap/protocol`,
- *     `@moltzap/client`, `@modelcontextprotocol/sdk`, and `effect` into the
- *     plugin's local `node_modules` so the plugin's imports resolve at
- *     MCP-load time without depending on the parent's resolution paths.
- *   - `seedWorkspaceFiles` — same shape as openclaw's helper.
+ * The plugin-install + workspace-seed helpers live in
+ * `channel-plugin-install.ts` so openclaw and claude-code share one
+ * implementation (issue #272 item 8). What stays here is the bit unique
+ * to claude-code: the MCP-config JSON `claude --mcp-config` reads.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { SpawnInput } from "./runtime.js";
 
 export interface WriteClaudeCodeMcpConfigOpts {
   readonly stateDir: string;
@@ -72,100 +64,4 @@ export function writeClaudeCodeMcpConfig(
   const configPath = path.join(opts.stateDir, "mcp-config.json");
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
   return configPath;
-}
-
-export function seedWorkspaceFiles(
-  stateDir: string,
-  workspaceFiles: SpawnInput["workspaceFiles"],
-): void {
-  if (workspaceFiles === undefined) {
-    return;
-  }
-  const workspaceDir = path.join(stateDir, "workspace");
-  fs.mkdirSync(workspaceDir, { recursive: true });
-  for (const file of workspaceFiles) {
-    const destination = path.join(workspaceDir, file.relativePath);
-    fs.mkdirSync(path.dirname(destination), { recursive: true });
-    fs.writeFileSync(destination, file.content);
-  }
-}
-
-export function installChannelPlugin(
-  stateDir: string,
-  channelDistDir: string,
-  repoRoot: string,
-): string {
-  const extDir = path.join(stateDir, "extensions", "claude-code-channel");
-  const channelPackageDir = path.dirname(channelDistDir);
-  fs.mkdirSync(path.dirname(extDir), { recursive: true });
-
-  // Copy the plugin package: dist/ + package.json. Claude Code's MCP
-  // command points at the in-state-dir bin path; the plugin's package.json
-  // gets copied so node's module resolution starts from the plugin root.
-  fs.mkdirSync(extDir, { recursive: true });
-  fs.cpSync(channelDistDir, path.join(extDir, "dist"), {
-    recursive: true,
-    dereference: true,
-    filter: (src) => {
-      const rel = path.relative(channelDistDir, src);
-      return !rel.startsWith("node_modules") && !rel.startsWith("src");
-    },
-  });
-  const packageJsonPath = path.join(channelPackageDir, "package.json");
-  if (fs.existsSync(packageJsonPath)) {
-    fs.copyFileSync(packageJsonPath, path.join(extDir, "package.json"));
-  }
-
-  // Symlink the runtime imports cc-channel resolves at MCP-load time.
-  // Without these the spawned bin would fail in the state dir's isolated
-  // resolution. Mirrors openclaw's `installChannelPlugin` logic.
-  const pluginNm = path.join(extDir, "node_modules");
-  fs.mkdirSync(path.join(pluginNm, "@moltzap"), { recursive: true });
-  fs.symlinkSync(
-    path.join(repoRoot, "packages/protocol"),
-    path.join(pluginNm, "@moltzap/protocol"),
-    "dir",
-  );
-  fs.symlinkSync(
-    path.join(repoRoot, "packages/client"),
-    path.join(pluginNm, "@moltzap/client"),
-    "dir",
-  );
-  // The MCP SDK is a runtime dep of cc-channel (`@modelcontextprotocol/sdk`)
-  // and `effect` is a workspace-pinned dep used by both cc-channel and
-  // @moltzap/client. Both have to resolve from the plugin's node_modules.
-  fs.mkdirSync(path.join(pluginNm, "@modelcontextprotocol"), {
-    recursive: true,
-  });
-  symlinkPreferring(
-    [
-      path.join(channelPackageDir, "node_modules/@modelcontextprotocol/sdk"),
-      path.join(repoRoot, "node_modules/@modelcontextprotocol/sdk"),
-    ],
-    path.join(pluginNm, "@modelcontextprotocol/sdk"),
-  );
-  symlinkPreferring(
-    [
-      path.join(channelPackageDir, "node_modules/effect"),
-      path.join(repoRoot, "node_modules/effect"),
-    ],
-    path.join(pluginNm, "effect"),
-  );
-
-  return extDir;
-}
-
-function symlinkPreferring(
-  candidates: ReadonlyArray<string>,
-  target: string,
-): void {
-  for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
-      fs.symlinkSync(candidate, target, "dir");
-      return;
-    }
-  }
-  throw new Error(
-    `claude-code adapter: none of the candidate paths exist for ${target}: ${candidates.join(", ")}`,
-  );
 }

--- a/packages/runtimes/src/claude-code-process.ts
+++ b/packages/runtimes/src/claude-code-process.ts
@@ -1,0 +1,171 @@
+/**
+ * Internal config + plugin-install helpers for the Claude Code runtime
+ * adapter (issue #255).
+ *
+ * Mirrors `openclaw-adapter.ts`'s module-private `writeOpenClawConfig` /
+ * `installChannelPlugin` shape, projected onto Claude Code's spawn surface:
+ *   - `writeClaudeCodeMcpConfig` — emits the `claude --mcp-config` JSON
+ *     pointing at the disk-installed channel plugin's `bin` script.
+ *   - `installChannelPlugin` — copies cc-channel's `dist/` + `package.json`
+ *     into the agent state dir, then symlinks `@moltzap/protocol`,
+ *     `@moltzap/client`, `@modelcontextprotocol/sdk`, and `effect` into the
+ *     plugin's local `node_modules` so the plugin's imports resolve at
+ *     MCP-load time without depending on the parent's resolution paths.
+ *   - `seedWorkspaceFiles` — same shape as openclaw's helper.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { SpawnInput } from "./runtime.js";
+
+export interface WriteClaudeCodeMcpConfigOpts {
+  readonly stateDir: string;
+  readonly extDir: string;
+  readonly serverUrl: string;
+  readonly apiKey: string;
+  readonly agentName: string;
+}
+
+/**
+ * MCP server name as it appears under `mcpServers.<name>` in the JSON
+ * config Claude Code reads. Cold-read: `moltzap` because Claude Code's
+ * channel-tag rendering is keyed on the plugin's own MCP namespace, not
+ * this server name; this string is only the local config alias.
+ */
+const MCP_SERVER_ALIAS = "moltzap";
+
+interface ClaudeCodeMcpConfig {
+  readonly mcpServers: {
+    readonly [name: string]: {
+      readonly command: string;
+      readonly args: ReadonlyArray<string>;
+      readonly env: Readonly<Record<string, string>>;
+    };
+  };
+}
+
+export function writeClaudeCodeMcpConfig(
+  opts: WriteClaudeCodeMcpConfigOpts,
+): string {
+  // The cc-channel ws-client expects http(s):// urls; strip /ws and flip
+  // ws→http (same normalization as openclaw / nanoclaw adapters).
+  const serverUrl = opts.serverUrl
+    .replace(/\/ws$/, "")
+    .replace(/^ws:/, "http:")
+    .replace(/^wss:/, "https:");
+
+  const binPath = path.join(opts.extDir, "dist", "bin.js");
+
+  const config: ClaudeCodeMcpConfig = {
+    mcpServers: {
+      [MCP_SERVER_ALIAS]: {
+        command: "node",
+        args: [binPath],
+        env: {
+          MOLTZAP_API_KEY: opts.apiKey,
+          MOLTZAP_SERVER_URL: serverUrl,
+          MOLTZAP_SERVER_NAME: `@moltzap/claude-code-channel/${opts.agentName}`,
+        },
+      },
+    },
+  };
+
+  const configPath = path.join(opts.stateDir, "mcp-config.json");
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  return configPath;
+}
+
+export function seedWorkspaceFiles(
+  stateDir: string,
+  workspaceFiles: SpawnInput["workspaceFiles"],
+): void {
+  if (workspaceFiles === undefined) {
+    return;
+  }
+  const workspaceDir = path.join(stateDir, "workspace");
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  for (const file of workspaceFiles) {
+    const destination = path.join(workspaceDir, file.relativePath);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.writeFileSync(destination, file.content);
+  }
+}
+
+export function installChannelPlugin(
+  stateDir: string,
+  channelDistDir: string,
+  repoRoot: string,
+): string {
+  const extDir = path.join(stateDir, "extensions", "claude-code-channel");
+  const channelPackageDir = path.dirname(channelDistDir);
+  fs.mkdirSync(path.dirname(extDir), { recursive: true });
+
+  // Copy the plugin package: dist/ + package.json. Claude Code's MCP
+  // command points at the in-state-dir bin path; the plugin's package.json
+  // gets copied so node's module resolution starts from the plugin root.
+  fs.mkdirSync(extDir, { recursive: true });
+  fs.cpSync(channelDistDir, path.join(extDir, "dist"), {
+    recursive: true,
+    dereference: true,
+    filter: (src) => {
+      const rel = path.relative(channelDistDir, src);
+      return !rel.startsWith("node_modules") && !rel.startsWith("src");
+    },
+  });
+  const packageJsonPath = path.join(channelPackageDir, "package.json");
+  if (fs.existsSync(packageJsonPath)) {
+    fs.copyFileSync(packageJsonPath, path.join(extDir, "package.json"));
+  }
+
+  // Symlink the runtime imports cc-channel resolves at MCP-load time.
+  // Without these the spawned bin would fail in the state dir's isolated
+  // resolution. Mirrors openclaw's `installChannelPlugin` logic.
+  const pluginNm = path.join(extDir, "node_modules");
+  fs.mkdirSync(path.join(pluginNm, "@moltzap"), { recursive: true });
+  fs.symlinkSync(
+    path.join(repoRoot, "packages/protocol"),
+    path.join(pluginNm, "@moltzap/protocol"),
+    "dir",
+  );
+  fs.symlinkSync(
+    path.join(repoRoot, "packages/client"),
+    path.join(pluginNm, "@moltzap/client"),
+    "dir",
+  );
+  // The MCP SDK is a runtime dep of cc-channel (`@modelcontextprotocol/sdk`)
+  // and `effect` is a workspace-pinned dep used by both cc-channel and
+  // @moltzap/client. Both have to resolve from the plugin's node_modules.
+  fs.mkdirSync(path.join(pluginNm, "@modelcontextprotocol"), {
+    recursive: true,
+  });
+  symlinkPreferring(
+    [
+      path.join(channelPackageDir, "node_modules/@modelcontextprotocol/sdk"),
+      path.join(repoRoot, "node_modules/@modelcontextprotocol/sdk"),
+    ],
+    path.join(pluginNm, "@modelcontextprotocol/sdk"),
+  );
+  symlinkPreferring(
+    [
+      path.join(channelPackageDir, "node_modules/effect"),
+      path.join(repoRoot, "node_modules/effect"),
+    ],
+    path.join(pluginNm, "effect"),
+  );
+
+  return extDir;
+}
+
+function symlinkPreferring(
+  candidates: ReadonlyArray<string>,
+  target: string,
+): void {
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      fs.symlinkSync(candidate, target, "dir");
+      return;
+    }
+  }
+  throw new Error(
+    `claude-code adapter: none of the candidate paths exist for ${target}: ${candidates.join(", ")}`,
+  );
+}

--- a/packages/runtimes/src/fleet.ts
+++ b/packages/runtimes/src/fleet.ts
@@ -5,6 +5,10 @@ import {
   type RuntimeLaunchFailed,
 } from "./errors.js";
 import {
+  createWorkspaceClaudeCodeAdapter,
+  type WorkspaceClaudeCodeAdapterInput,
+} from "./claude-code-adapter.js";
+import {
   NanoclawAdapter,
   type NanoclawAdapterDeps,
 } from "./nanoclaw-adapter.js";
@@ -22,7 +26,7 @@ import {
   type WorkspaceFile,
 } from "./runtime.js";
 
-export type RuntimeKind = "openclaw" | "nanoclaw";
+export type RuntimeKind = "openclaw" | "nanoclaw" | "claude-code";
 
 export interface RuntimeAgentSpec {
   readonly agentName: string;
@@ -40,6 +44,7 @@ export interface RuntimeStartOptions {
   readonly readyTimeoutMs: number;
   readonly openclaw?: Omit<WorkspaceOpenClawAdapterInput, "server">;
   readonly nanoclaw?: Omit<NanoclawAdapterDeps, "server">;
+  readonly claudeCode?: Omit<WorkspaceClaudeCodeAdapterInput, "server">;
 }
 
 export interface RuntimeFleetLaunchOptions {
@@ -49,6 +54,7 @@ export interface RuntimeFleetLaunchOptions {
   readonly readyTimeoutMs: number;
   readonly openclaw?: Omit<WorkspaceOpenClawAdapterInput, "server">;
   readonly nanoclaw?: Omit<NanoclawAdapterDeps, "server">;
+  readonly claudeCode?: Omit<WorkspaceClaudeCodeAdapterInput, "server">;
 }
 
 export interface RuntimeFleetProcessSignalOptions
@@ -99,16 +105,23 @@ class UnknownRuntimeAgent extends Error {
 }
 
 function createRuntime(options: RuntimeStartOptions): Runtime {
-  if (options.kind === "openclaw") {
-    return createWorkspaceOpenClawAdapter({
-      server: options.server,
-      ...options.openclaw,
-    });
+  switch (options.kind) {
+    case "openclaw":
+      return createWorkspaceOpenClawAdapter({
+        server: options.server,
+        ...options.openclaw,
+      });
+    case "nanoclaw":
+      return new NanoclawAdapter({
+        server: options.server,
+        ...options.nanoclaw,
+      });
+    case "claude-code":
+      return createWorkspaceClaudeCodeAdapter({
+        server: options.server,
+        ...options.claudeCode,
+      });
   }
-  return new NanoclawAdapter({
-    server: options.server,
-    ...options.nanoclaw,
-  });
 }
 
 function toSpawnInput(agent: RuntimeAgentSpec): SpawnInput {
@@ -206,6 +219,9 @@ export function launchRuntimeFleet(
               : {}),
             ...(options.nanoclaw !== undefined
               ? { nanoclaw: options.nanoclaw }
+              : {}),
+            ...(options.claudeCode !== undefined
+              ? { claudeCode: options.claudeCode }
               : {}),
           });
           const startedAgent = {

--- a/packages/runtimes/src/index.ts
+++ b/packages/runtimes/src/index.ts
@@ -13,6 +13,13 @@ export {
 } from "./nanoclaw-adapter.js";
 
 export {
+  type ClaudeCodeAdapterDeps,
+  type WorkspaceClaudeCodeAdapterInput,
+  ClaudeCodeAdapter,
+  createWorkspaceClaudeCodeAdapter,
+} from "./claude-code-adapter.js";
+
+export {
   SpawnFailed,
   RuntimeExitedBeforeReady,
   RuntimeReadyTimedOut,

--- a/packages/runtimes/src/openclaw-adapter.ts
+++ b/packages/runtimes/src/openclaw-adapter.ts
@@ -14,6 +14,10 @@ import type {
   ReadyOutcome,
 } from "./runtime.js";
 import { SpawnFailed } from "./errors.js";
+import {
+  installChannelPlugin as installSharedChannelPlugin,
+  seedWorkspaceFiles as seedSharedWorkspaceFiles,
+} from "./channel-plugin-install.js";
 
 const OPENCLAW_TERM_WAIT_MS = 10_000;
 const OPENCLAW_KILL_WAIT_MS = 5_000;
@@ -389,15 +393,7 @@ function seedWorkspaceFiles(
   stateDir: string,
   workspaceFiles: SpawnInput["workspaceFiles"],
 ): void {
-  if (workspaceFiles === undefined) {
-    return;
-  }
-  const workspaceDir = path.join(stateDir, "workspace");
-  for (const file of workspaceFiles) {
-    const destination = path.join(workspaceDir, file.relativePath);
-    fs.mkdirSync(path.dirname(destination), { recursive: true });
-    fs.writeFileSync(destination, file.content);
-  }
+  seedSharedWorkspaceFiles(stateDir, workspaceFiles);
 }
 
 function installChannelPlugin(
@@ -405,53 +401,22 @@ function installChannelPlugin(
   channelDistDir: string,
   repoRoot: string,
 ): void {
-  const extDir = path.join(stateDir, "extensions", "openclaw-channel");
-  const channelPackageDir = path.dirname(channelDistDir);
-  fs.mkdirSync(path.dirname(extDir), { recursive: true });
-
-  // Copy the plugin package root, not just dist/. OpenClaw discovers channel
-  // ids via the package metadata (`openclaw.extensions`) and then loads the
-  // dist entrypoint from there.
-  fs.mkdirSync(extDir, { recursive: true });
-  fs.cpSync(channelDistDir, path.join(extDir, "dist"), {
-    recursive: true,
-    dereference: true,
-    filter: (src) => {
-      const rel = path.relative(channelDistDir, src);
-      return !rel.startsWith("node_modules") && !rel.startsWith("src");
-    },
+  installSharedChannelPlugin({
+    stateDir,
+    channelDistDir,
+    repoRoot,
+    extName: "openclaw-channel",
+    // OpenClaw discovers channels via `openclaw.plugin.json` in the
+    // package root; cc-channel has no equivalent manifest.
+    extraPackageFiles: ["openclaw.plugin.json"],
+    // OpenClaw's plugin imports `effect` at load time. Match the
+    // pre-refactor sourcing exactly (single candidate inside the
+    // channel's bundled node_modules).
+    extraSymlinks: [
+      {
+        linkPath: "effect",
+        candidates: [path.join(channelDistDir, "node_modules", "effect")],
+      },
+    ],
   });
-  const packageJsonPath = path.join(channelPackageDir, "package.json");
-  if (fs.existsSync(packageJsonPath)) {
-    fs.copyFileSync(packageJsonPath, path.join(extDir, "package.json"));
-  }
-  const pluginManifestPath = path.join(
-    channelPackageDir,
-    "openclaw.plugin.json",
-  );
-  if (fs.existsSync(pluginManifestPath)) {
-    fs.copyFileSync(
-      pluginManifestPath,
-      path.join(extDir, "openclaw.plugin.json"),
-    );
-  }
-
-  // Link workspace packages so the plugin's imports resolve.
-  const pluginNm = path.join(extDir, "node_modules");
-  fs.mkdirSync(path.join(pluginNm, "@moltzap"), { recursive: true });
-  fs.symlinkSync(
-    path.join(repoRoot, "packages/protocol"),
-    path.join(pluginNm, "@moltzap/protocol"),
-    "dir",
-  );
-  fs.symlinkSync(
-    path.join(repoRoot, "packages/client"),
-    path.join(pluginNm, "@moltzap/client"),
-    "dir",
-  );
-  fs.symlinkSync(
-    path.join(channelDistDir, "node_modules", "effect"),
-    path.join(pluginNm, "effect"),
-    "dir",
-  );
 }

--- a/packages/runtimes/src/runtimes.test.ts
+++ b/packages/runtimes/src/runtimes.test.ts
@@ -17,6 +17,10 @@ import {
   NanoclawAdapter,
   type NanoclawAdapterDeps,
 } from "./nanoclaw-adapter.js";
+import {
+  ClaudeCodeAdapter,
+  type ClaudeCodeAdapterDeps,
+} from "./claude-code-adapter.js";
 import type {
   Runtime,
   RuntimeServerHandle,
@@ -384,6 +388,75 @@ describe("NanoclawAdapter", () => {
     const marker = adapter.getInboundMarker();
     expect(typeof marker).toBe("string");
     expect(marker.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClaudeCodeAdapter — interface contract (issue #255)
+//
+// Mirror of the OpenClawAdapter unit suite: spawn against a non-existent
+// bin yields SpawnFailed, getLogs / getInboundMarker / waitUntilReady /
+// teardown all behave deterministically when no process has been spawned.
+// ---------------------------------------------------------------------------
+
+function stubClaudeCodeDeps(): ClaudeCodeAdapterDeps {
+  return {
+    server: stubServer(),
+    claudeBin: "/bin/false",
+    channelDistDir: "/nonexistent/cc-channel/dist",
+    repoRoot: "/nonexistent/repo",
+  };
+}
+
+describe("ClaudeCodeAdapter", () => {
+  it("satisfies the Runtime interface (structural typing)", () => {
+    const adapter: Runtime = new ClaudeCodeAdapter(stubClaudeCodeDeps());
+
+    expect(typeof adapter.spawn).toBe("function");
+    expect(typeof adapter.waitUntilReady).toBe("function");
+    expect(typeof adapter.teardown).toBe("function");
+    expect(typeof adapter.getLogs).toBe("function");
+    expect(typeof adapter.getInboundMarker).toBe("function");
+  });
+
+  it("getLogs returns empty slice when not spawned", () => {
+    const adapter = new ClaudeCodeAdapter(stubClaudeCodeDeps());
+    const slice: LogSlice = adapter.getLogs(0);
+    expect(slice.text).toBe("");
+    expect(slice.nextOffset).toBe(0);
+  });
+
+  it("getInboundMarker returns non-empty string", () => {
+    const adapter = new ClaudeCodeAdapter(stubClaudeCodeDeps());
+    const marker = adapter.getInboundMarker();
+    expect(typeof marker).toBe("string");
+    expect(marker.length).toBeGreaterThan(0);
+  });
+
+  it("waitUntilReady returns Ready when no process has been spawned", async () => {
+    const adapter = new ClaudeCodeAdapter(stubClaudeCodeDeps());
+    const outcome: ReadyOutcome = await Effect.runPromise(
+      adapter.waitUntilReady(1000),
+    );
+    expect(outcome._tag).toBe("Ready");
+  });
+
+  it("teardown is idempotent when no process has been spawned", async () => {
+    const adapter = new ClaudeCodeAdapter(stubClaudeCodeDeps());
+    await Effect.runPromise(adapter.teardown());
+    await Effect.runPromise(adapter.teardown());
+  });
+
+  it("spawn fails with SpawnFailed when the channel dist dir does not exist", async () => {
+    const adapter = new ClaudeCodeAdapter(stubClaudeCodeDeps());
+    const result = await Effect.runPromise(
+      Effect.either(adapter.spawn(stubSpawnInput())),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("SpawnFailed");
+      expect(result.left.agentName).toBe("test-agent");
+    }
   });
 });
 

--- a/packages/runtimes/src/trace-capture-harness.ts
+++ b/packages/runtimes/src/trace-capture-harness.ts
@@ -353,8 +353,14 @@ function decodePayload(
   }
 
   const runtimeKind = runtime?.kind;
-  if (runtimeKind !== "openclaw" && runtimeKind !== "nanoclaw") {
-    issues.push("runtime.kind must be 'openclaw' or 'nanoclaw'");
+  if (
+    runtimeKind !== "openclaw" &&
+    runtimeKind !== "nanoclaw" &&
+    runtimeKind !== "claude-code"
+  ) {
+    issues.push(
+      "runtime.kind must be 'openclaw', 'nanoclaw', or 'claude-code'",
+    );
   }
   if (
     runtime?.targetAgentName !== undefined &&
@@ -505,7 +511,11 @@ function decodePayload(
   }
 
   const narrowedRuntimeKind: RuntimeKind =
-    runtimeKind === "openclaw" ? "openclaw" : "nanoclaw";
+    runtimeKind === "openclaw"
+      ? "openclaw"
+      : runtimeKind === "claude-code"
+        ? "claude-code"
+        : "nanoclaw";
   const targetAgentName =
     typeof runtime?.targetAgentName === "string"
       ? runtime.targetAgentName
@@ -572,7 +582,14 @@ function decodePayload(
 }
 
 function defaultTargetAgentName(kind: RuntimeKind): string {
-  return kind === "openclaw" ? "openclaw-eval-agent" : "nanoclaw-eval-agent";
+  switch (kind) {
+    case "openclaw":
+      return "openclaw-eval-agent";
+    case "nanoclaw":
+      return "nanoclaw-eval-agent";
+    case "claude-code":
+      return "claude-code-eval-agent";
+  }
 }
 
 function closeClient(client: HarnessClient): Effect.Effect<void, never, never> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
         version: 2.1.119
       '@effect/vitest':
         specifier: ^0.29.0
-        version: 0.29.0(effect@3.21.0)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.29.0(effect@3.21.0)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@moltzap/client':
         specifier: workspace:*
         version: link:../client
@@ -290,14 +290,14 @@ importers:
         specifier: workspace:*
         version: link:../server
       '@types/node':
-        specifier: ^24.7.2
-        version: 24.12.0
+        specifier: ^25.5.0
+        version: 25.5.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server:
     dependencies:
@@ -8806,11 +8806,6 @@ snapshots:
     dependencies:
       effect: 3.21.0
 
-  '@effect/vitest@0.29.0(effect@3.21.0)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      effect: 3.21.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-
   '@effect/vitest@0.29.0(effect@3.21.0)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       effect: 3.21.0
@@ -11530,14 +11525,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -17213,27 +17200,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
@@ -17255,21 +17221,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      tsx: 4.21.0
-      yaml: 2.8.3
-
   vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
@@ -17284,48 +17235,6 @@ snapshots:
       jiti: 2.6.1
       tsx: 4.21.0
       yaml: 2.8.3
-
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.13
-      '@types/node': 24.12.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^10.18.0
         version: 10.28.0
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
@@ -258,6 +261,15 @@ importers:
 
   packages/runtimes:
     dependencies:
+      '@effect/platform':
+        specifier: ^0.96.0
+        version: 0.96.0(effect@3.21.0)
+      '@effect/platform-node':
+        specifier: ^0.106.0
+        version: 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@moltzap/claude-code-channel':
+        specifier: workspace:*
+        version: link:../claude-code-channel
       effect:
         specifier: 3.21.0
         version: 3.21.0
@@ -265,9 +277,18 @@ importers:
         specifier: 2026.3.31
         version: 2026.3.31(@cfworker/json-schema@4.1.1)(@napi-rs/canvas@0.1.97)
     devDependencies:
+      '@anthropic-ai/claude-code':
+        specifier: ^2.1.119
+        version: 2.1.119
       '@effect/vitest':
         specifier: ^0.29.0
         version: 0.29.0(effect@3.21.0)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@moltzap/client':
+        specifier: workspace:*
+        version: link:../client
+      '@moltzap/server-core':
+        specifier: workspace:*
+        version: link:../server
       '@types/node':
         specifier: ^24.7.2
         version: 24.12.0
@@ -374,6 +395,51 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/claude-code-darwin-arm64@2.1.119':
+    resolution: {integrity: sha512-+DC98VI72gZeuSz6VgEc+aAe5RlQGy4gdylf3moyypYPOGzY2eX099pXggdK1sAlFiHQ5xRXCq6QfBnw4/RvZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-code-darwin-x64@2.1.119':
+    resolution: {integrity: sha512-4O848nP+ligPgfGKuuQ1MspbwY3eDSwpH0mWfr97HWs8T79Q22Ev291j0tTGJf0qYQ9YP0oCCvVfS93ThVn6zg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.119':
+    resolution: {integrity: sha512-ALgp64QveCo9s/AR56CUJBDQT6Z7j5twRXFs2LGMvZfod+LxBp9LHCcVfCk0BpJx2edMw/2OOwXFosK5qlXtLA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-code-linux-arm64@2.1.119':
+    resolution: {integrity: sha512-b+ricBXcR7iiEmzelRcRjMGJgpazkvlJzcezFUK41kcJ6HKCPCHVCvGh/4yhoK74PACFA74oSWCp1PK68o0boQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-code-linux-x64-musl@2.1.119':
+    resolution: {integrity: sha512-GTUn2pFM2I+ZiN+bEmgnH59SQ4M0SOEqUUXw1bA75LVVVKMLarZsb52fBp/KU0ja3O9hx5AaXpT+/FMu5eGBKg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-code-linux-x64@2.1.119':
+    resolution: {integrity: sha512-i6nqfRnvW0IaCTJSHADxX23ykQTlYsmHRja72W92HhjyG8fudaSH2f1XM/zSbaSOp5s33mZAZ3js5coiH6Ksdw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-code-win32-arm64@2.1.119':
+    resolution: {integrity: sha512-eoMd3ocujGELdMi2jLrMpDEtC2KLTK/NCO7+oVTAKfsBUo6X7V2GQVa4Vdejk0zhxo+o68Jb4oTKQHt/wlRO6g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-code-win32-x64@2.1.119':
+    resolution: {integrity: sha512-vf8Zoqk1ysHsN+0zh/PTx75oVTLL/Tr3qXLnjewycM3lCYDDhtowTyCCkQGU587npHC3BG0FW9+eskaHKZBnzA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-code@2.1.119':
+    resolution: {integrity: sha512-gt9dxiIQU60eWcSM26fwu31vzLeL1NYwY3HDFby1TipzwF5lNY766DEqKLkGemZGxaAOXKe9nY3c8GQK/gQ7VA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   '@anthropic-ai/sdk@0.73.0':
     resolution: {integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==}
@@ -7925,6 +7991,41 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/claude-code-darwin-arm64@2.1.119':
+    optional: true
+
+  '@anthropic-ai/claude-code-darwin-x64@2.1.119':
+    optional: true
+
+  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.119':
+    optional: true
+
+  '@anthropic-ai/claude-code-linux-arm64@2.1.119':
+    optional: true
+
+  '@anthropic-ai/claude-code-linux-x64-musl@2.1.119':
+    optional: true
+
+  '@anthropic-ai/claude-code-linux-x64@2.1.119':
+    optional: true
+
+  '@anthropic-ai/claude-code-win32-arm64@2.1.119':
+    optional: true
+
+  '@anthropic-ai/claude-code-win32-x64@2.1.119':
+    optional: true
+
+  '@anthropic-ai/claude-code@2.1.119':
+    optionalDependencies:
+      '@anthropic-ai/claude-code-darwin-arm64': 2.1.119
+      '@anthropic-ai/claude-code-darwin-x64': 2.1.119
+      '@anthropic-ai/claude-code-linux-arm64': 2.1.119
+      '@anthropic-ai/claude-code-linux-arm64-musl': 2.1.119
+      '@anthropic-ai/claude-code-linux-x64': 2.1.119
+      '@anthropic-ai/claude-code-linux-x64-musl': 2.1.119
+      '@anthropic-ai/claude-code-win32-arm64': 2.1.119
+      '@anthropic-ai/claude-code-win32-x64': 2.1.119
 
   '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
Bundles three cc-channel-adjacent epics in one coordinated push, per the
team-lead bundle scope decision (one staff teammate covering all three).
Stamina-flagged refinements from #272 are folded into a follow-up polish
commit on the same branch.

Closes https://github.com/chughtapan/moltzap/issues/254
Closes https://github.com/chughtapan/moltzap/issues/255
Closes https://github.com/chughtapan/moltzap/issues/256
Closes https://github.com/chughtapan/moltzap/issues/272

## Per-epic AC checklist

### #254 — claude-code-channel as 4th client-side conformance wrapper
- [x] `packages/claude-code-channel/src/__tests__/conformance/suite.test.ts` (~30 LOC) calls `runClientConformanceSuite` with cc-channel's real-client factory.
- [x] 4th client-side matrix job added to `.github/workflows/conformance.yml` (and trigger-paths + failure-artifacts list).
- [x] All 13 client-side properties either pass or correctly mark unavailable per cc-channel's API surface — local run: 9 passed, 4 unavailable, 0 failed.
- [x] Existing 3 wrappers untouched.
- [x] `test-support.ts` + `vitest.conformance.config.ts` + `test:conformance` script + `./test-support` subpath export — same shape as nanoclaw.

### #255 — claude-code runtime adapter
- [x] `packages/runtimes/src/claude-code-adapter.ts` follows the openclaw pattern: `ClaudeCodeAdapterDeps` carries `server`, `claudeBin`, `channelDistDir`, `repoRoot`. `spawn` writes a per-agent state dir, installs cc-channel as a disk-resident MCP plugin, configures `claude --strict-mcp-config --mcp-config <path>`, and spawns the real Anthropic `claude` CLI.
- [x] Plugin install + workspace-seed helpers live in `packages/runtimes/src/channel-plugin-install.ts` (extracted in the polish commit per #272 item 8) and are consumed by both the openclaw and claude-code adapters. Per-adapter differences (subdir name, extra package files, extra symlink targets) are config to the shared helper.
- [x] `createWorkspaceClaudeCodeAdapter` resolves `claudeBin` from `packages/runtimes/node_modules/.bin/claude` with repo-root fallback (mirror of `createWorkspaceOpenClawAdapter`).
- [x] `@anthropic-ai/claude-code` added as a devDep of `@moltzap/runtimes` (mirrors how `openclaw` is wired). The package's own postinstall fetches the platform-native binary; the test calls it directly.
- [x] `@effect/platform` and `@effect/platform-node` added as runtime deps for the Command surface — adapter is **Effect-native**: subprocess spawned via `Command.start` + `NodeContext.layer`; `Scope.make()` allocates a long-lived scope so the process outlives the spawn-effect, `Scope.close` on teardown reaps it; `waitUntilReady` is `Effect.iterate` + `Effect.timeoutTo`; stdout/stderr consumed via `Stream.runForEach` in fibers forked into the process scope (`Effect.forkIn(scope)`); exit detection uses `Fiber.poll` (no side-channel mutable, post #272 item 5); teardown is a single Effect chain (SIGTERM → race vs `TERM_WAIT_MS` → SIGKILL → `Scope.close` → `rmSync`). No `Effect.runPromise` inside the adapter.
- [x] cc-channel ships a one-line `bin` (per first-round-review approval): `package.json` adds `bin: { moltzap-claude-code-channel: ./dist/bin.js }`, plus `packages/claude-code-channel/src/bin.ts` is the stdio MCP-server entry that `claude --mcp-config` subprocess-spawns. No new exports beyond the bin.
- [x] Integration test (`claude-code-adapter.integration.test.ts`) drives the real `claude` CLI + cc-channel MCP plugin against an in-process moltzap `coreApp`; asserts `spawn → ready → teardown` completes plus second-call teardown is a no-op. Skip-condition is just "claude bin not on disk" — adapter does not pass `--bare`, so OAuth/keychain auth on the host is honored.
- [x] `RuntimeKind` extended to `'openclaw' | 'nanoclaw' | 'claude-code'`; `fleet.ts` `createRuntime` is now an exhaustive switch; `trace-capture-harness.ts` decoder + `defaultTargetAgentName` updated for the new kind. No back-compat shims.

### #256 — echo.integration.test.ts drift fix
- [x] Option (a): `BootOptions._testTransportFactory` exposed (underscore-prefixed, "tests-only" tagged in JSDoc).
- [x] `entry.ts` threads the optional factory into `bootChannelMcpServer`.
- [x] `echo.integration.test.ts` migrated to call `bootClaudeCodeChannel` directly, no longer duplicates `entry.ts:106-143`.
- [x] Test still exercises the full inbound pipeline (gate → translate → record → push) — asserts unchanged contract meta keys + tool round-trips.

### #272 — stamina-flagged refinements (folded inline in commit `c4c05ce`)
- [x] Item 1 — `extDir` double-computation: hoisted to single mkdir in shared helper.
- [x] Item 2 — `--dangerously-skip-permissions`: verified still required (claude in `--print` mode blocks on permission prompts with no TTY); added a one-line justification comment.
- [x] Item 3 — `waitUntilReady` polling: kept `Effect.iterate` (cleaner than `Schedule.spaced` + `Effect.repeat`, which returns the schedule output rather than the inner effect's value).
- [x] Item 4 — `Effect.try` / `SpawnFailed` repetition: hoisted to a per-call `tryStep<A>(fn)` helper inside `spawn()`; the four sequential fs/spawn steps now read as one tryStep call each.
- [x] Item 5 — `let resolvedExit` / `isExited` mirror: replaced with `Fiber.poll`. Side-fix surfaced: the prior code forked observers via `Effect.fork` (current scope) which interrupted them the moment spawn returned; switched to `Effect.forkIn(scope)` so the fibers live in `proc.scope`. The let-mirror had been masking this — `Fiber.poll` correctly reports an interrupted fiber as exited, which is what made the bug visible.
- [x] Item 6 — `Object.assign` in `bin.ts`: replaced with conditional spread.
- [x] Item 7 — `globalThis.process.env as Record<string, string>` cast: dropped via a tiny `filterDefinedEnv` helper that walks `process.env`, drops undefined entries, and folds adapter extras (`CLAUDE_CODE_HOME`) on top.
- [x] Item 8 — `installChannelPlugin` + `seedWorkspaceFiles` duplication: extracted to `packages/runtimes/src/channel-plugin-install.ts` consumed by both adapters. Net -73 LOC.
- [x] Item 9 — `@types/node` workspace pin: bumped `@moltzap/runtimes` to `^25.5.0` to match `@moltzap/openclaw-channel` and the other workspace packages.

## Standing rules honored

- **Effect-native subprocess** — `@effect/platform` Command/Process; no raw `node:child_process` in the new adapter; fibers correctly scoped via `Effect.forkIn(scope)` so they outlive the spawn-effect.
- **No back-compat shims** — `RuntimeKind` extension updated every consumer site (fleet, trace-capture-harness, runtime tests).
- **No `--no-verify`** — pre-commit hook (oxfmt + lint + typecheck + sloppy-code guards) ran clean on both the bundle commit and the polish commit.
- **Minimal cc-channel surface** — only the `bin` entry was added (single-file scope, blessed in the first-round review).
- **Minimize tech debt** — shared `channel-plugin-install.ts` extracted now that two live adapters consume the shape (rather than parking it).

## Verification

```
pnpm -r build                                         # green
pnpm typecheck                                        # green
pnpm lint                                             # 23 pre-existing warnings, 0 errors
pnpm -F @moltzap/runtimes test                        # 31 passed
pnpm -F @moltzap/runtimes test:integration            # 1 passed (real claude CLI + cc-channel MCP)
pnpm -F @moltzap/claude-code-channel test             # 47 passed (incl. conformance)
pnpm -F @moltzap/claude-code-channel test:integration # 5 passed
pnpm -F @moltzap/claude-code-channel test:conformance # 9 passed, 4 unavail, 0 failed
pnpm -F @moltzap/openclaw-channel test                # 78 passed (incl. conformance) — shared installChannelPlugin lands the same on-disk layout
pnpm -F @moltzap/nanoclaw-channel test                # 19 passed (regression sanity)
```

`pnpm -F @moltzap/openclaw-channel test:integration` fails on a separate
pre-existing import-rot issue tracked as #273 (not introduced by this
PR; not in scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)