### PR TITLE
fix(server): trace blocked message hooks

### DIFF
--- a/packages/server/src/__tests__/integration/36-trace-capture.integration.test.ts
+++ b/packages/server/src/__tests__/integration/36-trace-capture.integration.test.ts
@@ -7,19 +7,26 @@ import {
   stopTestServer,
   resetTestDb,
   registerAndConnect,
+  getKyselyDb,
+  type ConnectedAgent,
 } from "./helpers.js";
 import {
   InMemoryTraceCaptureLive,
   type TraceCapture,
 } from "../../runtime-surface/trace-capture.js";
+import type { CoreApp } from "../../app/types.js";
+import { ErrorCodes } from "@moltzap/protocol";
+import { expectRpcFailure } from "../../test-utils/index.js";
 
 let traceCapture: TraceCapture;
+let coreApp: CoreApp;
 
 beforeAll(async () => {
   const server = await startTestServer({
     traceCaptureLayer: InMemoryTraceCaptureLive,
   });
   traceCapture = server.coreApp.traceCapture;
+  coreApp = server.coreApp;
 }, 60_000);
 
 afterAll(async () => {
@@ -30,6 +37,35 @@ beforeEach(async () => {
   await resetTestDb();
   await Effect.runPromise(traceCapture.clear());
 });
+
+function registerAppAgent(name: string): Effect.Effect<ConnectedAgent, Error> {
+  return Effect.gen(function* () {
+    const agent = yield* registerAndConnect(name);
+    const db = getKyselyDb();
+    yield* Effect.tryPromise(() =>
+      db
+        .updateTable("agents")
+        .set({ owner_user_id: crypto.randomUUID() })
+        .where("id", "=", agent.agentId)
+        .execute(),
+    );
+    return agent;
+  });
+}
+
+function registerTestApp(appId: string): void {
+  coreApp.registerApp({
+    appId,
+    name: `Trace Test App ${appId}`,
+    permissions: { required: [], optional: [] },
+    conversations: [
+      { key: "main", name: "Main Channel", participantFilter: "all" },
+    ],
+    hooks: {
+      before_message_delivery: { timeout_ms: 5000 },
+    },
+  });
+}
 
 describe("trace capture", () => {
   it.live("records delivered messages through the server DI capture", () =>
@@ -65,6 +101,50 @@ describe("trace capture", () => {
 
       yield* alice.client.close();
       yield* bob.client.close();
+    }),
+  );
+
+  it.live("records blocked before_message_delivery hooks", () =>
+    Effect.gen(function* () {
+      const appId = "trace-hook-blocker";
+      const orchestrator = yield* registerAppAgent("trace-hook-orchestrator");
+
+      registerTestApp(appId);
+      coreApp.onBeforeMessageDelivery(appId, () => ({
+        block: true,
+        reason: "trace_blocked_command",
+      }));
+
+      const session = (yield* orchestrator.client.sendRpc("apps/create", {
+        appId,
+        invitedAgentIds: [],
+      })) as {
+        session: { conversations: Record<string, string> };
+      };
+      const conversationId = session.session.conversations["main"]!;
+
+      yield* expectRpcFailure(
+        orchestrator.client.sendRpc("messages/send", {
+          conversationId,
+          parts: [{ type: "text", text: "bad command for trace" }],
+        }),
+        ErrorCodes.HookBlocked,
+      );
+
+      const events = yield* traceCapture.snapshot();
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        _tag: "HookBlocked",
+        hookName: "before_message_delivery",
+        conversationId,
+        channelKey: "main",
+        senderAgentId: orchestrator.agentId,
+        senderDisplayName: orchestrator.name,
+        reason: "trace_blocked_command",
+        parts: [{ type: "text", text: "bad command for trace" }],
+      });
+
+      yield* orchestrator.client.close();
     }),
   );
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -90,6 +90,7 @@ export type {
 export type {
   TraceCapture,
   TraceEvent,
+  TraceHookBlockedEvent,
   TraceMessageEvent,
 } from "./runtime-surface/trace-capture.js";
 

--- a/packages/server/src/runtime-surface/trace-capture.ts
+++ b/packages/server/src/runtime-surface/trace-capture.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer, Ref } from "effect";
-import type { Message } from "@moltzap/protocol";
+import type { Message, Part } from "@moltzap/protocol";
 
 export interface TraceMessageEvent {
   readonly _tag: "Message";
@@ -10,7 +10,19 @@ export interface TraceMessageEvent {
   readonly deliveredAgentIds: readonly string[];
 }
 
-export type TraceEvent = TraceMessageEvent;
+export interface TraceHookBlockedEvent {
+  readonly _tag: "HookBlocked";
+  readonly hookName: "before_message_delivery";
+  readonly conversationId: string;
+  readonly channelKey: string;
+  readonly senderAgentId: string;
+  readonly senderDisplayName: string;
+  readonly reason: string;
+  readonly parts: readonly Part[];
+  readonly createdAt: string;
+}
+
+export type TraceEvent = TraceMessageEvent | TraceHookBlockedEvent;
 
 export interface TraceCapture {
   record(event: TraceEvent): Effect.Effect<void, never, never>;

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -129,6 +129,28 @@ export class MessageService {
             dispatchLeaseId,
           );
           if (hookResponse?.result.block) {
+            const traceCapture = this.traceCapture;
+            if (traceCapture) {
+              yield* this.getTraceMessageMetadata(
+                conversationId,
+                senderAgentId,
+              ).pipe(
+                Effect.flatMap((traceMetadata) =>
+                  traceCapture.record({
+                    _tag: "HookBlocked",
+                    hookName: "before_message_delivery",
+                    conversationId,
+                    channelKey: traceMetadata.channelKey,
+                    senderAgentId,
+                    senderDisplayName: traceMetadata.senderDisplayName,
+                    reason: hookResponse.result.reason ?? "Blocked by app",
+                    parts,
+                    createdAt: new Date().toISOString(),
+                  }),
+                ),
+                Effect.catchAll(() => Effect.void),
+              );
+            }
             return yield* Effect.fail(
               new RpcFailure({
                 code: ErrorCodes.HookBlocked,


### PR DESCRIPTION
## Summary
- add HookBlocked trace events for before_message_delivery blocks
- record hook block reason, sender, channel key, message parts, and timestamp in MessageService
- add integration coverage proving blocked sends are visible through TraceCapture

## Verification
- pnpm --dir lib/moltzap --filter @moltzap/server-core exec tsc --noEmit
- pnpm --dir lib/moltzap --filter @moltzap/server-core test:integration -- src/__tests__/integration/36-trace-capture.integration.test.ts

Note: the second command ran the full server-core integration suite under the current Vitest config: 33 files, 124 tests passed.