### PR TITLE
[impl-junior] Fix app/hookTimeout schema to allow before_dispatch + on_session_active

### DIFF
--- a/packages/protocol/src/schema/events.test.ts
+++ b/packages/protocol/src/schema/events.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { AppHookTimeoutEventSchema } from "./events.js";
+
+const ajv = addFormats(new Ajv({ strict: true }));
+
+describe("AppHookTimeoutEventSchema", () => {
+  const validate = ajv.compile(AppHookTimeoutEventSchema);
+
+  const baseEvent = {
+    sessionId: "550e8400-e29b-41d4-a716-446655440000",
+    appId: "werewolf",
+    timeoutMs: 5000,
+  };
+
+  it("accepts hookName=before_message_delivery", () => {
+    expect(
+      validate({ ...baseEvent, hookName: "before_message_delivery" }),
+    ).toBe(true);
+  });
+
+  it("accepts hookName=before_dispatch", () => {
+    expect(validate({ ...baseEvent, hookName: "before_dispatch" })).toBe(true);
+  });
+
+  it("accepts hookName=on_join", () => {
+    expect(validate({ ...baseEvent, hookName: "on_join" })).toBe(true);
+  });
+
+  it("accepts hookName=on_session_active", () => {
+    expect(validate({ ...baseEvent, hookName: "on_session_active" })).toBe(
+      true,
+    );
+  });
+
+  it("accepts hookName=on_close", () => {
+    expect(validate({ ...baseEvent, hookName: "on_close" })).toBe(true);
+  });
+
+  it("rejects unknown hookName", () => {
+    expect(validate({ ...baseEvent, hookName: "after_dispatch" })).toBe(false);
+  });
+
+  it("rejects missing hookName", () => {
+    expect(validate(baseEvent)).toBe(false);
+  });
+
+  it("rejects extra properties", () => {
+    expect(
+      validate({
+        ...baseEvent,
+        hookName: "before_dispatch",
+        extra: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/protocol/src/schema/events.ts
+++ b/packages/protocol/src/schema/events.ts
@@ -186,7 +186,13 @@ export const AppHookTimeoutEventSchema = Type.Object(
   {
     sessionId: AppSessionId,
     appId: Type.String(),
-    hookName: stringEnum(["before_message_delivery", "on_join", "on_close"]),
+    hookName: stringEnum([
+      "before_message_delivery",
+      "before_dispatch",
+      "on_join",
+      "on_session_active",
+      "on_close",
+    ]),
     timeoutMs: Type.Integer(),
   },
   { additionalProperties: false },


### PR DESCRIPTION
Closes #287

## What changed
`AppHookTimeoutEventSchema.hookName` enum extended with `before_dispatch` and `on_session_active`. AppHost (`packages/server/src/app/app-host.ts`) already emits these hook names but the protocol schema rejected them at the validation boundary — pre-existing bug. Added `events.test.ts` covering each accepted hookName, plus unknown/missing/extra-property rejections.

## Scope
- Module: `packages/protocol/src/schema/events.ts` (+ colocated `events.test.ts`)
- Tier: junior (one schema field, one test file)
- New exported signatures: none
- New deps: none

## Tests
- `accepts hookName=before_message_delivery`
- `accepts hookName=before_dispatch` (new)
- `accepts hookName=on_join`
- `accepts hookName=on_session_active` (new)
- `accepts hookName=on_close`
- `rejects unknown hookName`
- `rejects missing hookName`
- `rejects extra properties`

All 8 events tests pass; full protocol suite (87 tests) passes; lint clean.

## Confidence
HIGH — the AppHost emit sites for `before_dispatch` (app-host.ts:568) and `on_session_active` (app-host.ts:1606+) already use these literal hook names, and integration tests in `packages/server/src/__tests__/integration/31-on-session-active.integration.test.ts:263` already assert `data.hookName === "on_session_active"`. Only the schema enum was missing.