### PR TITLE
[impl-junior] @moltzap/nanoclaw-channel test:integration script (#299)

### DIFF
--- a/packages/nanoclaw-channel/package.json
+++ b/packages/nanoclaw-channel/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
+    "test:integration": "echo '@moltzap/nanoclaw-channel has no integration tests by design (smoke-test package; coverage lives in unit + conformance suites)'",
     "test:conformance": "bash ../protocol/scripts/check-divergence-proofs.sh && vitest run -c vitest.conformance.config.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #299

## What changed

Added a no-op `test:integration` script to `packages/nanoclaw-channel/package.json`:

```json
"test:integration": "echo '@moltzap/nanoclaw-channel has no integration tests by design (smoke-test package; coverage lives in unit + conformance suites)'"
```

## Rationale (smaller blast radius)

verify-295's brief listed `pnpm --filter @moltzap/nanoclaw-channel test:integration` as a check step, but the package had no such script. The acceptance criteria offered two paths:

1. **Add real integration tests** — requires creating `vitest.integration.config.ts`, `vitest.integration.globalSetup.ts`, integration test files, and likely new dev deps (testcontainers, etc., mirroring openclaw-channel). This expands scope across multiple files and would re-architect a package that is explicitly described as a "smoke test package, not published" (see `package.json:4`).
2. **Document no integration tests exist** *(chosen)* — single-line addition that documents intent in the contract file (`package.json`) orchestrators read, and makes any current/future verify brief that filters on `test:integration` a no-op rather than a hard failure.

`nanoclaw-channel` has only:
- `src/channels/moltzap.test.ts` (unit)
- `src/__tests__/conformance/suite.test.ts` (conformance)

…and no `*.integration.test.ts` files. CI (`.github/workflows/ci.yml`) only runs `test:integration` for `@moltzap/server-core` and `@moltzap/openclaw-channel` — never nanoclaw — so this PR does not change CI behavior.

## Scope

- Module: `packages/nanoclaw-channel/package.json` (1 file, +1 line)
- Tier (from `safer-diff-scope`): junior
- New exported signatures: none
- New deps: none
- Lockfile changes: none

## Tests

- Verified locally: `pnpm --filter @moltzap/nanoclaw-channel test:integration` exits 0 with the documentation message.
- No new test files (this is a documentation-via-script change for a package that intentionally has no integration suite).

## Confidence

**HIGH** — single-line additive change to scripts; no source/test/build/CI configuration touched; rationale traces directly to `package.json` description ("smoke test package, not published") and the absence of any `*.integration.test.ts` in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)