### PR TITLE
[impl-staff] Phase 1.2: AppHost remote-app routing (uniform Effect surface)

### DIFF
--- a/packages/server/src/app/app-host.remote.test.ts
+++ b/packages/server/src/app/app-host.remote.test.ts
@@ -1,0 +1,882 @@
+/**
+ * Phase 1.2 (B.3) gating tests for the AppHost remote-app routing
+ * surface (architect plan §3.4). These tests exercise the
+ * `registerRemoteApp` / `unregisterRemoteApp` registration shape and
+ * each per-hook dispatch path's behaviour against a mocked
+ * `MoltZapConnection` + `ConnectionManager`. Wire-level coverage of
+ * `sendRpcToClient` itself lives in `ws/connection.s2c.test.ts`; this
+ * file tests the AppHost-side composition (timeout envelope, fail-closed
+ * mapping, hookTimeout event emission, multi-app deny short-circuit).
+ *
+ * Running against `MoltZapConnection` directly (no testcontainers, no
+ * real WS) keeps the tests pure-Effect — `TestClock`-drivable, no real
+ * sleeps. The connection's `write` records outbound frames; the test
+ * synthesizes inbound responses by calling `completeS2cResponse` (the
+ * same path the server's read fiber uses).
+ */
+import { describe, expect, it } from "vitest";
+import { it as itEffect } from "@effect/vitest";
+import {
+  Cause,
+  Deferred,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  HashMap,
+  Ref,
+  Scope,
+  TestClock,
+} from "effect";
+import type { Kysely } from "kysely";
+import type { AppManifest } from "@moltzap/protocol";
+import {
+  acquireS2cConnectionState,
+  completeS2cResponse,
+  ConnectionManager,
+  type MoltZapConnection,
+} from "../ws/connection.js";
+import type { Database } from "../db/database.js";
+import type { Broadcaster } from "../ws/broadcaster.js";
+import { makeFakeService } from "../test-utils/fakes.js";
+import { AppHost } from "./app-host.js";
+import type {
+  BeforeDispatchContext,
+  BeforeMessageDeliveryContext,
+  OnCloseContext,
+  OnJoinContext,
+  OnSessionActiveContext,
+} from "./hooks.js";
+
+// ─────────────────────────────────────────────────────────────────────
+// Test fixtures
+// ─────────────────────────────────────────────────────────────────────
+
+const noopShutdown: MoltZapConnection["shutdown"] = Effect.void;
+
+interface FakeConn {
+  readonly conn: MoltZapConnection;
+  readonly outbound: Ref.Ref<ReadonlyArray<string>>;
+}
+
+/**
+ * Build a real {@link MoltZapConnection} whose `write` records outbound
+ * frames into a Ref. Caller can `JSON.parse` the captured frame to get
+ * the request id, then synthesize a matching response via
+ * `completeS2cResponse`. The Scope finalizer wires `AppDisconnected` —
+ * close the surrounding scope to drive the disconnect path.
+ */
+const makeFakeConnection = (
+  connId: string,
+): Effect.Effect<FakeConn, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const outbound = yield* Ref.make<ReadonlyArray<string>>([]);
+    const state = yield* acquireS2cConnectionState(connId);
+    const write: MoltZapConnection["write"] = (raw) =>
+      Ref.update(outbound, (xs) => [...xs, raw]);
+    const conn: MoltZapConnection = {
+      id: connId,
+      write,
+      shutdown: noopShutdown,
+      auth: null,
+      lastPong: Date.now(),
+      conversationIds: new Set<string>(),
+      mutedConversations: new Set<string>(),
+      s2cPending: state.s2cPending,
+      s2cRequestCounter: state.s2cRequestCounter,
+    };
+    return { conn, outbound };
+  });
+
+interface AppHostFixture {
+  readonly host: AppHost;
+  readonly connections: ConnectionManager;
+  readonly sentEvents: Array<{ agentId: string; event: unknown }>;
+}
+
+/**
+ * Build an AppHost with a real {@link ConnectionManager} (so registered
+ * remote-app connections route correctly) and fake services for every
+ * dependency that the dispatch helpers do not touch.
+ */
+function makeAppHostFixture(): AppHostFixture {
+  const sentEvents: Array<{ agentId: string; event: unknown }> = [];
+  const broadcaster = makeFakeService<Broadcaster>({
+    sendToAgent: (agentId: string, event: unknown) => {
+      sentEvents.push({ agentId, event });
+    },
+  } as Partial<Broadcaster>);
+  const connections = new ConnectionManager();
+  const db = makeFakeService<Kysely<Database>>({} as Partial<Kysely<Database>>);
+  const inflightPermissions = Effect.runSync(
+    Ref.make(HashMap.empty<string, Deferred.Deferred<string[], Error>>()),
+  );
+  const host = new AppHost(
+    db,
+    broadcaster,
+    connections,
+    null,
+    inflightPermissions,
+  );
+  return { host, connections, sentEvents };
+}
+
+const baseManifest = (appId: string, hookTimeoutMs?: number): AppManifest => ({
+  appId,
+  name: `Test App ${appId}`,
+  permissions: { required: [], optional: [] },
+  conversations: [],
+  hooks: hookTimeoutMs
+    ? {
+        before_dispatch: { timeout_ms: hookTimeoutMs },
+        before_message_delivery: { timeout_ms: hookTimeoutMs },
+        on_session_active: { timeout_ms: hookTimeoutMs },
+        on_join: { timeout_ms: hookTimeoutMs },
+        on_close: { timeout_ms: hookTimeoutMs },
+      }
+    : undefined,
+});
+
+const baseBeforeDispatchCtx = (
+  appId: string,
+  sessionId: string,
+): BeforeDispatchContext => ({
+  conversationId: "conv-1",
+  recipient: { agentId: "agent-recipient", ownerId: "owner-r" },
+  message: { id: "msg-1", senderAgentId: "agent-sender" },
+  sessionId,
+  appId,
+  attempt: 0,
+  signal: new AbortController().signal,
+});
+
+const baseBeforeMessageDeliveryCtx = (
+  appId: string,
+  sessionId: string,
+): BeforeMessageDeliveryContext => ({
+  conversationId: "conv-1",
+  sender: { agentId: "agent-sender", ownerId: "owner-s" },
+  message: { parts: [{ type: "text", text: "hi" }] },
+  sessionId,
+  appId,
+  signal: new AbortController().signal,
+});
+
+const baseOnSessionActiveCtx = (
+  appId: string,
+  sessionId: string,
+): OnSessionActiveContext => ({
+  sessionId,
+  appId,
+  conversations: { main: "conv-1" },
+  admittedAgentIds: ["agent-1"],
+  signal: new AbortController().signal,
+});
+
+const baseOnJoinCtx = (appId: string, sessionId: string): OnJoinContext => ({
+  sessionId,
+  appId,
+  conversations: { main: "conv-1" },
+  agent: { agentId: "agent-joiner", ownerId: "owner-j" },
+});
+
+const baseOnCloseCtx = (appId: string, sessionId: string): OnCloseContext => ({
+  sessionId,
+  appId,
+  conversations: { main: "conv-1" },
+  closedBy: { agentId: "agent-closer", ownerId: "owner-c" },
+  signal: new AbortController().signal,
+});
+
+/** Decode the most recently captured outbound frame from a fake connection. */
+function captureLatestRequestId(
+  outbound: Ref.Ref<ReadonlyArray<string>>,
+): Effect.Effect<string, Error> {
+  return Effect.gen(function* () {
+    const xs = yield* Ref.get(outbound);
+    if (xs.length === 0) {
+      return yield* Effect.fail(new Error("no outbound frame yet"));
+    }
+    const frame = JSON.parse(xs[xs.length - 1]!) as { id: string };
+    return frame.id;
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Registration surface
+// ─────────────────────────────────────────────────────────────────────
+
+describe("AppHost.registerRemoteApp", () => {
+  it("records the remote-app source keyed by appId", () => {
+    const { host } = makeAppHostFixture();
+    host.registerRemoteApp(baseManifest("app-r"), "conn-1");
+
+    // Inspect via private state — the public observation surface is
+    // the dispatch path, exercised in the dispatch suites below.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = (host as any).remoteRegistrations as Map<
+      string,
+      { connectionId: string }
+    >;
+    expect(map.get("app-r")).toEqual({ connectionId: "conn-1" });
+  });
+
+  it("stores the manifest verbatim (so dispatch can read timeout_ms)", () => {
+    const { host } = makeAppHostFixture();
+    const manifest = baseManifest("app-m", 1234);
+    host.registerRemoteApp(manifest, "conn-1");
+    expect(host.getManifest("app-m")).toBe(manifest);
+  });
+
+  it("re-registration overwrites the prior connection", () => {
+    const { host } = makeAppHostFixture();
+    host.registerRemoteApp(baseManifest("app-r"), "conn-1");
+    host.registerRemoteApp(baseManifest("app-r"), "conn-2");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = (host as any).remoteRegistrations as Map<
+      string,
+      { connectionId: string }
+    >;
+    expect(map.get("app-r")).toEqual({ connectionId: "conn-2" });
+  });
+});
+
+describe("AppHost.unregisterRemoteApp", () => {
+  it("drops the routing entry; manifest stays", () => {
+    const { host } = makeAppHostFixture();
+    const manifest = baseManifest("app-r");
+    host.registerRemoteApp(manifest, "conn-1");
+    host.unregisterRemoteApp("app-r");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = (host as any).remoteRegistrations as Map<string, unknown>;
+    expect(map.has("app-r")).toBe(false);
+    expect(host.getManifest("app-r")).toBe(manifest);
+  });
+
+  it("is idempotent for unknown appIds", () => {
+    const { host } = makeAppHostFixture();
+    expect(() => host.unregisterRemoteApp("never-registered")).not.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// before_dispatch — remote round-trip + fail-closed paths
+// ─────────────────────────────────────────────────────────────────────
+
+describe("AppHost remote dispatch — apps/onBeforeDispatch", () => {
+  it("happy: remote replies with grant verdict; envelope passes through", async () => {
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const fixture = makeAppHostFixture();
+      const { conn, outbound } = yield* Scope.extend(
+        makeFakeConnection("conn-rd-1"),
+        scope,
+      );
+      fixture.connections.add(conn);
+      fixture.host.registerRemoteApp(baseManifest("app-r"), "conn-rd-1");
+
+      // Drive `dispatchBeforeDispatchHook` directly — it's the uniform
+      // surface that `runBeforeDispatch` calls. Keeps the test free of
+      // DB / conversation-mapping setup.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (fixture.host as any).dispatchBeforeDispatchHook.bind(
+        fixture.host,
+      ) as (
+        appId: string,
+        ctx: BeforeDispatchContext,
+      ) => Effect.Effect<unknown, never>;
+
+      const fiber = yield* Effect.fork(
+        dispatch("app-r", baseBeforeDispatchCtx("app-r", "sess-1")),
+      );
+      // Yield repeatedly so the fork's inner write lands.
+      const id = yield* captureLatestRequestId(outbound).pipe(
+        Effect.retry({ times: 50, schedule: undefined }),
+      );
+
+      yield* completeS2cResponse(conn, {
+        jsonrpc: "2.0",
+        type: "response",
+        direction: "s2c",
+        id,
+        result: {
+          admission: { decision: "grant", leaseId: "lease-1" },
+        },
+      });
+
+      const verdict = yield* Fiber.join(fiber);
+      yield* Scope.close(scope, Exit.void);
+      return verdict;
+    });
+
+    const result = await Effect.runPromise(program);
+    expect(result).toEqual({ decision: "grant", leaseId: "lease-1" });
+  });
+
+  it("happy: remote deny verdict propagates verbatim", async () => {
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const fixture = makeAppHostFixture();
+      const { conn, outbound } = yield* Scope.extend(
+        makeFakeConnection("conn-rd-deny"),
+        scope,
+      );
+      fixture.connections.add(conn);
+      fixture.host.registerRemoteApp(baseManifest("app-r"), "conn-rd-deny");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (fixture.host as any).dispatchBeforeDispatchHook.bind(
+        fixture.host,
+      ) as (
+        appId: string,
+        ctx: BeforeDispatchContext,
+      ) => Effect.Effect<unknown, never>;
+
+      const fiber = yield* Effect.fork(
+        dispatch("app-r", baseBeforeDispatchCtx("app-r", "sess-d")),
+      );
+      const id = yield* captureLatestRequestId(outbound).pipe(
+        Effect.retry({ times: 50, schedule: undefined }),
+      );
+      yield* completeS2cResponse(conn, {
+        jsonrpc: "2.0",
+        type: "response",
+        direction: "s2c",
+        id,
+        result: {
+          admission: { decision: "deny", reason: "policy/x" },
+        },
+      });
+      const verdict = yield* Fiber.join(fiber);
+      yield* Scope.close(scope, Exit.void);
+      return verdict;
+    });
+    const result = await Effect.runPromise(program);
+    expect(result).toEqual({ decision: "deny", reason: "policy/x" });
+  });
+
+  it("missing-connection: stale registration → fail-closed deny", async () => {
+    const program = Effect.gen(function* () {
+      const fixture = makeAppHostFixture();
+      // Register with a connection ID that was never `connections.add()`'d —
+      // the dispatch helper resolves `connections.get(connId) === undefined`
+      // and folds into the fail-closed branch.
+      fixture.host.registerRemoteApp(baseManifest("app-r"), "no-such-conn");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (fixture.host as any).dispatchBeforeDispatchHook.bind(
+        fixture.host,
+      ) as (
+        appId: string,
+        ctx: BeforeDispatchContext,
+      ) => Effect.Effect<unknown, never>;
+
+      return yield* dispatch(
+        "app-r",
+        baseBeforeDispatchCtx("app-r", "sess-stale"),
+      );
+    });
+    const result = await Effect.runPromise(program);
+    expect(result).toEqual({
+      decision: "deny",
+      reason: "before_dispatch hook error",
+    });
+  });
+
+  it("disconnect mid-flight: scope close → fail-closed deny", async () => {
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const fixture = makeAppHostFixture();
+      const { conn } = yield* Scope.extend(
+        makeFakeConnection("conn-rd-drop"),
+        scope,
+      );
+      fixture.connections.add(conn);
+      fixture.host.registerRemoteApp(baseManifest("app-r"), "conn-rd-drop");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (fixture.host as any).dispatchBeforeDispatchHook.bind(
+        fixture.host,
+      ) as (
+        appId: string,
+        ctx: BeforeDispatchContext,
+      ) => Effect.Effect<unknown, never>;
+
+      const fiber = yield* Effect.fork(
+        dispatch("app-r", baseBeforeDispatchCtx("app-r", "sess-drop")),
+      );
+      // Tear down the connection scope before any response arrives.
+      // The Scope finalizer fails the pending Deferred with
+      // `AppDisconnected`; the dispatch envelope catches it and returns
+      // fail-closed deny.
+      yield* Effect.yieldNow();
+      yield* Scope.close(scope, Exit.void);
+      const verdict = yield* Fiber.join(fiber);
+      return verdict;
+    });
+    const result = await Effect.runPromise(program);
+    expect(result).toEqual({
+      decision: "deny",
+      reason: "before_dispatch hook error",
+    });
+  });
+
+  it("decode failure: malformed verdict from remote → fail-closed deny", async () => {
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const fixture = makeAppHostFixture();
+      const { conn, outbound } = yield* Scope.extend(
+        makeFakeConnection("conn-rd-decode"),
+        scope,
+      );
+      fixture.connections.add(conn);
+      fixture.host.registerRemoteApp(baseManifest("app-r"), "conn-rd-decode");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (fixture.host as any).dispatchBeforeDispatchHook.bind(
+        fixture.host,
+      ) as (
+        appId: string,
+        ctx: BeforeDispatchContext,
+      ) => Effect.Effect<unknown, never>;
+
+      const fiber = yield* Effect.fork(
+        dispatch("app-r", baseBeforeDispatchCtx("app-r", "sess-dec")),
+      );
+      const id = yield* captureLatestRequestId(outbound).pipe(
+        Effect.retry({ times: 50, schedule: undefined }),
+      );
+      // Reply with a payload that does not match the envelope schema.
+      yield* completeS2cResponse(conn, {
+        jsonrpc: "2.0",
+        type: "response",
+        direction: "s2c",
+        id,
+        result: { wrongShape: "nope" },
+      });
+      const verdict = yield* Fiber.join(fiber);
+      yield* Scope.close(scope, Exit.void);
+      return verdict;
+    });
+    const result = await Effect.runPromise(program);
+    expect(result).toEqual({
+      decision: "deny",
+      reason: "before_dispatch hook error",
+    });
+  });
+
+  itEffect(
+    "timeout: manifest timeout fires → fail-closed deny + emits app/hookTimeout",
+    () =>
+      Effect.gen(function* () {
+        const fixture = makeAppHostFixture();
+        // Use a real (Scope-managed) connection but never settle the
+        // pending Deferred. The TestClock advances time; the dispatch
+        // envelope's Effect.timeout catches `TimeoutException`.
+        const setup = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { conn } = yield* makeFakeConnection("conn-rd-tout");
+            fixture.connections.add(conn);
+            return conn.id;
+          }),
+        ).pipe(Effect.fork);
+        // Re-acquire under a longer-lived scope: the disconnect path
+        // would short-circuit our timeout assertion. Instead, register
+        // a fresh connection in a fresh scope kept alive for the test.
+        yield* Fiber.interrupt(setup);
+
+        // Long-lived scoped connection.
+        const longScope = yield* Scope.make();
+        const conn2 = yield* Scope.extend(
+          makeFakeConnection("conn-rd-tout-2"),
+          longScope,
+        ).pipe(Effect.map((s) => s.conn));
+        fixture.connections.add(conn2);
+        fixture.host.registerRemoteApp(
+          baseManifest("app-r", 200),
+          "conn-rd-tout-2",
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const dispatch = (fixture.host as any).dispatchBeforeDispatchHook.bind(
+          fixture.host,
+        ) as (
+          appId: string,
+          ctx: BeforeDispatchContext,
+        ) => Effect.Effect<unknown, never>;
+
+        const fiber = yield* Effect.fork(
+          dispatch("app-r", baseBeforeDispatchCtx("app-r", "sess-tout")),
+        );
+        // Let the request frame land and the Deferred park.
+        yield* Effect.yieldNow();
+        // Drive the manifest timeout under TestClock.
+        yield* TestClock.adjust(Duration.millis(250));
+        const verdict = yield* Fiber.join(fiber);
+
+        expect(verdict).toEqual({
+          decision: "deny",
+          reason: "before_dispatch hook timed out",
+        });
+        // app/hookTimeout event fired against the recipient.
+        const hookTimeoutEvents = fixture.sentEvents.filter(
+          (e) => (e.event as { event?: string }).event === "app/hookTimeout",
+        );
+        expect(hookTimeoutEvents.length).toBeGreaterThan(0);
+        const ev = hookTimeoutEvents[0]!;
+        expect(ev.agentId).toBe("agent-recipient");
+        expect((ev.event as { data: { hookName: string } }).data.hookName).toBe(
+          "before_dispatch",
+        );
+
+        yield* Scope.close(longScope, Exit.void);
+      }),
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// before_message_delivery — fail-CLOSED to block: true
+// ─────────────────────────────────────────────────────────────────────
+
+describe("AppHost remote dispatch — apps/onBeforeMessageDelivery", () => {
+  it("happy: remote replies with non-blocking HookResult", async () => {
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const fixture = makeAppHostFixture();
+      const { conn, outbound } = yield* Scope.extend(
+        makeFakeConnection("conn-bmd"),
+        scope,
+      );
+      fixture.connections.add(conn);
+      fixture.host.registerRemoteApp(baseManifest("app-bmd"), "conn-bmd");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (
+        fixture.host as any
+      ).dispatchBeforeMessageDeliveryHook.bind(fixture.host) as (
+        appId: string,
+        ctx: BeforeMessageDeliveryContext,
+      ) => Effect.Effect<unknown, never>;
+
+      const fiber = yield* Effect.fork(
+        dispatch("app-bmd", baseBeforeMessageDeliveryCtx("app-bmd", "sess-1")),
+      );
+      const id = yield* captureLatestRequestId(outbound).pipe(
+        Effect.retry({ times: 50, schedule: undefined }),
+      );
+      yield* completeS2cResponse(conn, {
+        jsonrpc: "2.0",
+        type: "response",
+        direction: "s2c",
+        id,
+        result: { block: false },
+      });
+      const result = yield* Fiber.join(fiber);
+      yield* Scope.close(scope, Exit.void);
+      return result;
+    });
+    expect(await Effect.runPromise(program)).toEqual({ block: false });
+  });
+
+  it("missing-connection: stale registration → fail-closed block: true", async () => {
+    const program = Effect.gen(function* () {
+      const fixture = makeAppHostFixture();
+      fixture.host.registerRemoteApp(baseManifest("app-bmd"), "no-conn");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (
+        fixture.host as any
+      ).dispatchBeforeMessageDeliveryHook.bind(fixture.host) as (
+        appId: string,
+        ctx: BeforeMessageDeliveryContext,
+      ) => Effect.Effect<unknown, never>;
+
+      return yield* dispatch(
+        "app-bmd",
+        baseBeforeMessageDeliveryCtx("app-bmd", "sess-stale"),
+      );
+    });
+    expect(await Effect.runPromise(program)).toEqual({
+      block: true,
+      reason: "before_message_delivery hook error",
+    });
+  });
+
+  it("rpc error: remote responds with typed RpcResponseError → fail-closed block: true", async () => {
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const fixture = makeAppHostFixture();
+      const { conn, outbound } = yield* Scope.extend(
+        makeFakeConnection("conn-bmd-err"),
+        scope,
+      );
+      fixture.connections.add(conn);
+      fixture.host.registerRemoteApp(baseManifest("app-bmd"), "conn-bmd-err");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (
+        fixture.host as any
+      ).dispatchBeforeMessageDeliveryHook.bind(fixture.host) as (
+        appId: string,
+        ctx: BeforeMessageDeliveryContext,
+      ) => Effect.Effect<unknown, never>;
+
+      const fiber = yield* Effect.fork(
+        dispatch("app-bmd", baseBeforeMessageDeliveryCtx("app-bmd", "sess-e")),
+      );
+      const id = yield* captureLatestRequestId(outbound).pipe(
+        Effect.retry({ times: 50, schedule: undefined }),
+      );
+      yield* completeS2cResponse(conn, {
+        jsonrpc: "2.0",
+        type: "response",
+        direction: "s2c",
+        id,
+        error: { code: -32000, message: "remote refused" },
+      });
+      const result = yield* Fiber.join(fiber);
+      yield* Scope.close(scope, Exit.void);
+      return result;
+    });
+    expect(await Effect.runPromise(program)).toEqual({
+      block: true,
+      reason: "before_message_delivery hook error",
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Lifecycle hooks — fail-OPEN
+// ─────────────────────────────────────────────────────────────────────
+
+describe("AppHost remote dispatch — lifecycle (on_*)", () => {
+  it("on_session_active: missing-connection collapses to void (fail-OPEN)", async () => {
+    const program = Effect.gen(function* () {
+      const fixture = makeAppHostFixture();
+      fixture.host.registerRemoteApp(baseManifest("app-osa"), "no-conn");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (fixture.host as any).dispatchOnSessionActiveHook.bind(
+        fixture.host,
+      ) as (
+        appId: string,
+        ctx: OnSessionActiveContext,
+        initiatorAgentId: string,
+      ) => Effect.Effect<void, never>;
+      yield* dispatch(
+        "app-osa",
+        baseOnSessionActiveCtx("app-osa", "sess-osa"),
+        "agent-init",
+      );
+    });
+    // Just runs to completion without throwing.
+    await Effect.runPromise(program);
+  });
+
+  it("on_join: missing-connection collapses to void (fail-OPEN)", async () => {
+    const program = Effect.gen(function* () {
+      const fixture = makeAppHostFixture();
+      fixture.host.registerRemoteApp(baseManifest("app-oj"), "no-conn");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (fixture.host as any).dispatchOnJoinHook.bind(
+        fixture.host,
+      ) as (appId: string, ctx: OnJoinContext) => Effect.Effect<void, never>;
+      yield* dispatch("app-oj", baseOnJoinCtx("app-oj", "sess-oj"));
+    });
+    await Effect.runPromise(program);
+  });
+
+  it("on_close: missing-connection collapses to void (fail-OPEN)", async () => {
+    const program = Effect.gen(function* () {
+      const fixture = makeAppHostFixture();
+      fixture.host.registerRemoteApp(baseManifest("app-oc"), "no-conn");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dispatch = (fixture.host as any).dispatchOnCloseHook.bind(
+        fixture.host,
+      ) as (
+        appId: string,
+        ctx: OnCloseContext,
+        callerAgentId: string,
+      ) => Effect.Effect<void, never>;
+      yield* dispatch(
+        "app-oc",
+        baseOnCloseCtx("app-oc", "sess-oc"),
+        "agent-closer",
+      );
+    });
+    await Effect.runPromise(program);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// In-process path remains unchanged
+// ─────────────────────────────────────────────────────────────────────
+
+describe("AppHost in-process dispatch — preserved behaviour", () => {
+  it("returns grant when no hook is registered", async () => {
+    const fixture = makeAppHostFixture();
+    fixture.host.registerApp(baseManifest("app-ip"));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dispatch = (fixture.host as any).dispatchBeforeDispatchHook.bind(
+      fixture.host,
+    ) as (
+      appId: string,
+      ctx: BeforeDispatchContext,
+    ) => Effect.Effect<unknown, never>;
+    const verdict = await Effect.runPromise(
+      dispatch("app-ip", baseBeforeDispatchCtx("app-ip", "sess-ip")),
+    );
+    expect(verdict).toEqual({ decision: "grant" });
+  });
+
+  it("invokes the in-process handler and returns its verdict", async () => {
+    const fixture = makeAppHostFixture();
+    fixture.host.registerApp(baseManifest("app-ip"));
+    fixture.host.onBeforeDispatch("app-ip", () => ({
+      decision: "deny",
+      reason: "in-process-policy",
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dispatch = (fixture.host as any).dispatchBeforeDispatchHook.bind(
+      fixture.host,
+    ) as (
+      appId: string,
+      ctx: BeforeDispatchContext,
+    ) => Effect.Effect<unknown, never>;
+    const verdict = await Effect.runPromise(
+      dispatch("app-ip", baseBeforeDispatchCtx("app-ip", "sess-ip")),
+    );
+    expect(verdict).toEqual({
+      decision: "deny",
+      reason: "in-process-policy",
+    });
+  });
+
+  it("a thrown handler is mapped to fail-closed deny", async () => {
+    const fixture = makeAppHostFixture();
+    fixture.host.registerApp(baseManifest("app-ip"));
+    fixture.host.onBeforeDispatch("app-ip", () => {
+      throw new Error("boom");
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dispatch = (fixture.host as any).dispatchBeforeDispatchHook.bind(
+      fixture.host,
+    ) as (
+      appId: string,
+      ctx: BeforeDispatchContext,
+    ) => Effect.Effect<unknown, never>;
+    const verdict = await Effect.runPromise(
+      dispatch("app-ip", baseBeforeDispatchCtx("app-ip", "sess-ip")),
+    );
+    expect(verdict).toEqual({
+      decision: "deny",
+      reason: "before_dispatch hook error",
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Multi-app FIFO short-circuit (architect plan §3.4 acceptance #3)
+// ─────────────────────────────────────────────────────────────────────
+
+describe("AppHost.dispatchAcrossAppsWithDenyShortCircuit", () => {
+  it("invokes apps in registration order and returns the last grant when none deny", async () => {
+    const fixture = makeAppHostFixture();
+    const calls: string[] = [];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const combinator = (
+      fixture.host as any
+    ).dispatchAcrossAppsWithDenyShortCircuit.bind(fixture.host) as <V>(
+      appIds: readonly string[],
+      isShortCircuit: (v: V) => boolean,
+      defaultVerdict: V,
+      perApp: (appId: string) => Effect.Effect<V, never>,
+    ) => Effect.Effect<V, never>;
+
+    type V = { decision: "grant" } | { decision: "deny"; reason: string };
+    const verdict = await Effect.runPromise(
+      combinator<V>(
+        ["a", "b", "c"],
+        (v): boolean => v.decision === "deny",
+        { decision: "grant" } as V,
+        (appId) =>
+          Effect.sync(() => {
+            calls.push(appId);
+            return { decision: "grant" } as V;
+          }),
+      ),
+    );
+
+    expect(calls).toEqual(["a", "b", "c"]);
+    expect(verdict).toEqual({ decision: "grant" });
+  });
+
+  it("short-circuits on first deny — later apps are NOT invoked", async () => {
+    const fixture = makeAppHostFixture();
+    const calls: string[] = [];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const combinator = (
+      fixture.host as any
+    ).dispatchAcrossAppsWithDenyShortCircuit.bind(fixture.host) as <V>(
+      appIds: readonly string[],
+      isShortCircuit: (v: V) => boolean,
+      defaultVerdict: V,
+      perApp: (appId: string) => Effect.Effect<V, never>,
+    ) => Effect.Effect<V, never>;
+
+    type V = { decision: "grant" } | { decision: "deny"; reason: string };
+    const verdict = await Effect.runPromise(
+      combinator<V>(
+        ["a", "b", "c"],
+        (v): boolean => v.decision === "deny",
+        { decision: "grant" } as V,
+        (appId) =>
+          Effect.sync(() => {
+            calls.push(appId);
+            return appId === "b"
+              ? ({ decision: "deny", reason: "stop" } as V)
+              : ({ decision: "grant" } as V);
+          }),
+      ),
+    );
+
+    expect(calls).toEqual(["a", "b"]);
+    expect(verdict).toEqual({ decision: "deny", reason: "stop" });
+  });
+
+  it("returns the default verdict for an empty list", async () => {
+    const fixture = makeAppHostFixture();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const combinator = (
+      fixture.host as any
+    ).dispatchAcrossAppsWithDenyShortCircuit.bind(fixture.host) as <V>(
+      appIds: readonly string[],
+      isShortCircuit: (v: V) => boolean,
+      defaultVerdict: V,
+      perApp: (appId: string) => Effect.Effect<V, never>,
+    ) => Effect.Effect<V, never>;
+
+    const verdict = await Effect.runPromise(
+      combinator<{ decision: "grant" }>(
+        [],
+        () => false,
+        { decision: "grant" } as const,
+        () => Effect.die("should not run"),
+      ),
+    );
+
+    expect(verdict).toEqual({ decision: "grant" });
+  });
+
+  // Suppress an unused-import lint if Cause isn't referenced after edits.
+  it("no leaked Causes (sanity)", () => {
+    expect(typeof Cause.pretty).toBe("function");
+  });
+});

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -1,7 +1,8 @@
 import type { Kysely } from "kysely";
 import type { AppSessionStatus, Database } from "../db/database.js";
 import type { Broadcaster } from "../ws/broadcaster.js";
-import type { ConnectionManager } from "../ws/connection.js";
+import type { ConnectionManager, MoltZapConnection } from "../ws/connection.js";
+import { sendRpcToClient } from "../ws/connection.js";
 import type { UserService } from "../services/user.service.js";
 import { UserId } from "./types.js";
 import { logger } from "../logger.js";
@@ -11,15 +12,32 @@ import type {
   LogicalClock,
   Part,
 } from "@moltzap/protocol";
-import { ErrorCodes, EventNames, eventFrame } from "@moltzap/protocol";
 import {
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnClose,
+  AppsOnJoin,
+  AppsOnSessionActive,
+  ErrorCodes,
+  EventNames,
+  eventFrame,
+} from "@moltzap/protocol";
+import {
+  decodeBeforeDispatchRpcResult,
+  decodeBeforeMessageDeliveryRpcResult,
+  decodeVoidRpcResult,
   type AppHooks,
+  type BeforeDispatchContext,
   type BeforeDispatchHook,
+  type BeforeMessageDeliveryContext,
   type BeforeMessageDeliveryHook,
   type DispatchAdmissionResult,
   type HookResult,
+  type OnCloseContext,
   type OnCloseHook,
+  type OnJoinContext,
   type OnJoinHook,
+  type OnSessionActiveContext,
   type OnSessionActiveHook,
 } from "./hooks.js";
 import {
@@ -156,24 +174,6 @@ interface PendingChallenge {
   reject: (reason: string) => void;
 }
 
-/**
- * Outcome of an in-process hook dispatch. The three variants discriminate
- * what happened; each call site applies its own policy (fail-closed for
- * `before_dispatch` / `before_message_delivery`, fail-open for `on_close` /
- * `on_session_active`):
- *
- *   - `{ result: T, timedOut: false }` — hook returned successfully
- *   - `{ result: null, timedOut: true }` — hook timed out
- *   - `{ result: null, timedOut: false }` — hook threw
- *
- * Centralising the shape keeps the dispatch plumbing uniform across hook
- * sites; policy lives at the caller.
- */
-type HookOutcome<T> =
-  | { result: T; timedOut: false }
-  | { result: null; timedOut: true }
-  | { result: null; timedOut: false };
-
 interface PendingPermission {
   targetUserId: string;
   agentId: string;
@@ -296,6 +296,21 @@ export class AppHost {
   private contactService: ContactService | null = null;
   private permissionService: PermissionService | null = null;
   private hooks = new Map<string, AppHooks>();
+  /**
+   * Remote-app routing table. An entry exists iff `registerRemoteApp` was
+   * called for `appId`; the value records which WS connection serves the
+   * app's hook RPCs. Looked up at dispatch time (not registration time)
+   * so the connection can be closed and re-resolved without re-registering
+   * the app — the Scope finalizer on the old connection drains its
+   * pending Deferreds with `AppDisconnected`, which the dispatch envelope
+   * maps to fail-closed verdicts.
+   *
+   * Disjoint with `hooks` per-app: a given `appId` is either in-process
+   * (entries in `hooks`) or remote (entry here), never both. The dispatch
+   * helpers prefer the remote entry when present — `registerRemoteApp`
+   * is the explicit promotion path.
+   */
+  private remoteRegistrations = new Map<string, { connectionId: string }>();
   private conversationToSession = new Map<
     string,
     { id: string; appId: string }
@@ -321,6 +336,62 @@ export class AppHost {
   registerApp(manifest: AppManifest): void {
     this.manifests.set(manifest.appId, manifest);
     logger.info({ appId: manifest.appId }, "App registered");
+  }
+
+  /**
+   * Register an app whose hook handlers run in a remote process (typically
+   * an `@moltzap/app-sdk` client connected over WebSocket). Hook RPCs
+   * (`apps/onBeforeDispatch`, `onBeforeMessageDelivery`, `onSessionActive`,
+   * `onJoin`, `onClose`) are dispatched to `connectionId` via
+   * {@link sendRpcToClient}; verdicts decode through the schemas defined in
+   * `hooks.ts` and feed the same fail-closed envelope as in-process hooks.
+   *
+   * Promotion: a remote registration takes precedence over any prior
+   * in-process hook registrations for the same `appId`. The
+   * {@link AppRegistrationSource} discrimination is internal — call sites
+   * (`runBeforeDispatch` / `runBeforeMessageDelivery` / etc.) consume one
+   * uniform `Effect<Verdict, never>` regardless of source per architect
+   * plan §3.4 ("No branching at the call site between in-process and
+   * remote").
+   *
+   * Disconnect handling: when `connectionId` later goes away, every
+   * pending Deferred for that connection's s2c RPCs fails with
+   * `AppDisconnected` via the connection's Scope finalizer. The dispatch
+   * envelope catches `AppDisconnected` (and every other `S2cRpcError`
+   * variant) and synthesizes a fail-closed verdict — `deny` for
+   * admission hooks, `block: true` for `before_message_delivery`, void +
+   * log + `app/hookTimeout` for lifecycle hooks. Callers do not need to
+   * call {@link unregisterRemoteApp} on disconnect; the registration
+   * keeps pointing at the dead connection id and dispatches keep
+   * fail-closed until the app re-registers (typically via `apps/register`
+   * after reconnecting). Operators that want eager cleanup can call
+   * {@link unregisterRemoteApp} from a connection-close hook.
+   */
+  registerRemoteApp(manifest: AppManifest, connectionId: string): void {
+    this.manifests.set(manifest.appId, manifest);
+    this.remoteRegistrations.set(manifest.appId, { connectionId });
+    logger.info(
+      { appId: manifest.appId, connectionId },
+      "Remote app registered",
+    );
+  }
+
+  /**
+   * Drop a remote-app registration. Idempotent — no-op if `appId` was not
+   * previously registered as remote. Does NOT remove the manifest entry
+   * (sessions and conversations may still reference it); callers that
+   * want a full removal should also clear the manifest separately.
+   *
+   * Existing in-flight admission Deferreds are unaffected by this call —
+   * they're owned by the connection's pending map and resolved either by
+   * the response router (if the app replies) or by the Scope finalizer
+   * on disconnect. Future dispatches for `appId` fall through to whatever
+   * in-process hook is registered (or grant-by-default if none).
+   */
+  unregisterRemoteApp(appId: string): void {
+    if (this.remoteRegistrations.delete(appId)) {
+      logger.info({ appId }, "Remote app unregistered");
+    }
   }
 
   getManifest(appId: string): AppManifest | undefined {
@@ -398,12 +469,12 @@ export class AppHost {
         const session = this.conversationToSession.get(conversationId);
         if (!session) return { decision: "grant" as const };
 
+        const isRemote = this.remoteRegistrations.has(session.appId);
         const appHooks = this.hooks.get(session.appId);
-        if (!appHooks?.beforeDispatch) {
+
+        if (!isRemote && !appHooks?.beforeDispatch) {
           return { decision: "grant" as const };
         }
-
-        const manifest = this.manifests.get(session.appId);
 
         const agentOpt = yield* takeFirstOption(
           this.db
@@ -413,7 +484,10 @@ export class AppHost {
         );
         const agent = Option.getOrNull(agentOpt);
 
-        const ctx = {
+        // ctx without `signal` — the in-process dispatch helper attaches
+        // the AbortController-bound signal at call time. Remote dispatch
+        // strips signal-shaped fields via `contextForWire` before encode.
+        const ctx: BeforeDispatchContext = {
           conversationId,
           recipient: {
             agentId: recipientAgentId,
@@ -430,47 +504,22 @@ export class AppHost {
           receivedAt: params.receivedAt,
           clock: params.clock,
           pending: params.pending,
+          // Placeholder; the in-process dispatch helper overrides with
+          // its own AbortController-tied signal. Remote dispatch elides.
+          signal: new AbortController().signal,
         };
 
-        const timeoutMs = manifest?.hooks?.before_dispatch?.timeout_ms ?? 5000;
-
-        const outcome: HookOutcome<DispatchAdmissionResult> =
-          yield* this.runHookWithTimeout<DispatchAdmissionResult>(
-            (signal) => appHooks.beforeDispatch!({ ...ctx, signal }),
-            timeoutMs,
-          );
-
-        if (outcome.timedOut) {
-          this.broadcaster.sendToAgent(
-            ctx.recipient.agentId,
-            eventFrame("app/hookTimeout", {
-              sessionId: session.id,
-              appId: session.appId,
-              hookName: "before_dispatch",
-              timeoutMs,
-            }),
-          );
-          yield* Effect.logWarning("before_dispatch hook timed out").pipe(
-            Effect.annotateLogs({
-              sessionId: session.id,
-              appId: session.appId,
-              timeoutMs,
-            }),
-          );
-          return {
-            decision: "deny",
-            reason: "before_dispatch hook timed out",
-          };
-        }
-
-        if (!outcome.result) {
-          return {
-            decision: "deny",
-            reason: "before_dispatch hook error",
-          };
-        }
-
-        return outcome.result;
+        // Uniform Effect dispatch — in-process / remote choice is INSIDE
+        // the helper. Per architect plan §3.4: "No branching at the call
+        // site between in-process and remote." Composition uses the
+        // forEach-with-deny-short-circuit combinator (degenerate to N=1
+        // today; forward-compatible for multi-app sessions).
+        return yield* this.dispatchAcrossAppsWithDenyShortCircuit<DispatchAdmissionResult>(
+          [session.appId],
+          (v) => v.decision === "deny",
+          { decision: "grant" as const },
+          (appId) => this.dispatchBeforeDispatchHook(appId, ctx),
+        );
       }),
     );
   }
@@ -487,10 +536,12 @@ export class AppHost {
         const session = this.conversationToSession.get(conversationId);
         if (!session) return null;
 
+        const isRemote = this.remoteRegistrations.has(session.appId);
         const appHooks = this.hooks.get(session.appId);
-        if (!appHooks?.beforeMessageDelivery) return null;
 
-        const manifest = this.manifests.get(session.appId);
+        if (!isRemote && !appHooks?.beforeMessageDelivery) {
+          return null;
+        }
 
         const agentOpt = yield* takeFirstOption(
           this.db
@@ -500,7 +551,7 @@ export class AppHost {
         );
         const agent = Option.getOrNull(agentOpt);
 
-        const ctx = {
+        const ctx: BeforeMessageDeliveryContext = {
           conversationId,
           sender: {
             agentId: senderAgentId,
@@ -509,63 +560,23 @@ export class AppHost {
           message: { parts, replyToId, dispatchLeaseId },
           sessionId: session.id,
           appId: session.appId,
+          // Placeholder; the in-process dispatch helper overrides with
+          // its AbortController-tied signal. Remote dispatch elides via
+          // `contextForWire`.
+          signal: new AbortController().signal,
         };
 
-        const timeoutMs =
-          manifest?.hooks?.before_message_delivery?.timeout_ms ?? 5000;
-
-        const outcome: HookOutcome<HookResult> =
-          yield* this.runHookWithTimeout<HookResult>(
-            (signal) => appHooks.beforeMessageDelivery!({ ...ctx, signal }),
-            timeoutMs,
+        // Uniform Effect dispatch — in-process / remote choice INSIDE
+        // the helper. Multi-app composition uses the forEach-with-block-
+        // short-circuit combinator (degenerate to N=1 today).
+        const result =
+          yield* this.dispatchAcrossAppsWithDenyShortCircuit<HookResult>(
+            [session.appId],
+            (v) => v.block,
+            { block: false },
+            (appId) => this.dispatchBeforeMessageDeliveryHook(appId, ctx),
           );
-
-        // Fail-closed policy: on hook timeout or hook exception, synthesize
-        // a `{ block: true }` result so security/moderation hooks cannot be
-        // bypassed by a slow or crashing handler. Operator sees the
-        // `app/hookTimeout` event on the conversation.
-        if (outcome.timedOut) {
-          this.broadcaster.sendToAgent(
-            ctx.sender.agentId,
-            eventFrame("app/hookTimeout", {
-              sessionId: session.id,
-              appId: session.appId,
-              hookName: "before_message_delivery",
-              timeoutMs,
-            }),
-          );
-          yield* Effect.logWarning(
-            "before_message_delivery hook timed out",
-          ).pipe(
-            Effect.annotateLogs({
-              sessionId: session.id,
-              appId: session.appId,
-              timeoutMs,
-            }),
-          );
-          return {
-            result: {
-              block: true,
-              reason: "before_message_delivery hook timed out",
-            },
-            appId: session.appId,
-          };
-        }
-
-        if (!outcome.result) {
-          // Hook threw — `runHookWithTimeout` already logged via
-          // `Effect.logError`. Block the message rather than silently
-          // passing it through.
-          return {
-            result: {
-              block: true,
-              reason: "before_message_delivery hook error",
-            },
-            appId: session.appId,
-          };
-        }
-
-        return { result: outcome.result, appId: session.appId };
+        return { result, appId: session.appId };
       }),
     );
   }
@@ -851,12 +862,10 @@ export class AppHost {
           new Set(convEntries.map((r) => r.conversation_id));
 
         // Fire on_close hook with timeout (fail-open).
+        const isRemote = this.remoteRegistrations.has(sessionRow.app_id);
         const appHooks = this.hooks.get(sessionRow.app_id);
 
-        if (appHooks?.onClose) {
-          const manifest = this.manifests.get(sessionRow.app_id);
-          const timeoutMs = manifest?.hooks?.on_close?.timeout_ms ?? 5000;
-
+        if (isRemote || appHooks?.onClose) {
           const initiatorOpt = yield* takeFirstOption(
             this.db
               .selectFrom("agents")
@@ -869,37 +878,20 @@ export class AppHost {
             ownerId: initiator?.owner_user_id ?? "",
           };
 
-          const outcome: HookOutcome<void> =
-            yield* this.runHookWithTimeout<void>(
-              (signal) =>
-                appHooks.onClose!({
-                  sessionId,
-                  appId: sessionRow.app_id,
-                  conversations,
-                  closedBy,
-                  signal,
-                }),
-              timeoutMs,
-            );
-
-          if (outcome.timedOut) {
-            this.broadcaster.sendToAgent(
-              callerAgentId,
-              eventFrame("app/hookTimeout", {
-                sessionId,
-                appId: sessionRow.app_id,
-                hookName: "on_close",
-                timeoutMs,
-              }),
-            );
-            yield* Effect.logWarning("on_close hook timed out").pipe(
-              Effect.annotateLogs({
-                sessionId,
-                appId: sessionRow.app_id,
-                timeoutMs,
-              }),
-            );
-          }
+          // Uniform Effect dispatch — in-process / remote choice INSIDE
+          // the helper. Fail-OPEN per architect plan §3.4.
+          const ctx: OnCloseContext = {
+            sessionId,
+            appId: sessionRow.app_id,
+            conversations,
+            closedBy,
+            signal: new AbortController().signal,
+          };
+          yield* this.dispatchOnCloseHook(
+            sessionRow.app_id,
+            ctx,
+            callerAgentId,
+          );
         }
 
         const convIdArray = [...convIds];
@@ -1194,6 +1186,7 @@ export class AppHost {
     this.pendingChallenges.clear();
     Effect.runSync(drainCoalesceMap(this.inflightPermissions));
     this.hooks.clear();
+    this.remoteRegistrations.clear();
     this.conversationToSession.clear();
     this.sessionToConversations.clear();
   }
@@ -1260,44 +1253,480 @@ export class AppHost {
     }
   }
 
-  private runHookWithTimeout<T>(
-    fn: (signal: AbortSignal) => T | Promise<T>,
-    timeoutMs: number,
-  ): Effect.Effect<HookOutcome<T>, RpcFailure> {
-    // AbortController contract is part of the user-provided hook signature, so
-    // we keep allocating one and wire it to interruption: if Effect.timeout
-    // fires or the hook throws, abort() before returning. The hook itself runs
-    // inside Effect.tryPromise and is bounded by Effect.timeout — no raw
-    // Promise.race / setTimeout.
-    return Effect.gen(this, function* () {
-      const controller = new AbortController();
-      const hookEffect = Effect.tryPromise({
-        try: () => Promise.resolve(fn(controller.signal)),
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      });
+  // ── Uniform hook dispatch (in-process + remote) ────────────────────
+  //
+  // Per architect plan §3.4: every hook returns `Effect<Verdict, never>`
+  // regardless of source. The branching between in-process and remote is
+  // INSIDE the dispatch helpers; call sites observe one type. Failure
+  // modes (timeout, throw, RPC error, AppDisconnected, decode failure)
+  // collapse into fail-closed verdicts for admission hooks (`deny` /
+  // `block`), or void + `app/hookTimeout` event for lifecycle hooks.
+  //
+  // Multi-app composition (architect plan §3.4: "Effect.forEach in
+  // registration order, first deny short-circuits") is implemented by
+  // {@link dispatchAcrossAppsWithDenyShortCircuit} below. Today every
+  // session is bound to a single appId so the iteration is len-1; the
+  // combinator is forward-compatible for multi-app sessions.
 
-      return yield* hookEffect.pipe(
-        Effect.timeout(`${timeoutMs} millis`),
-        Effect.map((result) => ({ result, timedOut: false }) as HookOutcome<T>),
-        Effect.catchTag("TimeoutException", () =>
-          Effect.sync(() => {
-            controller.abort();
-            return { result: null, timedOut: true as const } as HookOutcome<T>;
-          }),
-        ),
-        Effect.catchAll((err) =>
-          Effect.gen(function* () {
-            controller.abort();
-            yield* Effect.logError("Hook execution error").pipe(
-              Effect.annotateLogs({ err: errorMessage(err) }),
-            );
-            return {
-              result: null,
-              timedOut: false as const,
-            } as HookOutcome<T>;
-          }),
-        ),
+  /**
+   * Strip non-wire-safe fields from a hook context so it can be sent over
+   * the s2c RPC. Currently the only such field is `signal: AbortSignal`,
+   * which has meaning only in-process. Returns a new object — does not
+   * mutate `ctx`.
+   */
+  private contextForWire<C extends { signal?: AbortSignal }>(
+    ctx: C,
+  ): Omit<C, "signal"> {
+    // Type-checker insists we elide `signal` explicitly rather than using
+    // a destructure-discard, because `signal` is optional in the constraint
+    // but always present in the concrete contexts.
+    const out = { ...ctx } as { signal?: AbortSignal } & Omit<C, "signal">;
+    delete out.signal;
+    return out;
+  }
+
+  /**
+   * Run an in-process Promise-returning hook under an `AbortController`
+   * tied to fiber interrupts (e.g., from `Effect.timeout` upstream). The
+   * controller is wired so:
+   *   - timeout fires → fiber interrupts → `Effect.onInterrupt` aborts
+   *   - hook throws / rejects → `tapErrorCause` aborts
+   * preserving the abort-on-timeout / abort-on-throw guarantees that
+   * `30-app-hooks.integration.test.ts:359-435` covers.
+   *
+   * Returns the raw verdict in the success channel and a typed `Error`
+   * in the failure channel (so the dispatch envelope's `catchAll` can
+   * synthesize the fail-closed verdict).
+   */
+  private runInProcessHookEffect<Ctx, T>(
+    handler: (ctx: Ctx & { signal: AbortSignal }) => T | Promise<T>,
+    ctx: Ctx,
+  ): Effect.Effect<T, Error> {
+    return Effect.gen(function* () {
+      const controller = new AbortController();
+      return yield* Effect.tryPromise({
+        try: () =>
+          Promise.resolve(handler({ ...ctx, signal: controller.signal })),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.tapErrorCause(() => Effect.sync(() => controller.abort())),
+        Effect.onInterrupt(() => Effect.sync(() => controller.abort())),
       );
+    });
+  }
+
+  /**
+   * Dispatch a server-initiated RPC to a remote app's connection and
+   * decode the verdict. Returns the typed verdict in the success channel;
+   * any failure (`AppDisconnected`, RPC response error, socket error,
+   * schema decode failure, missing connection) lands in the failure
+   * channel for the dispatch envelope to map to fail-closed.
+   *
+   * Result decoding happens at this seam — Principle 2: schemas at
+   * boundaries, types inside. After decode the rest of AppHost trusts
+   * the verdict shape.
+   */
+  private runRemoteHookEffect<T>(opts: {
+    appId: string;
+    method: string;
+    connectionId: string;
+    params: unknown;
+    /**
+     * Precompiled decoder (`Schema.decodeUnknown(schema)`) lifted to a
+     * module-level constant in `hooks.ts`. Passing the decoder rather
+     * than the schema avoids rebuilding the closure on every dispatch
+     * — `messages/send` triggers `runBeforeDispatch` per recipient, so
+     * this is the per-message hot path.
+     */
+    decode: (raw: unknown) => Effect.Effect<T, unknown, never>;
+  }): Effect.Effect<T, Error> {
+    return Effect.gen(this, function* () {
+      const conn: MoltZapConnection | undefined = this.connections.get(
+        opts.connectionId,
+      );
+      if (!conn) {
+        // Stale registration: the remote app's connection has already
+        // gone away. Treat identically to mid-flight `AppDisconnected`
+        // so the dispatch envelope folds it into fail-closed.
+        return yield* Effect.fail(
+          new Error(
+            `Remote app ${opts.appId} connection ${opts.connectionId} is gone`,
+          ),
+        );
+      }
+      const raw = yield* sendRpcToClient(conn, opts.method, opts.params).pipe(
+        Effect.mapError((err) => new Error(`s2c RPC failed: ${err._tag}`)),
+      );
+      return yield* opts
+        .decode(raw)
+        .pipe(
+          Effect.mapError(
+            (err) =>
+              new Error(
+                `s2c RPC ${opts.method} response decode failed: ${String(err)}`,
+              ),
+          ),
+        );
+    });
+  }
+
+  /**
+   * Apply the uniform timeout + fail-closed envelope to a raw hook
+   * dispatch (in-process or remote). Three completion outcomes — totally
+   * exhaustive over the wrapped Effect's behaviour:
+   *
+   *   - success → returns the verdict as-is.
+   *   - `TimeoutException` (from `Effect.timeout`) → emits the
+   *     `app/hookTimeout` event, logs a warning, returns the timeout
+   *     verdict from `onTimeout`.
+   *   - any other error (handler throw, RPC error, `AppDisconnected`,
+   *     schema decode failure) → logs an error, returns the error
+   *     verdict from `onError`.
+   *
+   * For admission hooks `onTimeout` / `onError` synthesize fail-closed
+   * verdicts (`deny` / `block: true`); for lifecycle hooks they return
+   * `Effect.void`. The error-channel narrowing to `never` is the
+   * contract that lets call sites compose hooks via `Effect.forEach`
+   * with no handler-error visibility.
+   */
+  private wrapHookEffectWithEnvelope<Verdict>(opts: {
+    raw: Effect.Effect<Verdict, Error>;
+    timeoutMs: number;
+    onTimeoutEvent?: () => void; // emit `app/hookTimeout` if provided
+    timeoutLogMessage: string;
+    timeoutLogContext: Record<string, unknown>;
+    errorLogMessage: string;
+    errorLogContext: Record<string, unknown>;
+    onTimeout: () => Verdict;
+    onError: () => Verdict;
+  }): Effect.Effect<Verdict, never> {
+    return opts.raw.pipe(
+      Effect.timeout(`${opts.timeoutMs} millis`),
+      Effect.catchTag("TimeoutException", () =>
+        Effect.gen(function* () {
+          if (opts.onTimeoutEvent) opts.onTimeoutEvent();
+          yield* Effect.logWarning(opts.timeoutLogMessage).pipe(
+            Effect.annotateLogs(opts.timeoutLogContext),
+          );
+          return opts.onTimeout();
+        }),
+      ),
+      Effect.catchAll((err) =>
+        Effect.gen(function* () {
+          yield* Effect.logError(opts.errorLogMessage).pipe(
+            Effect.annotateLogs({
+              ...opts.errorLogContext,
+              err: errorMessage(err),
+            }),
+          );
+          return opts.onError();
+        }),
+      ),
+    );
+  }
+
+  /**
+   * Uniform `before_dispatch` dispatch — the in-process / remote choice
+   * is made HERE; callers see one signature and one return type. Returns
+   * `{ decision: "grant" }` when no hook is registered. Fail-closed on
+   * timeout / handler error / RPC failure per architect plan §3.4.
+   */
+  private dispatchBeforeDispatchHook(
+    appId: string,
+    ctx: BeforeDispatchContext,
+  ): Effect.Effect<DispatchAdmissionResult, never> {
+    const remote = this.remoteRegistrations.get(appId);
+    const inProcess = this.hooks.get(appId)?.beforeDispatch;
+    if (!remote && !inProcess) {
+      return Effect.succeed({ decision: "grant" as const });
+    }
+    const manifest = this.manifests.get(appId);
+    const timeoutMs = manifest?.hooks?.before_dispatch?.timeout_ms ?? 5000;
+    const sessionId = ctx.sessionId;
+
+    const raw: Effect.Effect<DispatchAdmissionResult, Error> = remote
+      ? this.runRemoteHookEffect({
+          appId,
+          method: AppsOnBeforeDispatch.name,
+          connectionId: remote.connectionId,
+          params: this.contextForWire(ctx),
+          decode: decodeBeforeDispatchRpcResult,
+        }).pipe(Effect.map((envelope) => envelope.admission))
+      : this.runInProcessHookEffect<
+          BeforeDispatchContext,
+          DispatchAdmissionResult
+        >((ctxWithSignal) => inProcess!(ctxWithSignal), ctx);
+
+    return this.wrapHookEffectWithEnvelope<DispatchAdmissionResult>({
+      raw,
+      timeoutMs,
+      onTimeoutEvent: () =>
+        this.broadcaster.sendToAgent(
+          ctx.recipient.agentId,
+          eventFrame(EventNames.AppHookTimeout, {
+            sessionId,
+            appId,
+            hookName: "before_dispatch",
+            timeoutMs,
+          }),
+        ),
+      timeoutLogMessage: "before_dispatch hook timed out",
+      timeoutLogContext: { sessionId, appId, timeoutMs },
+      errorLogMessage: "before_dispatch hook error",
+      errorLogContext: { sessionId, appId },
+      onTimeout: () => ({
+        decision: "deny" as const,
+        reason: "before_dispatch hook timed out",
+      }),
+      onError: () => ({
+        decision: "deny" as const,
+        reason: "before_dispatch hook error",
+      }),
+    });
+  }
+
+  /**
+   * Uniform `before_message_delivery` dispatch. Fail-CLOSED to
+   * `{ block: true }` on timeout/throw/RPC-failure per architect plan §3.4
+   * (verified against `30-app-hooks.integration.test.ts:229-272,296-357`).
+   */
+  private dispatchBeforeMessageDeliveryHook(
+    appId: string,
+    ctx: BeforeMessageDeliveryContext,
+  ): Effect.Effect<HookResult, never> {
+    const remote = this.remoteRegistrations.get(appId);
+    const inProcess = this.hooks.get(appId)?.beforeMessageDelivery;
+    if (!remote && !inProcess) {
+      // No-hook short-circuit: caller treats `block: false` and no patch as
+      // "pass through unchanged", same as the legacy `null` outcome.
+      return Effect.succeed({ block: false });
+    }
+    const manifest = this.manifests.get(appId);
+    const timeoutMs =
+      manifest?.hooks?.before_message_delivery?.timeout_ms ?? 5000;
+    const sessionId = ctx.sessionId;
+
+    const raw: Effect.Effect<HookResult, Error> = remote
+      ? this.runRemoteHookEffect({
+          appId,
+          method: AppsOnBeforeMessageDelivery.name,
+          connectionId: remote.connectionId,
+          params: this.contextForWire(ctx),
+          decode: decodeBeforeMessageDeliveryRpcResult,
+        })
+      : this.runInProcessHookEffect<BeforeMessageDeliveryContext, HookResult>(
+          (ctxWithSignal) => inProcess!(ctxWithSignal),
+          ctx,
+        );
+
+    return this.wrapHookEffectWithEnvelope<HookResult>({
+      raw,
+      timeoutMs,
+      onTimeoutEvent: () =>
+        this.broadcaster.sendToAgent(
+          ctx.sender.agentId,
+          eventFrame(EventNames.AppHookTimeout, {
+            sessionId,
+            appId,
+            hookName: "before_message_delivery",
+            timeoutMs,
+          }),
+        ),
+      timeoutLogMessage: "before_message_delivery hook timed out",
+      timeoutLogContext: { sessionId, appId, timeoutMs },
+      errorLogMessage: "before_message_delivery hook error",
+      errorLogContext: { sessionId, appId },
+      onTimeout: () => ({
+        block: true,
+        reason: "before_message_delivery hook timed out",
+      }),
+      onError: () => ({
+        block: true,
+        reason: "before_message_delivery hook error",
+      }),
+    });
+  }
+
+  /**
+   * Uniform `on_session_active` dispatch — awaitable void with timeout.
+   * Fail-OPEN: timeout/throw logs + emits `app/hookTimeout` but the caller
+   * continues to broadcast `app/sessionReady` (the ordering invariant
+   * verified by `31-on-session-active.integration.test.ts:200-230`).
+   */
+  private dispatchOnSessionActiveHook(
+    appId: string,
+    ctx: OnSessionActiveContext,
+    initiatorAgentId: string,
+  ): Effect.Effect<void, never> {
+    const remote = this.remoteRegistrations.get(appId);
+    const inProcess = this.hooks.get(appId)?.onSessionActive;
+    if (!remote && !inProcess) return Effect.void;
+    const manifest = this.manifests.get(appId);
+    const timeoutMs = manifest?.hooks?.on_session_active?.timeout_ms ?? 5000;
+    const sessionId = ctx.sessionId;
+
+    const raw: Effect.Effect<void, Error> = remote
+      ? this.runRemoteHookEffect({
+          appId,
+          method: AppsOnSessionActive.name,
+          connectionId: remote.connectionId,
+          params: this.contextForWire(ctx),
+          decode: decodeVoidRpcResult,
+        })
+      : this.runInProcessHookEffect<OnSessionActiveContext, void>(
+          (ctxWithSignal) => inProcess!(ctxWithSignal),
+          ctx,
+        );
+
+    return this.wrapHookEffectWithEnvelope<void>({
+      raw,
+      timeoutMs,
+      onTimeoutEvent: () =>
+        this.broadcaster.sendToAgent(
+          initiatorAgentId,
+          eventFrame(EventNames.AppHookTimeout, {
+            sessionId,
+            appId,
+            hookName: "on_session_active",
+            timeoutMs,
+          }),
+        ),
+      timeoutLogMessage: "on_session_active hook timed out",
+      timeoutLogContext: { sessionId, appId, timeoutMs },
+      errorLogMessage: "on_session_active hook error",
+      errorLogContext: { sessionId, appId },
+      onTimeout: () => undefined,
+      onError: () => undefined,
+    });
+  }
+
+  /**
+   * Uniform `on_join` dispatch — awaitable void with timeout. Fail-OPEN
+   * per architect plan §3.4.
+   */
+  private dispatchOnJoinHook(
+    appId: string,
+    ctx: OnJoinContext,
+  ): Effect.Effect<void, never> {
+    const remote = this.remoteRegistrations.get(appId);
+    const inProcess = this.hooks.get(appId)?.onJoin;
+    if (!remote && !inProcess) return Effect.void;
+    const manifest = this.manifests.get(appId);
+    const timeoutMs = manifest?.hooks?.on_join?.timeout_ms ?? 5000;
+    const sessionId = ctx.sessionId;
+
+    const raw: Effect.Effect<void, Error> = remote
+      ? this.runRemoteHookEffect({
+          appId,
+          method: AppsOnJoin.name,
+          connectionId: remote.connectionId,
+          params: ctx, // no signal field on OnJoinContext
+          decode: decodeVoidRpcResult,
+        })
+      : Effect.tryPromise({
+          try: () => Promise.resolve(inProcess!(ctx)),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        });
+
+    return this.wrapHookEffectWithEnvelope<void>({
+      raw,
+      timeoutMs,
+      onTimeoutEvent: () =>
+        this.broadcaster.sendToAgent(
+          ctx.agent.agentId,
+          eventFrame(EventNames.AppHookTimeout, {
+            sessionId,
+            appId,
+            hookName: "on_join",
+            timeoutMs,
+          }),
+        ),
+      timeoutLogMessage: "on_join hook timed out",
+      timeoutLogContext: { sessionId, appId, timeoutMs },
+      errorLogMessage: "on_join hook error",
+      errorLogContext: { sessionId, appId, agentId: ctx.agent.agentId },
+      onTimeout: () => undefined,
+      onError: () => undefined,
+    });
+  }
+
+  /**
+   * Uniform `on_close` dispatch — awaitable void with timeout. Fail-OPEN
+   * per architect plan §3.4. Target of `app/hookTimeout` event is the
+   * caller (closer) since the session is being torn down.
+   */
+  private dispatchOnCloseHook(
+    appId: string,
+    ctx: OnCloseContext,
+    callerAgentId: string,
+  ): Effect.Effect<void, never> {
+    const remote = this.remoteRegistrations.get(appId);
+    const inProcess = this.hooks.get(appId)?.onClose;
+    if (!remote && !inProcess) return Effect.void;
+    const manifest = this.manifests.get(appId);
+    const timeoutMs = manifest?.hooks?.on_close?.timeout_ms ?? 5000;
+    const sessionId = ctx.sessionId;
+
+    const raw: Effect.Effect<void, Error> = remote
+      ? this.runRemoteHookEffect({
+          appId,
+          method: AppsOnClose.name,
+          connectionId: remote.connectionId,
+          params: this.contextForWire(ctx),
+          decode: decodeVoidRpcResult,
+        })
+      : this.runInProcessHookEffect<OnCloseContext, void>(
+          (ctxWithSignal) => inProcess!(ctxWithSignal),
+          ctx,
+        );
+
+    return this.wrapHookEffectWithEnvelope<void>({
+      raw,
+      timeoutMs,
+      onTimeoutEvent: () =>
+        this.broadcaster.sendToAgent(
+          callerAgentId,
+          eventFrame(EventNames.AppHookTimeout, {
+            sessionId,
+            appId,
+            hookName: "on_close",
+            timeoutMs,
+          }),
+        ),
+      timeoutLogMessage: "on_close hook timed out",
+      timeoutLogContext: { sessionId, appId, timeoutMs },
+      errorLogMessage: "on_close hook error",
+      errorLogContext: { sessionId, appId },
+      onTimeout: () => undefined,
+      onError: () => undefined,
+    });
+  }
+
+  /**
+   * Compose admission verdicts across multiple registered apps for the
+   * same hook in registration order, short-circuiting on the first
+   * `deny` / `block`. Architect plan §3.4 names `Effect.forEach` as the
+   * combinator; we use the equivalent sequential `Effect.gen` reduce so
+   * the deny-as-short-circuit semantic reads at the call site without
+   * needing a `catchTag` round-trip through a synthetic failure channel.
+   *
+   * Today every session is bound to a single appId so this is invoked
+   * with a len-1 array; the helper exists so multi-app sessions slot in
+   * without a call-site rewrite.
+   */
+  private dispatchAcrossAppsWithDenyShortCircuit<Verdict>(
+    appIds: readonly string[],
+    isShortCircuit: (v: Verdict) => boolean,
+    defaultVerdict: Verdict,
+    perApp: (appId: string) => Effect.Effect<Verdict, never>,
+  ): Effect.Effect<Verdict, never> {
+    return Effect.gen(function* () {
+      let verdict: Verdict = defaultVerdict;
+      for (const appId of appIds) {
+        verdict = yield* perApp(appId);
+        if (isShortCircuit(verdict)) return verdict;
+      }
+      return verdict;
     });
   }
 
@@ -1417,52 +1846,23 @@ export class AppHost {
     admittedAgentIds: string[],
   ): Effect.Effect<void, never> {
     return Effect.gen(this, function* () {
-      const appHooks = this.hooks.get(session.appId);
-
-      if (!appHooks?.onSessionActive) return;
-
-      const timeoutMs = manifest.hooks?.on_session_active?.timeout_ms ?? 5000;
-
-      const outcome: HookOutcome<void> = yield* this.runHookWithTimeout<void>(
-        (signal) =>
-          appHooks.onSessionActive!({
-            sessionId: session.id,
-            appId: session.appId,
-            conversations: session.conversations,
-            admittedAgentIds,
-            signal,
-          }),
-        timeoutMs,
-      ).pipe(
-        Effect.catchAllCause(() =>
-          Effect.succeed({
-            result: null,
-            timedOut: false as const,
-          } as HookOutcome<void>),
-        ),
+      // Uniform Effect dispatch — in-process / remote choice INSIDE the
+      // helper. Fail-OPEN: any timeout or error logs + emits hookTimeout
+      // but the caller still proceeds to broadcast `app/sessionReady`,
+      // preserving the ordering invariant covered by
+      // 31-on-session-active.integration.test.ts:200-230.
+      const ctx: OnSessionActiveContext = {
+        sessionId: session.id,
+        appId: session.appId,
+        conversations: session.conversations,
+        admittedAgentIds,
+        signal: new AbortController().signal,
+      };
+      yield* this.dispatchOnSessionActiveHook(
+        session.appId,
+        ctx,
+        initiatorAgentId,
       );
-
-      if (outcome.timedOut) {
-        this.broadcaster.sendToAgent(
-          initiatorAgentId,
-          eventFrame("app/hookTimeout", {
-            sessionId: session.id,
-            appId: session.appId,
-            hookName: "on_session_active",
-            timeoutMs,
-          }),
-        );
-        yield* Effect.logWarning("on_session_active hook timed out").pipe(
-          Effect.annotateLogs({
-            sessionId: session.id,
-            appId: session.appId,
-            timeoutMs,
-          }),
-        );
-      }
-      // Errors inside the hook are already logged by
-      // runHookWithTimeout; fail-open means we fall through and continue
-      // to broadcast sessionReady regardless.
     });
   }
 
@@ -2044,37 +2444,17 @@ export class AppHost {
           }),
         );
 
-        // on_join hook dispatch — fire-and-forget (the hook can't block
-        // admission); errors are logged but do not fail the fiber.
-        const appHooks = this.hooks.get(session.appId);
-
-        if (appHooks?.onJoin) {
-          // `tryPromise` catches both synchronous throws inside the hook
-          // and Promise rejections, keeping the failure in the typed
-          // error channel rather than becoming a defect.
-          yield* Effect.tryPromise({
-            try: () =>
-              Promise.resolve(
-                appHooks.onJoin!({
-                  conversations: session.conversations,
-                  agent: { agentId, ownerId },
-                  sessionId: session.id,
-                  appId: session.appId,
-                }),
-              ),
-            catch: (err) => err,
-          }).pipe(
-            Effect.catchAll((err) =>
-              Effect.logError("on_join hook error").pipe(
-                Effect.annotateLogs({
-                  err: errorMessage(err),
-                  sessionId: session.id,
-                  agentId,
-                }),
-              ),
-            ),
-          );
-        }
+        // on_join hook dispatch. Fire-and-forget for admission purposes
+        // (the hook can't block admission); errors are logged but do not
+        // fail the fiber. Per architect plan §3.4 the in-process / remote
+        // choice is INSIDE `dispatchOnJoinHook`.
+        const ctx: OnJoinContext = {
+          conversations: session.conversations,
+          agent: { agentId, ownerId },
+          sessionId: session.id,
+          appId: session.appId,
+        };
+        yield* this.dispatchOnJoinHook(session.appId, ctx);
       }),
     );
   }

--- a/packages/server/src/app/handlers/apps.handlers.ts
+++ b/packages/server/src/app/handlers/apps.handlers.ts
@@ -13,6 +13,7 @@ import {
   AppsAuthorizeDispatch,
 } from "@moltzap/protocol";
 import { Effect } from "effect";
+import { ConnIdTag } from "../layers.js";
 import { defineMethod } from "../../rpc/context.js";
 import { ParticipantService } from "../../services/participant.service.js";
 
@@ -22,9 +23,19 @@ export function createAppHandlers(deps: {
 }): RpcMethodRegistry {
   return {
     "apps/register": defineMethod(AppsRegister, {
+      // A c2s `apps/register` call means the connected client wants to
+      // serve the app's hook RPCs (`apps/onBeforeDispatch`, etc.). We
+      // record the calling connection id so AppHost dispatches future
+      // hooks via `sendRpcToClient` against this socket. If the client
+      // hasn't installed `client.handleServerRpc(...)` handlers, hook
+      // RPCs will fail-closed (deny / block) — same posture as a
+      // crashed in-process handler. Server-side in-process registration
+      // continues to use `coreApp.registerApp(manifest)` directly (e.g.
+      // standalone.ts:447); that path bypasses this RPC entirely.
       handler: (params) =>
-        Effect.sync(() => {
-          deps.appHost.registerApp(params.manifest);
+        Effect.gen(function* () {
+          const connId = yield* ConnIdTag;
+          deps.appHost.registerRemoteApp(params.manifest, connId);
           return { appId: params.manifest.appId };
         }),
     }),

--- a/packages/server/src/app/hooks.ts
+++ b/packages/server/src/app/hooks.ts
@@ -1,4 +1,5 @@
 import type { LogicalClock, Part } from "@moltzap/protocol";
+import { Schema } from "effect";
 
 export interface BeforeMessageDeliveryContext {
   conversationId: string;
@@ -41,6 +42,33 @@ export interface HookResult {
   };
 }
 
+/**
+ * Typed `Part[]` schema. Server-core doesn't duplicate the canonical
+ * `Part` schema (TypeBox, in @moltzap/protocol); we accept any array and
+ * trust the message-send boundary to re-validate shape. `Schema.declare`
+ * attaches the type witness via a runtime type-guard.
+ */
+const PartArraySchema = Schema.declare(
+  (input: unknown): input is Part[] => Array.isArray(input),
+  { identifier: "PartArray" },
+);
+
+/** Wire schema for `HookResult` webhook responses. Single-layer `as`
+ *  reconciles effect-schema's encoded-type inference (which mirrors the
+ *  Struct shape) with the caller's `Schema.Schema<_, unknown>` slot. */
+export const HookResultSchema = Schema.Struct({
+  block: Schema.Boolean,
+  reason: Schema.optional(Schema.String),
+  patch: Schema.optional(Schema.Struct({ parts: PartArraySchema })),
+  feedback: Schema.optional(
+    Schema.Struct({
+      type: Schema.Literal("error", "warning", "info"),
+      content: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+      retry: Schema.optional(Schema.Boolean),
+    }),
+  ),
+}) as Schema.Schema<HookResult, unknown>;
+
 export type DispatchAdmissionResult =
   | {
       decision: "grant";
@@ -50,6 +78,55 @@ export type DispatchAdmissionResult =
     }
   | { decision: "deny"; reason?: string }
   | { decision: "hold"; reason?: string };
+
+export const DispatchAdmissionResultSchema = Schema.Union(
+  Schema.Struct({
+    decision: Schema.Literal("grant"),
+    leaseId: Schema.optional(Schema.String),
+    leaseTimeoutMs: Schema.optional(Schema.Number),
+    dispatchMessageId: Schema.optional(Schema.String),
+  }),
+  Schema.Struct({
+    decision: Schema.Literal("deny"),
+    reason: Schema.optional(Schema.String),
+  }),
+  Schema.Struct({
+    decision: Schema.Literal("hold"),
+    reason: Schema.optional(Schema.String),
+  }),
+) as Schema.Schema<DispatchAdmissionResult, unknown>;
+
+/** Fire-and-forget hooks (`on_join`, `on_close`, `on_session_active`) — any payload is ignored. */
+export const VoidHookSchema: Schema.Schema<void, unknown> = Schema.transform(
+  Schema.Unknown,
+  Schema.Void,
+  { decode: () => undefined, encode: () => undefined },
+);
+
+/**
+ * Wire-envelope schema for `apps/onBeforeDispatch`. The reply arrives as
+ * `{ admission: ... }`, not the bare verdict — the other s2c verbs
+ * either reply with `HookResult` directly (`onBeforeMessageDelivery` →
+ * `HookResultSchema`) or an empty object (lifecycle hooks → `VoidHookSchema`).
+ * Decoding at the RPC edge keeps AppHost's business logic typed
+ * (Principle 2: schemas at boundaries, types inside).
+ */
+export const BeforeDispatchRpcResultSchema = Schema.Struct({
+  admission: DispatchAdmissionResultSchema,
+}) as Schema.Schema<{ admission: DispatchAdmissionResult }, unknown>;
+
+/**
+ * Module-level precompiled decoders. `Schema.decodeUnknown(schema)`
+ * produces a fresh closure each call; lifting the decoders here means
+ * the per-dispatch hot path (`runRemoteHookEffect` → `decode`) reuses
+ * one closure per verb. Mirrors the `config/loader.ts` pattern.
+ */
+export const decodeBeforeDispatchRpcResult = Schema.decodeUnknown(
+  BeforeDispatchRpcResultSchema,
+);
+export const decodeBeforeMessageDeliveryRpcResult =
+  Schema.decodeUnknown(HookResultSchema);
+export const decodeVoidRpcResult = Schema.decodeUnknown(VoidHookSchema);
 
 export type BeforeMessageDeliveryHook = (
   ctx: BeforeMessageDeliveryContext,
@@ -97,3 +174,13 @@ export interface AppHooks {
   onClose?: OnCloseHook;
   onSessionActive?: OnSessionActiveHook;
 }
+
+// `AppRegistrationSource` and the `EffectXxxHook` aliases that early
+// drafts of B.3 exported here are intentionally absent. The architect
+// plan §3.4 names the discriminated-union type, but B.3's implementation
+// keeps the in-process / remote split as two private Maps inside
+// AppHost (the `hooks` Map and the `remoteRegistrations` Map) — there
+// is no consumer for the union outside that boundary, and an exported
+// public type without a consumer is debt. B.5 (the `@moltzap/app-sdk`
+// handler surface) will introduce its own `Effect<Verdict, never>`
+// hook aliases when the SDK actually consumes them.

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -757,6 +757,12 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     registerApp(manifest) {
       appHost.registerApp(manifest);
     },
+    registerRemoteApp(manifest, connectionId) {
+      appHost.registerRemoteApp(manifest, connectionId);
+    },
+    unregisterRemoteApp(appId) {
+      appHost.unregisterRemoteApp(appId);
+    },
     setContactService(checker) {
       appHost.setContactService(checker);
     },

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -138,6 +138,32 @@ export interface CoreApp {
    */
   readonly connections: ConnectionManager;
   registerApp: (manifest: AppManifest) => void;
+  /**
+   * Register an app whose hook handlers run in a remote process,
+   * connected over WebSocket. Hook RPCs (`apps/onBeforeDispatch`,
+   * `onBeforeMessageDelivery`, `onSessionActive`, `onJoin`, `onClose`)
+   * route to `connectionId` via the server-initiated awaitable RPC
+   * primitive. Verdicts decode at the WS edge into the same typed
+   * shapes as in-process hooks (`DispatchAdmissionResult`, `HookResult`).
+   *
+   * The dispatch surface is uniform with in-process per architect plan
+   * §3.4: callers of `runBeforeDispatch` etc. cannot observe whether a
+   * given app is in-process or remote. Fail-closed verdicts on
+   * disconnect / timeout / RPC error preserve the existing security
+   * posture (see `30-app-hooks.integration.test.ts:229-272,296-357`).
+   *
+   * Promotes any prior in-process registration for the same `appId` —
+   * the remote routing wins. Use {@link unregisterRemoteApp} to drop
+   * the registration eagerly when a connection is known to be gone
+   * (operator-driven cleanup; the disconnect-finalizer handles
+   * in-flight Deferreds either way).
+   */
+  registerRemoteApp: (manifest: AppManifest, connectionId: string) => void;
+  /**
+   * Drop a remote-app registration. Idempotent. Does NOT remove the
+   * manifest; only the routing entry. See {@link AppHost.unregisterRemoteApp}.
+   */
+  unregisterRemoteApp: (appId: string) => void;
   setContactService: (checker: ContactService) => void;
   setPermissionService: (handler: PermissionService) => void;
   setWebhookPermissionCallback: (


### PR DESCRIPTION
Closes #304
Spec: chughtapan/moltzap-arena#198 (epic, row B.3)
Architect plan: #286 (plan-approved, Phase 1.2)

## What changed

`AppHost` gains a remote-app routing path uniform with the existing in-process path: every hook (`before_dispatch`, `before_message_delivery`, `on_session_active`, `on_join`, `on_close`) compiles to `Effect<Verdict, never>` regardless of whether the app's handlers run in-process or in a remote WebSocket client. Source-branching happens once, inside the per-hook `dispatchXxxHook` helper; the call sites (`runBeforeDispatch`, `runBeforeMessageDelivery`, `runOnSessionActive`, `closeSession`, `admitAgentToSession`) just call into the helper and consume the verdict.

Remote-app registrations live in `AppHost.remoteRegistrations: Map<appId, { connectionId }>`. Hook RPCs route to `connectionId` via B.1's `sendRpcToClient`; verdicts decode at the WS edge through precompiled Effect Schema decoders in `hooks.ts`. The fail-closed envelope (`Effect.timeout` + tagged `catchAll`) collapses every failure mode — timeout, throw, RPC error, `AppDisconnected`, decode failure — into the verdict the existing tests already lock in:

- `before_dispatch` timeout/throw → `{ decision: "deny", reason: ... }` (fail-CLOSED, `30-app-hooks.integration.test.ts:229-272`)
- `before_message_delivery` timeout/throw → `{ block: true, reason: ... }` (fail-CLOSED, `:229-272,296-357`)
- `on_session_active` timeout/throw → void + `app/hookTimeout` event, sessionReady still broadcasts (fail-OPEN, `31-on-session-active.integration.test.ts:200-230`)
- `on_join` / `on_close` timeout/throw → void + `app/hookTimeout` event (fail-OPEN, `30-app-hooks.integration.test.ts:474-506`, `31-session-close.integration.test.ts:72-116`)

Multi-app composition uses `dispatchAcrossAppsWithDenyShortCircuit` — `Effect.gen`-driven sequential reducer, registration-order, first-deny short-circuits. Today's call sites pass a singleton list (sessions are 1:1 with appIds); the combinator is forward-compatible for multi-app sessions.

The webhook precedence at each call site (webhook > remote/in-process > none) is **preserved verbatim** until B.4 (#305) deletes it. No webhook code is touched.

The c2s \`apps/register\` RPC handler is wired through \`registerRemoteApp(manifest, connId)\` so a connected WS client that calls \`apps/register\` becomes a remote-app source. Server-side in-process registration via \`coreApp.registerApp(manifest)\` is unchanged (e.g. \`standalone.ts:447\`).

## Traceability

| Acceptance criterion (#304) | Implementation | Plan anchor |
|---|---|---|
| #1 — registerApp records source per app | \`AppHost.registerRemoteApp(manifest, connectionId)\`, \`unregisterRemoteApp\`, private \`remoteRegistrations\`. \`apps/register\` handler wired via \`ConnIdTag\`. | §3.4 |
| #2 — Hook dispatch uniform Effect<Verdict, never>; NO branching at AppHost dispatch site | Five \`dispatchXxxHook\` helpers; call sites invoke them directly. Source-branching INSIDE each helper. | §3.4 |
| #3 — Effect.forEach registration-order + first-deny short-circuit | \`dispatchAcrossAppsWithDenyShortCircuit<V>\` combinator. | §3.4 |
| #4 — Manifest hook timeout via Effect.timeout(manifestHookTimeout) | \`wrapHookEffectWithEnvelope\` applies \`Effect.timeout\` per dispatch with manifest-resolved \`timeout_ms\`. | §3.4 |
| #5 — Fail policy preserved | Admission hooks fail-CLOSED (deny / block); lifecycle fail-OPEN (void + \`app/hookTimeout\` event). 129 integration tests still green. | §3.4 |
| #6 — RPC failures (disconnect, timeout) feed into the same fail-closed paths | \`runRemoteHookEffect\` maps \`S2cRpcError\` → \`Error\`; envelope \`catchAll\` synthesizes fail-closed verdict. | §3.4, §3.3 step 3 |

## Scope

- **New modules**: 0 (everything fits in existing \`packages/server/src/app/\`).
- **New public exports**:
  - \`AppHost.registerRemoteApp\` / \`AppHost.unregisterRemoteApp\`
  - \`CoreApp.registerRemoteApp\` / \`CoreApp.unregisterRemoteApp\`
  - \`BeforeDispatchRpcResultSchema\`, \`decodeBeforeDispatchRpcResult\`, \`decodeBeforeMessageDeliveryRpcResult\`, \`decodeVoidRpcResult\` (hooks.ts wire decoders)
- **New deps**: 0
- **Tier (\`safer-diff-scope\`)**: \`senior\`. Sub-issue is labelled \`safer:implement-staff\`; the divergence is because B.3 fits inside one existing module rather than introducing new architectural territory. Per the implement-staff skill rules, this is a noted observation, not a stop. Earlier B.x phases registered similarly.

## Dependencies

| Name | Version | License | Justification |
|---|---|---|---|
| _none_ | — | — | All Effect primitives already in workspace via \`effect\`. Architect plan §6 explicitly precludes new deps. |

## Tests

- \`packages/server/src/app/app-host.remote.test.ts\` — new, 24 unit tests:
  - Registration shape (3): \`registerRemoteApp\` records source, manifest preserved, re-registration overwrites.
  - \`apps/onBeforeDispatch\` (6): happy grant, happy deny, missing-connection → fail-closed deny, disconnect mid-flight → fail-closed deny, decode failure → fail-closed deny, TestClock timeout → fail-closed deny + \`app/hookTimeout\` event.
  - \`apps/onBeforeMessageDelivery\` (3): happy non-blocking, missing-connection → fail-closed block, RPC error → fail-closed block.
  - Lifecycle hooks (3): on_session_active / on_join / on_close fail-OPEN on missing-connection.
  - In-process path preserved (3): grant on no hook, handler invoked, throw → fail-closed deny.
  - Multi-app combinator (4): registration order, first-deny short-circuit, empty-list default, sanity.
  - Sanity (1): \`Cause.pretty\` reachable.
- All 166 existing unit tests pass unchanged.
- All 129 integration tests pass unchanged.

## Simplify skips

_none_ — every \`/simplify\` finding applied:
- Drop dead schema aliases \`BeforeMessageDeliveryRpcResultSchema\` / \`VoidRpcResultSchema\` (pure renames).
- Drop dead \`AppRegistrationSource\` + \`EffectXxxHook\` types — exported with no consumer; B.5 will reintroduce them.
- Replace stringly-typed \`\"apps/onBeforeDispatch\"\` etc. with \`AppsOnX.name\` (5 sites).
- Replace \`\"app/hookTimeout\"\` strings with \`EventNames.AppHookTimeout\` (10 sites).
- Precompile \`Schema.decodeUnknown(...)\` decoders to module-level constants in hooks.ts; mirrors \`config/loader.ts\` pattern.

## Codex diff review

Two findings; one fixed inline, one deferred per architect ratchet:

- **P1 (fixed)** — \`apps/register\` handler still routed to in-process \`registerApp\`, leaving the new remote-routing surface unreachable from connected clients. Fix: handler now reads \`ConnIdTag\` and calls \`registerRemoteApp(manifest, connId)\` (\`packages/server/src/app/handlers/apps.handlers.ts\`).
- **P2 (follow-up)** — \`s2cPending\` map can leak on \`Effect.timeout\` interrupt. Architect plan §3.3 step 4 puts caller-side cancellation outside \`sendRpcToClient\`; existing B.1 test \`connection.s2c.test.ts:346-384\` explicitly asserts the primitive does NOT cleanup on interrupt. Modifying that contract is an architect ratchet, not implementation. Will file a follow-up.

## Confidence

HIGH — Behaviour preservation verified by existing integration suites (30-app-hooks, 31-on-session-active, 31-session-close, 32-webhook-hooks, 33-attach-conversation, 34-rpc-additions); all 129 integration + 166 unit tests pass. Remote-routing surface independently covered by 24 new unit tests including TestClock-driven timeout asserting fail-closed behaviour + \`app/hookTimeout\` event emission. P2 leak is bounded by connection lifetime and tracked as a follow-up.