### PR TITLE
[impl-senior] Phase 1.6: TestClient handleServerRpc + awaitServerRequest type narrowing

### DIFF
--- a/packages/protocol/src/testing/__tests__/test-client.s2c.test.ts
+++ b/packages/protocol/src/testing/__tests__/test-client.s2c.test.ts
@@ -125,7 +125,7 @@ const withClient = <A>(
         yield* server.connected;
         return yield* body(client, server);
       }),
-    ) as Effect.Effect<A>,
+    ).pipe(Effect.orDie),
   );
 
 const findResponse = (

--- a/packages/protocol/src/testing/__tests__/test-client.s2c.test.ts
+++ b/packages/protocol/src/testing/__tests__/test-client.s2c.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for the s2c (server→client) RPC test surface on `TestClient`:
+ *
+ *   - `handleServerRpc(method, handler)` — registers a handler for a
+ *     server-initiated request method.
+ *   - `awaitServerRequest(method, predicate?, timeoutMs?)` — observes the
+ *     inbound request payload (independent from handler dispatch).
+ *
+ * Implementation lives in `../test-client.ts`. Architect plan §3.6
+ * (chughtapan/moltzap#286 comment-4356088436) covers acceptance for B.7.
+ *
+ * Pattern: spin up an in-process `@effect/platform-node` WebSocket server
+ * that scripts the s2c traffic the test wants. `autoConnect: false` skips
+ * the auth/connect handshake — these tests exercise the s2c machinery
+ * directly without leaning on registered server-core verbs (which don't
+ * exist yet in Phase 1.0; B.2 lands the first ones).
+ */
+import { describe, it, expect } from "vitest";
+import { Cause, Deferred, Effect, Exit, Ref, Scope } from "effect";
+import * as NodeSocketServer from "@effect/platform-node/NodeSocketServer";
+import * as Socket from "@effect/platform/Socket";
+import { makeTestClient, type TestClient } from "../test-client.js";
+import { RpcResponseError } from "../errors.js";
+import type { RequestFrame, ResponseFrame } from "../../schema/frames.js";
+
+interface ScriptedServerHandle {
+  readonly wsUrl: string;
+  /** Push an arbitrary frame to the connected client. */
+  readonly send: (frame: unknown) => Effect.Effect<void>;
+  /**
+   * Resolve once the client opens the WS. Useful so a test can sequence
+   * "send s2c" after the socket has come up but before any other
+   * traffic.
+   */
+  readonly connected: Effect.Effect<void>;
+  /** All raw frames the server has received, in order. */
+  readonly received: Effect.Effect<ReadonlyArray<string>>;
+}
+
+/**
+ * Bind a tiny WS server on `127.0.0.1:0` whose only job is to:
+ *  - accept ONE inbound socket;
+ *  - record every received frame on `received`;
+ *  - expose `send` so the test scripts s2c traffic.
+ *
+ * The server is owned by the surrounding `Scope`; closing the scope shuts
+ * it down. There is no auth/connect auto-reply — tests construct
+ * TestClient with `autoConnect: false`.
+ */
+const makeScriptedServer: Effect.Effect<
+  ScriptedServerHandle,
+  unknown,
+  Scope.Scope
+> = Effect.gen(function* () {
+  const server = yield* NodeSocketServer.makeWebSocket({
+    port: 0,
+    host: "127.0.0.1",
+  });
+  const addr = server.address;
+  if (addr._tag !== "TcpAddress") {
+    return yield* Effect.die("expected TcpAddress");
+  }
+  const writerRef = yield* Ref.make<
+    | ((raw: string | Uint8Array | Socket.CloseEvent) => Effect.Effect<void>)
+    | null
+  >(null);
+  const receivedRef = yield* Ref.make<ReadonlyArray<string>>([]);
+  const connectedDef = yield* Deferred.make<void>();
+
+  yield* Effect.forkScoped(
+    server
+      .run((sock) =>
+        Effect.gen(function* () {
+          const write = yield* sock.writer;
+          yield* Ref.set(writerRef, (raw) => write(raw).pipe(Effect.ignore));
+          yield* Deferred.succeed(connectedDef, undefined).pipe(Effect.ignore);
+          yield* sock.runRaw((data) =>
+            Ref.update(receivedRef, (arr) => [
+              ...arr,
+              typeof data === "string"
+                ? data
+                : new TextDecoder("utf-8").decode(data),
+            ]),
+          );
+        }),
+      )
+      .pipe(Effect.ignore),
+  );
+
+  const send: ScriptedServerHandle["send"] = (frame) =>
+    Effect.gen(function* () {
+      const writer = yield* Ref.get(writerRef);
+      if (writer === null) return;
+      yield* writer(JSON.stringify(frame));
+    });
+
+  return {
+    wsUrl: `http://${addr.hostname}:${addr.port}`,
+    send,
+    connected: Deferred.await(connectedDef),
+    received: Ref.get(receivedRef),
+  };
+});
+
+const baseTestClientConfig = (wsUrl: string) =>
+  ({
+    serverUrl: wsUrl,
+    agentKey: "test-key",
+    agentId: "test-agent",
+    defaultTimeoutMs: 2_000,
+    captureCapacity: 64,
+    autoConnect: false,
+  }) as const;
+
+const withClient = <A>(
+  body: (client: TestClient, server: ScriptedServerHandle) => Effect.Effect<A>,
+): Promise<A> =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* makeScriptedServer;
+        const client = yield* makeTestClient(
+          baseTestClientConfig(server.wsUrl),
+        );
+        yield* server.connected;
+        return yield* body(client, server);
+      }),
+    ) as Effect.Effect<A>,
+  );
+
+const findResponse = (
+  raw: ReadonlyArray<string>,
+  id: string,
+): ResponseFrame | undefined => {
+  for (const r of raw) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(r);
+    } catch {
+      continue;
+    }
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      (parsed as { type?: unknown }).type === "response" &&
+      (parsed as { id?: unknown }).id === id
+    ) {
+      return parsed as ResponseFrame;
+    }
+  }
+  return undefined;
+};
+
+const s2cRequest = (
+  id: string,
+  method: string,
+  params: unknown,
+): RequestFrame =>
+  ({
+    type: "request",
+    jsonrpc: "2.0",
+    direction: "s2c",
+    id,
+    method,
+    params,
+  }) as RequestFrame;
+
+const waitForResponse = (
+  server: ScriptedServerHandle,
+  id: string,
+  maxMs = 2_000,
+): Effect.Effect<ResponseFrame> =>
+  Effect.gen(function* () {
+    const deadline = Date.now() + maxMs;
+    while (true) {
+      const raw = yield* server.received;
+      const found = findResponse(raw, id);
+      if (found !== undefined) return found;
+      if (Date.now() > deadline) {
+        return yield* Effect.die(
+          new Error(`waitForResponse timeout for id=${id}`),
+        );
+      }
+      yield* Effect.sleep("10 millis");
+    }
+  });
+
+describe("TestClient — handleServerRpc", () => {
+  it("dispatches an inbound s2c request to the registered handler and writes the response back", async () => {
+    await withClient((client, server) =>
+      Effect.gen(function* () {
+        yield* client.handleServerRpc("apps/onJoin", (params) =>
+          Effect.succeed({
+            ack: true,
+            saw: (params as { sessionId: string }).sessionId,
+          }),
+        );
+        yield* server.send(
+          s2cRequest("srv-1", "apps/onJoin", { sessionId: "S" }),
+        );
+        const reply = yield* waitForResponse(server, "srv-1");
+        expect(reply.direction).toBe("s2c");
+        expect(reply.error).toBeUndefined();
+        expect(reply.result).toEqual({ ack: true, saw: "S" });
+      }),
+    );
+  });
+
+  it("encodes a typed RpcResponseError from the handler as a `response` frame with `error`", async () => {
+    await withClient((client, server) =>
+      Effect.gen(function* () {
+        yield* client.handleServerRpc("apps/onClose", () =>
+          Effect.fail(
+            new RpcResponseError({
+              method: "apps/onClose",
+              requestId: "srv-2",
+              code: -32099,
+              message: "domain-rejected",
+              data: { reason: "x" },
+            }),
+          ),
+        );
+        yield* server.send(s2cRequest("srv-2", "apps/onClose", {}));
+        const reply = yield* waitForResponse(server, "srv-2");
+        expect(reply.error).toBeDefined();
+        expect(reply.error?.code).toBe(-32099);
+        expect(reply.error?.message).toBe("domain-rejected");
+        expect(reply.error?.data).toEqual({ reason: "x" });
+        expect(reply.result).toBeUndefined();
+      }),
+    );
+  });
+
+  it("rejects an unregistered method with -32601 (no handler)", async () => {
+    await withClient((_client, server) =>
+      Effect.gen(function* () {
+        yield* server.send(
+          s2cRequest("srv-3", "apps/onSessionActive", { foo: 1 }),
+        );
+        const reply = yield* waitForResponse(server, "srv-3");
+        expect(reply.error).toBeDefined();
+        expect(reply.error?.code).toBe(-32601);
+        expect(reply.error?.message).toContain("apps/onSessionActive");
+      }),
+    );
+  });
+
+  it("registration ordering: a later handleServerRpc replaces the prior handler", async () => {
+    await withClient((client, server) =>
+      Effect.gen(function* () {
+        // Both registrations target the same method. The second wins —
+        // TestClient deliberately differs from the production
+        // `MoltZapWsClient.handleServerRpc`, which raises
+        // `DuplicateServerRpcHandlerError`. Tests routinely swap handler
+        // bodies mid-scenario.
+        yield* client.handleServerRpc("apps/onJoin", () =>
+          Effect.succeed({ winner: "first" }),
+        );
+        yield* client.handleServerRpc("apps/onJoin", () =>
+          Effect.succeed({ winner: "second" }),
+        );
+        yield* server.send(s2cRequest("srv-4", "apps/onJoin", {}));
+        const reply = yield* waitForResponse(server, "srv-4");
+        expect(reply.result).toEqual({ winner: "second" });
+      }),
+    );
+  });
+});
+
+describe("TestClient — awaitServerRequest", () => {
+  it("resolves with the inbound request params and runs the handler in parallel", async () => {
+    await withClient((client, server) =>
+      Effect.gen(function* () {
+        yield* client.handleServerRpc("apps/onJoin", (params) =>
+          Effect.succeed({ saw: (params as { sessionId: string }).sessionId }),
+        );
+        // Set up the awaiter BEFORE sending the request — the awaiter
+        // notification fires from `notifyAwaiters` during `handleInbound`,
+        // which runs synchronously per inbound frame.
+        const awaitFiber = yield* Effect.fork(
+          client.awaitServerRequest("apps/onJoin"),
+        );
+        // Tiny yield so the awaiter has a chance to enrol.
+        yield* Effect.sleep("10 millis");
+        yield* server.send(
+          s2cRequest("srv-5", "apps/onJoin", { sessionId: "Z" }),
+        );
+
+        const observed = yield* awaitFiber;
+        expect(observed).toEqual({ sessionId: "Z" });
+
+        // Handler still ran — server saw the response.
+        const reply = yield* waitForResponse(server, "srv-5");
+        expect(reply.result).toEqual({ saw: "Z" });
+      }),
+    );
+  });
+
+  it("predicate selects the FIRST matching request and skips earlier non-matches", async () => {
+    await withClient((client, server) =>
+      Effect.gen(function* () {
+        yield* client.handleServerRpc("apps/onJoin", () => Effect.succeed({}));
+        // Predicate matches sessionId === "WANTED".
+        const awaitFiber = yield* Effect.fork(
+          client.awaitServerRequest(
+            "apps/onJoin",
+            (p) => (p as { sessionId?: string }).sessionId === "WANTED",
+          ),
+        );
+        yield* Effect.sleep("10 millis");
+        // Send a non-matching request first.
+        yield* server.send(
+          s2cRequest("srv-skip", "apps/onJoin", { sessionId: "OTHER" }),
+        );
+        // Then the wanted one.
+        yield* server.send(
+          s2cRequest("srv-want", "apps/onJoin", { sessionId: "WANTED" }),
+        );
+
+        const observed = yield* awaitFiber;
+        expect((observed as { sessionId: string }).sessionId).toBe("WANTED");
+      }),
+    );
+  });
+
+  it("times out with a typed Error after caller-supplied timeoutMs", async () => {
+    const exit = await withClient((client) =>
+      Effect.gen(function* () {
+        // Caller-controlled timeout. No s2c request is ever sent — the
+        // awaiter must terminate by the timeout, not hang.
+        return yield* Effect.exit(
+          client.awaitServerRequest("apps/onJoin", undefined, 50),
+        );
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const opt = Cause.failureOption(exit.cause);
+      expect(opt._tag).toBe("Some");
+      if (opt._tag === "Some") {
+        expect(opt.value).toBeInstanceOf(Error);
+        expect(opt.value.message).toMatch(/Timeout.*apps\/onJoin/);
+      }
+    }
+  });
+
+  it("respects an outer Effect.timeout wrapped at the call site (overrides built-in default)", async () => {
+    const exit = await withClient((client) =>
+      Effect.gen(function* () {
+        // Pass a generous internal timeout, then gate at the call site
+        // with a tighter Effect.timeout. The architect plan §3.6 names
+        // this as the supported pattern: "Effect.timeout at call site,
+        // not schema cap."
+        return yield* Effect.exit(
+          client.awaitServerRequest("apps/onJoin", undefined, 60_000).pipe(
+            Effect.timeoutFail({
+              duration: "30 millis",
+              onTimeout: () => new Error("call-site-timeout"),
+            }),
+          ),
+        );
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const opt = Cause.failureOption(exit.cause);
+      expect(opt._tag).toBe("Some");
+      if (opt._tag === "Some") {
+        expect(opt.value.message).toBe("call-site-timeout");
+      }
+    }
+  });
+});

--- a/packages/protocol/src/testing/test-client.ts
+++ b/packages/protocol/src/testing/test-client.ts
@@ -25,7 +25,12 @@ import {
 } from "effect";
 import * as Socket from "@effect/platform/Socket";
 import * as NodeSocket from "@effect/platform-node/NodeSocket";
-import type { RpcMap, RpcMethodName } from "../rpc-registry.js";
+import type {
+  RpcMap,
+  RpcMethodName,
+  S2cRpcMap,
+  S2cRpcMethodName,
+} from "../rpc-registry.js";
 import type { EventFrame } from "../schema/frames.js";
 import { responseFrame } from "../helpers.js";
 import { PROTOCOL_VERSION } from "../version.js";
@@ -109,44 +114,82 @@ export interface TestClient {
   ) => Effect.Effect<EventFrame, Error>;
   readonly drainEvents: Effect.Effect<ReadonlyArray<EventFrame>>;
 
-  // ── PHASE 1.6 STUBS — server-initiated RPC test surface (B.0 architect) ──
-  //
-  // `handleServerRpc(method, handler)` registers a handler for a server-
-  // initiated RPC method. When `handleInbound` (line ~181) sees a `request`
-  // frame with `direction: "s2c"`, it looks up the handler, runs it as an
-  // Effect, encodes the response, and writes back over the WS.
-  //
-  // `awaitServerRequest(method, predicate?)` lets a test inspect the inbound
-  // request payload BEFORE replying — used to assert e.g. the multi-app
-  // FIFO short-circuit (the test must verify the FIRST app's request landed
-  // and the SECOND app's did not).
-  //
-  // Implementer (B.7): the inbound dispatch in `handleInbound` currently
-  // routes only `response` and `event`. Add a third branch for
-  // `frame.type === "request"` that:
-  //   1. Looks up the registered handler by `frame.method` in a
-  //      `Ref<Map<string, Handler>>`.
-  //   2. Decodes `params` against the s2c method's params schema.
-  //   3. Runs the handler as an Effect.
-  //   4. Encodes a response frame with `direction: "s2c"` and `id =
-  //      frame.id`, writes it over the socket.
-  //   5. Records both inbound request and outbound response in `captures`.
-  //
-  // Type ergonomics: the stub uses `string` for the method name; B.7 narrows
-  // to a `S2cRpcMethodName` union once `s2cRpcMethods` exists in
-  // `rpc-registry.ts`.
-
-  readonly handleServerRpc: (
-    method: string,
-    handler: (params: unknown) => Effect.Effect<unknown, RpcResponseError>,
+  /**
+   * Register a handler for a server-initiated (`direction: "s2c"`) RPC.
+   * When `handleInbound` sees a request frame whose method matches, the
+   * handler runs and its outcome is encoded as the s2c response:
+   *   - `Effect.succeed(value)` → `{ result: value }`
+   *   - `Effect.fail(err: RpcResponseError)` → `{ error: { code, message, data? } }`
+   *   - defects collapse to a generic `-32603 InternalError` reply so the
+   *     server's `Deferred.await` cannot hang on a crashing handler.
+   *
+   * Re-registration replaces the prior handler (later wins) — mirrors
+   * `HashMap.set`. The TestClient does NOT raise on duplicates the way the
+   * production client does; tests routinely swap behaviour mid-scenario.
+   *
+   * Type narrowing: once `s2cRpcMethods` (`packages/protocol/src/rpc-registry.ts`)
+   * registers verbs in B.2, `M` constrains to the registered method names
+   * and `params`/`result` bind to `S2cRpcMap[M]`. While the registry is
+   * empty, the constraint falls through to `string` / `unknown` so callers
+   * can still drive the surface — see {@link ServerRpcMethod}.
+   */
+  readonly handleServerRpc: <M extends ServerRpcMethod>(
+    method: M,
+    handler: (
+      params: ServerRpcParams<M>,
+    ) => Effect.Effect<ServerRpcResult<M>, RpcResponseError>,
   ) => Effect.Effect<void>;
 
-  readonly awaitServerRequest: (
-    method: string,
-    predicate?: (params: unknown) => boolean,
+  /**
+   * Park until the server sends an s2c request for `method`. The handler
+   * registered via {@link handleServerRpc} (if any) still runs and replies;
+   * `awaitServerRequest` is an OBSERVATION primitive — it lets a test
+   * assert the request payload before the response goes back without
+   * stealing the dispatch.
+   *
+   * `predicate` narrows to the first request whose params satisfy it.
+   * Multiple awaiters per method form a FIFO queue (registration order).
+   *
+   * `timeoutMs` defaults to 5_000; callers wanting to drive timing
+   * themselves can pass a generous value here and gate the returned
+   * Effect with `Effect.timeout` at the call site (architect plan §3.6
+   * "Effect.timeout at call site, not schema cap").
+   */
+  readonly awaitServerRequest: <M extends ServerRpcMethod>(
+    method: M,
+    predicate?: (params: ServerRpcParams<M>) => boolean,
     timeoutMs?: number,
-  ) => Effect.Effect<unknown, Error>;
+  ) => Effect.Effect<ServerRpcParams<M>, Error>;
 }
+
+/**
+ * Method-name constraint for server-initiated RPC test surface. Narrows to
+ * the registered s2c methods (`S2cRpcMethodName`) once B.2 populates
+ * `s2cRpcMethods` in `rpc-registry.ts`. While the registry is empty, the
+ * constraint falls through to `string` so the test surface remains usable
+ * during Phase 1.0 — `[never] extends [never]` is true, but `never` as a
+ * generic constraint blocks every caller. The fallback collapses
+ * automatically the moment a verb registers.
+ */
+export type ServerRpcMethod = [S2cRpcMethodName] extends [never]
+  ? string
+  : S2cRpcMethodName;
+
+/**
+ * Inbound params type for an s2c method. Resolves to the registered
+ * params schema via `S2cRpcMap[M]["params"]` once verbs land; falls
+ * through to `unknown` for the bootstrap window — same condition as
+ * {@link ServerRpcMethod}.
+ */
+export type ServerRpcParams<M extends ServerRpcMethod> =
+  M extends S2cRpcMethodName ? S2cRpcMap[M]["params"] : unknown;
+
+/**
+ * Outbound result type for an s2c method handler. See {@link ServerRpcParams}
+ * for the bootstrap fallback rationale.
+ */
+export type ServerRpcResult<M extends ServerRpcMethod> =
+  M extends S2cRpcMethodName ? S2cRpcMap[M]["result"] : unknown;
 
 export interface CloseableTestClient extends TestClient {
   readonly close: Effect.Effect<void, never>;
@@ -204,6 +247,12 @@ export function makeTestClient(
     // `result`, typed errors encode as `error`. Defects collapse to a
     // generic InternalError reply so the server's `Deferred.await` never
     // hangs on a crashing test handler.
+    //
+    // The internal type is intentionally `unknown → unknown`: handlers
+    // registered via the typed `handleServerRpc<M>` overload are widened
+    // at the registration boundary so the dispatcher can dispatch by
+    // string method name regardless of which method-specific shape was
+    // registered. Type narrowing is restored at the public surface.
     type S2cHandler = (
       params: unknown,
     ) => Effect.Effect<unknown, RpcResponseError>;
@@ -615,23 +664,30 @@ export function makeTestClient(
         HashMap.set(m, method, handler as S2cHandler),
       );
 
-    const awaitServerRequest: TestClient["awaitServerRequest"] = (
-      method,
-      predicate,
+    const awaitServerRequest: TestClient["awaitServerRequest"] = <
+      M extends ServerRpcMethod,
+    >(
+      method: M,
+      predicate?: (params: ServerRpcParams<M>) => boolean,
       timeoutMs = 5_000,
-    ) =>
+    ): Effect.Effect<ServerRpcParams<M>, Error> =>
       Effect.gen(function* () {
         const deferred = yield* Deferred.make<unknown, Error>();
-        const entry: AwaitEntry = predicate
-          ? { predicate, deferred }
-          : { deferred };
+        const entry: AwaitEntry = {
+          deferred,
+          ...(predicate !== undefined
+            ? {
+                predicate: predicate as (params: unknown) => boolean,
+              }
+            : {}),
+        };
         yield* Ref.update(awaitersRef, (m) => {
           const bucket = HashMap.get(m, method);
           const next =
             bucket._tag === "Some" ? [...bucket.value, entry] : [entry];
           return HashMap.set(m, method, next as ReadonlyArray<AwaitEntry>);
         });
-        return yield* Deferred.await(deferred).pipe(
+        const result = yield* Deferred.await(deferred).pipe(
           Effect.timeoutFail({
             duration: Duration.millis(timeoutMs),
             onTimeout: () =>
@@ -652,6 +708,7 @@ export function makeTestClient(
               : Effect.void,
           ),
         );
+        return result as ServerRpcParams<M>;
       });
 
     const client: TestClient = {


### PR DESCRIPTION
Closes #301

**Architect plan (PLAN-APPROVED):**
- https://github.com/chughtapan/moltzap/issues/286#issuecomment-4356088436 (§3.6)

**Depends on:** B.1 / PR #295 (handleServerRpc + awaitServerRequest stubs landed string-typed; B.1 explicitly deferred type-narrowing to B.7).

## What changed

`packages/protocol/src/testing/test-client.ts` narrows the s2c test surface against `S2cRpcMap[M]`:

- `handleServerRpc<M>(method: M, handler)` and `awaitServerRequest<M>(method, predicate?, timeoutMs?)` now constrain `M` against the registered s2c method names. While `s2cRpcMethods` is empty (Phase 1.0), the constraint falls through to `string` so callers stay unblocked. The fallback collapses automatically the moment B.2 registers admission verbs — no follow-up edit needed.
- Three exported helper aliases (`ServerRpcMethod`, `ServerRpcParams<M>`, `ServerRpcResult<M>`) carry the bootstrap-aware projection so the conditional type isn't repeated at every callsite.
- Internals stay string-keyed; handlers are widened at the registration boundary so the dispatcher logic is unchanged.

Tests (`packages/protocol/src/testing/__tests__/test-client.s2c.test.ts`, 8 cases) script an in-process `@effect/platform-node` WS server and exercise the dispatcher directly — `autoConnect: false` keeps the tests independent of server-core verbs (which don't ship until B.2).

## Plan anchors

| Change | Plan anchor |
|---|---|
| Narrow `handleServerRpc<M>` against `S2cRpcMap[M]` | §3.6 stub note: "B.7 narrows to S2cRpcMethodName once s2cRpcMethods exists in rpc-registry.ts" + sub-issue acceptance §1 |
| Narrow `awaitServerRequest<M>` against `S2cRpcMap[M]["params"]` | §3.6 stub + sub-issue acceptance §2 |
| `ServerRpcMethod` / `ServerRpcParams<M>` / `ServerRpcResult<M>` aliases | §3.6 implementation note (handler params/result narrowing); bootstrap fallback documented inline |
| Test: handler registration + invocation (success + RpcResponseError) | sub-issue acceptance §4(1) |
| Test: awaitServerRequest with predicate (FIFO + filter) | sub-issue acceptance §4(2) |
| Test: awaitServerRequest internal timeoutMs (caller-controlled) | sub-issue acceptance §4(3) |
| Test: outer Effect.timeout at the call site | §3.6 "Effect.timeout at call site, not schema cap" |
| Test: unknown s2c method rejection (-32601) | sub-issue acceptance §4(4) |
| Test: registration ordering (later wins) | sub-issue acceptance §4(5) |

## Scope

- Modules touched: `packages/protocol/src/testing/test-client.ts` + a new sibling test file under `packages/protocol/src/testing/__tests__/`.
- `safer-diff-scope --head HEAD --base origin/main`: `tier: senior` (2 files, 3 exported signature changes).
- New modules: 0
- New public signatures outside the plan: 0 (the 3 helper aliases support the plan's stated narrowing; rationale documented inline)
- New deps: 0

## Tests

| Check | Result |
|---|---|
| `pnpm -r build` | green |
| `pnpm -r test` (all packages) | 11/11 packages green; protocol 100/100 (was 92/92 — +8 new) |
| `pnpm typecheck` | clean |
| `pnpm lint` | 0 errors / 0 warnings |
| `pnpm format` | clean |
| `scripts/sloppy-code-guard.sh` | clean |

## Pre-PR review passes

- `/simplify` applied — 1 finding fixed: `withClient` test helper used `as Effect.Effect<A>` cast where `Effect.orDie` is the honest answer (separate commit `simplify(B.7):` for traceability).
- `/safer:review-senior` requested in this PR.

## Confidence

**HIGH** — every edit traces to plan §3.6 or sub-issue acceptance §4; build + test + typecheck + lint + format + sloppy-code-guard all clean; type narrowing self-resolves once B.2 lands verbs (no manual follow-up needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)