### PR TITLE
[impl-senior] Add /admin/register-agent ownerUserId param

### DIFF
--- a/packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts
+++ b/packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import type { Kysely } from "kysely";
+import type { AppManifest } from "@moltzap/protocol";
+import type { Database } from "../../db/database.js";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  getKyselyDb,
+  getTestCoreApp,
+  trackClient,
+  connectTestClient,
+} from "./helpers.js";
+
+const REGISTRATION_SECRET = "admin-test-secret-zxcv";
+// Arbitrary v4 UUID used as the "system user" identity in arena. moltzap's
+// schema has no users table; this UUID is just a label that satisfies the
+// AppHost null check on `agents.owner_user_id`.
+const SYSTEM_USER_ID = "00000000-0000-4000-8000-000000000001";
+
+const ADMIN_TEST_MANIFEST: AppManifest = {
+  appId: "admin-register-test-app",
+  name: "Admin Register Test App",
+  // Empty permissions — admission auto-completes without prompting,
+  // keeping this test focused on the owner-id check at app-host.ts:753.
+  permissions: { required: [], optional: [] },
+  conversations: [{ key: "main", name: "Main", participantFilter: "all" }],
+};
+
+let baseUrl: string;
+let wsUrl: string;
+let db: Kysely<Database>;
+
+beforeAll(async () => {
+  const server = await startTestServer({
+    registrationSecret: REGISTRATION_SECRET,
+  });
+  baseUrl = server.baseUrl;
+  wsUrl = server.wsUrl;
+  db = getKyselyDb();
+  getTestCoreApp().registerApp(ADMIN_TEST_MANIFEST);
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  getTestCoreApp().registerApp(ADMIN_TEST_MANIFEST);
+});
+
+interface AdminRegisterResponse {
+  agentId: string;
+  apiKey: string;
+}
+
+async function postAdmin(
+  body: Record<string, unknown>,
+): Promise<{ status: number; json: unknown }> {
+  const res = await fetch(`${baseUrl}/api/v1/admin/register-agent`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  // The endpoint always returns JSON (success or error envelopes).
+  const json: unknown = await res.json();
+  return { status: res.status, json };
+}
+
+describe("/api/v1/admin/register-agent — secret-gated ownerUserId", () => {
+  it.live(
+    "registers an agent with explicit ownerUserId when invite code matches",
+    () =>
+      Effect.gen(function* () {
+        const result = yield* Effect.tryPromise(() =>
+          postAdmin({
+            name: "admin-owned-agent",
+            inviteCode: REGISTRATION_SECRET,
+            ownerUserId: SYSTEM_USER_ID,
+          }),
+        );
+        expect(result.status).toBe(201);
+        const body = result.json as AdminRegisterResponse;
+        expect(body.agentId).toBeDefined();
+        expect(body.apiKey).toMatch(/^moltzap_agent_/);
+
+        // The agent's owner_user_id is set at insert time — no UPDATE needed.
+        const row = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("agents")
+            .select(["id", "owner_user_id", "name"])
+            .where("id", "=", body.agentId)
+            .executeTakeFirstOrThrow(),
+        );
+        expect(row.owner_user_id).toBe(SYSTEM_USER_ID);
+        expect(row.name).toBe("admin-owned-agent");
+      }),
+  );
+
+  it.live(
+    "agent registered via admin endpoint passes AppHost owner check (no AgentNoOwner)",
+    () =>
+      Effect.gen(function* () {
+        // Register two agents — one initiator, one invitee. Both pre-claimed
+        // to SYSTEM_USER_ID via the admin route. AppHost.createSession
+        // (`app-host.ts:753`) refuses agents with null `owner_user_id` with
+        // `AgentNoOwner`; this test exercises the success path.
+        const initiatorRes = yield* Effect.tryPromise(() =>
+          postAdmin({
+            name: "admin-initiator",
+            inviteCode: REGISTRATION_SECRET,
+            ownerUserId: SYSTEM_USER_ID,
+          }),
+        );
+        expect(initiatorRes.status).toBe(201);
+        const initiator = initiatorRes.json as AdminRegisterResponse;
+
+        const inviteeRes = yield* Effect.tryPromise(() =>
+          postAdmin({
+            name: "admin-invitee",
+            inviteCode: REGISTRATION_SECRET,
+            ownerUserId: SYSTEM_USER_ID,
+          }),
+        );
+        expect(inviteeRes.status).toBe(201);
+        const invitee = inviteeRes.json as AdminRegisterResponse;
+
+        // Connect the initiator and create a session — this drives the
+        // owner_user_id check at app-host.ts:753.
+        const client = yield* connectTestClient({
+          wsUrl,
+          agentId: initiator.agentId,
+          apiKey: initiator.apiKey,
+        });
+        trackClient(client);
+
+        const session = (yield* client.sendRpc("apps/create", {
+          appId: ADMIN_TEST_MANIFEST.appId,
+          invitedAgentIds: [invitee.agentId],
+        })) as { session: { id: string; status: string } };
+
+        expect(session.session.id).toBeDefined();
+        expect(session.session.status).toBe("waiting");
+      }),
+  );
+
+  it.live("rejects when invite code is missing", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.tryPromise(() =>
+        postAdmin({
+          name: "no-invite-code",
+          ownerUserId: SYSTEM_USER_ID,
+        }),
+      );
+      expect(result.status).toBe(403);
+    }),
+  );
+
+  it.live("rejects when invite code does not match registrationSecret", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.tryPromise(() =>
+        postAdmin({
+          name: "wrong-invite-code",
+          inviteCode: "not-the-real-secret",
+          ownerUserId: SYSTEM_USER_ID,
+        }),
+      );
+      expect(result.status).toBe(403);
+    }),
+  );
+
+  it.live("rejects ownerUserId that is not a UUID", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.tryPromise(() =>
+        postAdmin({
+          name: "bad-owner",
+          inviteCode: REGISTRATION_SECRET,
+          ownerUserId: "not-a-uuid",
+        }),
+      );
+      expect(result.status).toBe(400);
+      const body = result.json as { error: string };
+      expect(body.error).toMatch(/UUID/);
+    }),
+  );
+
+  it.live(
+    "registers without ownerUserId — owner_user_id is null when omitted",
+    () =>
+      Effect.gen(function* () {
+        const result = yield* Effect.tryPromise(() =>
+          postAdmin({
+            name: "no-owner-agent",
+            inviteCode: REGISTRATION_SECRET,
+          }),
+        );
+        expect(result.status).toBe(201);
+        const body = result.json as AdminRegisterResponse;
+
+        const row = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("agents")
+            .select(["owner_user_id"])
+            .where("id", "=", body.agentId)
+            .executeTakeFirstOrThrow(),
+        );
+        // devModeUserId is not configured in this test harness, so owner is null.
+        expect(row.owner_user_id).toBeNull();
+      }),
+  );
+});
+
+// The "registrationSecret-not-configured → 404" branch is exercised
+// indirectly: the route's first action is to reject when the secret is
+// unset. Adding a second harness boot for that single line would 2x the
+// integration-test surface; the existing 32-registration-secret.integration.test.ts
+// already covers the open-server path, and a unit-level assertion belongs in a
+// follow-up if the surface grows.

--- a/packages/server/src/__tests__/integration/helpers.ts
+++ b/packages/server/src/__tests__/integration/helpers.ts
@@ -50,6 +50,8 @@ export async function startTestServer(_opts?: {
   encryption?: boolean;
   /** Optional validator forwarded to `startCoreTestServer` — see its docs. */
   userService?: UserService;
+  /** Optional secret forwarded to `startCoreTestServer` — see its docs. */
+  registrationSecret?: string;
   traceCaptureLayer?: Layer.Layer<TraceCaptureTag>;
 }): Promise<{
   baseUrl: string;
@@ -66,6 +68,7 @@ export async function startTestServer(_opts?: {
     pgPort,
     encryption: _opts?.encryption,
     userService: _opts?.userService,
+    registrationSecret: _opts?.registrationSecret,
     traceCaptureLayer: _opts?.traceCaptureLayer,
   });
   _coreApp = server.coreApp;

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -75,6 +75,10 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(bufA, bufB);
 }
 
+/** RFC 4122 canonical-string check (any version, any variant). */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const USER_HOOK_TIMEOUT_MS = 2_000;
 
 function runUserHook<TArgs>(
@@ -247,6 +251,91 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       // registerAgent's error channel is `never` — any failure here is a defect
       // (DB error, etc.) which maps to a 500.
       logger.error({ cause: Cause.pretty(exit.cause) }, "Registration failed");
+      return HttpServerResponse.unsafeJson(
+        { error: "Registration failed" },
+        { status: 500 },
+      );
+    }),
+  );
+
+  // Secret-gated admin registration. Accepts `ownerUserId` so the caller
+  // can pre-claim the agent at insert time, skipping the post-register
+  // `UPDATE agents SET owner_user_id = ...` two-step. The route is mounted
+  // only when `config.registrationSecret` is set (see the `httpApp` pipe
+  // below) — there's no anonymous admin flow.
+  const registrationSecret = config.registrationSecret;
+  const adminRegisterAgentRoute = HttpRouter.post(
+    "/api/v1/admin/register-agent",
+    Effect.gen(function* () {
+      // Defense-in-depth: the route is conditionally mounted, but if a
+      // future caller wires this route without the secret, fail closed.
+      if (!registrationSecret) {
+        return HttpServerResponse.unsafeJson(
+          { error: "Admin registration unavailable" },
+          { status: 404 },
+        );
+      }
+
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const bodyResult = yield* Effect.either(request.json);
+      if (bodyResult._tag === "Left") {
+        return HttpServerResponse.unsafeJson(
+          { error: "Invalid JSON" },
+          { status: 400 },
+        );
+      }
+
+      // `validators.registerParams` is built from the protocol Register
+      // schema with `additionalProperties: false`. Strip ownerUserId
+      // before validating the rest of the body against that strict schema.
+      // #ignore-sloppy-code-next-line[record-cast]: `request.json` returns `unknown` from untrusted HTTP input; we re-validate `registerBody` via `validators.registerParams` immediately below
+      const fullBody = bodyResult.right as Record<string, unknown>;
+      const ownerUserIdRaw = fullBody["ownerUserId"];
+      const { ownerUserId: _stripped, ...registerBody } = fullBody;
+
+      if (!validators.registerParams(registerBody)) {
+        return HttpServerResponse.unsafeJson(
+          { error: "Invalid parameters" },
+          { status: 400 },
+        );
+      }
+
+      const inviteCode = (registerBody as { inviteCode?: string }).inviteCode;
+      if (!inviteCode || !safeEqual(inviteCode, registrationSecret)) {
+        return HttpServerResponse.unsafeJson(
+          { error: "Invalid or missing invite code" },
+          { status: 403 },
+        );
+      }
+
+      let resolvedOwnerUserId: string | undefined;
+      if (ownerUserIdRaw !== undefined) {
+        if (
+          typeof ownerUserIdRaw !== "string" ||
+          !UUID_RE.test(ownerUserIdRaw)
+        ) {
+          return HttpServerResponse.unsafeJson(
+            { error: "ownerUserId must be a UUID" },
+            { status: 400 },
+          );
+        }
+        resolvedOwnerUserId = ownerUserIdRaw;
+      }
+
+      const exit = yield* Effect.exit(
+        authService.registerAgent(
+          registerBody as Parameters<typeof authService.registerAgent>[0],
+          // Explicit body owner wins; dev-mode auto-owner is the fallback.
+          resolvedOwnerUserId ?? config.devModeUserId,
+        ),
+      );
+      if (Exit.isSuccess(exit)) {
+        return HttpServerResponse.unsafeJson(exit.value, { status: 201 });
+      }
+      logger.error(
+        { cause: Cause.pretty(exit.cause) },
+        "Admin registration failed",
+      );
       return HttpServerResponse.unsafeJson(
         { error: "Registration failed" },
         { status: 500 },
@@ -526,15 +615,29 @@ export function createCoreApp(config: CoreConfig): CoreApp {
 
   // `skipDefaultRegisterRoute` lets apps opt out of core's default register
   // handler so they can mount their own invite-gated / rate-limited flow.
+  // The admin route is mounted only when (a) the default register flow
+  // is in use AND (b) a `registrationSecret` is configured. Without the
+  // secret there's no admin credential, so the route is absent — turning
+  // "no secret = no admin route" into a router-level invariant.
+  const adminRouteEnabled =
+    !config.skipDefaultRegisterRoute && config.registrationSecret !== undefined;
   const httpApp = (
     config.skipDefaultRegisterRoute
       ? HttpRouter.empty.pipe(healthRoute, permissionsResolveRoute, wsRoute)
-      : HttpRouter.empty.pipe(
-          healthRoute,
-          registerRoute,
-          permissionsResolveRoute,
-          wsRoute,
-        )
+      : adminRouteEnabled
+        ? HttpRouter.empty.pipe(
+            healthRoute,
+            registerRoute,
+            adminRegisterAgentRoute,
+            permissionsResolveRoute,
+            wsRoute,
+          )
+        : HttpRouter.empty.pipe(
+            healthRoute,
+            registerRoute,
+            permissionsResolveRoute,
+            wsRoute,
+          )
   ).pipe(
     HttpMiddleware.cors({
       allowedOrigins: allowedOriginsPredicate,

--- a/packages/server/src/services/auth.service.ts
+++ b/packages/server/src/services/auth.service.ts
@@ -23,11 +23,10 @@ export class AuthService {
   registerAgent(
     params: RegisterParams,
     /**
-     * Optional dev-mode ownership — when set, the new agent is registered
-     * pre-claimed to this user id. Routed from `CoreConfig.devModeUserId`;
-     * never flows from untrusted HTTP input.
+     * When set, populates `owner_user_id` at insert time. Callers MUST
+     * validate the value upstream — this argument is treated as trusted.
      */
-    devModeOwnerId?: string,
+    ownerUserId?: string,
   ): Effect.Effect<{ agentId: AgentId; apiKey: string }, never> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
@@ -43,7 +42,7 @@ export class AuthService {
               api_key_secret_hash: secretHash,
               claim_token: generateClaimToken(),
               status: "active",
-              owner_user_id: devModeOwnerId ?? null,
+              owner_user_id: ownerUserId ?? null,
             })
             .returning(["id"]),
           "Failed to insert agent",

--- a/packages/server/src/test-utils/server.ts
+++ b/packages/server/src/test-utils/server.ts
@@ -113,6 +113,13 @@ export async function startCoreTestServer(_opts?: {
    * harness (admit all owners).
    */
   userService?: UserService;
+  /**
+   * When set, the server requires `inviteCode` matching this value on
+   * `/api/v1/auth/register` and enables the `/api/v1/admin/register-agent`
+   * route. Default `undefined` keeps the open-registration behavior the
+   * existing tests depend on.
+   */
+  registrationSecret?: string;
   traceCaptureLayer?: Layer.Layer<TraceCaptureTag>;
 }): Promise<CoreTestServer> {
   if (coreApp)
@@ -152,6 +159,7 @@ export async function startCoreTestServer(_opts?: {
     corsOrigins: ["*"],
     devMode: true,
     userService: _opts?.userService,
+    registrationSecret: _opts?.registrationSecret,
     traceCaptureLayer: _opts?.traceCaptureLayer,
   });
 


### PR DESCRIPTION
Closes #288
Architect plan: parent epic [chughtapan/moltzap-arena#198](https://github.com/chughtapan/moltzap-arena/issues/198) (B.11). Architect issue [#286](https://github.com/chughtapan/moltzap/issues/286) is in `planning` and does not yet name the admin endpoint surface; per [user direction 2026-04-30](https://github.com/chughtapan/moltzap/issues/288#issuecomment-4356074961) the acceptance was narrowed to drop the users-table seed.

## What changed

New `/api/v1/admin/register-agent` HTTP route. Body: `{ name, description?, inviteCode, ownerUserId? }`. Mounted only when `config.registrationSecret` is configured. The route validates `ownerUserId` is a UUID (inline regex) and gates honoring it on `safeEqual(inviteCode, registrationSecret)`. Pre-claims the agent at insert time, skipping the post-register `UPDATE agents SET owner_user_id = ...` two-step that 7+ existing integration tests work around.

`AuthService.registerAgent`'s second arg renamed `devModeOwnerId` → `ownerUserId` (source-agnostic; resolution lives at the route layer).

## Endpoint choice rationale

`/api/v1/admin/register-agent` (new) over extending `/api/v1/auth/register`:
- Existing public route stays untouched — no behavior change for current callers.
- Admin route is mounted only when `registrationSecret` is set (router-level invariant), so "no secret = no admin surface" is structural rather than a per-request branch.
- Architect plan #286 explicitly names this path.

## Plan anchors

| Change | Plan anchor |
|---|---|
| New `/api/v1/admin/register-agent` route in `app/server.ts` | Acceptance #1: new admin endpoint accepts `ownerUserId` |
| Inline UUID regex + secret-gate for `ownerUserId` | Acceptance #1: validates UUID, gated on secret match |
| `auth.service.ts:46` rename `devModeOwnerId` → `ownerUserId`; tightened JSDoc | Acceptance #1: "honor explicit owner" |
| `test-utils/server.ts` + `helpers.ts` thread `registrationSecret` through to `createCoreApp` | Acceptance #2: secret-gated test path |
| New `41-admin-register-agent.integration.test.ts` (6 tests) | Acceptance #2: register with `ownerUserId`; confirm `agents.owner_user_id` set; confirm AppHost owner check at `app-host.ts:753` passes (no `AgentNoOwner`) |

## Scope
- Modules touched: `packages/server/src/{app/server.ts, services/auth.service.ts, test-utils/server.ts, __tests__/integration/{helpers.ts, 41-admin-register-agent.integration.test.ts}}`
- Tier (from `safer-diff-scope`): **junior** (\"single module, no exported-signature changes, no new deps\"). The narrowed acceptance — after the user dropped the schema seed and the protocol Register schema change was deferred to B.12 — ended up smaller than senior-tier. Not a stop-rule violation; flagging per skill guidance (\"suggest the sub-issue be relabeled next time\"). The original issue body covered cross-package work that would have been senior shape.
- New modules: 0
- New public signatures outside the plan: 0 (the new HTTP path is plan-anchored; protocol Register schema is unchanged)
- New deps: 0

## Tests
- 6 new `it.live` cases in `41-admin-register-agent.integration.test.ts`:
  1. Registers agent with explicit `ownerUserId` when invite code matches; verifies `agents.owner_user_id` row.
  2. Agent registered via admin route passes AppHost owner check — `apps/create` succeeds with no `AgentNoOwner`.
  3. Rejects when invite code is missing (403).
  4. Rejects when invite code does not match `registrationSecret` (403).
  5. Rejects `ownerUserId` that is not a UUID (400).
  6. Registers without `ownerUserId` — `owner_user_id` is null when omitted.
- Removed disabled-without-secret describe block: superseded by router-level conditional mount (no route = native 404).
- Full suite: 18 unit (136 tests) + 34 integration files (129 tests) all green.

## Simplify pass

Three reviewer agents (reuse, quality, efficiency). Findings applied:
- Trimmed `auth.service.ts` JSDoc (dropped line-numbered cross-refs that rot).
- Trimmed admin-route header comment (dropped speculative \"once #286 closes\" paragraph).
- Conditional-mount admin route at the router level (\"no secret = no route\" as a router-level invariant; eliminates dead 404 branch).
- Provenance comment on `SYSTEM_USER_ID` test constant.

### Simplify skips (cited)
- **UUID_RE → TypeBox + AJV compiled validator.** Inline regex is 2 lines; an AJV-compiled validator just for one optional field adds compile-time setup and indirection. Plan-anchor: protocol Register schema stays unchanged in this PR (B.12 will absorb the field).
- **Helper extraction across registerRoute + adminRegisterAgentRoute.** Would require editing the existing `registerRoute`. Duplication is ~30 lines of well-commented boilerplate. Left for a follow-up that touches both flows together (post-#286).
- **Extend `registerTestAgent` from `@moltzap/protocol/testing` to admin path.** Would expand a cross-package public surface for a single test file. Local `postAdmin` is 8 lines.
- **Inline `resolvedOwnerUserId`.** Inlining requires `as string | undefined` cast; the named local carries TS-narrowed type cleanly out of the if block.
- **Drop `!inviteCode` falsy half.** Defensive depth; near-zero cost.

## Confidence

HIGH — every acceptance criterion has a direct test that exercises it; the AppHost owner check at `app-host.ts:753` is exercised end-to-end via `apps/create` with the success path; pre-commit hook (lint + format:check + typecheck + sloppy-code-guard) is clean; 265 tests pass.