### PR TITLE
[impl-senior] sweep latent lint warnings

### DIFF
--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -136,13 +136,12 @@ export class MoltZapApp {
   // ── Lifecycle ──────────────────────────────────────────────────────
 
   start(): Effect.Effect<AppSessionHandle, StartError> {
-    const self = this;
-    return Effect.gen(function* () {
+    return Effect.gen(this, function* () {
       // Spec #222 OQ-4 deletion: per-event `onEvent` callback is gone.
       // Replacement: register a `{}` filter subscription before
       // `connect()` so every inbound event still reaches `handleEvent`.
-      const sub = yield* self.client
-        .subscribe({}, (event) => Effect.sync(() => self.handleEvent(event)))
+      const sub = yield* this.client
+        .subscribe({}, (event) => Effect.sync(() => this.handleEvent(event)))
         .pipe(
           Effect.mapError(
             (err) =>
@@ -155,9 +154,9 @@ export class MoltZapApp {
 
       // Track the handle so stop() can unsubscribe, and so tapError below
       // can clean up if a later step fails (preventing subscription leaks).
-      self.activeSubscription = sub;
+      this.activeSubscription = sub;
 
-      yield* self.client
+      yield* this.client
         .connect()
         .pipe(
           Effect.mapError(
@@ -169,22 +168,22 @@ export class MoltZapApp {
           ),
         );
 
-      yield* self.client
-        .sendRpc("apps/register", { manifest: self.manifest })
+      yield* this.client
+        .sendRpc("apps/register", { manifest: this.manifest })
         .pipe(
           Effect.mapError(
             (err) =>
               new ManifestRegistrationError(
-                `Failed to register manifest for "${self.manifest.appId}"`,
+                `Failed to register manifest for "${this.manifest.appId}"`,
                 err instanceof Error ? err : undefined,
               ),
           ),
         );
 
-      const sessionResult = (yield* self.client
+      const sessionResult = (yield* this.client
         .sendRpc("apps/create", {
-          appId: self.manifest.appId,
-          invitedAgentIds: self.invitedAgentIds,
+          appId: this.manifest.appId,
+          invitedAgentIds: this.invitedAgentIds,
         })
         .pipe(
           Effect.mapError(
@@ -197,22 +196,22 @@ export class MoltZapApp {
         )) as { session: AppSession };
 
       const handle = new AppSessionHandle(sessionResult.session);
-      self.sessions.set(handle.id, handle);
-      self.buildReverseConvMap(handle);
+      this.sessions.set(handle.id, handle);
+      this.buildReverseConvMap(handle);
 
-      self.heartbeat.start(
-        () => self.sendPing(),
-        self.heartbeatIntervalMs,
+      this.heartbeat.start(
+        () => this.sendPing(),
+        this.heartbeatIntervalMs,
         (err) => {
-          self.logger.warn("Heartbeat ping failed:", err.message);
-          self.trackFork(self.client.disconnect());
+          this.logger.warn("Heartbeat ping failed:", err.message);
+          this.trackFork(this.client.disconnect());
         },
       );
 
-      self.started = true;
+      this.started = true;
 
       if (handle.isActive) {
-        self.fireSessionReady(handle);
+        this.fireSessionReady(handle);
       }
 
       return handle;
@@ -220,9 +219,9 @@ export class MoltZapApp {
       // If any step after subscribe() fails, clean up the subscription so
       // a retry does not accumulate orphaned subscriptions.
       Effect.tapError(() => {
-        const sub = self.activeSubscription;
+        const sub = this.activeSubscription;
         if (sub !== null) {
-          self.activeSubscription = null;
+          this.activeSubscription = null;
           return sub.unsubscribe;
         }
         return Effect.void;
@@ -231,36 +230,35 @@ export class MoltZapApp {
   }
 
   stop(): Effect.Effect<void, never> {
-    const self = this;
-    return Effect.gen(function* () {
-      self.heartbeat.destroy();
+    return Effect.gen(this, function* () {
+      this.heartbeat.destroy();
 
-      const pending = [...self.backgroundFibers];
-      self.backgroundFibers.clear();
-      self.recoveringSessions.clear();
+      const pending = [...this.backgroundFibers];
+      this.backgroundFibers.clear();
+      this.recoveringSessions.clear();
       if (pending.length > 0) {
         yield* Fiber.interruptAll(pending);
       }
 
-      for (const session of self.sessions.values()) {
+      for (const session of this.sessions.values()) {
         if (session.isActive) {
-          yield* self.client
+          yield* this.client
             .sendRpc("apps/closeSession", { sessionId: session.id })
             .pipe(Effect.ignore);
         }
       }
 
-      self.sessions.clear();
-      self.reverseConvMap.clear();
-      self.firedSessionReady.clear();
+      this.sessions.clear();
+      this.reverseConvMap.clear();
+      this.firedSessionReady.clear();
 
-      if (self.activeSubscription !== null) {
-        yield* self.activeSubscription.unsubscribe;
-        self.activeSubscription = null;
+      if (this.activeSubscription !== null) {
+        yield* this.activeSubscription.unsubscribe;
+        this.activeSubscription = null;
       }
 
-      yield* self.client.close();
-      self.started = false;
+      yield* this.client.close();
+      this.started = false;
     });
   }
 
@@ -286,11 +284,10 @@ export class MoltZapApp {
   createSession(
     invitedAgentIds?: string[],
   ): Effect.Effect<AppSessionHandle, SessionError> {
-    const self = this;
-    return Effect.gen(function* () {
-      const result = (yield* self.client
+    return Effect.gen(this, function* () {
+      const result = (yield* this.client
         .sendRpc("apps/create", {
-          appId: self.manifest.appId,
+          appId: this.manifest.appId,
           invitedAgentIds: invitedAgentIds ?? [],
         })
         .pipe(
@@ -304,8 +301,8 @@ export class MoltZapApp {
         )) as { session: AppSession };
 
       const handle = new AppSessionHandle(result.session);
-      self.sessions.set(handle.id, handle);
-      self.buildReverseConvMap(handle);
+      this.sessions.set(handle.id, handle);
+      this.buildReverseConvMap(handle);
       return handle;
     });
   }
@@ -353,11 +350,10 @@ export class MoltZapApp {
     conversationKey: string,
     parts: Part[],
   ): Effect.Effect<void, SendError | ConversationKeyError> {
-    const self = this;
-    return Effect.gen(function* () {
+    return Effect.gen(this, function* () {
       const conversationId =
-        yield* self.resolveConversationKey(conversationKey);
-      yield* self.sendTo(conversationId, parts);
+        yield* this.resolveConversationKey(conversationKey);
+      yield* this.sendTo(conversationId, parts);
     });
   }
 
@@ -652,7 +648,6 @@ export class MoltZapApp {
   private recoverSessionOnReconnect(
     session: AppSessionHandle,
   ): Effect.Effect<void, never> {
-    const self = this;
     return this.client
       .sendRpc("apps/getSession", { sessionId: session.id })
       .pipe(
@@ -665,26 +660,26 @@ export class MoltZapApp {
               freshSession.status === "closed" ||
               freshSession.status === "failed"
             ) {
-              self.sessions.delete(session.id);
-              self.firedSessionReady.delete(session.id);
+              this.sessions.delete(session.id);
+              this.firedSessionReady.delete(session.id);
               for (const convId of Object.values(session.conversations)) {
-                self.reverseConvMap.delete(convId);
+                this.reverseConvMap.delete(convId);
               }
-              self.emitError(
+              this.emitError(
                 new SessionClosedError(
                   `Session ${session.id} closed during disconnect`,
                 ),
               );
             } else {
               const updated = new AppSessionHandle(freshSession);
-              self.sessions.set(session.id, updated);
-              self.buildReverseConvMap(updated);
+              this.sessions.set(session.id, updated);
+              this.buildReverseConvMap(updated);
             }
           }),
         ),
         Effect.catchAll((err) =>
           Effect.sync(() => {
-            self.emitError(
+            this.emitError(
               new SessionError(
                 `Failed to recover session ${session.id} after reconnect`,
                 err instanceof Error ? err : undefined,
@@ -694,7 +689,7 @@ export class MoltZapApp {
         ),
         Effect.ensuring(
           Effect.sync(() => {
-            self.recoveringSessions.delete(session.id);
+            this.recoveringSessions.delete(session.id);
           }),
         ),
       );

--- a/packages/claude-code-channel/src/__tests__/server.test.ts
+++ b/packages/claude-code-channel/src/__tests__/server.test.ts
@@ -212,8 +212,9 @@ describe("notification emission (spec A5, A6)", () => {
       await new Promise((r) => setTimeout(r, 10));
       expect(notifications).toHaveLength(1);
       const n = notifications[0];
-      expect(n?.method).toBe("notifications/claude/channel");
-      const meta = (n?.params as { meta: Record<string, unknown> }).meta;
+      expect(n).toBeDefined();
+      expect(n!.method).toBe("notifications/claude/channel");
+      const meta = (n!.params as { meta: Record<string, unknown> }).meta;
       expect(meta).toMatchObject({
         chat_id: "C1",
         message_id: "M1",

--- a/packages/client/src/cli/commands/apps.test.ts
+++ b/packages/client/src/cli/commands/apps.test.ts
@@ -20,7 +20,6 @@ import {
   type MockInstance,
 } from "vitest";
 import {
-  AppsInputError,
   appsAttestSkillHandler,
   appsCloseHandler,
   appsCreateHandler,

--- a/packages/client/src/cli/profile.test.ts
+++ b/packages/client/src/cli/profile.test.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { Effect } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   emitNoPersist,
   loadLayeredConfig,

--- a/packages/client/src/cli/runtime.ts
+++ b/packages/client/src/cli/runtime.ts
@@ -62,7 +62,7 @@ export const effectLogger = EffectLogger.make(
           })\n`,
         );
         // #ignore-sloppy-code-next-line[bare-catch]: inner fallback for stderr write failure — last resort, nothing to log to
-      } catch (_innerErr) {
+      } catch {
         // stderr unavailable — drop rather than crash.
       }
     }

--- a/packages/client/src/cli/transport.test.ts
+++ b/packages/client/src/cli/transport.test.ts
@@ -5,7 +5,6 @@
  */
 import { Cause, Effect, Exit, Option } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { RpcServerError } from "../runtime/errors.js";
 import {
   decideTransport,
   makeTransportLayer,

--- a/packages/client/src/runtime/runtime.test.ts
+++ b/packages/client/src/runtime/runtime.test.ts
@@ -1,6 +1,6 @@
 import { it } from "@effect/vitest";
 import { Effect, Exit } from "effect";
-import { expect } from "vitest";
+import { expect, it as itSync } from "vitest";
 import {
   NotConnectedError,
   RpcServerError,
@@ -24,21 +24,17 @@ it.effect("tagged errors discriminate by _tag", () =>
   }),
 );
 
-it.effect("RpcServerError preserves wire fields", () =>
-  Effect.gen(function* () {
-    const err = new RpcServerError({
-      code: -32002,
-      message: "Not found",
-    });
-    expect(err.code).toBe(-32002);
-    expect(err.message).toBe("Not found");
-    expect(err.data).toBeUndefined();
-  }),
-);
+itSync("RpcServerError preserves wire fields", () => {
+  const err = new RpcServerError({
+    code: -32002,
+    message: "Not found",
+  });
+  expect(err.code).toBe(-32002);
+  expect(err.message).toBe("Not found");
+  expect(err.data).toBeUndefined();
+});
 
-it.effect("NotConnectedError compiles and carries message", () =>
-  Effect.gen(function* () {
-    const err = new NotConnectedError({ message: "socket closed" });
-    expect(err.message).toBe("socket closed");
-  }),
-);
+itSync("NotConnectedError compiles and carries message", () => {
+  const err = new NotConnectedError({ message: "socket closed" });
+  expect(err.message).toBe("socket closed");
+});

--- a/packages/client/src/ws-client.test.ts
+++ b/packages/client/src/ws-client.test.ts
@@ -18,7 +18,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { it as itEffect } from "@effect/vitest";
 import {
   Cause,
-  Deferred,
   Duration,
   Effect,
   Exit,
@@ -288,18 +287,6 @@ function makeClient(
     );
   }
   return client;
-}
-
-function parseSent(raw: string): {
-  id: string;
-  method: string;
-  params?: unknown;
-} {
-  return JSON.parse(raw) as {
-    id: string;
-    method: string;
-    params?: unknown;
-  };
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────

--- a/packages/openclaw-channel/src/__tests__/openclaw-routing.integration.test.ts
+++ b/packages/openclaw-channel/src/__tests__/openclaw-routing.integration.test.ts
@@ -22,12 +22,10 @@ import {
   extractText,
 } from "./test-helpers.js";
 
-let baseUrl: string;
 let wsUrl: string;
 
 beforeAll(() => {
   initWorker();
-  baseUrl = inject("baseUrl");
   wsUrl = inject("wsUrl");
 });
 

--- a/packages/openclaw-channel/src/__tests__/stress.integration.test.ts
+++ b/packages/openclaw-channel/src/__tests__/stress.integration.test.ts
@@ -19,7 +19,6 @@ import {
 } from "./test-helpers.js";
 import type { Message } from "@moltzap/protocol";
 
-let baseUrl: string;
 let wsUrl: string;
 
 async function waitForRepliesByList(params: {
@@ -65,7 +64,6 @@ describe("Stress: concurrent multi-agent messaging", () => {
 
   beforeAll(() => {
     initWorker();
-    baseUrl = inject("baseUrl");
     wsUrl = inject("wsUrl");
   });
 

--- a/packages/protocol/src/schema/methods/contacts.ts
+++ b/packages/protocol/src/schema/methods/contacts.ts
@@ -1,4 +1,4 @@
-import { Type, type Static } from "@sinclair/typebox";
+import { Type } from "@sinclair/typebox";
 import { ContactId, UserId } from "../primitives.js";
 import { ContactSchema, ContactSourceEnum } from "../contacts.js";
 import { defineRpc } from "../../rpc.js";

--- a/packages/protocol/src/testing/conformance/registry.ts
+++ b/packages/protocol/src/testing/conformance/registry.ts
@@ -14,7 +14,6 @@
  * outside the build surface.
  */
 import { Data, Effect, Ref } from "effect";
-import type { ConformanceRunContext } from "./runner.js";
 
 /**
  * Context key for a property registry. Server-side properties key by

--- a/packages/protocol/src/testing/conformance/schema-conformance.ts
+++ b/packages/protocol/src/testing/conformance/schema-conformance.ts
@@ -23,7 +23,7 @@ import {
   arbitraryEventFrame,
   arbitraryMalformedFrame,
 } from "../arbitraries/frames.js";
-import { decodeFrame, encodeFrame, malformFrame } from "../codec.js";
+import { decodeFrame, encodeFrame } from "../codec.js";
 import {
   EventFrameSchema,
   ResponseFrameSchema,

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -135,7 +135,7 @@ export const effectLogger = EffectLogger.make(
           })\n`,
         );
         // #ignore-sloppy-code-next-line[bare-catch]: both sinks failed — nowhere left to report
-      } catch (_innerErr) {
+      } catch {
         // stderr unavailable; drop the entry rather than crash the fiber.
       }
     }


### PR DESCRIPTION
Drives `pnpm lint` from **21 warnings, 0 errors** → **0 warnings, 0 errors** across the workspace. No runtime behavior change.

## What changed (per warning class)

### `typescript-eslint(no-this-alias)` — `packages/app-sdk/src/app.ts` (5x)

Replaced the `const self = this; return Effect.gen(function* () { ...self.X... })` pattern with Effect's two-arg overload `Effect.gen(this, function* () { ...this.X... })`, which binds `this` lexically inside the generator. Spot-verified against existing usage in `packages/client/src/{channel-core,service,ws-client}.ts`, `packages/server/src/services/*` — this is the established project idiom; `app.ts` was the lone outlier. Lines 138/233/288/355/654.

For `recoverSessionOnReconnect` (last site), `self` was only used inside arrow callbacks within `.pipe(...)` — no `Effect.gen` involved — so just dropping the alias and letting lexical `this` bind through the arrow was sufficient.

### `eslint(no-unsafe-optional-chaining)` — `packages/claude-code-channel/src/__tests__/server.test.ts:216`

The `(n?.params as ...).meta` cast wouldn't have prevented a TypeError if `n` was `undefined`. Added `expect(n).toBeDefined();` then switched to `n!.params`. Matches the existing `toBeDefined()`-then-bang pattern used in `packages/client/src/channel-core.test.ts:487` and `service.integration.test.ts:120`.

### `eslint(require-yield)` — `packages/client/src/runtime/runtime.test.ts` (2x)

Both flagged tests had no `yield*` — they're synchronous error-class assertions wrapped in `Effect.gen`. Dropped the wrapper; switched to plain `it("...", () => { ... })` from vitest (imported as `itSync` to avoid colliding with `it` from `@effect/vitest` already in use).

### `eslint(no-unused-vars)` — 13 instances across 9 files

Mechanical removals; nothing load-bearing for side-effects:

- `packages/client/src/cli/profile.test.ts:9` — drop `afterEach`, `beforeEach` (both unused).
- `packages/client/src/cli/transport.test.ts:8` — drop unused `RpcServerError` import.
- `packages/client/src/cli/commands/apps.test.ts:23` — drop unused `AppsInputError` import.
- `packages/client/src/ws-client.test.ts:21` — drop unused `Deferred` import.
- `packages/client/src/ws-client.test.ts:293` — delete dead `parseSent` helper (zero references).
- `packages/protocol/src/schema/methods/contacts.ts:1` — drop `type Static` import.
- `packages/protocol/src/testing/conformance/registry.ts:17` — drop `type ConformanceRunContext` import.
- `packages/protocol/src/testing/conformance/schema-conformance.ts:26` — drop unused `malformFrame` import.
- `packages/openclaw-channel/src/__tests__/openclaw-routing.integration.test.ts:25` — drop vestigial `baseUrl` declaration + `inject()` (only `wsUrl` is read).
- `packages/openclaw-channel/src/__tests__/stress.integration.test.ts:22, 68` — same as above.

### `eslint(no-unused-vars)` — catch-binding cases

- `packages/client/src/cli/runtime.ts:65` and `packages/server/src/logger.ts:138` — converted `} catch (_innerErr) {` to bare `} catch {`. The pre-existing `// #ignore-sloppy-code-next-line[bare-catch]` directive comment is correctly placed on the immediately-preceding line in both spots.

## Plan anchors

| Change | Rationale |
|---|---|
| 5x `Effect.gen(this, function*())` in `app.ts` | no-this-alias; matches existing project idiom |
| `n!` after `toBeDefined()` in server.test.ts:216 | no-unsafe-optional-chaining; matches existing test pattern |
| Drop `Effect.gen` wrapper in 2 sync runtime.test.ts cases | require-yield; team-lead instruction "don't add a token yield" |
| 11 unused imports/vars deleted | no-unused-vars; verified zero side-effect imports |
| `_innerErr` → bare `catch {}` | no-unused-vars; directive comment was already in place |

## Verification

- `pnpm lint` → **0 warnings, 0 errors** (was 21/0)
- `pnpm typecheck` → green
- `pnpm -r build` → green
- `pnpm -r test` → green (unit tests across all packages)
- `pnpm -F @moltzap/openclaw-channel test:integration` → see "Out of scope" below; failure is **pre-existing on `origin/main`**, unrelated to this diff.

## Scope

- Modules touched: 7 packages, 14 files (lint-warning fixes only)
- Tier: senior (no new modules, no new public surface, no new deps, no `package.json`/lockfile changes)
- New error channels: 0
- /simplify pass: ran 3 reviewers (reuse, quality, efficiency); **no findings** — diff is minimal and matches existing project conventions.

## Out of scope (discovered during verification)

`pnpm -F @moltzap/openclaw-channel test:integration` fails to load `vitest.integration.globalSetup.ts` with `Missing "./phone-hash" specifier in "@moltzap/protocol" package`. This failure is **pre-existing on `origin/main`** (verified by `git stash`-ing this diff and re-running) and the rot extends well beyond a single import:

- `vitest.integration.globalSetup.ts:23` imports the deleted `@moltzap/protocol/phone-hash` subpath.
- Same file (lines 54-66) applies migrations from a non-existent `supabase/migrations/` directory; schema now lives at `packages/server/src/app/core-schema.sql`.
- `vitest.integration.globalSetup.ts` lines 110-124 insert into the dropped `users` table.
- `packages/openclaw-channel/src/__tests__/test-helpers.ts` `registerAndClaim` (L46-94) and `makeContact` (L96-102) also write to the dropped `users` and `contacts` tables.
- Three integration test files (`openclaw-routing.integration.test.ts`, `reconnection.integration.test.ts`, `stress.integration.test.ts`) all consume those broken helpers.
- These tests don't run in CI; they've been silently broken since the users-table drop.

Tracked in #273 — `openclaw-channel integration test infrastructure rot (post users-table drop)`. Decision (rewrite agent-only vs. delete the suite) lives in that issue.

## Confidence

HIGH — minimal mechanical fixes, every change traces to a specific lint rule, all four verification gates green (lint, typecheck, build, unit tests).
