### PR TITLE
[impl-junior] Fix client test:integration globalSetup path (#298)

### DIFF
--- a/packages/client/vitest.integration.globalSetup.ts
+++ b/packages/client/vitest.integration.globalSetup.ts
@@ -17,13 +17,14 @@ export default async function ({ provide }: GlobalSetupContext) {
     .withPassword("test")
     .start();
 
-  // Apply core-schema.sql from server-core
+  // Apply core-schema.sql from the server package.
   const pool = new pg.Pool({ connectionString: container.getConnectionUri() });
   const schemaPath = join(
     dirname(fileURLToPath(import.meta.url)),
     "..",
-    "server-core",
-    "examples",
+    "server",
+    "src",
+    "app",
     "core-schema.sql",
   );
   const sql = readFileSync(schemaPath, "utf-8");


### PR DESCRIPTION
Closes #298.

## What changed
`packages/client/vitest.integration.globalSetup.ts:22-28@5230663` pointed at `packages/server-core/examples/core-schema.sql`, a path that never existed in this repo. The schema lives at `packages/server/src/app/core-schema.sql` (package name `@moltzap/server-core`, directory `packages/server/`). Updated the relative path and refreshed the comment. `pnpm --filter @moltzap/client test:integration` now runs end-to-end.

## Scope
- Module: `packages/client/`
- Tier (from `safer-diff-scope --head HEAD`): `junior` (`{"tier":"junior","files":1,"modules":1,"exports":0,"new_deps":0}`)
- New exported signatures: none
- New deps: none
- LOC: +4 / -3

## Tests
- No new tests. The fix re-enables the existing 39-test `service.integration.test.ts` suite, which never ran successfully before this change.
- Local run: `pnpm --filter @moltzap/client test:integration` → `Test Files 1 passed (1) | Tests 39 passed (39)` (~57s, real Postgres testcontainer).

## CI integration (Acceptance #3)
Documenting in this PR rather than wiring the script in: `.github/workflows/ci.yml` is a second module outside the junior charter (Junior Dev Rule, Principle 5; "Touching infrastructure (CI, ...)" is in the explicit forbidden list). Filed as a follow-up: chughtapan/moltzap#313. The follow-up is one-line and trivially junior; it just lives outside this module.

## Pre-PR hygiene
- `/simplify`: no findings (single-line path correction, no surface changes).
- `/review`: no findings.

## Confidence
HIGH — `packages/server/src/app/core-schema.sql` exists; the integration suite passes end-to-end locally; `safer-diff-scope` reports junior; `pnpm lint`, `pnpm typecheck`, `pnpm format:check` all green at repo root.