### PR TITLE
[impl-staff] runtimes: replace getByAgent with awaitAgentReady

### DIFF
--- a/packages/runtimes/src/await-agent-ready.ts
+++ b/packages/runtimes/src/await-agent-ready.ts
@@ -1,0 +1,88 @@
+/**
+ * Default `awaitAgentReady` implementation for in-process consumers whose
+ * `ConnectionManager` is reachable synchronously. Polls every 500 ms.
+ *
+ * Out-of-process consumers (e.g., zapbot's orchestrator over a remote
+ * moltzap-server) implement `awaitAgentReady` directly without this helper
+ * — see the `@example` block on `awaitAgentReadyByPolling` for the WS-presence
+ * sketch.
+ */
+import { Effect, pipe } from "effect";
+import type { ReadyOutcome } from "./runtime.js";
+
+interface ConnectionState {
+  readonly auth: unknown | null;
+}
+
+interface PollingConnections {
+  getByAgent(agentId: string): ReadonlyArray<ConnectionState>;
+}
+
+/**
+ * Polls `connections.getByAgent(agentId)` every `pollIntervalMs` until at
+ * least one connection has authenticated, then resolves to `Ready`. Resolves
+ * to `Timeout` after `timeoutMs` if no authenticated connection ever appears.
+ *
+ * `ProcessExited` is intentionally NOT produced here: the helper only sees
+ * the server's `ConnectionManager`, never the agent's owning subprocess. A
+ * caller that wants exit-before-ready surfaced should compose this helper
+ * with its own exit detector (e.g., via `Effect.race`) — that is what the
+ * runtime adapters do.
+ *
+ * @example
+ * Out-of-process consumer (zapbot orchestrator) replaces this helper with a
+ * WebSocket presence subscription against a standalone moltzap-server:
+ *
+ * ```ts
+ * function awaitAgentReadyOverPresenceWS(
+ *   wsClient: MoltZapWsClient,
+ *   agentId: string,
+ *   timeoutMs: number,
+ * ): Effect.Effect<ReadyOutcome, never, never> {
+ *   return Effect.async<ReadyOutcome, never, never>((resume) => {
+ *     const handle = wsClient.subscribePresence(agentId, (event) => {
+ *       if (event.kind === "auth-success") {
+ *         resume(Effect.succeed({ _tag: "Ready" }));
+ *       }
+ *     });
+ *     const timer = setTimeout(() => {
+ *       resume(Effect.succeed({ _tag: "Timeout", timeoutMs }));
+ *     }, timeoutMs);
+ *     return Effect.sync(() => {
+ *       handle.unsubscribe();
+ *       clearTimeout(timer);
+ *     });
+ *   });
+ * }
+ * ```
+ */
+export function awaitAgentReadyByPolling(
+  connections: PollingConnections,
+  agentId: string,
+  timeoutMs: number,
+  pollIntervalMs: number = 500,
+): Effect.Effect<ReadyOutcome, never, never> {
+  const tick = Effect.sync(() => {
+    const conns = connections.getByAgent(agentId);
+    return conns.length > 0 && conns[0]!.auth !== null;
+  });
+  const pollLoop = pipe(
+    tick,
+    Effect.flatMap((ready) =>
+      Effect.iterate(ready, {
+        while: (s) => !s,
+        body: () =>
+          Effect.sleep(`${pollIntervalMs} millis`).pipe(Effect.zipRight(tick)),
+      }),
+    ),
+    Effect.as<ReadyOutcome>({ _tag: "Ready" as const }),
+  );
+  return pipe(
+    pollLoop,
+    Effect.timeoutTo({
+      duration: `${timeoutMs} millis`,
+      onSuccess: (outcome): ReadyOutcome => outcome,
+      onTimeout: (): ReadyOutcome => ({ _tag: "Timeout" as const, timeoutMs }),
+    }),
+  );
+}

--- a/packages/runtimes/src/await-agent-ready.ts
+++ b/packages/runtimes/src/await-agent-ready.ts
@@ -14,6 +14,17 @@ interface ConnectionState {
   readonly auth: unknown | null;
 }
 
+/**
+ * Structural subset of `@moltzap/server-core`'s `ConnectionManager` that the
+ * polling helper actually needs. Typically vended by a `RuntimeServerHandle`
+ * implementation; see `@moltzap/server-core`'s test-utils `startCoreTestServer`
+ * for the in-process construction pattern that wires `coreApp.connections`
+ * directly into the helper.
+ *
+ * Out-of-process consumers do NOT use this interface — they implement
+ * `RuntimeServerHandle.awaitAgentReady` directly per the `@example` block on
+ * `awaitAgentReadyByPolling`.
+ */
 interface PollingConnections {
   getByAgent(agentId: string): ReadonlyArray<ConnectionState>;
 }
@@ -29,27 +40,61 @@ interface PollingConnections {
  * with its own exit detector (e.g., via `Effect.race`) — that is what the
  * runtime adapters do.
  *
+ * Out-of-process implementations MAY emit `ProcessExited` if the server has
+ * a way to detect process termination (e.g., heartbeat absence on the
+ * WebSocket connection, or an explicit `process-exited` event from a
+ * presence channel). Implementations that cannot detect process exit should
+ * let the presence subscription remain pending; `Timeout` will fire after
+ * `timeoutMs` and the caller can investigate via the runtime adapter's
+ * `getLogs(0)`.
+ *
  * @example
  * Out-of-process consumer (zapbot orchestrator) replaces this helper with a
- * WebSocket presence subscription against a standalone moltzap-server:
+ * WebSocket presence subscription against a standalone moltzap-server.
  *
  * ```ts
+ * // Sketch — replace `WSClientLike` with your real client type. The
+ * // structural shape below is the minimum the example uses.
+ * interface WSClientLike {
+ *   subscribePresence(
+ *     agentId: string,
+ *     onEvent: (event: {
+ *       kind: "auth-success" | "auth-failure" | "process-exited";
+ *     }) => void,
+ *   ): { unsubscribe: () => void };
+ * }
+ *
  * function awaitAgentReadyOverPresenceWS(
- *   wsClient: MoltZapWsClient,
+ *   wsClient: WSClientLike,
  *   agentId: string,
  *   timeoutMs: number,
  * ): Effect.Effect<ReadyOutcome, never, never> {
  *   return Effect.async<ReadyOutcome, never, never>((resume) => {
- *     const handle = wsClient.subscribePresence(agentId, (event) => {
- *       if (event.kind === "auth-success") {
- *         resume(Effect.succeed({ _tag: "Ready" }));
- *       }
- *     });
- *     const timer = setTimeout(() => {
+ *     // The returned cleanup is invoked on Effect interruption (and after
+ *     // the first `resume`); it must unsubscribe + clear the timer to
+ *     // prevent resource leaks when the caller cancels the wait.
+ *     let handle: { unsubscribe: () => void } | null = null;
+ *     try {
+ *       handle = wsClient.subscribePresence(agentId, (event) => {
+ *         if (event.kind === "auth-success") {
+ *           resume(Effect.succeed({ _tag: "Ready" }));
+ *         }
+ *         // `process-exited` and `auth-failure` fall through to the
+ *         // timeout path; tighten this branch if your server emits a
+ *         // structured exit event you can map to `ProcessExited`.
+ *       });
+ *     } catch (cause) {
+ *       // Subscribe failure: log the cause and surface as Timeout — the
+ *       // contract is "never became ready," so a sync subscribe error is
+ *       // observably equivalent to no presence event ever arriving.
+ *       console.warn("[awaitAgentReady] subscribePresence failed", { cause });
+ *       resume(Effect.succeed({ _tag: "Timeout", timeoutMs }));
+ *     }
+ *     const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
  *       resume(Effect.succeed({ _tag: "Timeout", timeoutMs }));
  *     }, timeoutMs);
  *     return Effect.sync(() => {
- *       handle.unsubscribe();
+ *       handle?.unsubscribe();
  *       clearTimeout(timer);
  *     });
  *   });

--- a/packages/runtimes/src/claude-code-adapter.integration.test.ts
+++ b/packages/runtimes/src/claude-code-adapter.integration.test.ts
@@ -86,7 +86,7 @@ if (CLAUDE_BIN === null) {
       );
 
       const adapter = createWorkspaceClaudeCodeAdapter({
-        server: { connections: server.coreApp.connections },
+        server: server.runtimeServer,
         claudeBin: CLAUDE_BIN,
         channelDistDir: CC_CHANNEL_DIST,
         repoRoot: REPO_ROOT,

--- a/packages/runtimes/src/claude-code-adapter.ts
+++ b/packages/runtimes/src/claude-code-adapter.ts
@@ -382,6 +382,27 @@ export class ClaudeCodeAdapter implements Runtime {
 
     return pipe(
       Effect.race(serverReady, exitLoop),
+      // Final-check: if the race resolved `Timeout`, the process may have
+      // exited within the last `exitLoop` tick window — give the adapter one
+      // last sync poll so a near-deadline exit still surfaces with stderr
+      // instead of an opaque `Timeout`.
+      Effect.flatMap((outcome) =>
+        outcome._tag !== "Timeout"
+          ? Effect.succeed(outcome)
+          : pipe(
+              pollExitCode(proc.exitFiber),
+              Effect.map(
+                (exitOpt): ReadyOutcome =>
+                  Option.isSome(exitOpt)
+                    ? {
+                        _tag: "ProcessExited" as const,
+                        exitCode: exitOpt.value,
+                        stderr: logBuffer.value,
+                      }
+                    : outcome,
+              ),
+            ),
+      ),
       // Failure outcomes (Timeout, ProcessExited) tear down before returning
       // — keeps the Runtime contract that the adapter cleans up after itself.
       Effect.tap((outcome) =>

--- a/packages/runtimes/src/claude-code-adapter.ts
+++ b/packages/runtimes/src/claude-code-adapter.ts
@@ -346,13 +346,17 @@ export class ClaudeCodeAdapter implements Runtime {
     const { process: proc, spawnInput, logBuffer } = this.state;
     const agentId = spawnInput.agentId;
 
-    // One probe per tick: returns a `ReadyOutcome` once the agent is
-    // authenticated or the subprocess has exited; returns `null` to
-    // signal "keep polling." The exit check uses `Fiber.poll` (no
-    // side-channel mutable — issue #272 item 5).
-    const tick: Effect.Effect<ReadyOutcome | null, never, never> = Effect.gen(
-      this,
-      function* () {
+    // The server side of readiness — Ready when ConnectionManager records
+    // an authenticated connection, Timeout if it never does. Pluggable per
+    // server-handle implementation (in-process polling vs. out-of-process
+    // WS-presence subscription).
+    const serverReady = this.deps.server.awaitAgentReady(agentId, timeoutMs);
+
+    // The adapter side of readiness — only resolves on `ProcessExited`.
+    // Effect.race interrupts whichever branch loses, so as long as one
+    // side resolves the other gets cancelled cleanly.
+    const exitTick: Effect.Effect<ReadyOutcome | null, never, never> =
+      Effect.gen(function* () {
         const exitOpt = yield* pollExitCode(proc.exitFiber);
         if (Option.isSome(exitOpt)) {
           return {
@@ -361,41 +365,23 @@ export class ClaudeCodeAdapter implements Runtime {
             stderr: logBuffer.value,
           };
         }
-        const connections = this.deps.server.connections.getByAgent(agentId);
-        if (connections.length > 0 && connections[0]!.auth !== null) {
-          return { _tag: "Ready" as const };
-        }
         return null;
-      },
-    );
-
-    // Probe once, then iterate-with-sleep until probe yields a non-null
-    // outcome. `Effect.iterate` is the Effect-native equivalent of a
-    // `while (state === null) { sleep; state = probe(); }` loop and
-    // returns the final state.
-    const pollLoop = pipe(
-      tick,
-      Effect.flatMap((initial) =>
-        Effect.iterate(initial, {
-          while: (state) => state === null,
-          body: () => Effect.sleep("500 millis").pipe(Effect.zipRight(tick)),
-        }),
+      });
+    const exitLoop: Effect.Effect<ReadyOutcome, never, never> = pipe(
+      Effect.iterate(null as ReadyOutcome | null, {
+        while: (s) => s === null,
+        body: () => Effect.sleep("250 millis").pipe(Effect.zipRight(exitTick)),
+      }),
+      // The `?? Timeout` fallback is unreachable (iterate exits only on
+      // non-null), but TypeScript narrows away the `null` branch and gives
+      // us a uniform `ReadyOutcome` for the race.
+      Effect.map(
+        (s): ReadyOutcome => s ?? { _tag: "Timeout" as const, timeoutMs },
       ),
     );
 
     return pipe(
-      pollLoop,
-      // Timeout fans the never-ready case into a `Timeout` outcome and
-      // hands the rest of the pipeline a uniform `ReadyOutcome` value.
-      Effect.timeoutTo({
-        duration: `${timeoutMs} millis`,
-        onSuccess: (outcome): ReadyOutcome =>
-          outcome ?? { _tag: "Ready" as const },
-        onTimeout: (): ReadyOutcome => ({
-          _tag: "Timeout" as const,
-          timeoutMs,
-        }),
-      }),
+      Effect.race(serverReady, exitLoop),
       // Failure outcomes (Timeout, ProcessExited) tear down before returning
       // — keeps the Runtime contract that the adapter cleans up after itself.
       Effect.tap((outcome) =>

--- a/packages/runtimes/src/index.ts
+++ b/packages/runtimes/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./runtime.js";
 
+export { awaitAgentReadyByPolling } from "./await-agent-ready.js";
+
 export {
   type OpenClawAdapterDeps,
   type WorkspaceOpenClawAdapterInput,

--- a/packages/runtimes/src/nanoclaw-adapter.ts
+++ b/packages/runtimes/src/nanoclaw-adapter.ts
@@ -85,6 +85,26 @@ export class NanoclawAdapter implements Runtime {
 
     return pipe(
       Effect.race(serverReady, exitLoop),
+      // Final-check: if the race resolved `Timeout`, nanoclaw's subprocess
+      // may have exited within the last `exitLoop` tick window — one last
+      // sync probe promotes that case to `ProcessExited` with the actual
+      // exit code so the diagnostic stderr isn't lost behind an opaque
+      // `Timeout`.
+      Effect.flatMap(
+        (outcome): Effect.Effect<ReadyOutcome, never, never> =>
+          outcome._tag !== "Timeout"
+            ? Effect.succeed(outcome)
+            : Effect.sync(
+                (): ReadyOutcome =>
+                  handle.proc.exitCode !== null
+                    ? {
+                        _tag: "ProcessExited" as const,
+                        exitCode: handle.proc.exitCode,
+                        stderr: getNanoclawRuntimeLogs(handle),
+                      }
+                    : outcome,
+              ),
+      ),
       Effect.tap((outcome) =>
         outcome._tag === "Ready" ? Effect.void : this.teardown(),
       ),

--- a/packages/runtimes/src/nanoclaw-adapter.ts
+++ b/packages/runtimes/src/nanoclaw-adapter.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, pipe } from "effect";
 
 import type {
   Runtime,
@@ -53,47 +53,42 @@ export class NanoclawAdapter implements Runtime {
   }
 
   waitUntilReady(timeoutMs: number): Effect.Effect<ReadyOutcome, never, never> {
-    return Effect.async<ReadyOutcome, never, never>((resume) => {
-      if (!this.state) {
-        resume(Effect.succeed({ _tag: "Ready" as const }));
-        return;
-      }
+    if (!this.state) {
+      return Effect.succeed({ _tag: "Ready" as const });
+    }
+    const { handle, spawnInput } = this.state;
+    const agentId = spawnInput.agentId;
 
-      const deadline = Date.now() + timeoutMs;
-      const { handle, spawnInput } = this.state;
-      const agentId = spawnInput.agentId;
+    const serverReady = this.deps.server.awaitAgentReady(agentId, timeoutMs);
 
-      const check = () => {
-        if (handle.proc.exitCode !== null) {
-          const stderr = getNanoclawRuntimeLogs(handle);
-          this.runTeardown();
-          resume(
-            Effect.succeed({
-              _tag: "ProcessExited" as const,
-              exitCode: handle.proc.exitCode,
-              stderr,
-            }),
-          );
-          return;
-        }
+    // Adapter-side `ProcessExited` detector. Polls the nanoclaw subprocess'
+    // exit code until it terminates, then surfaces stderr from the runtime's
+    // log accumulator.
+    const exitTick: Effect.Effect<ReadyOutcome | null, never, never> =
+      Effect.sync(() => {
+        if (handle.proc.exitCode === null) return null;
+        return {
+          _tag: "ProcessExited" as const,
+          exitCode: handle.proc.exitCode,
+          stderr: getNanoclawRuntimeLogs(handle),
+        };
+      });
+    const exitLoop: Effect.Effect<ReadyOutcome, never, never> = pipe(
+      Effect.iterate(null as ReadyOutcome | null, {
+        while: (s) => s === null,
+        body: () => Effect.sleep("250 millis").pipe(Effect.zipRight(exitTick)),
+      }),
+      Effect.map(
+        (s): ReadyOutcome => s ?? { _tag: "Timeout" as const, timeoutMs },
+      ),
+    );
 
-        const connections = this.deps.server.connections.getByAgent(agentId);
-        if (connections.length > 0 && connections[0]!.auth !== null) {
-          resume(Effect.succeed({ _tag: "Ready" as const }));
-          return;
-        }
-
-        if (Date.now() > deadline) {
-          this.runTeardown();
-          resume(Effect.succeed({ _tag: "Timeout" as const, timeoutMs }));
-          return;
-        }
-
-        setTimeout(check, 500);
-      };
-
-      check();
-    });
+    return pipe(
+      Effect.race(serverReady, exitLoop),
+      Effect.tap((outcome) =>
+        outcome._tag === "Ready" ? Effect.void : this.teardown(),
+      ),
+    );
   }
 
   teardown(): Effect.Effect<void, never, never> {
@@ -117,10 +112,5 @@ export class NanoclawAdapter implements Runtime {
     if (!this.state || this.state.tornDown) return;
     this.state.tornDown = true;
     await stopNanoclawRuntime(this.state.handle);
-  }
-
-  private runTeardown(): void {
-    // #ignore-sloppy-code-next-line[promise-type]: fire-and-forget cleanup — resume callback cannot await
-    void this.doTeardown();
   }
 }

--- a/packages/runtimes/src/openclaw-adapter.ts
+++ b/packages/runtimes/src/openclaw-adapter.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, pipe } from "effect";
 import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
@@ -123,49 +123,43 @@ export class OpenClawAdapter implements Runtime {
   }
 
   waitUntilReady(timeoutMs: number): Effect.Effect<ReadyOutcome, never, never> {
-    return Effect.async<ReadyOutcome, never, never>((resume) => {
-      if (!this.state) {
-        resume(Effect.succeed({ _tag: "Ready" as const }));
-        return;
-      }
+    if (!this.state) {
+      return Effect.succeed({ _tag: "Ready" as const });
+    }
+    const { child, spawnInput } = this.state;
+    const agentId = spawnInput.agentId;
 
-      const deadline = Date.now() + timeoutMs;
-      const { child, spawnInput } = this.state;
-      const agentId = spawnInput.agentId;
+    const serverReady = this.deps.server.awaitAgentReady(agentId, timeoutMs);
 
-      const check = () => {
-        if (child.exitCode !== null) {
-          const stderr = this.state?.logBuffer ?? "";
-          // #ignore-sloppy-code-next-line[promise-type]: fire-and-forget cleanup — resume callback cannot await
-          void this.doTeardown();
-          resume(
-            Effect.succeed({
-              _tag: "ProcessExited" as const,
-              exitCode: child.exitCode,
-              stderr,
-            }),
-          );
-          return;
-        }
+    // Adapter-side `ProcessExited` detector. Polls `child.exitCode` until
+    // the process exits, then returns the outcome with stderr captured
+    // from the live log buffer.
+    const exitTick: Effect.Effect<ReadyOutcome | null, never, never> =
+      Effect.sync(() => {
+        if (child.exitCode === null) return null;
+        return {
+          _tag: "ProcessExited" as const,
+          exitCode: child.exitCode,
+          stderr: this.state?.logBuffer ?? "",
+        };
+      });
+    const exitLoop: Effect.Effect<ReadyOutcome, never, never> = pipe(
+      Effect.iterate(null as ReadyOutcome | null, {
+        while: (s) => s === null,
+        body: () => Effect.sleep("250 millis").pipe(Effect.zipRight(exitTick)),
+      }),
+      Effect.map(
+        (s): ReadyOutcome => s ?? { _tag: "Timeout" as const, timeoutMs },
+      ),
+    );
 
-        const connections = this.deps.server.connections.getByAgent(agentId);
-        if (connections.length > 0 && connections[0]!.auth !== null) {
-          resume(Effect.succeed({ _tag: "Ready" as const }));
-          return;
-        }
-
-        if (Date.now() > deadline) {
-          // #ignore-sloppy-code-next-line[promise-type]: fire-and-forget cleanup — resume callback cannot await
-          void this.doTeardown();
-          resume(Effect.succeed({ _tag: "Timeout" as const, timeoutMs }));
-          return;
-        }
-
-        setTimeout(check, 500);
-      };
-
-      check();
-    });
+    return pipe(
+      Effect.race(serverReady, exitLoop),
+      // Failure outcomes (Timeout, ProcessExited) tear down before returning.
+      Effect.tap((outcome) =>
+        outcome._tag === "Ready" ? Effect.void : this.teardown(),
+      ),
+    );
   }
 
   teardown(): Effect.Effect<void, never, never> {

--- a/packages/runtimes/src/openclaw-adapter.ts
+++ b/packages/runtimes/src/openclaw-adapter.ts
@@ -155,6 +155,25 @@ export class OpenClawAdapter implements Runtime {
 
     return pipe(
       Effect.race(serverReady, exitLoop),
+      // Final-check: if the race resolved `Timeout`, the child may have
+      // exited within the last `exitLoop` tick window — one last sync probe
+      // promotes that case to `ProcessExited` with the actual exit code so
+      // the diagnostic stderr isn't lost behind an opaque `Timeout`.
+      Effect.flatMap(
+        (outcome): Effect.Effect<ReadyOutcome, never, never> =>
+          outcome._tag !== "Timeout"
+            ? Effect.succeed(outcome)
+            : Effect.sync(
+                (): ReadyOutcome =>
+                  child.exitCode !== null
+                    ? {
+                        _tag: "ProcessExited" as const,
+                        exitCode: child.exitCode,
+                        stderr: this.state?.logBuffer ?? "",
+                      }
+                    : outcome,
+              ),
+      ),
       // Failure outcomes (Timeout, ProcessExited) tear down before returning.
       Effect.tap((outcome) =>
         outcome._tag === "Ready" ? Effect.void : this.teardown(),

--- a/packages/runtimes/src/runtime.ts
+++ b/packages/runtimes/src/runtime.ts
@@ -15,14 +15,24 @@ export interface WorkspaceFile {
   readonly content: string;
 }
 
-export interface RuntimeConnection {
-  readonly auth: unknown | null;
-}
-
 export interface RuntimeServerHandle {
-  readonly connections: {
-    getByAgent(agentId: string): ReadonlyArray<RuntimeConnection>;
-  };
+  /**
+   * Resolves to `Ready` when the named agent has authenticated against the
+   * server. Resolves to `Timeout` after `timeoutMs` if no authenticated
+   * connection ever appears. Resolves to `ProcessExited` only if the
+   * implementation can detect that the agent's owning process exited before
+   * authenticating; otherwise `Timeout` covers that case (the runtime
+   * adapters layer their own exit-detection on top via `Effect.race`).
+   *
+   * In-process implementations wire this through `awaitAgentReadyByPolling`.
+   * Out-of-process implementations (e.g., a zapbot orchestrator talking to
+   * a standalone moltzap-server) implement it directly, typically via a
+   * presence-event subscription on the server's WebSocket API.
+   */
+  awaitAgentReady(
+    agentId: string,
+    timeoutMs: number,
+  ): Effect.Effect<ReadyOutcome, never, never>;
 }
 
 export interface SpawnInput {

--- a/packages/runtimes/src/runtimes.test.ts
+++ b/packages/runtimes/src/runtimes.test.ts
@@ -53,11 +53,12 @@ vi.mock("./openclaw-adapter.js", async () => {
 });
 
 // Minimal stub for the live server surface the adapters poll for readiness.
+// `awaitAgentReady` returns `Effect.never` to model "agent never authenticates" —
+// adapters under test either short-circuit on no-spawn or rely on their own
+// process-exit detector to resolve the race.
 function stubServer(): RuntimeServerHandle {
   return {
-    connections: {
-      getByAgent: (_agentId: string) => [],
-    },
+    awaitAgentReady: (_agentId: string, _timeoutMs: number) => Effect.never,
   };
 }
 

--- a/packages/runtimes/src/trace-capture-harness.ts
+++ b/packages/runtimes/src/trace-capture-harness.ts
@@ -106,20 +106,36 @@ interface ClientTestModule {
 }
 
 interface CoreAppHandle {
-  readonly connections: {
-    getByAgent(
-      agentId: string,
-    ): ReadonlyArray<{ readonly auth: unknown | null }>;
-  };
   readonly traceCapture: {
     snapshot(): Effect.Effect<readonly TraceCaptureEvent[], never, never>;
   };
+}
+
+// Pre-wired RuntimeServerHandle that startCoreTestServer now exposes — the
+// harness threads this directly into startRuntimeAgent. Structural shape only;
+// the concrete implementation lives in @moltzap/server-core's test-utils.
+interface RuntimeServerLike {
+  awaitAgentReady(
+    agentId: string,
+    timeoutMs: number,
+  ): Effect.Effect<
+    | { readonly _tag: "Ready" }
+    | { readonly _tag: "Timeout"; readonly timeoutMs: number }
+    | {
+        readonly _tag: "ProcessExited";
+        readonly exitCode: number | null;
+        readonly stderr: string;
+      },
+    never,
+    never
+  >;
 }
 
 interface CoreTestServer {
   readonly baseUrl: string;
   readonly wsUrl: string;
   readonly coreApp: CoreAppHandle;
+  readonly runtimeServer: RuntimeServerLike;
 }
 
 interface ServerIndexModule {
@@ -1101,7 +1117,7 @@ function createCoordinator(sourcePath: string, payload: HarnessPayload) {
               return yield* Effect.acquireUseRelease(
                 startRuntimeAgent({
                   kind: payload.runtime.kind,
-                  server: server.coreApp,
+                  server: server.runtimeServer,
                   readyTimeoutMs:
                     payload.runtime.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
                   agent: {

--- a/packages/server/src/test-utils/server.ts
+++ b/packages/server/src/test-utils/server.ts
@@ -5,6 +5,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Kysely } from "kysely";
+import { Effect, pipe, type Layer } from "effect";
 import { createCoreApp } from "../app/server.js";
 import { seedInitialKek } from "../crypto/key-rotation.js";
 import { EnvelopeEncryption } from "../crypto/envelope.js";
@@ -13,12 +14,68 @@ import type { TraceCaptureTag } from "../runtime-surface/trace-capture.js";
 import type { Database } from "../db/database.js";
 import type { UserService } from "../services/user.service.js";
 import { makeEffectKysely } from "../db/effect-kysely-toolkit.js";
-import type { Layer } from "effect";
 
 export type { Database } from "../db/database.js";
 export type { CoreApp } from "../app/types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Minimal duplicate of `@moltzap/runtimes`'s `awaitAgentReadyByPolling` and
+// `RuntimeServerHandle`/`ReadyOutcome` shapes. We can't import from
+// `@moltzap/runtimes` here without flipping the workspace dep direction
+// (runtimes already devDeps server-core); structural typing keeps both
+// sides honest — the integration test threads `runtimeServer` directly into
+// the adapter's `RuntimeServerHandle` slot, so any drift surfaces at compile
+// time on the consumer.
+type CoreTestReadyOutcome =
+  | { readonly _tag: "Ready" }
+  | { readonly _tag: "Timeout"; readonly timeoutMs: number }
+  | {
+      readonly _tag: "ProcessExited";
+      readonly exitCode: number | null;
+      readonly stderr: string;
+    };
+
+export interface CoreTestRuntimeServerHandle {
+  awaitAgentReady(
+    agentId: string,
+    timeoutMs: number,
+  ): Effect.Effect<CoreTestReadyOutcome, never, never>;
+}
+
+function awaitAgentReadyByPolling(
+  connections: {
+    getByAgent(id: string): ReadonlyArray<{ readonly auth: unknown | null }>;
+  },
+  agentId: string,
+  timeoutMs: number,
+): Effect.Effect<CoreTestReadyOutcome, never, never> {
+  const tick = Effect.sync(() => {
+    const conns = connections.getByAgent(agentId);
+    return conns.length > 0 && conns[0]!.auth !== null;
+  });
+  const pollLoop = pipe(
+    tick,
+    Effect.flatMap((ready) =>
+      Effect.iterate(ready, {
+        while: (s) => !s,
+        body: () => Effect.sleep("500 millis").pipe(Effect.zipRight(tick)),
+      }),
+    ),
+    Effect.as<CoreTestReadyOutcome>({ _tag: "Ready" as const }),
+  );
+  return pipe(
+    pollLoop,
+    Effect.timeoutTo({
+      duration: `${timeoutMs} millis`,
+      onSuccess: (outcome): CoreTestReadyOutcome => outcome,
+      onTimeout: (): CoreTestReadyOutcome => ({
+        _tag: "Timeout" as const,
+        timeoutMs,
+      }),
+    }),
+  );
+}
 
 let coreApp: CoreApp | null = null;
 let appDb: Kysely<Database> | null = null;
@@ -35,6 +92,14 @@ export interface CoreTestServer {
   wsUrl: string;
   db: Kysely<Database>;
   coreApp: CoreApp;
+  /**
+   * Pre-wired `RuntimeServerHandle` for runtime-adapter tests. Implements
+   * `awaitAgentReady` by polling the live `ConnectionManager` — the same
+   * pattern `@moltzap/runtimes`'s `awaitAgentReadyByPolling` exports for
+   * downstream in-process consumers. Out-of-process consumers (zapbot's
+   * orchestrator) construct their own handle over WebSocket presence.
+   */
+  runtimeServer: CoreTestRuntimeServerHandle;
 }
 
 export async function startCoreTestServer(_opts?: {
@@ -96,7 +161,18 @@ export async function startCoreTestServer(_opts?: {
   _baseUrl = `http://localhost:${assignedPort}`;
   _wsUrl = `ws://localhost:${assignedPort}/ws`;
 
-  return { baseUrl: _baseUrl, wsUrl: _wsUrl, db: appDb, coreApp };
+  const runtimeServer: CoreTestRuntimeServerHandle = {
+    awaitAgentReady: (agentId, timeoutMs) =>
+      awaitAgentReadyByPolling(coreApp!.connections, agentId, timeoutMs),
+  };
+
+  return {
+    baseUrl: _baseUrl,
+    wsUrl: _wsUrl,
+    db: appDb,
+    coreApp,
+    runtimeServer,
+  };
 }
 
 export async function stopCoreTestServer(): Promise<void> {


### PR DESCRIPTION
## Summary

Replaces the synchronous, in-memory `RuntimeServerHandle.connections.getByAgent` surface with an Effect-native, pluggable `awaitAgentReady(agentId, timeoutMs)`. Out-of-process consumers (a remote orchestrator talking to a standalone moltzap-server over WebSocket presence) can now implement readiness without round-tripping through an in-process `ConnectionManager`. The default in-process consumer reuses the existing 500 ms poll via the new `awaitAgentReadyByPolling` helper, exported from `@moltzap/runtimes`.

Tracks chughtapan/zapbot#372 (sub-issue), chughtapan/zapbot#371 (architect doc — published at https://github.com/chughtapan/zapbot/issues/369#issuecomment-4348152762), under parent epic chughtapan/zapbot#369.

## Interface change

Before:

```ts
interface RuntimeServerHandle {
  readonly connections: {
    getByAgent(agentId: string): ReadonlyArray<RuntimeConnection>;
  };
}
```

After:

```ts
interface RuntimeServerHandle {
  awaitAgentReady(
    agentId: string,
    timeoutMs: number,
  ): Effect.Effect<ReadyOutcome, never, never>;
}
```

`RuntimeConnection` is dropped from the public surface (it remains internal to the in-process polling helper). No back-compat shim — per PRINCIPLES § "back-compat is not a default" and the architect doc's directive.

## Per-adapter migration

`waitUntilReady` in all three adapters (`claude-code-adapter.ts`, `openclaw-adapter.ts`, `nanoclaw-adapter.ts`) was rewritten as `Effect.race(serverReady, exitLoop)`:

- **`serverReady`** — the pluggable `this.deps.server.awaitAgentReady(agentId, timeoutMs)` call. The server-handle implementation decides how readiness is detected.
- **`exitLoop`** — adapter-side process-exit detector. Polls the subprocess' exit fiber / `child.exitCode` every 250 ms and surfaces `ProcessExited` with stderr from the live log buffer if the agent dies before authenticating. The exit detector cannot terminate by itself: if the process never exits and `awaitAgentReady` resolves first (Ready or Timeout), the race interrupts the loser cleanly.

This split keeps the adapters honest about what they own (process lifecycle) versus what the server handle owns (authentication signal).

## New module: `await-agent-ready.ts`

Exports a single helper, `awaitAgentReadyByPolling(connections, agentId, timeoutMs, pollIntervalMs?)`. Polls `connections.getByAgent(agentId)` every 500 ms; resolves to `Ready` once an authenticated connection appears, `Timeout` after the deadline. The helper deliberately does NOT produce `ProcessExited` — it has no view of the agent's owning subprocess. Callers compose it with their own exit detector (see the adapter code).

Includes an `@example` TSDoc block sketching the out-of-process consumer pattern (zapbot orchestrator subscribing to WebSocket presence events) so downstream implementers see the canonical shape at the helper's docs site.

## Test wiring

- `packages/runtimes/src/runtimes.test.ts` — `stubServer()` now returns `awaitAgentReady: () => Effect.never`. This is the structural equivalent of the old `getByAgent: () => []` (an agent that never authenticates); unit tests that exercise the no-spawn early-out path keep passing without invoking the server side.
- `packages/runtimes/src/claude-code-adapter.integration.test.ts` — consumes the new pre-wired `server.runtimeServer` from `startCoreTestServer` instead of constructing a `{ connections: ... }` shim inline.
- `packages/server/src/test-utils/server.ts` — `startCoreTestServer` now exposes a pre-wired `runtimeServer: RuntimeServerHandle` that delegates to a polling helper structurally compatible with `awaitAgentReadyByPolling`.

Note: the helper is **inlined** in `test-utils/server.ts` rather than imported from `@moltzap/runtimes`. Importing across that boundary would invert the existing workspace edge — `@moltzap/runtimes` already devDeps `@moltzap/server-core` for its own integration test, and a reverse import (`@moltzap/server-core` → `@moltzap/runtimes`) would create a cycle. Structural typing on the consumer side (the integration test threads `runtimeServer` directly into the adapter's `RuntimeServerHandle` slot) catches drift at compile time.

## Out-of-cap edit (heads-up)

`packages/runtimes/src/trace-capture-harness.ts` is **not** in the architect doc's PR scope budget but had to be touched: it carries a structurally-typed `CoreTestServer` shape that mirrors the old pre-refactor wiring (`server.coreApp.connections` was passed straight into `startRuntimeAgent`'s `server` slot). With the new interface, that path no longer typechecks. The fix is mechanical:

- Replace `connections: getByAgent(...)` on the local `CoreAppHandle` shape with a `runtimeServer: RuntimeServerLike` sibling (structural to `RuntimeServerHandle`).
- Pass `server.runtimeServer` to `startRuntimeAgent` instead of `server.coreApp`.

Flagging for the architect's awareness; happy to revert + escalate if a different approach is preferred.

## Verification

```
$ pnpm --filter "@moltzap/runtimes..." build
... done (5/5 workspace projects)

$ pnpm --filter "@moltzap/runtimes..." test
... runtimes (31 tests passed), client (209+6todo), server-core (136), claude-code-channel (47), protocol — all green

$ pnpm lint        # oxlint
Found 0 warnings and 0 errors.

$ pnpm typecheck   # tsc --noEmit across all packages
... no errors
```

Pre-commit guards (Type Safety Guardrails / Effect Hygiene / Bare Catch Guards / Test Integrity Guards) all clean.

## Test plan

- [x] `pnpm --filter "@moltzap/runtimes..." test` — green.
- [x] `pnpm --filter "@moltzap/runtimes..." build` — green.
- [x] `pnpm lint` (oxlint) — green.
- [x] `pnpm typecheck` — green.
- [ ] `pnpm test:integration` (claude-code-adapter integration test) — requires a real `claude` CLI auth setup; deferred to CI / reviewer environment.

## Reviewer

@chughtapan