### PR TITLE
Include server schema in npm package

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,7 +9,8 @@
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "src/app/core-schema.sql"
   ],
   "bin": {
     "moltzap-server": "bin/moltzap-server"

--- a/packages/server/src/package-metadata.test.ts
+++ b/packages/server/src/package-metadata.test.ts
@@ -16,10 +16,15 @@ describe("@moltzap/server-core package metadata", () => {
     };
 
     expect(packageJson.files).toContain("bin");
+    expect(packageJson.files).toContain("src/app/core-schema.sql");
     expect(packageJson.bin).toEqual({
       "moltzap-server": "bin/moltzap-server",
     });
 
     await access(path.join(packageRoot, "bin/moltzap-server"), constants.X_OK);
+    await access(
+      path.join(packageRoot, "src/app/core-schema.sql"),
+      constants.R_OK,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- include src/app/core-schema.sql in @moltzap/server-core npm files
- extend package metadata test so npx startup packaging needs are covered

## Validation
- pnpm -F @moltzap/server-core test -- package-metadata.test.ts
- pnpm -F @moltzap/server-core build
- pnpm pack includes bin/moltzap-server, dist/standalone.js, and src/app/core-schema.sql