### PR TITLE
Fix conformance stress dogfood cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ vite.config.ts.timestamp-*
 /moltzap.yaml
 /.moltzap/
 .codex
+/.tmp/

--- a/docs/development/testing.mdx
+++ b/docs/development/testing.mdx
@@ -89,3 +89,13 @@ CONFORMANCE_NUM_RUNS=250 pnpm test:conformance:stress
 CONFORMANCE_SEED_COUNT=10 pnpm test:conformance:stress
 FC_SEED=12345 pnpm test:conformance:toxiproxy
 ```
+
+Long-running local commands that create large Vitest/esbuild/temp artifacts can use the same
+temporary-directory isolation directly:
+
+```bash
+MOLTZAP_TMP_SCOPE=my-run scripts/with-tempdir.sh pnpm test
+```
+
+The wrapper sets `TMPDIR` to a repo-local directory under `.tmp/` for the child process and removes
+that per-run directory on exit or interruption.

--- a/packages/protocol/src/testing/arbitraries/from-typebox.ts
+++ b/packages/protocol/src/testing/arbitraries/from-typebox.ts
@@ -132,9 +132,9 @@ function stringArbitrary(node: TBNode): fc.Arbitrary<string> {
     return fc.uuid();
   }
   if (node.format === "date-time") {
-    return fc
-      .date({ min: new Date(2000, 0, 1), max: new Date(2100, 0, 1) })
-      .map((d) => d.toISOString());
+    const min = Date.UTC(2000, 0, 1);
+    const max = Date.UTC(2100, 0, 1);
+    return fc.integer({ min, max }).map((ms) => new Date(ms).toISOString());
   }
   return fc.string({
     minLength: node.minLength ?? 0,

--- a/packages/protocol/src/testing/conformance/schema-conformance.ts
+++ b/packages/protocol/src/testing/conformance/schema-conformance.ts
@@ -114,7 +114,14 @@ export function registerRequestWellFormedness(
             (r) => r.frame?.type === "response" && r.frame.id === expectedId,
           );
         }),
-        { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 3 },
+        {
+          seed: ctx.seed,
+          numRuns: ctx.opts.numRuns ?? 3,
+          // Dropped-response counterexamples pay the client RPC timeout.
+          // Shrinking repeats that timeout and makes executable proofs
+          // timing-sensitive under stress without increasing coverage.
+          endOnFailure: true,
+        },
       ),
     ),
   );

--- a/scripts/conformance-toxiproxy.sh
+++ b/scripts/conformance-toxiproxy.sh
@@ -23,6 +23,7 @@ fi
 
 cleanup() {
   docker compose -f "$COMPOSE_FILE" down -v
+  rm -rf "$ROOT_DIR/.tmp/conformance"
 }
 
 wait_for_toxiproxy() {
@@ -34,6 +35,15 @@ wait_for_toxiproxy() {
   done
   echo "Toxiproxy did not become healthy at $TOXIPROXY_URL" >&2
   return 1
+}
+
+ensure_toxiproxy() {
+  if curl -sf "$TOXIPROXY_URL/version" >/dev/null; then
+    return 0
+  fi
+  echo "Toxiproxy is not reachable; starting it"
+  docker compose -f "$COMPOSE_FILE" up -d
+  wait_for_toxiproxy
 }
 
 export TOXIPROXY_URL
@@ -65,7 +75,14 @@ for ((seed_index = 0; seed_index < CONFORMANCE_SEED_COUNT; seed_index++)); do
   export FC_SEED=$((BASE_FC_SEED + seed_index))
   echo "== seed pass $((seed_index + 1))/$CONFORMANCE_SEED_COUNT: FC_SEED=$FC_SEED"
   for pkg in "${PACKAGES[@]}"; do
+    ensure_toxiproxy
+    pkg_tmp="${pkg//@/}"
+    pkg_tmp="${pkg_tmp//\//-}"
+    export TMPDIR="$ROOT_DIR/.tmp/conformance/seed-$FC_SEED/$pkg_tmp"
+    rm -rf "$TMPDIR"
+    mkdir -p "$TMPDIR"
     echo "==> $pkg"
     pnpm -F "$pkg" test:conformance
+    rm -rf "$TMPDIR"
   done
 done

--- a/scripts/conformance-toxiproxy.sh
+++ b/scripts/conformance-toxiproxy.sh
@@ -23,7 +23,6 @@ fi
 
 cleanup() {
   docker compose -f "$COMPOSE_FILE" down -v
-  rm -rf "$ROOT_DIR/.tmp/conformance"
 }
 
 wait_for_toxiproxy() {
@@ -78,11 +77,9 @@ for ((seed_index = 0; seed_index < CONFORMANCE_SEED_COUNT; seed_index++)); do
     ensure_toxiproxy
     pkg_tmp="${pkg//@/}"
     pkg_tmp="${pkg_tmp//\//-}"
-    export TMPDIR="$ROOT_DIR/.tmp/conformance/seed-$FC_SEED/$pkg_tmp"
-    rm -rf "$TMPDIR"
-    mkdir -p "$TMPDIR"
     echo "==> $pkg"
-    pnpm -F "$pkg" test:conformance
-    rm -rf "$TMPDIR"
+    MOLTZAP_TMP_SCOPE="conformance-seed-$FC_SEED-$pkg_tmp" \
+      "$ROOT_DIR/scripts/with-tempdir.sh" \
+      pnpm -F "$pkg" test:conformance
   done
 done

--- a/scripts/with-tempdir.sh
+++ b/scripts/with-tempdir.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -eq 0 ]]; then
+  echo "usage: scripts/with-tempdir.sh <command> [args...]" >&2
+  exit 64
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="${MOLTZAP_TMP_ROOT:-$ROOT_DIR/.tmp}"
+TMP_SCOPE="${MOLTZAP_TMP_SCOPE:-command}"
+SAFE_SCOPE="$(printf '%s' "$TMP_SCOPE" | tr -c 'A-Za-z0-9_.-' '-')"
+
+mkdir -p "$TMP_ROOT"
+RUN_TMPDIR="$(mktemp -d "$TMP_ROOT/${SAFE_SCOPE}.XXXXXX")"
+
+cleanup() {
+  rm -rf "$RUN_TMPDIR"
+  rmdir "$TMP_ROOT" 2>/dev/null || true
+}
+
+on_signal() {
+  cleanup
+  exit 130
+}
+
+trap cleanup EXIT
+trap on_signal INT TERM
+
+export TMPDIR="$RUN_TMPDIR"
+"$@"


### PR DESCRIPTION
Follow-up to #262. The original PR merged before the final dogfood fixes landed on the branch, so this rebases only the remaining conformance stress cleanup on current `main`.

Changes:
- Keep local Toxiproxy stress temp files under repo-local `.tmp` and ignore it.
- Add reusable `scripts/with-tempdir.sh` for any local command needing isolated `TMPDIR`, with cleanup on exit/interruption.
- Use the reusable temp wrapper from the conformance stress runner.
- Bound slow dropped-response proof shrinking with `endOnFailure: true` so the intentional timeout-based divergence proof does not exceed Vitest caps under stress.
- Generate date-time arbitraries from finite epoch milliseconds instead of `fc.date(...)` to avoid invalid `Date` values.

Verification run locally on this rebased branch:
- `bash -n scripts/with-tempdir.sh && bash -n scripts/conformance-toxiproxy.sh`
- wrapper cleanup smoke
- `pnpm format:check`
- `pnpm -F @moltzap/protocol build`

Previously dogfooded before rebase:
- `FC_SEED=1777096531 CONFORMANCE_NUM_RUNS=1 CONFORMANCE_SEED_COUNT=5 pnpm test:conformance:stress` passed across server-core, client, openclaw, and nanoclaw.