### PR TITLE
Dispatch admission leases for channel backpressure

### DIFF
--- a/docs/protocol/methods/messages-send.mdx
+++ b/docs/protocol/methods/messages-send.mdx
@@ -25,6 +25,10 @@ Send a message to a conversation or agent. Creates a DM automatically when using
   Branded MessageId
 </ParamField>
 
+<ParamField path="dispatchLeaseId" type="string">
+  The dispatchLeaseId field.
+</ParamField>
+
 ## Response
 
 The created message with ID, sequence number, and timestamp.

--- a/packages/client/src/channel-core.test.ts
+++ b/packages/client/src/channel-core.test.ts
@@ -14,6 +14,7 @@ import {
   flushDispatchChain,
   type FakeChannelService,
 } from "./test-utils/index.js";
+import { RpcServerError } from "./runtime/errors.js";
 
 function customSetup(): {
   fake: FakeChannelService;
@@ -327,6 +328,47 @@ describe("MoltZapChannelCore", () => {
       expect(received.map((m) => m.id)).toEqual(["msg-1"]);
     });
 
+    it("reports a per-conversation observed logical clock to admission", async () => {
+      const { fake } = customSetup();
+      const clocks: unknown[] = [];
+      fake.service.authorizeDispatch = (request) =>
+        Effect.sync(() => {
+          clocks.push(request.clock);
+          expect(request.pending[0]?.clock).toEqual(request.clock);
+          return { _tag: "grant" as const };
+        });
+
+      fake.emit.message(
+        buildMessage({
+          id: "msg-1",
+          senderId: "agent-alice",
+          conversationId: "conv-1",
+        }),
+      );
+      await flushDispatchChain();
+      fake.emit.message(
+        buildMessage({
+          id: "msg-2",
+          senderId: "agent-bob",
+          conversationId: "conv-1",
+        }),
+      );
+      await flushDispatchChain();
+
+      expect(clocks).toEqual([
+        {
+          domainId: "conv-1",
+          epoch: 1,
+          vector: { "agent-alice": 1 },
+        },
+        {
+          domainId: "conv-1",
+          epoch: 2,
+          vector: { "agent-alice": 1, "agent-bob": 1 },
+        },
+      ]);
+    });
+
     it("attaches the active dispatch lease to replies made during handler execution", async () => {
       const fake = createFakeChannelService({ ownAgentId: "agent-self" });
       fake.state.setConversation("conv-1", { type: "dm", participants: [] });
@@ -346,6 +388,26 @@ describe("MoltZapChannelCore", () => {
           dispatchLeaseId: "lease-active",
         },
       ]);
+    });
+
+    it("passes the active dispatch lease to the inbound handler for async runtimes", async () => {
+      const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      fake.service.authorizeDispatch = () =>
+        Effect.succeed({ _tag: "grant" as const, leaseId: "lease-visible" });
+      const core = new MoltZapChannelCore({ service: fake.service });
+      const leases: Array<string | undefined> = [];
+      core.onInbound((msg) =>
+        Effect.sync(() => {
+          leases.push(msg.dispatchLeaseId);
+        }),
+      );
+
+      fake.emit.message(buildMessage({ id: "msg-with-visible-lease" }));
+      await flushDispatchChain();
+
+      expect(leases).toEqual(["lease-visible"]);
     });
 
     it("preserves service binding for dispatch admission methods", async () => {
@@ -390,59 +452,20 @@ describe("MoltZapChannelCore", () => {
       );
     });
 
-    it("requeues deferred inbound dispatch work and retries later", async () => {
+    it("holds head-of-line work until a new inbound message refreshes the snapshot", async () => {
       const { fake, received, infoSpy } = customSetup();
-      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
-      fake.state.setAgentName("agent-alice", "Alice");
-      const attempts: number[] = [];
-      fake.service.authorizeDispatch = (request) =>
-        Effect.sync(() => {
-          attempts.push(request.attempt);
-          return request.attempt === 0
-            ? {
-                _tag: "defer" as const,
-                retryAfterMs: 1,
-                reason: "slot busy",
-              }
-            : { _tag: "grant" as const };
-        });
-
-      fake.emit.message(buildMessage({ id: "msg-deferred" }));
-      await flushDispatchChain();
-      expect(received).toHaveLength(0);
-
-      await new Promise((resolve) => setTimeout(resolve, 5));
-      await flushDispatchChain();
-
-      expect(attempts).toEqual([0, 1]);
-      expect(received.map((m) => m.id)).toEqual(["msg-deferred"]);
-      expect(infoSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          messageId: "msg-deferred",
-          attempt: 0,
-          retryAfterMs: 1,
-          reason: "slot busy",
-        }),
-        "MoltZapChannelCore: inbound dispatch deferred",
-      );
-    });
-
-    it("keeps deferred work head-of-line and coalesces same-conversation backlog on grant", async () => {
-      const { fake, received } = customSetup();
       fake.state.setConversation("conv-1", { type: "group", participants: [] });
       fake.state.setAgentName("agent-alice", "Alice");
       fake.state.setAgentName("agent-bob", "Bob");
-      const pendingSnapshots: Array<ReadonlyArray<{ messageId: string }>> = [];
+      const pendingSnapshots: Array<ReadonlyArray<string>> = [];
+      let calls = 0;
       fake.service.authorizeDispatch = (request) =>
         Effect.sync(() => {
-          pendingSnapshots.push(request.pending);
-          return request.attempt === 0
-            ? {
-                _tag: "defer" as const,
-                retryAfterMs: 20,
-                reason: "lease active",
-              }
-            : { _tag: "grant" as const, leaseId: "lease-next" };
+          calls += 1;
+          pendingSnapshots.push(request.pending.map((m) => m.messageId));
+          return calls === 1
+            ? { _tag: "hold" as const, reason: "not_yet" }
+            : { _tag: "grant" as const, leaseId: "lease-after-hold" };
         });
 
       fake.emit.message(
@@ -454,6 +477,132 @@ describe("MoltZapChannelCore", () => {
         }),
       );
       await flushDispatchChain();
+
+      expect(calls).toBe(1);
+      expect(received).toHaveLength(0);
+
+      fake.emit.message(
+        buildMessage({
+          id: "msg-2",
+          senderId: "agent-bob",
+          conversationId: "conv-1",
+          parts: [{ type: "text", text: "second" }],
+        }),
+      );
+      await flushDispatchChain();
+
+      expect(pendingSnapshots).toEqual([["msg-1"], ["msg-1", "msg-2"]]);
+      expect(received).toHaveLength(1);
+      expect(received[0]!.id).toBe("msg-1");
+      expect(received[0]!.text).toContain("first");
+      expect(received[0]!.text).toContain("second");
+      expect(received[0]!.coalescedMessages?.map((m) => m.id)).toEqual([
+        "msg-1",
+        "msg-2",
+      ]);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: "msg-1",
+          attempt: 0,
+          reason: "not_yet",
+        }),
+        "MoltZapChannelCore: inbound dispatch held",
+      );
+    });
+
+    it("does not let held work in one conversation block another conversation", async () => {
+      const { fake, received } = customSetup();
+      fake.state.setConversation("town-square", {
+        type: "group",
+        participants: [],
+      });
+      fake.state.setConversation("werewolf-den", {
+        type: "group",
+        participants: [],
+      });
+      fake.state.setAgentName("agent-gm", "GM");
+      const requests: Array<{
+        messageId: string;
+        conversationId: string;
+        pending: ReadonlyArray<string>;
+      }> = [];
+
+      fake.service.authorizeDispatch = (request) =>
+        Effect.sync(() => {
+          requests.push({
+            messageId: request.message.id,
+            conversationId: request.conversationId,
+            pending: request.pending.map((m) => m.messageId),
+          });
+          if (request.conversationId === "town-square") {
+            return { _tag: "hold" as const, reason: "town_square_night" };
+          }
+          return { _tag: "grant" as const, leaseId: "lease-den" };
+        });
+
+      fake.emit.message(
+        buildMessage({
+          id: "town-night-narration",
+          senderId: "agent-gm",
+          conversationId: "town-square",
+          parts: [{ type: "text", text: "Night falls." }],
+        }),
+      );
+      await flushDispatchChain();
+
+      fake.emit.message(
+        buildMessage({
+          id: "den-kill-prompt",
+          senderId: "agent-gm",
+          conversationId: "werewolf-den",
+          parts: [{ type: "text", text: "Werewolves, choose a target." }],
+        }),
+      );
+      await flushDispatchChain();
+
+      expect(requests).toEqual([
+        {
+          messageId: "town-night-narration",
+          conversationId: "town-square",
+          pending: ["town-night-narration"],
+        },
+        {
+          messageId: "den-kill-prompt",
+          conversationId: "werewolf-den",
+          pending: ["den-kill-prompt", "town-night-narration"],
+        },
+      ]);
+      expect(received.map((m) => m.id)).toEqual(["den-kill-prompt"]);
+      expect(received[0]!.conversationId).toBe("werewolf-den");
+      expect(received[0]!.dispatchLeaseId).toBe("lease-den");
+    });
+
+    it("keeps blocked authorization head-of-line and coalesces same-conversation backlog on grant", async () => {
+      const { fake, received } = customSetup();
+      fake.state.setConversation("conv-1", { type: "group", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      fake.state.setAgentName("agent-bob", "Bob");
+      const pendingSnapshots: Array<ReadonlyArray<{ messageId: string }>> = [];
+      let grant!: () => void;
+      fake.service.authorizeDispatch = (request) =>
+        Effect.gen(function* () {
+          pendingSnapshots.push(request.pending);
+          yield* Effect.async<void>((resume) => {
+            grant = () => resume(Effect.void);
+          });
+          return { _tag: "grant" as const, leaseId: "lease-next" };
+        });
+
+      fake.emit.message(
+        buildMessage({
+          id: "msg-1",
+          senderId: "agent-alice",
+          conversationId: "conv-1",
+          parts: [{ type: "text", text: "first" }],
+        }),
+      );
+      await flushDispatchChain();
+      expect(received).toHaveLength(0);
       fake.emit.message(
         buildMessage({
           id: "msg-2",
@@ -463,12 +612,12 @@ describe("MoltZapChannelCore", () => {
         }),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 30));
+      grant();
       await flushDispatchChain();
 
       expect(
         pendingSnapshots.map((snapshot) => snapshot.map((m) => m.messageId)),
-      ).toEqual([["msg-1"], ["msg-1", "msg-2"]]);
+      ).toEqual([["msg-1"]]);
       expect(received).toHaveLength(1);
       expect(received[0]!.id).toBe("msg-1");
       expect(received[0]!.text).toContain("first");
@@ -479,7 +628,66 @@ describe("MoltZapChannelCore", () => {
       ]);
     });
 
-    it("fails open when dispatch admission errors", async () => {
+    it("dispatches an admitted pending marker and drops older same-conversation work", async () => {
+      const { fake, received } = customSetup();
+      fake.state.setConversation("conv-1", { type: "group", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      fake.state.setAgentName("agent-gm", "GM");
+      let grant!: () => void;
+      fake.service.authorizeDispatch = () =>
+        Effect.gen(function* () {
+          yield* Effect.async<void>((resume) => {
+            grant = () => resume(Effect.void);
+          });
+          return {
+            _tag: "grant" as const,
+            leaseId: "lease-marker",
+            dispatchMessageId: "msg-marker",
+          };
+        });
+
+      fake.emit.message(
+        buildMessage({
+          id: "msg-old",
+          senderId: "agent-alice",
+          conversationId: "conv-1",
+          parts: [{ type: "text", text: "old discussion" }],
+        }),
+      );
+      await flushDispatchChain();
+      fake.emit.message(
+        buildMessage({
+          id: "msg-marker",
+          senderId: "agent-gm",
+          conversationId: "conv-1",
+          parts: [{ type: "text", text: "Time to vote" }],
+        }),
+      );
+      fake.emit.message(
+        buildMessage({
+          id: "msg-after",
+          senderId: "agent-alice",
+          conversationId: "conv-1",
+          parts: [{ type: "text", text: "after marker" }],
+        }),
+      );
+
+      grant();
+      await flushDispatchChain();
+
+      expect(received).toHaveLength(1);
+      expect(received[0]!.id).toBe("msg-marker");
+      expect(received[0]!.text).toContain("Time to vote");
+      expect(received[0]!.text).toContain("after marker");
+      expect(received[0]!.text).not.toContain("old discussion");
+      expect(received[0]!.coalescedMessages?.map((m) => m.id)).toEqual([
+        "msg-marker",
+        "msg-after",
+      ]);
+      expect(received[0]!.dispatchLeaseId).toBe("lease-marker");
+    });
+
+    it("fails closed when dispatch admission errors", async () => {
       const fake = createFakeChannelService({ ownAgentId: "agent-self" });
       const received: EnrichedInboundMessage[] = [];
       const errorSpy = vi.fn();
@@ -497,25 +705,26 @@ describe("MoltZapChannelCore", () => {
       );
       fake.service.authorizeDispatch = () =>
         Effect.fail(
-          new Error("admission service unavailable"),
-        ) as unknown as ReturnType<
-          NonNullable<ChannelService["authorizeDispatch"]>
-        >;
+          new RpcServerError({
+            code: -32603,
+            message: "admission service unavailable",
+          }),
+        );
 
-      fake.emit.message(buildMessage({ id: "msg-fail-open" }));
+      fake.emit.message(buildMessage({ id: "msg-fail-closed" }));
       await flushDispatchChain();
 
-      expect(received.map((m) => m.id)).toEqual(["msg-fail-open"]);
+      expect(received).toHaveLength(0);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          messageId: "msg-fail-open",
+          messageId: "msg-fail-closed",
           attempt: 0,
         }),
-        "MoltZapChannelCore: dispatch admission failed open",
+        "MoltZapChannelCore: dispatch admission failed closed",
       );
     });
 
-    it("fails open when dispatch admission hangs", async () => {
+    it("fails closed when dispatch admission hangs", async () => {
       const fake = createFakeChannelService({ ownAgentId: "agent-self" });
       const received: EnrichedInboundMessage[] = [];
       const errorSpy = vi.fn();
@@ -534,17 +743,58 @@ describe("MoltZapChannelCore", () => {
       );
       fake.service.authorizeDispatch = () => Effect.never;
 
-      fake.emit.message(buildMessage({ id: "msg-timeout-open" }));
+      fake.emit.message(buildMessage({ id: "msg-timeout-closed" }));
       await new Promise((resolve) => setTimeout(resolve, 5));
       await flushDispatchChain();
 
-      expect(received.map((m) => m.id)).toEqual(["msg-timeout-open"]);
+      expect(received).toHaveLength(0);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          messageId: "msg-timeout-open",
+          messageId: "msg-timeout-closed",
           attempt: 0,
         }),
-        "MoltZapChannelCore: dispatch admission failed open",
+        "MoltZapChannelCore: dispatch admission failed closed",
+      );
+    });
+
+    it("continues draining inbound work after a dispatch lease expires", async () => {
+      const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+      const received: string[] = [];
+      const warnSpy = vi.fn();
+      const errorSpy = vi.fn();
+      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      fake.service.authorizeDispatch = (request) =>
+        Effect.succeed({
+          _tag: "grant" as const,
+          leaseId: `lease-${request.message.id}`,
+          leaseTimeoutMs: request.message.id === "msg-stuck" ? 1 : 50,
+        });
+      const core = new MoltZapChannelCore({
+        service: fake.service,
+        logger: { info: () => {}, warn: warnSpy, error: errorSpy },
+      });
+      core.onInbound((m) => {
+        if (m.id === "msg-stuck") return Effect.never;
+        return Effect.sync(() => {
+          received.push(m.id);
+        });
+      });
+
+      fake.emit.message(buildMessage({ id: "msg-stuck" }));
+      await flushDispatchChain();
+      fake.emit.message(buildMessage({ id: "msg-next" }));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushDispatchChain();
+
+      expect(received).toEqual(["msg-next"]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: "msg-stuck",
+          leaseId: "lease-msg-stuck",
+          timeoutMs: 1,
+        }),
+        "MoltZapChannelCore: inbound dispatch lease expired",
       );
     });
 

--- a/packages/client/src/channel-core.test.ts
+++ b/packages/client/src/channel-core.test.ts
@@ -19,21 +19,23 @@ function customSetup(): {
   fake: FakeChannelService;
   core: MoltZapChannelCore;
   received: EnrichedInboundMessage[];
+  infoSpy: ReturnType<typeof vi.fn>;
   errorSpy: ReturnType<typeof vi.fn>;
 } {
   const fake = createFakeChannelService({ ownAgentId: "agent-self" });
   const received: EnrichedInboundMessage[] = [];
+  const infoSpy = vi.fn();
   const errorSpy = vi.fn();
   const core = new MoltZapChannelCore({
     service: fake.service,
-    logger: { info: () => {}, warn: () => {}, error: errorSpy },
+    logger: { info: infoSpy, warn: () => {}, error: errorSpy },
   });
   core.onInbound((m) =>
     Effect.sync(() => {
       received.push(m);
     }),
   );
-  return { fake, core, received, errorSpy };
+  return { fake, core, received, infoSpy, errorSpy };
 }
 
 /** Stub out getAgentName on the fixture's service so resolveAgentName is the only path. */
@@ -304,6 +306,248 @@ describe("MoltZapChannelCore", () => {
   });
 
   describe("dispatch chain ordering", () => {
+    it("asks optional dispatch admission before delivering inbound work", async () => {
+      const { fake, received } = customSetup();
+      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      const requests: Array<{ messageId: string; attempt: number }> = [];
+      fake.service.authorizeDispatch = (request) =>
+        Effect.sync(() => {
+          requests.push({
+            messageId: request.message.id,
+            attempt: request.attempt,
+          });
+          return { _tag: "grant" as const, leaseId: "lease-1" };
+        });
+
+      fake.emit.message(buildMessage({ id: "msg-1" }));
+      await flushDispatchChain();
+
+      expect(requests).toEqual([{ messageId: "msg-1", attempt: 0 }]);
+      expect(received.map((m) => m.id)).toEqual(["msg-1"]);
+    });
+
+    it("attaches the active dispatch lease to replies made during handler execution", async () => {
+      const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      fake.service.authorizeDispatch = () =>
+        Effect.succeed({ _tag: "grant" as const, leaseId: "lease-active" });
+      const core = new MoltZapChannelCore({ service: fake.service });
+      core.onInbound((msg) => core.sendReply(msg.conversationId, "reply"));
+
+      fake.emit.message(buildMessage({ id: "msg-with-lease" }));
+      await flushDispatchChain();
+
+      expect(fake.state.sent).toEqual([
+        {
+          convId: "conv-1",
+          text: "reply",
+          dispatchLeaseId: "lease-active",
+        },
+      ]);
+    });
+
+    it("preserves service binding for dispatch admission methods", async () => {
+      const { fake, received } = customSetup();
+      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      const boundService = fake.service as ChannelService & {
+        admissionCalls: number;
+      };
+      boundService.admissionCalls = 0;
+      boundService.authorizeDispatch = function () {
+        this.admissionCalls += 1;
+        return Effect.succeed({ _tag: "grant" as const });
+      };
+
+      fake.emit.message(buildMessage({ id: "msg-bound-admission" }));
+      await flushDispatchChain();
+
+      expect(boundService.admissionCalls).toBe(1);
+      expect(received.map((m) => m.id)).toEqual(["msg-bound-admission"]);
+    });
+
+    it("drops denied inbound dispatch work without calling the handler", async () => {
+      const { fake, received, infoSpy } = customSetup();
+      fake.service.authorizeDispatch = () =>
+        Effect.succeed({
+          _tag: "deny" as const,
+          reason: "not this slot",
+        });
+
+      fake.emit.message(buildMessage({ id: "msg-denied" }));
+      await flushDispatchChain();
+
+      expect(received).toHaveLength(0);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: "msg-denied",
+          attempt: 0,
+          reason: "not this slot",
+        }),
+        "MoltZapChannelCore: inbound dispatch denied",
+      );
+    });
+
+    it("requeues deferred inbound dispatch work and retries later", async () => {
+      const { fake, received, infoSpy } = customSetup();
+      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      const attempts: number[] = [];
+      fake.service.authorizeDispatch = (request) =>
+        Effect.sync(() => {
+          attempts.push(request.attempt);
+          return request.attempt === 0
+            ? {
+                _tag: "defer" as const,
+                retryAfterMs: 1,
+                reason: "slot busy",
+              }
+            : { _tag: "grant" as const };
+        });
+
+      fake.emit.message(buildMessage({ id: "msg-deferred" }));
+      await flushDispatchChain();
+      expect(received).toHaveLength(0);
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await flushDispatchChain();
+
+      expect(attempts).toEqual([0, 1]);
+      expect(received.map((m) => m.id)).toEqual(["msg-deferred"]);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: "msg-deferred",
+          attempt: 0,
+          retryAfterMs: 1,
+          reason: "slot busy",
+        }),
+        "MoltZapChannelCore: inbound dispatch deferred",
+      );
+    });
+
+    it("keeps deferred work head-of-line and coalesces same-conversation backlog on grant", async () => {
+      const { fake, received } = customSetup();
+      fake.state.setConversation("conv-1", { type: "group", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      fake.state.setAgentName("agent-bob", "Bob");
+      const pendingSnapshots: Array<ReadonlyArray<{ messageId: string }>> = [];
+      fake.service.authorizeDispatch = (request) =>
+        Effect.sync(() => {
+          pendingSnapshots.push(request.pending);
+          return request.attempt === 0
+            ? {
+                _tag: "defer" as const,
+                retryAfterMs: 20,
+                reason: "lease active",
+              }
+            : { _tag: "grant" as const, leaseId: "lease-next" };
+        });
+
+      fake.emit.message(
+        buildMessage({
+          id: "msg-1",
+          senderId: "agent-alice",
+          conversationId: "conv-1",
+          parts: [{ type: "text", text: "first" }],
+        }),
+      );
+      await flushDispatchChain();
+      fake.emit.message(
+        buildMessage({
+          id: "msg-2",
+          senderId: "agent-bob",
+          conversationId: "conv-1",
+          parts: [{ type: "text", text: "second" }],
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      await flushDispatchChain();
+
+      expect(
+        pendingSnapshots.map((snapshot) => snapshot.map((m) => m.messageId)),
+      ).toEqual([["msg-1"], ["msg-1", "msg-2"]]);
+      expect(received).toHaveLength(1);
+      expect(received[0]!.id).toBe("msg-1");
+      expect(received[0]!.text).toContain("first");
+      expect(received[0]!.text).toContain("second");
+      expect(received[0]!.coalescedMessages?.map((m) => m.id)).toEqual([
+        "msg-1",
+        "msg-2",
+      ]);
+    });
+
+    it("fails open when dispatch admission errors", async () => {
+      const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+      const received: EnrichedInboundMessage[] = [];
+      const errorSpy = vi.fn();
+      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      const warnSpy = vi.fn();
+      const core = new MoltZapChannelCore({
+        service: fake.service,
+        logger: { info: () => {}, warn: warnSpy, error: errorSpy },
+      });
+      core.onInbound((m) =>
+        Effect.sync(() => {
+          received.push(m);
+        }),
+      );
+      fake.service.authorizeDispatch = () =>
+        Effect.fail(
+          new Error("admission service unavailable"),
+        ) as unknown as ReturnType<
+          NonNullable<ChannelService["authorizeDispatch"]>
+        >;
+
+      fake.emit.message(buildMessage({ id: "msg-fail-open" }));
+      await flushDispatchChain();
+
+      expect(received.map((m) => m.id)).toEqual(["msg-fail-open"]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: "msg-fail-open",
+          attempt: 0,
+        }),
+        "MoltZapChannelCore: dispatch admission failed open",
+      );
+    });
+
+    it("fails open when dispatch admission hangs", async () => {
+      const fake = createFakeChannelService({ ownAgentId: "agent-self" });
+      const received: EnrichedInboundMessage[] = [];
+      const errorSpy = vi.fn();
+      fake.state.setConversation("conv-1", { type: "dm", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      const warnSpy = vi.fn();
+      const core = new MoltZapChannelCore({
+        service: fake.service,
+        logger: { info: () => {}, warn: warnSpy, error: errorSpy },
+        dispatchAdmissionTimeoutMs: 1,
+      });
+      core.onInbound((m) =>
+        Effect.sync(() => {
+          received.push(m);
+        }),
+      );
+      fake.service.authorizeDispatch = () => Effect.never;
+
+      fake.emit.message(buildMessage({ id: "msg-timeout-open" }));
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await flushDispatchChain();
+
+      expect(received.map((m) => m.id)).toEqual(["msg-timeout-open"]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: "msg-timeout-open",
+          attempt: 0,
+        }),
+        "MoltZapChannelCore: dispatch admission failed open",
+      );
+    });
+
     it("serializes handlers so message order is preserved across async resolution", async () => {
       const { fake, received } = customSetup();
       fake.state.setConversation("conv-1", { type: "dm", participants: [] });

--- a/packages/client/src/channel-core.ts
+++ b/packages/client/src/channel-core.ts
@@ -2,7 +2,7 @@
  * Shared message-enrichment helper for MoltZap channel adapters.
  */
 
-import { Cause, Effect, Fiber, Queue } from "effect";
+import { Cause, Chunk, Duration, Effect, Fiber, Queue } from "effect";
 import type { Message, PermissionsRequiredEvent } from "@moltzap/protocol";
 import type {
   CrossConversationEntry,
@@ -40,7 +40,40 @@ export interface EnrichedInboundMessage {
   replyToId?: string;
   conversationMeta?: EnrichedConversationMeta;
   contextBlocks: ContextBlocks;
+  /**
+   * Present when multiple queued messages from the same conversation were
+   * coalesced into this single dispatch. Includes the primary message first.
+   */
+  coalescedMessages?: ReadonlyArray<{
+    id: string;
+    sender: EnrichedSender;
+    text: string;
+    createdAt: string;
+    replyToId?: string;
+  }>;
 }
+
+export interface PendingDispatchMessage {
+  messageId: string;
+  conversationId: string;
+  senderAgentId: string;
+  createdAt: string;
+  receivedAt: string;
+}
+
+export interface DispatchAdmissionRequest {
+  message: Message;
+  conversationId: string;
+  senderAgentId: string;
+  attempt: number;
+  receivedAt: string;
+  pending: ReadonlyArray<PendingDispatchMessage>;
+}
+
+export type DispatchAdmissionDecision =
+  | { _tag: "grant"; leaseId?: string }
+  | { _tag: "defer"; retryAfterMs: number; reason?: string }
+  | { _tag: "deny"; reason?: string };
 
 /** The subset of MoltZapService that MoltZapChannelCore needs. */
 export interface ChannelService {
@@ -57,6 +90,7 @@ export interface ChannelService {
   send(
     conversationId: string,
     text: string,
+    opts?: { dispatchLeaseId?: string },
   ): Effect.Effect<void, ServiceRpcError>;
   getConversation(
     convId: string,
@@ -71,11 +105,15 @@ export interface ChannelService {
     messages: CrossConvMessage[];
     commit: () => void;
   };
+  authorizeDispatch?(
+    request: DispatchAdmissionRequest,
+  ): Effect.Effect<DispatchAdmissionDecision, ServiceRpcError>;
 }
 
 export interface ChannelCoreOptions {
   service: ChannelService;
   logger?: WsClientLogger;
+  dispatchAdmissionTimeoutMs?: number;
 }
 
 /**
@@ -93,6 +131,27 @@ const noopLogger = {
   warn: () => {},
   error: () => {},
 };
+
+const DEFAULT_DISPATCH_ADMISSION_TIMEOUT_MS = 1000;
+
+function errorSummary(err: unknown): Record<string, unknown> {
+  if (err instanceof Error) {
+    return {
+      errorName: err.name,
+      errorMessage: err.message,
+      errorStack: err.stack,
+    };
+  }
+  return {
+    errorValue: String(err),
+  };
+}
+
+interface InboundDispatchWork {
+  message: Message;
+  attempt: number;
+  receivedAtMs: number;
+}
 
 function extractTextContent(parts: Message["parts"]): string {
   return parts
@@ -115,13 +174,14 @@ function extractTextContent(parts: Message["parts"]): string {
 export class MoltZapChannelCore {
   private readonly service: ChannelService;
   private readonly logger: WsClientLogger;
+  private readonly dispatchAdmissionTimeoutMs: number;
   private connected = false;
   private inboundHandler: InboundHandler<unknown> | null = null;
+  private activeDispatchLeaseId: string | undefined;
   /** Inbound messages enqueue synchronously; a single forked consumer fiber
    * serialises delivery so handlers execute one-at-a-time in arrival order. */
-  private readonly inboundQueue: Queue.Queue<Message> = Effect.runSync(
-    Queue.unbounded<Message>(),
-  );
+  private readonly inboundQueue: Queue.Queue<InboundDispatchWork> =
+    Effect.runSync(Queue.unbounded<InboundDispatchWork>());
   private readonly consumerFiber: Fiber.RuntimeFiber<void, never>;
   private disconnectHandlers: Array<() => void> = [];
   private reconnectHandlers: Array<() => void> = [];
@@ -132,9 +192,15 @@ export class MoltZapChannelCore {
   constructor(opts: ChannelCoreOptions) {
     this.service = opts.service;
     this.logger = opts.logger ?? noopLogger;
+    this.dispatchAdmissionTimeoutMs =
+      opts.dispatchAdmissionTimeoutMs ?? DEFAULT_DISPATCH_ADMISSION_TIMEOUT_MS;
 
     this.service.on("message", (message) => {
-      Queue.unsafeOffer(this.inboundQueue, message);
+      Queue.unsafeOffer(this.inboundQueue, {
+        message,
+        attempt: 0,
+        receivedAtMs: Date.now(),
+      });
     });
 
     // Both typed failures (Effect.fail) and defects (sync throws inside the
@@ -143,12 +209,17 @@ export class MoltZapChannelCore {
     // handler in either mode.
     const consumer = Effect.forever(
       Queue.take(this.inboundQueue).pipe(
-        Effect.flatMap((message) =>
-          this.dispatchInboundEffect(message).pipe(
+        Effect.flatMap((work) =>
+          this.dispatchInboundWork(work).pipe(
             Effect.catchAllCause((cause) =>
               Effect.sync(() =>
                 this.logger.error(
-                  { messageId: message.id, err: Cause.squash(cause) },
+                  {
+                    messageId: work.message.id,
+                    conversationId: work.message.conversationId,
+                    causePretty: Cause.pretty(cause),
+                    ...errorSummary(Cause.squash(cause)),
+                  },
                   "MoltZapChannelCore: inbound handler failed",
                 ),
               ),
@@ -237,7 +308,150 @@ export class MoltZapChannelCore {
     conversationId: string,
     text: string,
   ): Effect.Effect<void, ServiceRpcError> {
-    return this.service.send(conversationId, text);
+    return this.service.send(conversationId, text, {
+      dispatchLeaseId: this.activeDispatchLeaseId,
+    });
+  }
+
+  private dispatchAdmission(
+    work: InboundDispatchWork,
+  ): Effect.Effect<DispatchAdmissionDecision, ServiceRpcError> {
+    if (!this.service.authorizeDispatch) {
+      return Effect.succeed({ _tag: "grant" });
+    }
+    return Effect.suspend(() =>
+      this.service.authorizeDispatch!({
+        message: work.message,
+        conversationId: work.message.conversationId,
+        senderAgentId: work.message.senderId,
+        attempt: work.attempt,
+        receivedAt: new Date(work.receivedAtMs).toISOString(),
+        pending: this.pendingDispatchSnapshot(work),
+      }),
+    ).pipe(
+      Effect.timeoutFail({
+        duration: Duration.millis(this.dispatchAdmissionTimeoutMs),
+        onTimeout: () =>
+          new Error(
+            `dispatch admission timed out after ${this.dispatchAdmissionTimeoutMs}ms`,
+          ),
+      }),
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          this.logger.warn(
+            {
+              messageId: work.message.id,
+              conversationId: work.message.conversationId,
+              attempt: work.attempt,
+              err,
+            },
+            "MoltZapChannelCore: dispatch admission failed open",
+          );
+          return { _tag: "grant" as const };
+        }),
+      ),
+    );
+  }
+
+  private dispatchInboundWork(
+    work: InboundDispatchWork,
+  ): Effect.Effect<void, unknown> {
+    return Effect.gen(this, function* () {
+      const decision = yield* this.dispatchAdmission(work);
+      if (decision._tag === "grant") {
+        const messages = this.service.authorizeDispatch
+          ? yield* this.takeCoalescedConversationMessages(work)
+          : [work.message];
+        yield* Effect.acquireUseRelease(
+          Effect.sync(() => {
+            const previous = this.activeDispatchLeaseId;
+            this.activeDispatchLeaseId = decision.leaseId;
+            return previous;
+          }),
+          () => this.dispatchInboundEffect(messages),
+          (previous) =>
+            Effect.sync(() => {
+              this.activeDispatchLeaseId = previous;
+            }),
+        );
+        return;
+      }
+
+      if (decision._tag === "deny") {
+        yield* Effect.sync(() =>
+          this.logger.info(
+            {
+              messageId: work.message.id,
+              conversationId: work.message.conversationId,
+              attempt: work.attempt,
+              reason: decision.reason,
+            },
+            "MoltZapChannelCore: inbound dispatch denied",
+          ),
+        );
+        return;
+      }
+
+      const retryAfterMs = Math.max(0, Math.floor(decision.retryAfterMs));
+      yield* Effect.sync(() =>
+        this.logger.info(
+          {
+            messageId: work.message.id,
+            conversationId: work.message.conversationId,
+            attempt: work.attempt,
+            retryAfterMs,
+            reason: decision.reason,
+          },
+          "MoltZapChannelCore: inbound dispatch deferred",
+        ),
+      );
+      yield* Effect.sleep(Duration.millis(retryAfterMs));
+      yield* this.dispatchInboundWork({
+        ...work,
+        attempt: work.attempt + 1,
+      });
+    });
+  }
+
+  private pendingDispatchSnapshot(
+    active: InboundDispatchWork,
+  ): ReadonlyArray<PendingDispatchMessage> {
+    const queued = Chunk.toReadonlyArray(
+      Effect.runSync(Queue.takeAll(this.inboundQueue)),
+    );
+    for (const work of queued) {
+      Queue.unsafeOffer(this.inboundQueue, work);
+    }
+    return [active, ...queued].map((work) => ({
+      messageId: work.message.id,
+      conversationId: work.message.conversationId,
+      senderAgentId: work.message.senderId,
+      createdAt: work.message.createdAt,
+      receivedAt: new Date(work.receivedAtMs).toISOString(),
+    }));
+  }
+
+  private takeCoalescedConversationMessages(
+    work: InboundDispatchWork,
+  ): Effect.Effect<ReadonlyArray<Message>, never> {
+    return Effect.sync(() => {
+      const queued = Chunk.toReadonlyArray(
+        Effect.runSync(Queue.takeAll(this.inboundQueue)),
+      );
+      const coalesced: Message[] = [work.message];
+      const remaining: InboundDispatchWork[] = [];
+      for (const queuedWork of queued) {
+        if (queuedWork.message.conversationId === work.message.conversationId) {
+          coalesced.push(queuedWork.message);
+        } else {
+          remaining.push(queuedWork);
+        }
+      }
+      for (const remainingWork of remaining) {
+        Queue.unsafeOffer(this.inboundQueue, remainingWork);
+      }
+      return coalesced;
+    });
   }
 
   /**
@@ -246,7 +460,7 @@ export class MoltZapChannelCore {
    */
   static enrichMessage(
     service: ChannelService,
-    message: Message,
+    messageOrMessages: Message | ReadonlyArray<Message>,
   ): Effect.Effect<
     {
       enriched: EnrichedInboundMessage;
@@ -255,18 +469,50 @@ export class MoltZapChannelCore {
     never
   > {
     return Effect.gen(function* () {
+      const messages = Array.isArray(messageOrMessages)
+        ? [...messageOrMessages]
+        : [messageOrMessages];
+      const message = messages[0]!;
       const convMeta = service.getConversation(message.conversationId);
 
-      const cachedName = service.getAgentName(message.senderId);
-      // `resolveAgentName` has `never` in the error channel — it catches its
-      // own transport failures and falls back to `senderId` internally, so
-      // no explicit `catchAll` is needed here.
-      const senderName =
-        cachedName !== undefined
-          ? cachedName
-          : yield* service.resolveAgentName(message.senderId);
+      const senderNameFor = (agentId: string) => {
+        const cachedName = service.getAgentName(agentId);
+        // `resolveAgentName` has `never` in the error channel — it catches its
+        // own transport failures and falls back to `senderId` internally, so
+        // no explicit `catchAll` is needed here.
+        return cachedName !== undefined
+          ? Effect.succeed(cachedName)
+          : service.resolveAgentName(agentId);
+      };
 
-      const text = extractTextContent(message.parts);
+      const senderName = yield* senderNameFor(message.senderId);
+
+      const coalesced = [];
+      for (const [index, m] of messages.entries()) {
+        const name =
+          index === 0 ? senderName : yield* senderNameFor(m.senderId);
+        coalesced.push({
+          id: m.id,
+          sender: {
+            id: m.senderId,
+            name,
+          },
+          text: extractTextContent(m.parts),
+          createdAt: m.createdAt,
+          ...(m.replyToId ? { replyToId: m.replyToId } : {}),
+        });
+      }
+
+      const text =
+        coalesced.length === 1
+          ? coalesced[0]!.text
+          : coalesced
+              .map((m, index) =>
+                index === 0
+                  ? m.text
+                  : `[queued message from ${m.sender.name} at ${m.createdAt}]\n${m.text}`,
+              )
+              .join("\n\n");
 
       const isFromMe =
         service.ownAgentId !== undefined &&
@@ -315,6 +561,7 @@ export class MoltZapChannelCore {
           replyToId: message.replyToId,
           conversationMeta,
           contextBlocks,
+          ...(coalesced.length > 1 ? { coalescedMessages: coalesced } : {}),
         },
         commitContext: hasContext
           ? () => {
@@ -327,12 +574,12 @@ export class MoltZapChannelCore {
   }
 
   private dispatchInboundEffect(
-    message: Message,
+    messages: ReadonlyArray<Message>,
   ): Effect.Effect<void, unknown> {
     return Effect.gen(this, function* () {
       if (!this.inboundHandler) return;
       const { enriched, commitContext } =
-        yield* MoltZapChannelCore.enrichMessage(this.service, message);
+        yield* MoltZapChannelCore.enrichMessage(this.service, messages);
       // The handler is user code returning an Effect — yield it directly so
       // its typed error channel propagates to the consumer fiber, which logs
       // and continues. We await it inline to preserve arrival-order delivery.

--- a/packages/client/src/channel-core.ts
+++ b/packages/client/src/channel-core.ts
@@ -3,7 +3,11 @@
  */
 
 import { Cause, Chunk, Duration, Effect, Fiber, Queue } from "effect";
-import type { Message, PermissionsRequiredEvent } from "@moltzap/protocol";
+import type {
+  LogicalClock,
+  Message,
+  PermissionsRequiredEvent,
+} from "@moltzap/protocol";
 import type {
   CrossConversationEntry,
   CrossConvMessage,
@@ -51,6 +55,8 @@ export interface EnrichedInboundMessage {
     createdAt: string;
     replyToId?: string;
   }>;
+  /** Lease that authorizes a runtime reply for this dispatch, when present. */
+  dispatchLeaseId?: string;
 }
 
 export interface PendingDispatchMessage {
@@ -59,6 +65,8 @@ export interface PendingDispatchMessage {
   senderAgentId: string;
   createdAt: string;
   receivedAt: string;
+  clock?: LogicalClock;
+  parts?: Message["parts"];
 }
 
 export interface DispatchAdmissionRequest {
@@ -67,13 +75,19 @@ export interface DispatchAdmissionRequest {
   senderAgentId: string;
   attempt: number;
   receivedAt: string;
+  clock: LogicalClock;
   pending: ReadonlyArray<PendingDispatchMessage>;
 }
 
 export type DispatchAdmissionDecision =
-  | { _tag: "grant"; leaseId?: string }
-  | { _tag: "defer"; retryAfterMs: number; reason?: string }
-  | { _tag: "deny"; reason?: string };
+  | {
+      _tag: "grant";
+      leaseId?: string;
+      leaseTimeoutMs?: number;
+      dispatchMessageId?: string;
+    }
+  | { _tag: "deny"; reason?: string }
+  | { _tag: "hold"; reason?: string };
 
 /** The subset of MoltZapService that MoltZapChannelCore needs. */
 export interface ChannelService {
@@ -132,7 +146,19 @@ const noopLogger = {
   error: () => {},
 };
 
-const DEFAULT_DISPATCH_ADMISSION_TIMEOUT_MS = 1000;
+const DEFAULT_DISPATCH_ADMISSION_TIMEOUT_MS = 900_000;
+const DEFAULT_DISPATCH_LEASE_TIMEOUT_MS = 90_000;
+
+class DispatchLeaseExpired extends Error {
+  constructor(
+    readonly messageId: string,
+    readonly conversationId: string,
+    readonly timeoutMs: number,
+  ) {
+    super(`dispatch lease expired after ${timeoutMs}ms`);
+    this.name = "DispatchLeaseExpired";
+  }
+}
 
 function errorSummary(err: unknown): Record<string, unknown> {
   if (err instanceof Error) {
@@ -151,6 +177,7 @@ interface InboundDispatchWork {
   message: Message;
   attempt: number;
   receivedAtMs: number;
+  clock: LogicalClock;
 }
 
 function extractTextContent(parts: Message["parts"]): string {
@@ -178,6 +205,14 @@ export class MoltZapChannelCore {
   private connected = false;
   private inboundHandler: InboundHandler<unknown> | null = null;
   private activeDispatchLeaseId: string | undefined;
+  private readonly logicalClocks = new Map<
+    string,
+    { epoch: number; vector: Record<string, number> }
+  >();
+  private readonly parkedByConversation = new Map<
+    string,
+    InboundDispatchWork[]
+  >();
   /** Inbound messages enqueue synchronously; a single forked consumer fiber
    * serialises delivery so handlers execute one-at-a-time in arrival order. */
   private readonly inboundQueue: Queue.Queue<InboundDispatchWork> =
@@ -200,6 +235,7 @@ export class MoltZapChannelCore {
         message,
         attempt: 0,
         receivedAtMs: Date.now(),
+        clock: this.observeMessage(message),
       });
     });
 
@@ -307,10 +343,56 @@ export class MoltZapChannelCore {
   sendReply(
     conversationId: string,
     text: string,
+    opts?: { dispatchLeaseId?: string },
   ): Effect.Effect<void, ServiceRpcError> {
     return this.service.send(conversationId, text, {
-      dispatchLeaseId: this.activeDispatchLeaseId,
+      dispatchLeaseId: opts?.dispatchLeaseId ?? this.activeDispatchLeaseId,
     });
+  }
+
+  private observeMessage(message: Message): LogicalClock {
+    const current = this.logicalClocks.get(message.conversationId) ?? {
+      epoch: 0,
+      vector: {},
+    };
+    const vector = {
+      ...current.vector,
+      [message.senderId]: (current.vector[message.senderId] ?? 0) + 1,
+    };
+    const next = { epoch: current.epoch + 1, vector };
+    this.logicalClocks.set(message.conversationId, next);
+    return {
+      domainId: message.conversationId,
+      epoch: next.epoch,
+      vector,
+    };
+  }
+
+  private takeDispatchCandidate(
+    incoming: InboundDispatchWork,
+  ): InboundDispatchWork {
+    const conversationId = incoming.message.conversationId;
+    const parked = this.parkedByConversation.get(conversationId);
+    if (!parked || parked.length === 0) return incoming;
+
+    parked.push(incoming);
+    const next = parked.shift()!;
+    if (parked.length === 0) {
+      this.parkedByConversation.delete(conversationId);
+    } else {
+      this.parkedByConversation.set(conversationId, parked);
+    }
+    return next;
+  }
+
+  private parkDispatchWork(work: InboundDispatchWork): void {
+    const conversationId = work.message.conversationId;
+    const parked = this.parkedByConversation.get(conversationId) ?? [];
+    parked.unshift({
+      ...work,
+      attempt: work.attempt + 1,
+    });
+    this.parkedByConversation.set(conversationId, parked);
   }
 
   private dispatchAdmission(
@@ -326,9 +408,27 @@ export class MoltZapChannelCore {
         senderAgentId: work.message.senderId,
         attempt: work.attempt,
         receivedAt: new Date(work.receivedAtMs).toISOString(),
+        clock: work.clock,
         pending: this.pendingDispatchSnapshot(work),
       }),
     ).pipe(
+      Effect.tap((decision) =>
+        Effect.sync(() => {
+          if (decision._tag === "grant") {
+            this.logger.info(
+              {
+                messageId: work.message.id,
+                conversationId: work.message.conversationId,
+                attempt: work.attempt,
+                leaseId: decision.leaseId,
+                leaseTimeoutMs: decision.leaseTimeoutMs,
+                dispatchMessageId: decision.dispatchMessageId,
+              },
+              "MoltZapChannelCore: dispatch admission granted",
+            );
+          }
+        }),
+      ),
       Effect.timeoutFail({
         duration: Duration.millis(this.dispatchAdmissionTimeoutMs),
         onTimeout: () =>
@@ -345,9 +445,12 @@ export class MoltZapChannelCore {
               attempt: work.attempt,
               err,
             },
-            "MoltZapChannelCore: dispatch admission failed open",
+            "MoltZapChannelCore: dispatch admission failed closed",
           );
-          return { _tag: "grant" as const };
+          return {
+            _tag: "deny" as const,
+            reason: "dispatch admission unavailable",
+          };
         }),
       ),
     );
@@ -357,12 +460,44 @@ export class MoltZapChannelCore {
     work: InboundDispatchWork,
   ): Effect.Effect<void, unknown> {
     return Effect.gen(this, function* () {
-      const decision = yield* this.dispatchAdmission(work);
+      const current = this.takeDispatchCandidate(work);
+      const decision = yield* this.dispatchAdmission(current);
       if (decision._tag === "grant") {
         const messages = this.service.authorizeDispatch
-          ? yield* this.takeCoalescedConversationMessages(work)
-          : [work.message];
-        yield* Effect.acquireUseRelease(
+          ? yield* this.takeCoalescedConversationMessages(
+              current,
+              decision.dispatchMessageId,
+            )
+          : [current.message];
+        if (messages.length === 0) {
+          yield* Effect.sync(() =>
+            this.logger.warn(
+              {
+                messageId: current.message.id,
+                conversationId: current.message.conversationId,
+                attempt: current.attempt,
+                dispatchMessageId: decision.dispatchMessageId,
+              },
+              "MoltZapChannelCore: dispatch admission target unavailable",
+            ),
+          );
+          return;
+        }
+        const primaryMessage = messages[0]!;
+        yield* Effect.sync(() =>
+          this.logger.info(
+            {
+              messageId: primaryMessage.id,
+              admittedMessageId: current.message.id,
+              conversationId: current.message.conversationId,
+              attempt: current.attempt,
+              leaseId: decision.leaseId,
+              coalescedMessageCount: messages.length,
+            },
+            "MoltZapChannelCore: inbound dispatch starting",
+          ),
+        );
+        const dispatch = Effect.acquireUseRelease(
           Effect.sync(() => {
             const previous = this.activeDispatchLeaseId;
             this.activeDispatchLeaseId = decision.leaseId;
@@ -374,6 +509,57 @@ export class MoltZapChannelCore {
               this.activeDispatchLeaseId = previous;
             }),
         );
+        const timeoutMs = decision.leaseId
+          ? (decision.leaseTimeoutMs ?? DEFAULT_DISPATCH_LEASE_TIMEOUT_MS)
+          : undefined;
+        let dispatchTimedOut = false;
+        if (timeoutMs === undefined) {
+          yield* dispatch;
+        } else {
+          yield* dispatch.pipe(
+            Effect.timeoutFail({
+              duration: Duration.millis(timeoutMs),
+              onTimeout: () =>
+                new DispatchLeaseExpired(
+                  primaryMessage.id,
+                  primaryMessage.conversationId,
+                  timeoutMs,
+                ),
+            }),
+            Effect.catchAll((err) => {
+              if (err instanceof DispatchLeaseExpired) {
+                return Effect.sync(() => {
+                  dispatchTimedOut = true;
+                  this.logger.warn(
+                    {
+                      messageId: err.messageId,
+                      conversationId: err.conversationId,
+                      attempt: current.attempt,
+                      leaseId: decision.leaseId,
+                      timeoutMs: err.timeoutMs,
+                    },
+                    "MoltZapChannelCore: inbound dispatch lease expired",
+                  );
+                });
+              }
+              return Effect.fail(err);
+            }),
+          );
+        }
+        if (!dispatchTimedOut) {
+          yield* Effect.sync(() =>
+            this.logger.info(
+              {
+                messageId: primaryMessage.id,
+                admittedMessageId: current.message.id,
+                conversationId: current.message.conversationId,
+                attempt: current.attempt,
+                leaseId: decision.leaseId,
+              },
+              "MoltZapChannelCore: inbound dispatch completed",
+            ),
+          );
+        }
         return;
       }
 
@@ -381,9 +567,9 @@ export class MoltZapChannelCore {
         yield* Effect.sync(() =>
           this.logger.info(
             {
-              messageId: work.message.id,
-              conversationId: work.message.conversationId,
-              attempt: work.attempt,
+              messageId: current.message.id,
+              conversationId: current.message.conversationId,
+              attempt: current.attempt,
               reason: decision.reason,
             },
             "MoltZapChannelCore: inbound dispatch denied",
@@ -392,24 +578,18 @@ export class MoltZapChannelCore {
         return;
       }
 
-      const retryAfterMs = Math.max(0, Math.floor(decision.retryAfterMs));
       yield* Effect.sync(() =>
         this.logger.info(
           {
-            messageId: work.message.id,
-            conversationId: work.message.conversationId,
-            attempt: work.attempt,
-            retryAfterMs,
+            messageId: current.message.id,
+            conversationId: current.message.conversationId,
+            attempt: current.attempt,
             reason: decision.reason,
           },
-          "MoltZapChannelCore: inbound dispatch deferred",
+          "MoltZapChannelCore: inbound dispatch held",
         ),
       );
-      yield* Effect.sleep(Duration.millis(retryAfterMs));
-      yield* this.dispatchInboundWork({
-        ...work,
-        attempt: work.attempt + 1,
-      });
+      this.parkDispatchWork(current);
     });
   }
 
@@ -422,35 +602,53 @@ export class MoltZapChannelCore {
     for (const work of queued) {
       Queue.unsafeOffer(this.inboundQueue, work);
     }
-    return [active, ...queued].map((work) => ({
+    const parked = [...this.parkedByConversation.values()].flat();
+    return [active, ...parked, ...queued].map((work) => ({
       messageId: work.message.id,
       conversationId: work.message.conversationId,
       senderAgentId: work.message.senderId,
       createdAt: work.message.createdAt,
       receivedAt: new Date(work.receivedAtMs).toISOString(),
+      clock: work.clock,
+      parts: work.message.parts,
     }));
   }
 
   private takeCoalescedConversationMessages(
     work: InboundDispatchWork,
+    dispatchMessageId?: string,
   ): Effect.Effect<ReadonlyArray<Message>, never> {
     return Effect.sync(() => {
       const queued = Chunk.toReadonlyArray(
         Effect.runSync(Queue.takeAll(this.inboundQueue)),
       );
-      const coalesced: Message[] = [work.message];
+      const parked = this.parkedByConversation.get(work.message.conversationId);
+      const sameConversation: Message[] = [work.message];
       const remaining: InboundDispatchWork[] = [];
+      if (parked) {
+        sameConversation.push(
+          ...parked.map((parkedWork) => parkedWork.message),
+        );
+        this.parkedByConversation.delete(work.message.conversationId);
+      }
       for (const queuedWork of queued) {
         if (queuedWork.message.conversationId === work.message.conversationId) {
-          coalesced.push(queuedWork.message);
+          sameConversation.push(queuedWork.message);
         } else {
           remaining.push(queuedWork);
         }
       }
+      const startIndex =
+        dispatchMessageId === undefined
+          ? 0
+          : sameConversation.findIndex(
+              (message) => message.id === dispatchMessageId,
+            );
       for (const remainingWork of remaining) {
         Queue.unsafeOffer(this.inboundQueue, remainingWork);
       }
-      return coalesced;
+      if (startIndex < 0) return [];
+      return sameConversation.slice(startIndex);
     });
   }
 
@@ -580,10 +778,14 @@ export class MoltZapChannelCore {
       if (!this.inboundHandler) return;
       const { enriched, commitContext } =
         yield* MoltZapChannelCore.enrichMessage(this.service, messages);
+      const leased =
+        this.activeDispatchLeaseId !== undefined
+          ? { ...enriched, dispatchLeaseId: this.activeDispatchLeaseId }
+          : enriched;
       // The handler is user code returning an Effect — yield it directly so
       // its typed error channel propagates to the consumer fiber, which logs
       // and continues. We await it inline to preserve arrival-order delivery.
-      yield* this.inboundHandler(enriched);
+      yield* this.inboundHandler(leased);
       if (commitContext) commitContext();
     });
   }

--- a/packages/client/src/service.test.ts
+++ b/packages/client/src/service.test.ts
@@ -197,6 +197,52 @@ describe("sanitizeForSystemReminder", () => {
   });
 });
 
+describe("MoltZapService.authorizeDispatch", () => {
+  it("uses the long app-dispatch RPC timeout instead of the generic RPC timeout", async () => {
+    const service = new FakeMoltZapService();
+    service.setResponse("apps/authorizeDispatch", {
+      admission: {
+        decision: "grant",
+        leaseId: "lease-1",
+        leaseTimeoutMs: 90_000,
+      },
+    });
+
+    const result = await run(
+      service.authorizeDispatch({
+        conversationId: "conv-1",
+        senderAgentId: "agent-gm",
+        attempt: 0,
+        receivedAt: "2026-04-29T22:00:00.000Z",
+        clock: {
+          domainId: "conv-1",
+          epoch: 1,
+          vector: { "agent-gm": 1 },
+        },
+        pending: [],
+        message: {
+          id: "msg-1",
+          conversationId: "conv-1",
+          senderId: "agent-gm",
+          parts: [{ type: "text", text: "Time to vote!" }],
+          createdAt: "2026-04-29T22:00:00.000Z",
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      _tag: "grant",
+      leaseId: "lease-1",
+      leaseTimeoutMs: 90_000,
+    });
+    expect(service.calls).toHaveLength(1);
+    expect(service.calls[0]).toMatchObject({
+      method: "apps/authorizeDispatch",
+      opts: { timeoutMs: 900_000 },
+    });
+  });
+});
+
 describe("MoltZapService.getContext — XML injection hardening", () => {
   /** Build a message that lands in `messages` via addMessage(). */
   function msg(overrides: Partial<Message>): Message {

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -21,6 +21,27 @@ import {
   RpcTimeoutError,
 } from "./runtime/errors.js";
 import { getOr, snapshot } from "./runtime/refs.js";
+import type {
+  DispatchAdmissionDecision,
+  DispatchAdmissionRequest,
+} from "./channel-core.js";
+
+function appendClientEventTrace(record: Record<string, unknown>): void {
+  const dir = process.env["MOLTZAP_CLIENT_EVENT_LOG_DIR"];
+  if (!dir) return;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const agentId =
+      typeof record["agentId"] === "string" ? record["agentId"] : "unknown";
+    const safeAgentId = /^[A-Za-z0-9_-]+$/.test(agentId) ? agentId : "unknown";
+    fs.appendFileSync(
+      path.join(dir, `client-events-${safeAgentId}.jsonl`),
+      JSON.stringify(record) + "\n",
+    );
+  } catch {
+    // Best-effort diagnostics only.
+  }
+}
 
 /**
  * Errors that can surface from the Effect-based service API. Matches the
@@ -649,13 +670,59 @@ export class MoltZapService {
   send(
     convId: string,
     text: string,
-    opts?: { replyTo?: string },
+    opts?: { replyTo?: string; dispatchLeaseId?: string },
   ): Effect.Effect<void, ServiceRpcError> {
     return Effect.asVoid(
       this.sendRpc("messages/send", {
         conversationId: convId,
         parts: [{ type: "text", text }],
         ...(opts?.replyTo ? { replyToId: opts.replyTo } : {}),
+        ...(opts?.dispatchLeaseId
+          ? { dispatchLeaseId: opts.dispatchLeaseId }
+          : {}),
+      }),
+    );
+  }
+
+  authorizeDispatch(
+    request: DispatchAdmissionRequest,
+  ): Effect.Effect<DispatchAdmissionDecision, ServiceRpcError> {
+    return this.sendRpc("apps/authorizeDispatch", {
+      conversationId: request.conversationId,
+      messageId: request.message.id,
+      senderAgentId: request.senderAgentId,
+      parts: request.message.parts,
+      receivedAt: request.receivedAt,
+      pending: request.pending,
+      attempt: request.attempt,
+    }).pipe(
+      Effect.map((result) => {
+        const admission = (
+          result as {
+            admission:
+              | { decision: "grant"; leaseId?: string }
+              | { decision: "defer"; retryAfterMs: number; reason?: string }
+              | { decision: "deny"; reason?: string };
+          }
+        ).admission;
+        switch (admission.decision) {
+          case "grant":
+            return {
+              _tag: "grant" as const,
+              leaseId: admission.leaseId,
+            };
+          case "defer":
+            return {
+              _tag: "defer" as const,
+              retryAfterMs: admission.retryAfterMs,
+              reason: admission.reason,
+            };
+          case "deny":
+            return {
+              _tag: "deny" as const,
+              reason: admission.reason,
+            };
+        }
       }),
     );
   }
@@ -1000,6 +1067,30 @@ export class MoltZapService {
   }
 
   private handleEvent(event: EventFrame): void {
+    const eventData =
+      typeof event.data === "object" && event.data !== null
+        ? (event.data as Record<string, unknown>)
+        : {};
+    const message =
+      typeof eventData["message"] === "object" && eventData["message"] !== null
+        ? (eventData["message"] as Record<string, unknown>)
+        : undefined;
+    const conversation =
+      typeof eventData["conversation"] === "object" &&
+      eventData["conversation"] !== null
+        ? (eventData["conversation"] as Record<string, unknown>)
+        : undefined;
+    appendClientEventTrace({
+      ts: new Date().toISOString(),
+      agentId: this._ownAgentId ?? "unknown",
+      event: event.event,
+      messageId: message?.["id"],
+      messageConversationId: message?.["conversationId"],
+      messageSenderId: message?.["senderId"],
+      conversationId: conversation?.["id"],
+      conversationName: conversation?.["name"],
+    });
+
     fanout(this.rawEventHandlers, event, this.opts.logger);
 
     // The server validates event.data against each event's schema before

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -13,7 +13,11 @@ import {
   EventNames,
 } from "@moltzap/protocol";
 import { Effect, HashMap, Match, Option, Ref } from "effect";
-import { MoltZapWsClient, type WsClientLogger } from "./ws-client.js";
+import {
+  MoltZapWsClient,
+  type RpcCallOptions,
+  type WsClientLogger,
+} from "./ws-client.js";
 import {
   AgentNotFoundError,
   NotConnectedError,
@@ -25,6 +29,9 @@ import type {
   DispatchAdmissionDecision,
   DispatchAdmissionRequest,
 } from "./channel-core.js";
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
 
 function appendClientEventTrace(record: Record<string, unknown>): void {
   const dir = process.env["MOLTZAP_CLIENT_EVENT_LOG_DIR"];
@@ -38,8 +45,14 @@ function appendClientEventTrace(record: Record<string, unknown>): void {
       path.join(dir, `client-events-${safeAgentId}.jsonl`),
       JSON.stringify(record) + "\n",
     );
-  } catch {
-    // Best-effort diagnostics only.
+  } catch (err) {
+    try {
+      process.stderr.write(
+        `moltzap client event trace write failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    } catch (stderrErr) {
+      void stderrErr;
+    }
   }
 }
 
@@ -111,6 +124,8 @@ export interface ServiceOptions {
 }
 
 type EventHandler<T> = (data: T) => void;
+
+const DISPATCH_AUTHORIZATION_RPC_TIMEOUT_MS = 900_000;
 
 interface HelloOk {
   agentId: string;
@@ -687,22 +702,32 @@ export class MoltZapService {
   authorizeDispatch(
     request: DispatchAdmissionRequest,
   ): Effect.Effect<DispatchAdmissionDecision, ServiceRpcError> {
-    return this.sendRpc("apps/authorizeDispatch", {
-      conversationId: request.conversationId,
-      messageId: request.message.id,
-      senderAgentId: request.senderAgentId,
-      parts: request.message.parts,
-      receivedAt: request.receivedAt,
-      pending: request.pending,
-      attempt: request.attempt,
-    }).pipe(
+    return this.sendRpc(
+      "apps/authorizeDispatch",
+      {
+        conversationId: request.conversationId,
+        messageId: request.message.id,
+        senderAgentId: request.senderAgentId,
+        parts: request.message.parts,
+        receivedAt: request.receivedAt,
+        clock: request.clock,
+        pending: request.pending,
+        attempt: request.attempt,
+      },
+      { timeoutMs: DISPATCH_AUTHORIZATION_RPC_TIMEOUT_MS },
+    ).pipe(
       Effect.map((result) => {
         const admission = (
           result as {
             admission:
-              | { decision: "grant"; leaseId?: string }
-              | { decision: "defer"; retryAfterMs: number; reason?: string }
-              | { decision: "deny"; reason?: string };
+              | {
+                  decision: "grant";
+                  leaseId?: string;
+                  leaseTimeoutMs?: number;
+                  dispatchMessageId?: string;
+                }
+              | { decision: "deny"; reason?: string }
+              | { decision: "hold"; reason?: string };
           }
         ).admission;
         switch (admission.decision) {
@@ -710,16 +735,19 @@ export class MoltZapService {
             return {
               _tag: "grant" as const,
               leaseId: admission.leaseId,
-            };
-          case "defer":
-            return {
-              _tag: "defer" as const,
-              retryAfterMs: admission.retryAfterMs,
-              reason: admission.reason,
+              leaseTimeoutMs: admission.leaseTimeoutMs,
+              ...(admission.dispatchMessageId
+                ? { dispatchMessageId: admission.dispatchMessageId }
+                : {}),
             };
           case "deny":
             return {
               _tag: "deny" as const,
+              reason: admission.reason,
+            };
+          case "hold":
+            return {
+              _tag: "hold" as const,
               reason: admission.reason,
             };
         }
@@ -993,12 +1021,13 @@ export class MoltZapService {
   sendRpc(
     method: string,
     params?: unknown,
+    opts?: RpcCallOptions,
   ): Effect.Effect<unknown, ServiceRpcError> {
     return Effect.suspend(() => {
       if (!this.client) {
         return Effect.fail(new NotConnectedError({ message: "Not connected" }));
       }
-      return this.client.sendRpc(method, params);
+      return this.client.sendRpc(method, params, opts);
     });
   }
 
@@ -1067,19 +1096,13 @@ export class MoltZapService {
   }
 
   private handleEvent(event: EventFrame): void {
-    const eventData =
-      typeof event.data === "object" && event.data !== null
-        ? (event.data as Record<string, unknown>)
-        : {};
-    const message =
-      typeof eventData["message"] === "object" && eventData["message"] !== null
-        ? (eventData["message"] as Record<string, unknown>)
-        : undefined;
-    const conversation =
-      typeof eventData["conversation"] === "object" &&
-      eventData["conversation"] !== null
-        ? (eventData["conversation"] as Record<string, unknown>)
-        : undefined;
+    const eventData = isPlainRecord(event.data) ? event.data : {};
+    const message = isPlainRecord(eventData["message"])
+      ? eventData["message"]
+      : undefined;
+    const conversation = isPlainRecord(eventData["conversation"])
+      ? eventData["conversation"]
+      : undefined;
     appendClientEventTrace({
       ts: new Date().toISOString(),
       agentId: this._ownAgentId ?? "unknown",

--- a/packages/client/src/test-utils/channel-service-fixture.ts
+++ b/packages/client/src/test-utils/channel-service-fixture.ts
@@ -37,7 +37,11 @@ export interface ChannelServiceState {
   setFullMessages(currentConvId: string, messages: CrossConvMessage[]): void;
   setResolveAgentNameFailure(agentId: string, err: Error): void;
   setConnectResult(result: unknown): void;
-  readonly sent: ReadonlyArray<{ convId: string; text: string }>;
+  readonly sent: ReadonlyArray<{
+    convId: string;
+    text: string;
+    dispatchLeaseId?: string;
+  }>;
   readonly connectCalls: { count: number };
   readonly closeCalls: { count: number };
   resolveAgentNameCallCount(agentId: string): number;
@@ -67,7 +71,11 @@ export function createFakeChannelService(
   const fullMessagesByConv = new Map<string, CrossConvMessage[]>();
   const resolveFailures = new Map<string, Error>();
   const resolveCalls: string[] = [];
-  const sent: Array<{ convId: string; text: string }> = [];
+  const sent: Array<{
+    convId: string;
+    text: string;
+    dispatchLeaseId?: string;
+  }> = [];
   const connectCalls = { count: 0 };
   const closeCalls = { count: 0 };
   let connectResult: unknown = {};
@@ -104,9 +112,19 @@ export function createFakeChannelService(
       closeCalls.count++;
     },
 
-    send(conversationId: string, text: string) {
+    send(
+      conversationId: string,
+      text: string,
+      opts?: { dispatchLeaseId?: string },
+    ) {
       return Effect.sync(() => {
-        sent.push({ convId: conversationId, text });
+        sent.push({
+          convId: conversationId,
+          text,
+          ...(opts?.dispatchLeaseId
+            ? { dispatchLeaseId: opts.dispatchLeaseId }
+            : {}),
+        });
       });
     },
 

--- a/packages/client/src/test-utils/fake-service.ts
+++ b/packages/client/src/test-utils/fake-service.ts
@@ -25,12 +25,14 @@
 import type { Message, RpcMap, RpcMethodName } from "@moltzap/protocol";
 import { Effect, HashMap, Option, Ref } from "effect";
 import { MoltZapService, type ServiceRpcError } from "../service.js";
+import type { RpcCallOptions } from "../ws-client.js";
 import { RpcServerError } from "../runtime/errors.js";
 
 /** A tracked `sendRpc` invocation. */
 export interface RecordedCall {
   method: string;
   params: unknown;
+  opts?: RpcCallOptions;
 }
 
 /**
@@ -94,9 +96,12 @@ export class FakeMoltZapService extends MoltZapService {
   override sendRpc(
     method: string,
     params?: unknown,
+    opts?: RpcCallOptions,
   ): Effect.Effect<unknown, ServiceRpcError> {
     return Effect.suspend(() => {
-      this.calls.push({ method, params });
+      this.calls.push(
+        opts === undefined ? { method, params } : { method, params, opts },
+      );
       if (this.responses.has(method)) {
         const entry = this.responses.get(method);
         if (typeof entry === "function") {

--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -48,6 +48,10 @@ export type { CloseInfo };
  */
 export const RPC_TIMEOUT_MS = 30_000;
 
+export interface RpcCallOptions {
+  readonly timeoutMs?: number;
+}
+
 /** Reconnect backoff: 1s base, doubling per attempt up to the cap. */
 const BASE_RECONNECT_DELAY_MS = 1000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
@@ -265,6 +269,7 @@ export class MoltZapWsClient {
   sendRpc<D extends RpcDefinition<string, TSchema, TSchema>>(
     method: D,
     params: Static<D["paramsSchema"]>,
+    opts?: RpcCallOptions,
   ): Effect.Effect<
     Static<D["resultSchema"]>,
     NotConnectedError | RpcTimeoutError | RpcServerError
@@ -272,6 +277,7 @@ export class MoltZapWsClient {
   sendRpc(
     method: string,
     params?: unknown,
+    opts?: RpcCallOptions,
   ): Effect.Effect<
     unknown,
     NotConnectedError | RpcTimeoutError | RpcServerError
@@ -279,12 +285,13 @@ export class MoltZapWsClient {
   sendRpc(
     method: string | RpcDefinition<string, TSchema, TSchema>,
     params?: unknown,
+    opts?: RpcCallOptions,
   ): Effect.Effect<
     unknown,
     NotConnectedError | RpcTimeoutError | RpcServerError
   > {
     const methodName = typeof method === "string" ? method : method.name;
-    return this.sendRpcEffect(methodName, params);
+    return this.sendRpcEffect(methodName, params, opts);
   }
 
   /**
@@ -593,6 +600,7 @@ export class MoltZapWsClient {
   private sendRpcTrackedEffect(
     method: string,
     params: unknown,
+    opts?: RpcCallOptions,
   ): Effect.Effect<
     TrackedRpcResponse<unknown>,
     NotConnectedError | RpcTimeoutError | RpcServerError
@@ -643,11 +651,11 @@ export class MoltZapWsClient {
         );
       }
 
+      const timeoutMs = opts?.timeoutMs ?? RPC_TIMEOUT_MS;
       const result = yield* Deferred.await(deferred).pipe(
         Effect.timeoutFail({
-          duration: `${RPC_TIMEOUT_MS} millis`,
-          onTimeout: () =>
-            new RpcTimeoutError({ method, timeoutMs: RPC_TIMEOUT_MS }),
+          duration: `${timeoutMs} millis`,
+          onTimeout: () => new RpcTimeoutError({ method, timeoutMs }),
         }),
         Effect.onExit((exit) =>
           Exit.isFailure(exit)
@@ -678,11 +686,12 @@ export class MoltZapWsClient {
   private sendRpcEffect(
     method: string,
     params: unknown,
+    opts?: RpcCallOptions,
   ): Effect.Effect<
     unknown,
     NotConnectedError | RpcTimeoutError | RpcServerError
   > {
-    return this.sendRpcTrackedEffect(method, params).pipe(
+    return this.sendRpcTrackedEffect(method, params, opts).pipe(
       Effect.map((tracked) => tracked.result),
     );
   }

--- a/packages/nanoclaw-channel/src/channels/moltzap.test.ts
+++ b/packages/nanoclaw-channel/src/channels/moltzap.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { Effect } from "effect";
 import { MoltZapChannelCore } from "@moltzap/client";
 import {
   createFakeChannelService,
@@ -110,6 +111,30 @@ describe("MoltZapChannel (nanoclaw adapter)", () => {
       await harness.channel.sendMessage("mz:conv-42", "hello there");
       expect(harness.fake.state.sent).toEqual([
         { convId: "conv-42", text: "hello there" },
+      ]);
+    });
+
+    it("uses the dispatch lease from the inbound message for the next reply", async () => {
+      harness.fake.state.setConversation("conv-42", {
+        type: "dm",
+        participants: [],
+      });
+      harness.fake.state.setAgentName("agent-alice", "Alice");
+      harness.fake.service.authorizeDispatch = () =>
+        Effect.succeed({ _tag: "grant" as const, leaseId: "lease-nano" });
+
+      harness.fake.emit.message(
+        buildMessage({ id: "msg-lease", conversationId: "conv-42" }),
+      );
+      await flushDispatchChain();
+      await harness.channel.sendMessage("mz:conv-42", "hello with lease");
+
+      expect(harness.fake.state.sent).toEqual([
+        {
+          convId: "conv-42",
+          text: "hello with lease",
+          dispatchLeaseId: "lease-nano",
+        },
       ]);
     });
 

--- a/packages/nanoclaw-channel/src/channels/moltzap.ts
+++ b/packages/nanoclaw-channel/src/channels/moltzap.ts
@@ -65,6 +65,7 @@ function formatGroupBlock(meta: EnrichedConversationMeta): string {
 
 export class MoltZapChannel implements Channel {
   readonly name = "moltzap";
+  private readonly dispatchLeasesByJid = new Map<string, string>();
 
   constructor(
     private readonly opts: ChannelOpts,
@@ -104,8 +105,11 @@ export class MoltZapChannel implements Channel {
       throw new Error(`MoltZap channel does not own jid: ${jid}`);
     }
     await Effect.runPromise(
-      this.core.sendReply(conversationIdFromJid(jid), text),
+      this.core.sendReply(conversationIdFromJid(jid), text, {
+        dispatchLeaseId: this.dispatchLeasesByJid.get(jid),
+      }),
     );
+    this.dispatchLeasesByJid.delete(jid);
   }
 
   isConnected(): boolean {
@@ -124,6 +128,9 @@ export class MoltZapChannel implements Channel {
 
   private handleInbound(enriched: EnrichedInboundMessage): void {
     const chatJid = jidFromConversationId(enriched.conversationId);
+    if (enriched.dispatchLeaseId) {
+      this.dispatchLeasesByJid.set(chatJid, enriched.dispatchLeaseId);
+    }
 
     // SMOKE-TEST ONLY: auto-register unknown convs in MOLTZAP_EVAL_MODE.
     // Remove when the runtime-adapter interface lands.

--- a/packages/openclaw-channel/src/context-log.test.ts
+++ b/packages/openclaw-channel/src/context-log.test.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { contextLogPath, writeOpenClawContextLog } from "./context-log.js";
+
+const oldStateDir = process.env["OPENCLAW_STATE_DIR"];
+
+afterEach(() => {
+  if (oldStateDir === undefined) {
+    delete process.env["OPENCLAW_STATE_DIR"];
+  } else {
+    process.env["OPENCLAW_STATE_DIR"] = oldStateDir;
+  }
+});
+
+describe("writeOpenClawContextLog", () => {
+  it("does nothing when no log dir is configured", () => {
+    expect(() =>
+      writeOpenClawContextLog({
+        logDir: undefined,
+        accountId: "default",
+        accountAgentName: "eval-p1",
+        conversationId: "conv-town",
+        conversationType: "group",
+        from: "agent:gm",
+        to: "eval-p1",
+        body: "hello",
+        bodyForAgent: "hello",
+        crossConversationMessages: [],
+      }),
+    ).not.toThrow();
+  });
+
+  it("writes one JSONL record per context dispatch", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-context-log-"));
+    process.env["OPENCLAW_STATE_DIR"] = "/tmp/openclaw-eval-p1-abc";
+
+    writeOpenClawContextLog({
+      logDir: dir,
+      accountId: "default",
+      accountAgentName: "eval-p1",
+      ownAgentId: "agent-1",
+      conversationId: "conv-town",
+      conversationName: "town_square",
+      conversationType: "group",
+      from: "agent:gm",
+      to: "eval-p1",
+      body: "Time to vote",
+      bodyForAgent: "Messages (untrusted metadata):\n[]\n\nTime to vote",
+      crossConversationMessages: [
+        {
+          conversationId: "conv-den",
+          conversationName: "werewolf_den",
+          senderName: "gm",
+          senderId: "agent-gm",
+          text: "old kill reminder",
+          timestamp: "2026-04-25T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const file = contextLogPath(dir, "eval-p1");
+    const lines = fs.readFileSync(file, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]!) as Record<string, unknown>;
+    expect(entry["accountAgentName"]).toBe("eval-p1");
+    expect(entry["stateDir"]).toBe("/tmp/openclaw-eval-p1-abc");
+    expect(entry["conversationName"]).toBe("town_square");
+    expect(entry["bodyForAgent"]).toContain("Time to vote");
+    expect(entry["crossConversationMessageCount"]).toBe(1);
+  });
+});

--- a/packages/openclaw-channel/src/context-log.ts
+++ b/packages/openclaw-channel/src/context-log.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { CrossConvMessage } from "@moltzap/client";
+
+export interface OpenClawContextLogEntry {
+  readonly schemaVersion: 1;
+  readonly recordedAt: string;
+  readonly pid: number;
+  readonly cwd: string;
+  readonly stateDir?: string;
+  readonly accountId: string;
+  readonly accountAgentName?: string;
+  readonly ownAgentId?: string;
+  readonly conversationId: string;
+  readonly conversationName?: string;
+  readonly conversationType: "direct" | "group";
+  readonly from: string;
+  readonly to: string;
+  readonly body: string;
+  readonly bodyForAgent: string;
+  readonly crossConversationMessageCount: number;
+  readonly crossConversationMessages: readonly CrossConvMessage[];
+}
+
+export interface OpenClawContextLogInput {
+  readonly logDir: string | undefined;
+  readonly accountId: string;
+  readonly accountAgentName?: string;
+  readonly ownAgentId?: string;
+  readonly conversationId: string;
+  readonly conversationName?: string;
+  readonly conversationType: "direct" | "group";
+  readonly from: string;
+  readonly to: string;
+  readonly body: string;
+  readonly bodyForAgent: string;
+  readonly crossConversationMessages: readonly CrossConvMessage[];
+}
+
+function sanitizePathPart(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9._-]+/g, "_");
+  return sanitized.length > 0 ? sanitized : "unknown";
+}
+
+export function contextLogPath(
+  logDir: string,
+  accountAgentName: string | undefined,
+): string {
+  const stateDir = process.env["OPENCLAW_STATE_DIR"];
+  const stateName = stateDir ? path.basename(stateDir) : `pid-${process.pid}`;
+  const agentName = accountAgentName ?? "agent";
+  return path.join(
+    logDir,
+    `${sanitizePathPart(agentName)}.${sanitizePathPart(stateName)}.${process.pid}.contexts.jsonl`,
+  );
+}
+
+export function writeOpenClawContextLog(input: OpenClawContextLogInput): void {
+  if (!input.logDir) return;
+
+  const entry: OpenClawContextLogEntry = {
+    schemaVersion: 1,
+    recordedAt: new Date().toISOString(),
+    pid: process.pid,
+    cwd: process.cwd(),
+    ...(process.env["OPENCLAW_STATE_DIR"] !== undefined
+      ? { stateDir: process.env["OPENCLAW_STATE_DIR"] }
+      : {}),
+    accountId: input.accountId,
+    ...(input.accountAgentName !== undefined
+      ? { accountAgentName: input.accountAgentName }
+      : {}),
+    ...(input.ownAgentId !== undefined ? { ownAgentId: input.ownAgentId } : {}),
+    conversationId: input.conversationId,
+    ...(input.conversationName !== undefined
+      ? { conversationName: input.conversationName }
+      : {}),
+    conversationType: input.conversationType,
+    from: input.from,
+    to: input.to,
+    body: input.body,
+    bodyForAgent: input.bodyForAgent,
+    crossConversationMessageCount: input.crossConversationMessages.length,
+    crossConversationMessages: input.crossConversationMessages,
+  };
+
+  fs.mkdirSync(input.logDir, { recursive: true });
+  fs.appendFileSync(
+    contextLogPath(input.logDir, input.accountAgentName),
+    `${JSON.stringify(entry)}\n`,
+    "utf8",
+  );
+}

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -20,6 +20,7 @@ import {
 } from "@moltzap/client";
 import { Effect } from "effect";
 import { formatCrossConvOpenClaw } from "./format-cross-conv.js";
+import { writeOpenClawContextLog } from "./context-log.js";
 import {
   extractDelivery,
   extractConversationCreated,
@@ -39,6 +40,24 @@ const MOLTZAP_TARGET_RE = /^(agent|conv):.+$/;
 
 function isMoltZapTarget(raw: string): boolean {
   return MOLTZAP_TARGET_RE.test(raw);
+}
+
+function adaptOpenClawLogger(
+  logMethod: ((...args: unknown[]) => void) | undefined,
+): (...args: unknown[]) => void {
+  return (...args: unknown[]) => {
+    if (!logMethod) return;
+    if (
+      args.length >= 2 &&
+      typeof args[0] === "object" &&
+      args[0] !== null &&
+      typeof args[1] === "string"
+    ) {
+      logMethod(args[1], args[0]);
+      return;
+    }
+    logMethod(...args);
+  };
 }
 
 type MoltZapAccount = {
@@ -298,9 +317,9 @@ export function createMoltzapChannelPlugin() {
 
         const wsLogger: WsClientLogger | undefined = log
           ? {
-              info: log.info ?? (() => {}),
-              warn: log.warn ?? (() => {}),
-              error: log.error ?? (() => {}),
+              info: adaptOpenClawLogger(log.info),
+              warn: adaptOpenClawLogger(log.warn),
+              error: adaptOpenClawLogger(log.error),
             }
           : undefined;
 
@@ -332,13 +351,36 @@ export function createMoltzapChannelPlugin() {
               enriched.contextBlocks.crossConversationMessages ?? [],
               { ownAgentId: service.ownAgentId ?? "" },
             );
+            const crossConversationMessages =
+              enriched.contextBlocks.crossConversationMessages ?? [];
             const bodyForAgent = crossConvBlock
               ? `${crossConvBlock}\n\n${enriched.text}`
               : enriched.text;
 
+            try {
+              writeOpenClawContextLog({
+                logDir: process.env["MOLTZAP_OPENCLAW_CONTEXT_LOG_DIR"],
+                accountId,
+                accountAgentName: account.agentName,
+                ownAgentId: service.ownAgentId,
+                conversationId: enriched.conversationId,
+                conversationName: enriched.conversationMeta?.name,
+                conversationType: chatType,
+                from: fromId,
+                to: account.agentName ?? accountId,
+                body: enriched.text,
+                bodyForAgent,
+                crossConversationMessages,
+              });
+            } catch (error) {
+              log?.warn?.(
+                `MoltZap: failed to write OpenClaw context log: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
+
             if (crossConvBlock) {
               log?.info?.(
-                `MoltZap: BodyForAgent has cross-conv context (${enriched.contextBlocks.crossConversationMessages?.length ?? 0} msgs) for ${enriched.conversationId}: ${bodyForAgent.slice(0, 500)}`,
+                `MoltZap: BodyForAgent has cross-conv context (${crossConversationMessages.length} msgs) for ${enriched.conversationId}: ${bodyForAgent.slice(0, 500)}`,
               );
             }
 

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -388,6 +388,9 @@ export function createMoltzapChannelPlugin() {
               ctx.channelRuntime?.reply
                 ?.dispatchReplyWithBufferedBlockDispatcher;
             if (!dispatch) {
+              log?.warn?.(
+                `MoltZap: no OpenClaw reply dispatcher for ${enriched.conversationId}`,
+              );
               return;
             }
 
@@ -400,6 +403,9 @@ export function createMoltzapChannelPlugin() {
             // Bridge OpenClaw's Promise-shaped dispatch into Effect, then
             // catchAll back to a logged no-op so a single failed reply doesn't
             // crash the consumer fiber.
+            log?.info?.(
+              `MoltZap: dispatch start for ${enriched.conversationId} message ${enriched.id}`,
+            );
             const result = yield* Effect.tryPromise({
               try: () =>
                 dispatch({
@@ -465,6 +471,9 @@ export function createMoltzapChannelPlugin() {
                   return null;
                 }),
               ),
+            );
+            log?.info?.(
+              `MoltZap: dispatch finished for ${enriched.conversationId} message ${enriched.id}`,
             );
             if (result && !result.queuedFinal) {
               log?.debug?.(

--- a/packages/protocol/src/rpc-registry.ts
+++ b/packages/protocol/src/rpc-registry.ts
@@ -41,6 +41,7 @@ import {
   AppsCloseSession,
   AppsGetSession,
   AppsListSessions,
+  AppsAuthorizeDispatch,
 } from "./schema/methods/apps.js";
 import {
   SurfaceUpdate,
@@ -101,6 +102,7 @@ export const rpcMethods = [
   AppsCloseSession,
   AppsGetSession,
   AppsListSessions,
+  AppsAuthorizeDispatch,
   // Surfaces
   SurfaceUpdate,
   SurfaceGet,

--- a/packages/protocol/src/schema/apps.test.ts
+++ b/packages/protocol/src/schema/apps.test.ts
@@ -6,12 +6,19 @@ import {
   AppSessionSchema,
   AppParticipantStatusEnum,
 } from "./apps.js";
+import { AppsAuthorizeDispatch } from "./methods/apps.js";
 
 const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
 
 const validateManifest = ajv.compile(AppManifestSchema);
 const validateSession = ajv.compile(AppSessionSchema);
 const validateStatus = ajv.compile(AppParticipantStatusEnum);
+const validateAuthorizeDispatchResult = ajv.compile(
+  AppsAuthorizeDispatch.resultSchema,
+);
+const validateAuthorizeDispatchParams = ajv.compile(
+  AppsAuthorizeDispatch.paramsSchema,
+);
 
 describe("AppManifestSchema", () => {
   it("accepts a valid manifest", () => {
@@ -149,5 +156,63 @@ describe("AppParticipantStatusEnum", () => {
   it("rejects invalid values", () => {
     expect(validateStatus("invalid")).toBe(false);
     expect(validateStatus("")).toBe(false);
+  });
+});
+
+describe("AppsAuthorizeDispatch", () => {
+  it("rejects retry/defer admission results", () => {
+    expect(
+      validateAuthorizeDispatchResult({
+        admission: {
+          decision: "defer",
+          retryAfterMs: 100,
+          reason: "slot busy",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts grant, hold, and deny admission results", () => {
+    expect(
+      validateAuthorizeDispatchResult({
+        admission: {
+          decision: "grant",
+          leaseId: "lease-1",
+          leaseTimeoutMs: 90_000,
+          dispatchMessageId: "550e8400-e29b-41d4-a716-446655440010",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      validateAuthorizeDispatchResult({
+        admission: { decision: "deny", reason: "phase closed" },
+      }),
+    ).toBe(true);
+    expect(
+      validateAuthorizeDispatchResult({
+        admission: { decision: "hold", reason: "waiting for turn" },
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts pending message parts in authorization params", () => {
+    expect(
+      validateAuthorizeDispatchParams({
+        conversationId: "550e8400-e29b-41d4-a716-446655440002",
+        messageId: "550e8400-e29b-41d4-a716-446655440003",
+        senderAgentId: "550e8400-e29b-41d4-a716-446655440004",
+        parts: [{ type: "text", text: "old discussion" }],
+        pending: [
+          {
+            messageId: "550e8400-e29b-41d4-a716-446655440010",
+            conversationId: "550e8400-e29b-41d4-a716-446655440002",
+            senderAgentId: "550e8400-e29b-41d4-a716-446655440001",
+            createdAt: "2026-04-29T22:00:00.000Z",
+            receivedAt: "2026-04-29T22:00:00.000Z",
+            parts: [{ type: "text", text: "Time to vote" }],
+          },
+        ],
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/protocol/src/schema/apps.ts
+++ b/packages/protocol/src/schema/apps.ts
@@ -72,6 +72,23 @@ export const AppManifestSchema = Type.Object(
               { additionalProperties: false },
             ),
           ),
+          before_dispatch: Type.Optional(
+            Type.Object(
+              {
+                /**
+                 * Optional HTTPS endpoint. When set the MoltZap server POSTs
+                 * dispatch-admission context to this URL before a channel
+                 * endpoint starts local LLM/runtime dispatch for an inbound
+                 * message.
+                 */
+                webhook: Type.Optional(Type.String({ format: "uri" })),
+                timeout_ms: Type.Optional(
+                  Type.Integer({ default: 5000, minimum: 100, maximum: 30000 }),
+                ),
+              },
+              { additionalProperties: false },
+            ),
+          ),
           on_join: Type.Optional(
             Type.Object(
               {

--- a/packages/protocol/src/schema/index.ts
+++ b/packages/protocol/src/schema/index.ts
@@ -8,6 +8,7 @@ export * from "./identity.js";
 export * from "./contacts.js";
 export * from "./conversations.js";
 export * from "./messages.js";
+export * from "./logical-clock.js";
 export * from "./invites.js";
 export * from "./presence.js";
 export * from "./delivery.js";

--- a/packages/protocol/src/schema/logical-clock.ts
+++ b/packages/protocol/src/schema/logical-clock.ts
@@ -1,0 +1,20 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+/**
+ * Generic logical time frontier for one delivery domain.
+ *
+ * The domain is usually a conversation. `epoch` is a local monotonic sequence
+ * number for that domain, and `vector` records the latest observed count per
+ * participant or producer id. Servers may use this as admission metadata, but
+ * clients only report what they have actually observed.
+ */
+export const LogicalClockSchema = Type.Object(
+  {
+    domainId: Type.String({ minLength: 1 }),
+    epoch: Type.Integer({ minimum: 0 }),
+    vector: Type.Record(Type.String(), Type.Integer({ minimum: 0 })),
+  },
+  { additionalProperties: false },
+);
+
+export type LogicalClock = Static<typeof LogicalClockSchema>;

--- a/packages/protocol/src/schema/methods/apps.ts
+++ b/packages/protocol/src/schema/methods/apps.ts
@@ -1,6 +1,7 @@
 import { Type } from "@sinclair/typebox";
-import { AgentId } from "../primitives.js";
+import { AgentId, ConversationId, MessageId } from "../primitives.js";
 import { AppManifestSchema, AppSessionSchema } from "../apps.js";
+import { PartSchema } from "../messages.js";
 import { DateTimeString, stringEnum } from "../../helpers.js";
 import { defineRpc } from "../../rpc.js";
 
@@ -145,6 +146,69 @@ export const AppsListSessions = defineRpc({
   result: Type.Object(
     {
       sessions: Type.Array(AppSessionSchema),
+    },
+    { additionalProperties: false },
+  ),
+});
+
+const DispatchAdmissionDecision = Type.Union([
+  Type.Object(
+    {
+      decision: Type.Literal("grant"),
+      leaseId: Type.Optional(Type.String()),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      decision: Type.Literal("defer"),
+      retryAfterMs: Type.Integer({ minimum: 0, maximum: 60_000 }),
+      reason: Type.Optional(Type.String()),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      decision: Type.Literal("deny"),
+      reason: Type.Optional(Type.String()),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+export const AppsAuthorizeDispatch = defineRpc({
+  name: "apps/authorizeDispatch",
+  params: Type.Object(
+    {
+      conversationId: ConversationId,
+      messageId: MessageId,
+      senderAgentId: AgentId,
+      parts: Type.Optional(
+        Type.Array(PartSchema, { minItems: 1, maxItems: 10 }),
+      ),
+      receivedAt: Type.Optional(DateTimeString),
+      pending: Type.Optional(
+        Type.Array(
+          Type.Object(
+            {
+              messageId: MessageId,
+              conversationId: ConversationId,
+              senderAgentId: AgentId,
+              createdAt: DateTimeString,
+              receivedAt: DateTimeString,
+            },
+            { additionalProperties: false },
+          ),
+          { maxItems: 100 },
+        ),
+      ),
+      attempt: Type.Optional(Type.Integer({ minimum: 0 })),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object(
+    {
+      admission: DispatchAdmissionDecision,
     },
     { additionalProperties: false },
   ),

--- a/packages/protocol/src/schema/methods/apps.ts
+++ b/packages/protocol/src/schema/methods/apps.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import { AgentId, ConversationId, MessageId } from "../primitives.js";
 import { AppManifestSchema, AppSessionSchema } from "../apps.js";
 import { PartSchema } from "../messages.js";
+import { LogicalClockSchema } from "../logical-clock.js";
 import { DateTimeString, stringEnum } from "../../helpers.js";
 import { defineRpc } from "../../rpc.js";
 
@@ -156,20 +157,21 @@ const DispatchAdmissionDecision = Type.Union([
     {
       decision: Type.Literal("grant"),
       leaseId: Type.Optional(Type.String()),
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      decision: Type.Literal("defer"),
-      retryAfterMs: Type.Integer({ minimum: 0, maximum: 60_000 }),
-      reason: Type.Optional(Type.String()),
+      leaseTimeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+      dispatchMessageId: Type.Optional(MessageId),
     },
     { additionalProperties: false },
   ),
   Type.Object(
     {
       decision: Type.Literal("deny"),
+      reason: Type.Optional(Type.String()),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      decision: Type.Literal("hold"),
       reason: Type.Optional(Type.String()),
     },
     { additionalProperties: false },
@@ -196,12 +198,17 @@ export const AppsAuthorizeDispatch = defineRpc({
               senderAgentId: AgentId,
               createdAt: DateTimeString,
               receivedAt: DateTimeString,
+              clock: Type.Optional(LogicalClockSchema),
+              parts: Type.Optional(
+                Type.Array(PartSchema, { minItems: 1, maxItems: 10 }),
+              ),
             },
             { additionalProperties: false },
           ),
           { maxItems: 100 },
         ),
       ),
+      clock: Type.Optional(LogicalClockSchema),
       attempt: Type.Optional(Type.Integer({ minimum: 0 })),
     },
     { additionalProperties: false },

--- a/packages/protocol/src/schema/methods/messages.ts
+++ b/packages/protocol/src/schema/methods/messages.ts
@@ -11,6 +11,7 @@ export const MessagesSend = defineRpc({
       to: Type.Optional(Type.String()),
       parts: Type.Array(PartSchema, { minItems: 1, maxItems: 10 }),
       replyToId: Type.Optional(MessageId),
+      dispatchLeaseId: Type.Optional(Type.String()),
     },
     { additionalProperties: false },
   ),

--- a/packages/protocol/src/testing/models/dispatch.ts
+++ b/packages/protocol/src/testing/models/dispatch.ts
@@ -236,6 +236,7 @@ export function applyCall<M extends RpcMethodName>(
     case "apps/closeSession":
     case "apps/getSession":
     case "apps/listSessions":
+    case "apps/authorizeDispatch":
       return { next: baseNext, outcome: uncertainError() };
 
     // Surfaces — require surface/app context. Uncertain.

--- a/packages/protocol/src/validators.ts
+++ b/packages/protocol/src/validators.ts
@@ -57,6 +57,7 @@ import {
   AppsCloseSession,
   AppsGetSession,
   AppsListSessions,
+  AppsAuthorizeDispatch,
 } from "./schema/methods/apps.js";
 import { SystemPing } from "./schema/methods/system.js";
 
@@ -140,6 +141,7 @@ export const validators = {
   appsCloseSessionParams: AppsCloseSession.validateParams,
   appsGetSessionParams: AppsGetSession.validateParams,
   appsListSessionsParams: AppsListSessions.validateParams,
+  appsAuthorizeDispatchParams: AppsAuthorizeDispatch.validateParams,
 
   // System.
   systemPingParams: SystemPing.validateParams,

--- a/packages/runtimes/src/fleet.ts
+++ b/packages/runtimes/src/fleet.ts
@@ -47,6 +47,7 @@ export interface RuntimeFleetLaunchOptions {
   readonly server: RuntimeServerHandle;
   readonly agents: ReadonlyArray<RuntimeAgentSpec>;
   readonly readyTimeoutMs: number;
+  readonly concurrency?: number | "unbounded";
   readonly openclaw?: Omit<WorkspaceOpenClawAdapterInput, "server">;
   readonly nanoclaw?: Omit<NanoclawAdapterDeps, "server">;
 }
@@ -218,7 +219,7 @@ export function launchRuntimeFleet(
         });
 
       const started = yield* Effect.forEach(options.agents, launchOne, {
-        concurrency: 1,
+        concurrency: options.concurrency ?? 1,
       }).pipe(
         Effect.onExit((exit) =>
           Exit.isSuccess(exit)

--- a/packages/runtimes/src/openclaw-adapter.ts
+++ b/packages/runtimes/src/openclaw-adapter.ts
@@ -18,6 +18,7 @@ import { SpawnFailed } from "./errors.js";
 const OPENCLAW_TERM_WAIT_MS = 10_000;
 const OPENCLAW_KILL_WAIT_MS = 5_000;
 const PROCESS_GROUP_POLL_INTERVAL_MS = 100;
+const DEFAULT_OPENCLAW_MODEL_ID = "openai-codex/gpt-5.4";
 
 export interface OpenClawAdapterDeps {
   readonly server: RuntimeServerHandle;
@@ -350,7 +351,7 @@ function writeOpenClawConfig(opts: {
   const config: OpenClawConfig = {
     agents: {
       defaults: {
-        model: { primary: opts.modelId ?? "minimax/MiniMax-M2.7-highspeed" },
+        model: { primary: opts.modelId ?? DEFAULT_OPENCLAW_MODEL_ID },
         workspace: path.join(opts.stateDir, "workspace"),
         compaction: { mode: "safeguard" },
       },

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -9,10 +9,13 @@ import { logger } from "../logger.js";
 import type { AppManifest, AppSession, Part } from "@moltzap/protocol";
 import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
 import {
+  DispatchAdmissionResultSchema,
   HookResultSchema,
   VoidHookSchema,
   type AppHooks,
+  type BeforeDispatchHook,
   type BeforeMessageDeliveryHook,
+  type DispatchAdmissionResult,
   type HookResult,
   type OnCloseHook,
   type OnJoinHook,
@@ -355,6 +358,11 @@ export class AppHost {
         inProcessSet: Boolean(existing?.beforeMessageDelivery),
       },
       {
+        hookName: "before_dispatch",
+        webhookSet: Boolean(hooks.before_dispatch?.webhook),
+        inProcessSet: Boolean(existing?.beforeDispatch),
+      },
+      {
         hookName: "on_join",
         webhookSet: Boolean(hooks.on_join?.webhook),
         inProcessSet: Boolean(existing?.onJoin),
@@ -406,6 +414,13 @@ export class AppHost {
     this.warnIfWebhookConfigured(appId, "before_message_delivery");
   }
 
+  onBeforeDispatch(appId: string, handler: BeforeDispatchHook): void {
+    const existing = this.hooks.get(appId) ?? {};
+    existing.beforeDispatch = handler;
+    this.hooks.set(appId, existing);
+    this.warnIfWebhookConfigured(appId, "before_dispatch");
+  }
+
   onAppJoin(appId: string, handler: OnJoinHook): void {
     const existing = this.hooks.get(appId) ?? {};
     existing.onJoin = handler;
@@ -436,6 +451,7 @@ export class AppHost {
     appId: string,
     hookName:
       | "before_message_delivery"
+      | "before_dispatch"
       | "on_join"
       | "on_close"
       | "on_session_active",
@@ -451,11 +467,131 @@ export class AppHost {
     }
   }
 
+  runBeforeDispatch(
+    conversationId: string,
+    recipientAgentId: string,
+    params: {
+      messageId: string;
+      senderAgentId: string;
+      parts?: Part[];
+      attempt?: number;
+      receivedAt?: string;
+      pending?: ReadonlyArray<{
+        messageId: string;
+        conversationId: string;
+        senderAgentId: string;
+        createdAt: string;
+        receivedAt: string;
+      }>;
+    },
+  ): Effect.Effect<DispatchAdmissionResult, RpcFailure> {
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        const session = this.conversationToSession.get(conversationId);
+        if (!session) return { decision: "grant" as const };
+
+        const manifest = this.manifests.get(session.appId);
+        const webhookUrl = manifest?.hooks?.before_dispatch?.webhook;
+        const appHooks = this.hooks.get(session.appId);
+
+        if (!webhookUrl && !appHooks?.beforeDispatch) {
+          return { decision: "grant" as const };
+        }
+
+        const agentOpt = yield* takeFirstOption(
+          this.db
+            .selectFrom("agents")
+            .select("owner_user_id")
+            .where("id", "=", recipientAgentId),
+        );
+        const agent = Option.getOrNull(agentOpt);
+
+        const ctx = {
+          conversationId,
+          recipient: {
+            agentId: recipientAgentId,
+            ownerId: agent?.owner_user_id ?? "",
+          },
+          message: {
+            id: params.messageId,
+            senderAgentId: params.senderAgentId,
+            parts: params.parts,
+          },
+          sessionId: session.id,
+          appId: session.appId,
+          attempt: params.attempt ?? 0,
+          receivedAt: params.receivedAt,
+          pending: params.pending,
+        };
+
+        const timeoutMs = manifest?.hooks?.before_dispatch?.timeout_ms ?? 5000;
+
+        const outcome: HookOutcome<DispatchAdmissionResult> = webhookUrl
+          ? yield* this.dispatchWebhookHook<DispatchAdmissionResult>({
+              url: webhookUrl,
+              event: "app.before_dispatch",
+              secret: manifest?.hooks?.secret,
+              body: {
+                sessionId: session.id,
+                appId: session.appId,
+                conversationId: ctx.conversationId,
+                recipient: ctx.recipient,
+                message: ctx.message,
+                attempt: ctx.attempt,
+                receivedAt: ctx.receivedAt,
+                pending: ctx.pending,
+              },
+              timeoutMs,
+              schema: DispatchAdmissionResultSchema,
+            })
+          : yield* this.runHookWithTimeout<DispatchAdmissionResult>(
+              (signal) => appHooks!.beforeDispatch!({ ...ctx, signal }),
+              timeoutMs,
+            );
+
+        if (outcome.timedOut) {
+          this.broadcaster.sendToAgent(
+            ctx.recipient.agentId,
+            eventFrame("app/hookTimeout", {
+              sessionId: session.id,
+              appId: session.appId,
+              hookName: "before_dispatch",
+              timeoutMs,
+            }),
+          );
+          yield* Effect.logWarning("before_dispatch hook timed out").pipe(
+            Effect.annotateLogs({
+              sessionId: session.id,
+              appId: session.appId,
+              timeoutMs,
+            }),
+          );
+          return {
+            decision: "defer",
+            retryAfterMs: Math.min(timeoutMs, 5000),
+            reason: "before_dispatch hook timed out",
+          };
+        }
+
+        if (!outcome.result) {
+          return {
+            decision: "defer",
+            retryAfterMs: 1000,
+            reason: "before_dispatch hook error",
+          };
+        }
+
+        return outcome.result;
+      }),
+    );
+  }
+
   runBeforeMessageDelivery(
     conversationId: string,
     senderAgentId: string,
     parts: Part[],
     replyToId?: string,
+    dispatchLeaseId?: string,
   ): Effect.Effect<{ result: HookResult; appId: string } | null, RpcFailure> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
@@ -483,7 +619,7 @@ export class AppHost {
             agentId: senderAgentId,
             ownerId: agent?.owner_user_id ?? "",
           },
-          message: { parts, replyToId },
+          message: { parts, replyToId, dispatchLeaseId },
           sessionId: session.id,
           appId: session.appId,
         };

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -6,7 +6,12 @@ import type { ConnectionManager } from "../ws/connection.js";
 import type { UserService } from "../services/user.service.js";
 import { UserId } from "./types.js";
 import { logger } from "../logger.js";
-import type { AppManifest, AppSession, Part } from "@moltzap/protocol";
+import type {
+  AppManifest,
+  AppSession,
+  LogicalClock,
+  Part,
+} from "@moltzap/protocol";
 import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
 import {
   DispatchAdmissionResultSchema,
@@ -476,12 +481,15 @@ export class AppHost {
       parts?: Part[];
       attempt?: number;
       receivedAt?: string;
+      clock?: LogicalClock;
       pending?: ReadonlyArray<{
         messageId: string;
         conversationId: string;
         senderAgentId: string;
         createdAt: string;
         receivedAt: string;
+        clock?: LogicalClock;
+        parts?: Part[];
       }>;
     },
   ): Effect.Effect<DispatchAdmissionResult, RpcFailure> {
@@ -521,6 +529,7 @@ export class AppHost {
           appId: session.appId,
           attempt: params.attempt ?? 0,
           receivedAt: params.receivedAt,
+          clock: params.clock,
           pending: params.pending,
         };
 
@@ -539,6 +548,7 @@ export class AppHost {
                 message: ctx.message,
                 attempt: ctx.attempt,
                 receivedAt: ctx.receivedAt,
+                clock: ctx.clock,
                 pending: ctx.pending,
               },
               timeoutMs,
@@ -567,16 +577,14 @@ export class AppHost {
             }),
           );
           return {
-            decision: "defer",
-            retryAfterMs: Math.min(timeoutMs, 5000),
+            decision: "deny",
             reason: "before_dispatch hook timed out",
           };
         }
 
         if (!outcome.result) {
           return {
-            decision: "defer",
-            retryAfterMs: 1000,
+            decision: "deny",
             reason: "before_dispatch hook error",
           };
         }

--- a/packages/server/src/app/handlers/apps.handlers.ts
+++ b/packages/server/src/app/handlers/apps.handlers.ts
@@ -134,6 +134,7 @@ export function createAppHandlers(deps: {
               senderAgentId: params.senderAgentId,
               parts: params.parts,
               receivedAt: params.receivedAt,
+              clock: params.clock,
               pending: params.pending,
               attempt: params.attempt,
             },

--- a/packages/server/src/app/handlers/apps.handlers.ts
+++ b/packages/server/src/app/handlers/apps.handlers.ts
@@ -10,6 +10,7 @@ import {
   AppsCloseSession,
   AppsGetSession,
   AppsListSessions,
+  AppsAuthorizeDispatch,
 } from "@moltzap/protocol";
 import { Effect } from "effect";
 import { defineMethod } from "../../rpc/context.js";
@@ -118,6 +119,26 @@ export function createAppHandlers(deps: {
             limit: params.limit ?? 50,
           });
           return { sessions };
+        }),
+    }),
+
+    "apps/authorizeDispatch": defineMethod(AppsAuthorizeDispatch, {
+      requiresActive: true,
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          const admission = yield* deps.appHost.runBeforeDispatch(
+            params.conversationId,
+            ctx.agentId,
+            {
+              messageId: params.messageId,
+              senderAgentId: params.senderAgentId,
+              parts: params.parts,
+              receivedAt: params.receivedAt,
+              pending: params.pending,
+              attempt: params.attempt,
+            },
+          );
+          return { admission };
         }),
     }),
   };

--- a/packages/server/src/app/handlers/messages.handlers.ts
+++ b/packages/server/src/app/handlers/messages.handlers.ts
@@ -76,6 +76,7 @@ export function createMessageHandlers(deps: {
               ctx.agentId,
               params.replyToId,
               connId,
+              params.dispatchLeaseId,
             );
             return { message };
           }),

--- a/packages/server/src/app/hooks.ts
+++ b/packages/server/src/app/hooks.ts
@@ -4,9 +4,27 @@ import { Schema } from "effect";
 export interface BeforeMessageDeliveryContext {
   conversationId: string;
   sender: { agentId: string; ownerId: string };
-  message: { parts: Part[]; replyToId?: string };
+  message: { parts: Part[]; replyToId?: string; dispatchLeaseId?: string };
   sessionId: string;
   appId: string;
+  signal: AbortSignal;
+}
+
+export interface BeforeDispatchContext {
+  conversationId: string;
+  recipient: { agentId: string; ownerId: string };
+  message: { id: string; senderAgentId: string; parts?: Part[] };
+  sessionId: string;
+  appId: string;
+  attempt: number;
+  receivedAt?: string;
+  pending?: ReadonlyArray<{
+    messageId: string;
+    conversationId: string;
+    senderAgentId: string;
+    createdAt: string;
+    receivedAt: string;
+  }>;
   signal: AbortSignal;
 }
 
@@ -48,6 +66,27 @@ export const HookResultSchema = Schema.Struct({
   ),
 }) as Schema.Schema<HookResult, unknown>;
 
+export type DispatchAdmissionResult =
+  | { decision: "grant"; leaseId?: string }
+  | { decision: "defer"; retryAfterMs: number; reason?: string }
+  | { decision: "deny"; reason?: string };
+
+export const DispatchAdmissionResultSchema = Schema.Union(
+  Schema.Struct({
+    decision: Schema.Literal("grant"),
+    leaseId: Schema.optional(Schema.String),
+  }),
+  Schema.Struct({
+    decision: Schema.Literal("defer"),
+    retryAfterMs: Schema.Number,
+    reason: Schema.optional(Schema.String),
+  }),
+  Schema.Struct({
+    decision: Schema.Literal("deny"),
+    reason: Schema.optional(Schema.String),
+  }),
+) as Schema.Schema<DispatchAdmissionResult, unknown>;
+
 /** Fire-and-forget hooks (`on_join`, `on_close`, `on_session_active`) — any payload is ignored. */
 export const VoidHookSchema: Schema.Schema<void, unknown> = Schema.transform(
   Schema.Unknown,
@@ -58,6 +97,10 @@ export const VoidHookSchema: Schema.Schema<void, unknown> = Schema.transform(
 export type BeforeMessageDeliveryHook = (
   ctx: BeforeMessageDeliveryContext,
 ) => HookResult | Promise<HookResult>;
+
+export type BeforeDispatchHook = (
+  ctx: BeforeDispatchContext,
+) => DispatchAdmissionResult | Promise<DispatchAdmissionResult>;
 
 export interface OnJoinContext {
   conversations: Record<string, string>;
@@ -92,6 +135,7 @@ export type OnSessionActiveHook = (
 
 export interface AppHooks {
   beforeMessageDelivery?: BeforeMessageDeliveryHook;
+  beforeDispatch?: BeforeDispatchHook;
   onJoin?: OnJoinHook;
   onClose?: OnCloseHook;
   onSessionActive?: OnSessionActiveHook;

--- a/packages/server/src/app/hooks.ts
+++ b/packages/server/src/app/hooks.ts
@@ -1,4 +1,4 @@
-import type { Part } from "@moltzap/protocol";
+import type { LogicalClock, Part } from "@moltzap/protocol";
 import { Schema } from "effect";
 
 export interface BeforeMessageDeliveryContext {
@@ -18,12 +18,15 @@ export interface BeforeDispatchContext {
   appId: string;
   attempt: number;
   receivedAt?: string;
+  clock?: LogicalClock;
   pending?: ReadonlyArray<{
     messageId: string;
     conversationId: string;
     senderAgentId: string;
     createdAt: string;
     receivedAt: string;
+    clock?: LogicalClock;
+    parts?: Part[];
   }>;
   signal: AbortSignal;
 }
@@ -67,22 +70,28 @@ export const HookResultSchema = Schema.Struct({
 }) as Schema.Schema<HookResult, unknown>;
 
 export type DispatchAdmissionResult =
-  | { decision: "grant"; leaseId?: string }
-  | { decision: "defer"; retryAfterMs: number; reason?: string }
-  | { decision: "deny"; reason?: string };
+  | {
+      decision: "grant";
+      leaseId?: string;
+      leaseTimeoutMs?: number;
+      dispatchMessageId?: string;
+    }
+  | { decision: "deny"; reason?: string }
+  | { decision: "hold"; reason?: string };
 
 export const DispatchAdmissionResultSchema = Schema.Union(
   Schema.Struct({
     decision: Schema.Literal("grant"),
     leaseId: Schema.optional(Schema.String),
-  }),
-  Schema.Struct({
-    decision: Schema.Literal("defer"),
-    retryAfterMs: Schema.Number,
-    reason: Schema.optional(Schema.String),
+    leaseTimeoutMs: Schema.optional(Schema.Number),
+    dispatchMessageId: Schema.optional(Schema.String),
   }),
   Schema.Struct({
     decision: Schema.Literal("deny"),
+    reason: Schema.optional(Schema.String),
+  }),
+  Schema.Struct({
+    decision: Schema.Literal("hold"),
     reason: Schema.optional(Schema.String),
   }),
 ) as Schema.Schema<DispatchAdmissionResult, unknown>;

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -600,6 +600,9 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     onBeforeMessageDelivery(appId, handler) {
       appHost.onBeforeMessageDelivery(appId, handler);
     },
+    onBeforeDispatch(appId, handler) {
+      appHost.onBeforeDispatch(appId, handler);
+    },
     onAppJoin(appId, handler) {
       appHost.onAppJoin(appId, handler);
     },

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -14,6 +14,7 @@ import type { Broadcaster } from "../ws/broadcaster.js";
 import type { ConnectionManager } from "../ws/connection.js";
 import type {
   BeforeMessageDeliveryHook,
+  BeforeDispatchHook,
   OnCloseHook,
   OnJoinHook,
   OnSessionActiveHook,
@@ -152,6 +153,7 @@ export interface CoreApp {
     appId: string,
     handler: BeforeMessageDeliveryHook,
   ) => void;
+  onBeforeDispatch: (appId: string, handler: BeforeDispatchHook) => void;
   onAppJoin: (appId: string, handler: OnJoinHook) => void;
   onSessionClose: (appId: string, handler: OnCloseHook) => void;
   onSessionActive: (appId: string, handler: OnSessionActiveHook) => void;

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -80,6 +80,7 @@ export class MessageService {
     senderAgentId: string,
     replyToId?: string,
     excludeConnectionId?: string,
+    dispatchLeaseId?: string,
   ): Effect.Effect<Message, RpcFailure> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
@@ -125,6 +126,7 @@ export class MessageService {
             senderAgentId,
             parts,
             replyToId,
+            dispatchLeaseId,
           );
           if (hookResponse?.result.block) {
             return yield* Effect.fail(

--- a/packages/server/src/ws/broadcaster.ts
+++ b/packages/server/src/ws/broadcaster.ts
@@ -14,8 +14,11 @@ function appendBroadcastTrace(record: Record<string, unknown>): void {
       path.join(dir, "server-broadcasts.jsonl"),
       JSON.stringify(record) + "\n",
     );
-  } catch {
-    // Best-effort diagnostics only.
+  } catch (err) {
+    logger.debug(
+      { err },
+      "server broadcast trace write failed; continuing without diagnostics",
+    );
   }
 }
 

--- a/packages/server/src/ws/broadcaster.ts
+++ b/packages/server/src/ws/broadcaster.ts
@@ -1,7 +1,23 @@
 import { Effect } from "effect";
 import type { EventFrame } from "@moltzap/protocol";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import type { ConnectionManager } from "./connection.js";
 import { logger } from "../logger.js";
+
+function appendBroadcastTrace(record: Record<string, unknown>): void {
+  const dir = process.env["MOLTZAP_SERVER_BROADCAST_LOG_DIR"];
+  if (!dir) return;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(
+      path.join(dir, "server-broadcasts.jsonl"),
+      JSON.stringify(record) + "\n",
+    );
+  } catch {
+    // Best-effort diagnostics only.
+  }
+}
 
 export class Broadcaster {
   constructor(private connections: ConnectionManager) {}
@@ -27,14 +43,33 @@ export class Broadcaster {
       delivered.push(conn.auth.agentId);
     }
 
+    appendBroadcastTrace({
+      ts: new Date().toISOString(),
+      kind: "conversation",
+      conversationId,
+      event: event.event,
+      deliveredAgentIds: delivered,
+      deliveredCount: delivered.length,
+      excludedConnectionId: excludeConnectionId,
+    });
+
     return delivered;
   }
 
   sendToAgent(agentId: string, event: EventFrame): void {
     const raw = JSON.stringify(event);
+    let deliveredCount = 0;
     for (const conn of this.connections.getByAgent(agentId)) {
       this.forkWrite(conn.id, conn.write(raw), { agentId });
+      deliveredCount += 1;
     }
+    appendBroadcastTrace({
+      ts: new Date().toISOString(),
+      kind: "agent",
+      agentId,
+      event: event.event,
+      deliveredCount,
+    });
   }
 
   private forkWrite(


### PR DESCRIPTION
## Summary

This draft PR turns the lease/backpressure spike into the generic moltzap channel primitive used by OpenClaw and Nanoclaw.

- adds dispatch admission leases in `MoltZapChannelCore` before inbound LLM dispatch
- holds pending inbound callbacks by conversation until the app grants work, instead of retrying through server-side game hooks
- coalesces pending conversation context so a resumed dispatch sees the queued messages for that conversation
- carries `dispatchLeaseId` metadata on outbound sends when available, with protocol/docs coverage
- adds client/server trace logging hooks for per-agent and per-container investigation

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm check`
- `pnpm docs:check:drift`
- `./scripts/sloppy-code-guard.sh`

Not run: `pnpm test:conformance:toxiproxy`.
