### PR TITLE
Include pretty logger runtime dependency

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -53,6 +53,7 @@
     "kysely-pglite": "^0.6.1",
     "pg": "^8.12.0",
     "pino": "^9.6.0",
+    "pino-pretty": "^13.0.0",
     "yaml": "^2.8.3"
   },
   "devDependencies": {
@@ -61,7 +62,6 @@
     "@types/pg": "^8.11.0",
     "fast-check": "^4.0.0",
     "kysely-codegen": "^0.20.0",
-    "pino-pretty": "^13.0.0",
     "testcontainers": "^10.18.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",

--- a/packages/server/src/package-metadata.test.ts
+++ b/packages/server/src/package-metadata.test.ts
@@ -12,6 +12,7 @@ describe("@moltzap/server-core package metadata", () => {
   it("publishes a single executable bin for npx invocation", async () => {
     const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
       bin?: Record<string, string>;
+      dependencies?: Record<string, string>;
       files?: string[];
     };
 
@@ -20,6 +21,7 @@ describe("@moltzap/server-core package metadata", () => {
     expect(packageJson.bin).toEqual({
       "moltzap-server": "bin/moltzap-server",
     });
+    expect(packageJson.dependencies).toHaveProperty("pino-pretty");
 
     await access(path.join(packageRoot, "bin/moltzap-server"), constants.X_OK);
     await access(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
       pino:
         specifier: ^9.6.0
         version: 9.14.0
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.1.3
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -344,9 +347,6 @@ importers:
       kysely-codegen:
         specifier: ^0.20.0
         version: 0.20.0(kysely@0.28.16)(pg@8.20.0)(typescript@5.9.3)
-      pino-pretty:
-        specifier: ^13.0.0
-        version: 13.1.3
       testcontainers:
         specifier: ^10.18.0
         version: 10.28.0


### PR DESCRIPTION
## Summary
- move pino-pretty into @moltzap/server-core runtime dependencies for npx/development startup
- assert runtime package metadata includes pino-pretty
- update pnpm lockfile

## Validation
- pnpm install --no-frozen-lockfile --ignore-scripts
- pnpm -F @moltzap/server-core test -- package-metadata.test.ts
- pnpm -F @moltzap/server-core build
- pnpm pack includes bin/moltzap-server, dist/standalone.js, and src/app/core-schema.sql