### PR TITLE
Publish pnpm-packed workspace tarballs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -134,6 +134,8 @@ jobs:
             echo "Publishing ${NAME}@${VER}..."
             (
               cd "packages/$pkg"
-              npm publish --access public --provenance
+              TARBALL=$(pnpm pack --pack-gzip-level 9 | tail -1)
+              [ -f "$TARBALL" ] || { echo "ERROR: pack failed, tarball not found"; exit 1; }
+              npm publish "$TARBALL" --access public --provenance
             )
           done


### PR DESCRIPTION
## Summary
- publish `pnpm pack` tarballs with explicit npm provenance
- keeps OIDC trusted publishing while ensuring `workspace:*` dependencies are rewritten to concrete package versions

## Validation
- pnpm format:check .github/workflows/publish.yml
- pnpm pack for packages/server rewrites @moltzap/protocol to 2026.425.0 and preserves bin/moltzap-server

This fixes the registry package install failure observed with `npx @moltzap/server-core@latest`.