### PR TITLE
[impl-staff] Phase 1.1: Admission RPC verbs + apps/attachConversation

### DIFF
--- a/packages/protocol/src/rpc-registry.ts
+++ b/packages/protocol/src/rpc-registry.ts
@@ -169,8 +169,7 @@ export const s2cRpcMethods = [
 ] as const satisfies ReadonlyArray<RpcDefinition<string, any, any>>;
 
 /**
- * Projection of `s2cRpcMethods` by wire name. Empty until Phase 1.1 verbs
- * register. The shape mirrors `RpcMap`.
+ * Projection of `s2cRpcMethods` by wire name. Shape mirrors `RpcMap`.
  */
 export type S2cRpcMap = {
   [M in (typeof s2cRpcMethods)[number] as M["name"]]: {

--- a/packages/protocol/src/rpc-registry.ts
+++ b/packages/protocol/src/rpc-registry.ts
@@ -42,6 +42,12 @@ import {
   AppsGetSession,
   AppsListSessions,
   AppsAuthorizeDispatch,
+  AppsAttachConversation,
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnSessionActive,
+  AppsOnJoin,
+  AppsOnClose,
 } from "./schema/methods/apps.js";
 import {
   SurfaceUpdate,
@@ -103,6 +109,7 @@ export const rpcMethods = [
   AppsGetSession,
   AppsListSessions,
   AppsAuthorizeDispatch,
+  AppsAttachConversation,
   // Surfaces
   SurfaceUpdate,
   SurfaceGet,
@@ -144,22 +151,22 @@ export type AnyRpcDefinition = (typeof rpcMethods)[number] &
   RpcDefinition<string, any, any>;
 
 /**
- * Server-initiated RPC manifests (server → client). Parallel to `rpcMethods`
- * for c2s. Direction-namespaced so c2s dispatch (server router) cannot
- * collide with s2c dispatch (client handler registry).
+ * Server-initiated RPC manifests (server → client). Direction-namespaced so
+ * c2s dispatch (server router) cannot collide with s2c dispatch (client
+ * handler registry); the two pools may share `id` values without confusion.
  *
- * The tuple is intentionally empty in Phase 1.0 — the primitives ship before
- * any verbs do. Phase 1.1 (B.2) populates it with the admission/lifecycle
- * verbs (`apps/onBeforeDispatch`, `apps/onBeforeMessageDelivery`,
- * `apps/onSessionActive`, `apps/onJoin`, `apps/onClose`).
- *
- * Shape parity with `rpcMethods` is load-bearing: once verbs land, callers
- * type against `S2cRpcMethodName` and `S2cRpcMap[M]`, and the `as const`
- * preserves literal names for the projection.
+ * Shape parity with `rpcMethods` is load-bearing: callers type against
+ * `S2cRpcMethodName` / `S2cRpcMap[M]`, and the `as const` preserves literal
+ * names for the projection. All entries are AWAITABLE; void-result verbs
+ * still reply (with `{}`) so the caller's `Deferred.await` can fire.
  */
-export const s2cRpcMethods = [] as const satisfies ReadonlyArray<
-  RpcDefinition<string, any, any>
->;
+export const s2cRpcMethods = [
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnSessionActive,
+  AppsOnJoin,
+  AppsOnClose,
+] as const satisfies ReadonlyArray<RpcDefinition<string, any, any>>;
 
 /**
  * Projection of `s2cRpcMethods` by wire name. Empty until Phase 1.1 verbs
@@ -174,9 +181,10 @@ export type S2cRpcMap = {
 };
 
 /**
- * `S2cRpcMethodName = never` until verbs land in `s2cRpcMethods`. Once
- * populated, every `sendRpcToClient` / `handleServerRpc` call site narrows
- * against this union.
+ * Union of every s2c method's wire name. `sendRpcToClient` / `handleServerRpc`
+ * narrow against this — adding a verb to `s2cRpcMethods` widens the union
+ * automatically; renaming the wire `name` of a manifest fails every typed
+ * call site at compile time.
  */
 export type S2cRpcMethodName = keyof S2cRpcMap;
 

--- a/packages/protocol/src/schema/methods/apps.test.ts
+++ b/packages/protocol/src/schema/methods/apps.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Schema conformance for the admission RPC verbs.
+ *
+ * AJV checks against each manifest's compiled `paramsSchema` /
+ * `resultSchema`. The verdict-shape coverage on `DispatchAdmissionDecision`
+ * itself lives in the existing `AppsAuthorizeDispatch` block in
+ * `schema/apps.test.ts`; the cases here are smoke checks that the new
+ * `AppsOnBeforeDispatch` manifest references the same shared schema.
+ */
+import { describe, it, expect } from "vitest";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import {
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnSessionActive,
+  AppsOnJoin,
+  AppsOnClose,
+  AppsAttachConversation,
+  AppsCloseSession,
+} from "./apps.js";
+import {
+  rpcMethods,
+  s2cRpcMethods,
+  type S2cRpcMethodName,
+} from "../../rpc-registry.js";
+
+const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
+
+const SESSION_ID = "550e8400-e29b-41d4-a716-446655440000";
+const APP_ID = "werewolf";
+const CONVERSATION_ID = "550e8400-e29b-41d4-a716-446655440001";
+const AGENT_ID = "550e8400-e29b-41d4-a716-446655440002";
+const MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440003";
+
+const HOOK_AGENT = { agentId: AGENT_ID, ownerId: "owner-1" };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Registry membership — direction-namespaced. Wire-name renames fail at
+// compile time; tuple membership is asserted here against `manifest.name`
+// so a manifest dropped from the wrong tuple still fails the test.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("admission RPC registration", () => {
+  it("registers the five admission/lifecycle verbs as s2c", () => {
+    const s2cNames = s2cRpcMethods.map((m) => m.name);
+    expect(s2cNames).toEqual([
+      AppsOnBeforeDispatch.name,
+      AppsOnBeforeMessageDelivery.name,
+      AppsOnSessionActive.name,
+      AppsOnJoin.name,
+      AppsOnClose.name,
+    ] satisfies S2cRpcMethodName[]);
+  });
+
+  it("registers apps/attachConversation as c2s alongside apps/closeSession", () => {
+    const c2sNames = rpcMethods.map((m) => m.name);
+    expect(c2sNames).toContain(AppsAttachConversation.name);
+    expect(c2sNames).toContain(AppsCloseSession.name);
+  });
+
+  it("does not place apps/attachConversation in the s2c tuple", () => {
+    const s2cNames = s2cRpcMethods.map((m) => m.name);
+    expect(s2cNames).not.toContain(AppsAttachConversation.name);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// apps/onBeforeDispatch — params surface; verdict union covered separately
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AppsOnBeforeDispatch", () => {
+  const validateParams = AppsOnBeforeDispatch.validateParams;
+  const validateResult = ajv.compile(AppsOnBeforeDispatch.resultSchema);
+
+  const baseParams = {
+    sessionId: SESSION_ID,
+    appId: APP_ID,
+    conversationId: CONVERSATION_ID,
+    recipient: HOOK_AGENT,
+    message: {
+      id: MESSAGE_ID,
+      senderAgentId: AGENT_ID,
+      parts: [{ type: "text", text: "hi" }],
+    },
+    attempt: 0,
+  };
+
+  it("accepts a minimal valid context", () => {
+    expect(validateParams(baseParams)).toBe(true);
+  });
+
+  it("accepts the optional pending+clock+receivedAt envelope", () => {
+    expect(
+      validateParams({
+        ...baseParams,
+        receivedAt: "2026-04-29T22:00:00.000Z",
+        clock: {
+          domainId: CONVERSATION_ID,
+          epoch: 1,
+          vector: { [AGENT_ID]: 1 },
+        },
+        pending: [
+          {
+            messageId: MESSAGE_ID,
+            conversationId: CONVERSATION_ID,
+            senderAgentId: AGENT_ID,
+            createdAt: "2026-04-29T22:00:00.000Z",
+            receivedAt: "2026-04-29T22:00:00.000Z",
+            parts: [{ type: "text", text: "older" }],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects missing required fields", () => {
+    const { sessionId: _omit, ...withoutSession } = baseParams;
+    expect(validateParams(withoutSession)).toBe(false);
+    expect(validateParams({})).toBe(false);
+  });
+
+  it("rejects negative attempt", () => {
+    expect(validateParams({ ...baseParams, attempt: -1 })).toBe(false);
+  });
+
+  // Smoke check that the result schema points at the shared
+  // `DispatchAdmissionDecision` union — full grant/deny/hold round-trip
+  // coverage lives in `schema/apps.test.ts > AppsAuthorizeDispatch`.
+  it("references the DispatchAdmissionDecision union", () => {
+    expect(
+      validateResult({ admission: { decision: "grant", leaseId: "l1" } }),
+    ).toBe(true);
+    expect(validateResult({ admission: { decision: "allow" } })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// apps/onBeforeMessageDelivery — HookResult round-trip
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AppsOnBeforeMessageDelivery", () => {
+  const validateParams = AppsOnBeforeMessageDelivery.validateParams;
+  const validateResult = ajv.compile(AppsOnBeforeMessageDelivery.resultSchema);
+
+  const baseParams = {
+    sessionId: SESSION_ID,
+    appId: APP_ID,
+    conversationId: CONVERSATION_ID,
+    sender: HOOK_AGENT,
+    message: { parts: [{ type: "text", text: "hi" }] },
+  };
+
+  it("accepts a minimal valid context", () => {
+    expect(validateParams(baseParams)).toBe(true);
+  });
+
+  it("accepts replyToId + dispatchLeaseId on the message", () => {
+    expect(
+      validateParams({
+        ...baseParams,
+        message: {
+          parts: [{ type: "text", text: "reply" }],
+          replyToId: MESSAGE_ID,
+          dispatchLeaseId: "lease-7",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects empty parts (minItems: 1)", () => {
+    expect(validateParams({ ...baseParams, message: { parts: [] } })).toBe(
+      false,
+    );
+  });
+
+  it("accepts {block: false} (passthrough verdict)", () => {
+    expect(validateResult({ block: false })).toBe(true);
+  });
+
+  it("accepts {block: true, reason} (fail-closed verdict)", () => {
+    expect(validateResult({ block: true, reason: "rate-limit" })).toBe(true);
+  });
+
+  it("accepts patch + feedback verdicts", () => {
+    expect(
+      validateResult({
+        block: false,
+        patch: { parts: [{ type: "text", text: "redacted" }] },
+        feedback: {
+          type: "warning",
+          content: { hint: "be nicer" },
+          retry: false,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects an invalid feedback type", () => {
+    expect(
+      validateResult({
+        block: false,
+        feedback: { type: "fatal", content: {} },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects additional properties (no field invention)", () => {
+    expect(validateResult({ block: false, deflect: true })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Awaitable-void lifecycle hooks — onSessionActive / onJoin / onClose share
+// the `{}` result envelope; their context shapes diverge only in field set.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const onSessionActiveParams = {
+  sessionId: SESSION_ID,
+  appId: APP_ID,
+  conversations: { town_square: CONVERSATION_ID },
+  admittedAgentIds: [AGENT_ID],
+};
+
+const onJoinParams = {
+  sessionId: SESSION_ID,
+  appId: APP_ID,
+  conversations: { town_square: CONVERSATION_ID },
+  agent: HOOK_AGENT,
+};
+
+const onCloseParams = {
+  sessionId: SESSION_ID,
+  appId: APP_ID,
+  conversations: { town_square: CONVERSATION_ID },
+  closedBy: HOOK_AGENT,
+};
+
+describe.each([
+  {
+    label: "AppsOnSessionActive",
+    manifest: AppsOnSessionActive,
+    valid: onSessionActiveParams,
+  },
+  { label: "AppsOnJoin", manifest: AppsOnJoin, valid: onJoinParams },
+  { label: "AppsOnClose", manifest: AppsOnClose, valid: onCloseParams },
+])("$label", ({ manifest, valid }) => {
+  const validateResult = ajv.compile(manifest.resultSchema);
+
+  it("accepts a minimal valid context", () => {
+    expect(manifest.validateParams(valid)).toBe(true);
+  });
+
+  it("accepts an empty result envelope (awaitable void)", () => {
+    expect(validateResult({})).toBe(true);
+  });
+
+  it("rejects extra result fields (void hook payloads are ignored, not extended)", () => {
+    expect(validateResult({ ack: true })).toBe(false);
+  });
+});
+
+describe("AppsOnJoin", () => {
+  it("rejects missing agent.ownerId", () => {
+    expect(
+      AppsOnJoin.validateParams({
+        sessionId: SESSION_ID,
+        appId: APP_ID,
+        conversations: {},
+        agent: { agentId: AGENT_ID },
+      }),
+    ).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// apps/attachConversation — c2s, void result
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AppsAttachConversation", () => {
+  const validateParams = AppsAttachConversation.validateParams;
+  const validateResult = ajv.compile(AppsAttachConversation.resultSchema);
+
+  it("accepts {sessionId, conversationId}", () => {
+    expect(
+      validateParams({
+        sessionId: SESSION_ID,
+        conversationId: CONVERSATION_ID,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects malformed sessionId", () => {
+    expect(
+      validateParams({
+        sessionId: "not-a-uuid",
+        conversationId: CONVERSATION_ID,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects missing conversationId", () => {
+    expect(validateParams({ sessionId: SESSION_ID })).toBe(false);
+  });
+
+  it("accepts an empty result envelope", () => {
+    expect(validateResult({})).toBe(true);
+  });
+});

--- a/packages/protocol/src/schema/methods/apps.ts
+++ b/packages/protocol/src/schema/methods/apps.ts
@@ -222,31 +222,21 @@ export const AppsAuthorizeDispatch = defineRpc({
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// PHASE 1.1 STUBS — admission RPC verbs (server-initiated) and apps/attachConversation.
+// Admission + lifecycle RPC verbs.
 //
-// All five s2c verbs are AWAITABLE (NOT fire-and-forget):
-//   - onBeforeDispatch / onBeforeMessageDelivery → carry verdict in result.
-//   - onSessionActive / onJoin / onClose → awaitable void; AppHost waits for
-//     completion before emitting `app/sessionReady` (per
-//     31-on-session-active.integration.test.ts:200-230) and analogous ordering
-//     for the other lifecycle hooks. Result schema = empty object so the
-//     reply round-trip happens; payload is ignored.
+// All five s2c verbs are AWAITABLE — `onSessionActive` / `onJoin` / `onClose`
+// reply with an empty object so AppHost can `Deferred.await` and apply the
+// manifest hook timeout. They are NOT fire-and-forget; `app/sessionReady`
+// delivery is gated on the `onSessionActive` reply (existing ordering
+// invariant — see `31-on-session-active.integration.test.ts:200-230`).
 //
-// VERDICT SHAPES PRESERVED — DO NOT INVENT NEW SHAPES:
-//   - `DispatchAdmissionResult` matches `app/hooks.ts:72-80` exactly:
-//     grant + leaseId + leaseTimeoutMs + dispatchMessageId | deny + reason | hold + reason.
-//     `DispatchAdmissionDecision` constant above is already that shape and
-//     is reused below by `AppsOnBeforeDispatch`.
-//   - `HookResult` matches `app/hooks.ts:34-43`: { block, reason?, patch?, feedback? }.
+// Verdict shapes mirror `packages/server/src/app/hooks.ts` verbatim — the
+// `DispatchAdmissionDecision` constant defined above (and reused here) is the
+// same union, and `HookResultSchema` matches `HookResult` field-for-field.
+// Adding a new verdict tag is a protocol change; do it in the spec, not here.
 //
-// SCHEMA REGISTRATION: implementer (B.1) adds these definitions to a NEW
-// `s2cRpcMethods` tuple parallel to `rpcMethods` in `rpc-registry.ts`, with
-// a parallel `S2cRpcMap` and `S2cRpcMethodName`. Direction-namespaced so c2s
-// dispatch (server router) cannot collide with s2c dispatch (client handler
-// registry).
-//
-// `apps/attachConversation` is c2s (client-originated) and therefore registers
-// in the existing `rpcMethods` tuple alongside `apps/closeSession` etc.
+// `apps/attachConversation` is the only c2s verb in this block and is
+// registered in the c2s `rpcMethods` tuple, not `s2cRpcMethods`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const HookSenderSchema = Type.Object(

--- a/packages/protocol/src/testing/models/dispatch.ts
+++ b/packages/protocol/src/testing/models/dispatch.ts
@@ -237,6 +237,7 @@ export function applyCall<M extends RpcMethodName>(
     case "apps/getSession":
     case "apps/listSessions":
     case "apps/authorizeDispatch":
+    case "apps/attachConversation":
       return { next: baseNext, outcome: uncertainError() };
 
     // Surfaces — require surface/app context. Uncertain.

--- a/packages/protocol/src/validators.ts
+++ b/packages/protocol/src/validators.ts
@@ -58,6 +58,7 @@ import {
   AppsGetSession,
   AppsListSessions,
   AppsAuthorizeDispatch,
+  AppsAttachConversation,
 } from "./schema/methods/apps.js";
 import { SystemPing } from "./schema/methods/system.js";
 
@@ -142,6 +143,7 @@ export const validators = {
   appsGetSessionParams: AppsGetSession.validateParams,
   appsListSessionsParams: AppsListSessions.validateParams,
   appsAuthorizeDispatchParams: AppsAuthorizeDispatch.validateParams,
+  appsAttachConversationParams: AppsAttachConversation.validateParams,
 
   // System.
   systemPingParams: SystemPing.validateParams,


### PR DESCRIPTION
Closes chughtapan/moltzap#300 (B.2)
Parent epic: chughtapan/moltzap-arena#198 (decomposition row B.2)
Architect plan: chughtapan/moltzap#286 (plan-approved, codex round-2 approve)
Depends on: B.1 (PR #295, merged to main via #290 at 23:10:29Z) ✓

## What changed

Wire the six admission/lifecycle RPC manifests into the protocol registry on top of B.1's s2c primitives. The architect stub already authored the schema bodies in `packages/protocol/src/schema/methods/apps.ts`; this PR registers them, tightens the comment headers, and adds a schema-conformance test file.

Five s2c verbs join `s2cRpcMethods` (parallel to the c2s `rpcMethods`):
- `apps/onBeforeDispatch` — `DispatchAdmissionResult` (grant | deny | hold)
- `apps/onBeforeMessageDelivery` — `HookResult` (block | patch | feedback)
- `apps/onSessionActive` — awaitable void; gates `app/sessionReady` ordering (`31-on-session-active.integration.test.ts:200-230`)
- `apps/onJoin` — awaitable void
- `apps/onClose` — awaitable void

One c2s verb joins `rpcMethods`:
- `apps/attachConversation` — `{ sessionId, conversationId } → {}` (errors map to `SessionNotFound | ConversationNotFound | NotAuthorized` via the existing `RpcResponseError`; AppHost wiring is B.3).

Verdict shapes round-trip the existing `DispatchAdmissionResult` and `HookResult` types from `packages/server/src/app/hooks.ts:60-95` verbatim — no new verdict tags. Awaitable-void hooks reply with `{}` so AppHost's `Deferred.await` can fire and `Effect.timeout(manifestMs)` can apply (NOT fire-and-forget).

Adds the `apps/attachConversation` case to the reference-model `applyCall` exhaustive switch (`packages/protocol/src/testing/models/dispatch.ts:240`) so the `_exhaustive: never` guard remains green.

## Traceability

| New artifact | Kind | Spec / plan anchor |
|---|---|---|
| `s2cRpcMethods` populated with 5 admission/lifecycle manifests | registry | architect plan §3.2 + sub-issue #300 acceptance 1-5 |
| `apps/attachConversation` added to `rpcMethods` (c2s) | registry | architect plan §3.2 + sub-issue #300 acceptance 6 |
| `BeforeDispatchContextSchema`, `BeforeMessageDeliveryContextSchema`, `OnJoinContextSchema`, `OnCloseContextSchema`, `OnSessionActiveContextSchema`, `HookResultSchema` references in `apps.ts` (architect-authored, comment header tightened) | schemas | architect plan §3.2; verdict shapes mirror `app/hooks.ts:60-95` |
| `applyCall` switch case for `apps/attachConversation` | reference-model | preserves `_exhaustive: never` invariant in `dispatch.ts:253` |
| `packages/protocol/src/schema/methods/apps.test.ts` | tests | architect plan §7 row "Conformance suite cleanup" (minimum schema-conformance for new verbs) |

Every line traces. No spec revisions. No unanchored refactors of pre-existing code.

## Scope

- New modules: 0 (extensions to existing `@moltzap/protocol` files only)
- New public exports: 0 net (manifests `AppsOnBeforeDispatch` etc. were already authored by the architect stub; this PR wires them into the registry)
- New deps: 0
- Tier (from `safer-diff-scope`): staff — schema/registry surface for the new verbs is the public protocol contract for B.3 / B.5

## Verification

| Check | Result |
|---|---|
| `pnpm -r build` | green (10 packages) |
| `pnpm -r test` | green — protocol 122/122, server 142/142, client 231 + 6 todo, app-sdk 52/52, channels 145/145, runtimes 31/31 |
| `pnpm typecheck` | clean |
| `pnpm lint` | 0 errors / 0 warnings |
| `pnpm format:check` | clean |
| `bash scripts/sloppy-code-guard.sh` | all guards passed |

## Pre-PR review passes (orchestrator-mandatory)

### `/simplify` — applied
Three-agent fan-out (reuse / quality / efficiency). Findings applied:
- **Quality**: dropped forward-reference task narration ("B.3 is...", "B.5 is...") from comment headers in `apps.ts`, `rpc-registry.ts`, and the test file — kept only the WHY (awaitable-void invariant + verdict-shape preservation).
- **Quality**: collapsed three near-identical `describe` blocks for `AppsOnSessionActive`, `AppsOnJoin`, `AppsOnClose` into a single `describe.each` parameterized by `(manifest, validParams)`, plus a small standalone case for `AppsOnJoin`'s `agent.ownerId` requirement.
- **Quality**: replaced stringly-typed wire-name literals (`"apps/attachConversation"`, `"apps/onBeforeDispatch"`) with `manifest.name` references so a manifest rename fails the test, not just the registry.
- **Efficiency**: replaced six redundant `ajv.compile(M.paramsSchema)` calls with `M.validateParams` (each manifest already exposes a pre-compiled validator from `defineRpc()` — `rpc.ts:58`).
- **Reuse**: dropped redundant grant/deny/hold round-trip cases on `AppsOnBeforeDispatch.resultSchema` since the same `DispatchAdmissionDecision` union is fully covered by the existing `AppsAuthorizeDispatch` block in `schema/apps.test.ts:162-218`. Kept one positive smoke check + one `decision: "allow"` rejection.

No skipped findings.

### `/safer:review-senior` — applied (self-review at https://github.com/chughtapan/moltzap/pull/303#pullrequestreview)
- COMMENT verdict (GitHub blocks self-approval; same convention as PR #295).
- One nit (N1: stale `S2cRpcMap` doc) applied at 988c880.
- No P1/P2 findings.

### `/codex review` — applied at 988c880
- VERDICT: REQUEST_CHANGES → P2 applied.
- Missing `appsAttachConversationParams` in legacy `validators` table re-export. Fixed in 988c880.
Will be appended once the codex pass completes.

## Out of scope

- AppHost remote-app routing (B.3 — issue #301)
- Webhook deletion (B.4 — issue #302)
- App-sdk handler surface `MoltZapApp.onBeforeDispatch` etc. (B.5 — issue #303)
- TestClient handleServerRpc + awaitServerRequest (B.7 — separate sub-issue)
- Server integration tests for RPC admission (B.9)

## Confidence

**HIGH** — every artifact traces to an architect plan section or sub-issue acceptance line; verdict shapes preserved verbatim; no new deps; lint/typecheck/format/build/test all green; rebased onto main after B.1 landed at 23:10Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)