### PR TITLE
[impl-senior] Tighten sendRpcToClient interrupt-cleanup contract (#310)

### DIFF
--- a/packages/server/src/ws/connection.s2c.test.ts
+++ b/packages/server/src/ws/connection.s2c.test.ts
@@ -343,11 +343,12 @@ describe("sendRpcToClient — caller timeout", () => {
     expect(elapsed).toBeLessThan(2000);
   });
 
-  it("manual cleanup: cancelling the awaiting fiber leaves the pending entry; the disconnect finalizer drains it", async () => {
-    // The primitive itself does not register fiber-interruption finalizers
-    // (architect plan: caller controls timeout/cancellation, finalization
-    // happens at scope close). Verify that an interrupted fiber + scope
-    // close drains the pending map cleanly.
+  it("interrupt cleans up the pending entry: the primitive owns cancellation cleanup", async () => {
+    // Issue #310 contract: `sendRpcToClient` wraps the pending insert/
+    // remove in `Effect.acquireUseRelease`, so the entry is removed on
+    // interrupt before the inner exit unwinds. No need for the caller
+    // to wait for scope close; no orphan accretion across long-lived
+    // connections under timeout-driven interruption.
     const program = Effect.gen(function* () {
       const scope = yield* Scope.make();
       const { conn } = yield* Scope.extend(
@@ -375,12 +376,163 @@ describe("sendRpcToClient — caller timeout", () => {
 
     const { sizeAfterInterrupt, sizeAfterScope } =
       await Effect.runPromise(program);
-    // Interruption alone leaves the entry — primitive does not own
-    // cancellation cleanup. (Caller is expected to wrap with
-    // `Effect.timeout` or close the connection scope to drain.)
-    expect(sizeAfterInterrupt).toBe(1);
-    // Scope close drains via the disconnect finalizer.
+    // Interrupt fires the `acquireUseRelease` release, which removes
+    // the entry. Scope close is a clean no-op for this entry.
+    expect(sizeAfterInterrupt).toBe(0);
     expect(sizeAfterScope).toBe(0);
+  });
+
+  it("late response after interrupt is silently dropped (Option.none from completeS2cResponse)", async () => {
+    // Issue #310 contract test (a): after caller interrupt, the pending
+    // entry is gone, so an inbound response frame for that request id
+    // finds nothing in the map. `completeS2cResponse` returns
+    // `Option.none()` and the inbound router treats it as a stale
+    // reply. Proves the "freed Deferred re-resolve" hole is
+    // structurally closed.
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const { conn, outbound } = yield* Scope.extend(
+        makeFakeConnection("conn-late-reply"),
+        scope,
+      );
+
+      const fiber = yield* Effect.fork(
+        sendRpcToClient(conn, "apps/onJoin", { sessionId: "late" }),
+      );
+
+      // Wait for the entry to be registered + the frame to be written.
+      yield* Ref.get(conn.s2cPending).pipe(
+        Effect.flatMap((m) =>
+          HashMap.size(m) === 1
+            ? Effect.succeed(undefined)
+            : Effect.fail(new Error("not registered yet")),
+        ),
+        Effect.retry({ times: 50, schedule: undefined }),
+      );
+      const captured = yield* Ref.get(outbound).pipe(
+        Effect.flatMap((xs) =>
+          xs.length > 0
+            ? Effect.succeed(xs[0]!)
+            : Effect.fail(new Error("no frame yet")),
+        ),
+        Effect.retry({ times: 50, schedule: undefined }),
+      );
+      const { id: requestId } = JSON.parse(captured) as { id: string };
+
+      yield* Fiber.interrupt(fiber);
+      const sizeAfterInterrupt = HashMap.size(yield* Ref.get(conn.s2cPending));
+
+      // Inbound response arrives AFTER the caller was interrupted. The
+      // entry is already gone; this must return `Option.none()` and
+      // not throw, panic, or settle anything.
+      const completed = yield* completeS2cResponse(conn, {
+        jsonrpc: "2.0",
+        type: "response",
+        direction: "s2c",
+        id: requestId,
+        result: { ok: true },
+      });
+
+      yield* Scope.close(scope, Exit.void);
+      return { sizeAfterInterrupt, completed };
+    });
+
+    const { sizeAfterInterrupt, completed } = await Effect.runPromise(program);
+    expect(sizeAfterInterrupt).toBe(0);
+    expect(completed._tag).toBe("None");
+  });
+
+  it("scope close after interrupt is a clean no-op (no double-fail, no panic)", async () => {
+    // Issue #310 contract test (b): the disconnect-finalizer + the
+    // `acquireUseRelease` release converge through the same atomic
+    // `Ref.update`. Interrupt removes the entry; scope close then sees
+    // an empty map and the finalizer is a no-op. Verifies no second
+    // `Deferred.fail` lands on the (interrupted, never settled)
+    // Deferred.
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const { conn } = yield* Scope.extend(
+        makeFakeConnection("conn-int-then-close"),
+        scope,
+      );
+
+      const fiber = yield* Effect.fork(
+        sendRpcToClient(conn, "apps/onClose", {}),
+      );
+      yield* Ref.get(conn.s2cPending).pipe(
+        Effect.flatMap((m) =>
+          HashMap.size(m) === 1
+            ? Effect.succeed(undefined)
+            : Effect.fail(new Error("not registered yet")),
+        ),
+        Effect.retry({ times: 50, schedule: undefined }),
+      );
+
+      yield* Fiber.interrupt(fiber);
+      const sizeAfterInterrupt = HashMap.size(yield* Ref.get(conn.s2cPending));
+
+      // Scope close runs the disconnect finalizer on an empty map.
+      // Should not throw, should not log, should not affect the
+      // already-interrupted fiber's exit.
+      const closeExit = yield* Scope.close(scope, Exit.void).pipe(Effect.exit);
+
+      const fiberExit = yield* Fiber.await(fiber);
+      const sizeAfterScope = HashMap.size(yield* Ref.get(conn.s2cPending));
+
+      return { sizeAfterInterrupt, sizeAfterScope, closeExit, fiberExit };
+    });
+
+    const { sizeAfterInterrupt, sizeAfterScope, closeExit, fiberExit } =
+      await Effect.runPromise(program);
+    expect(sizeAfterInterrupt).toBe(0);
+    expect(sizeAfterScope).toBe(0);
+    // Scope close itself is a clean success.
+    expect(Exit.isSuccess(closeExit)).toBe(true);
+    // Interrupted fiber stays interrupted; the late finalizer didn't
+    // re-fail the (already-released) Deferred into a typed error.
+    expect(Exit.isInterrupted(fiberExit)).toBe(true);
+  });
+
+  it("Effect.timeout firing removes the pending entry (B.3 callsite shape)", async () => {
+    // Issue #310 contract test (c): the canonical B.3 callsite is
+    // `wrapHookEffectWithEnvelope` wrapping `sendRpcToClient` with
+    // `Effect.timeout`. `Effect.timeout` works by interrupting the
+    // inner fiber on fire. With the new contract, that interrupt fires
+    // the release, and the pending entry is removed *before* the
+    // timeout exit unwinds. No orphan accretion across N-hooks/sec on
+    // a long-lived connection.
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const { conn, outbound } = yield* Scope.extend(
+        makeFakeConnection("conn-timeout-drain"),
+        scope,
+      );
+
+      const exit = yield* sendRpcToClient(conn, "apps/onJoin", {
+        sessionId: "s",
+      }).pipe(Effect.timeout(Duration.millis(50)), Effect.exit);
+
+      // Frame was written before timeout fired (proves the primitive
+      // started its work).
+      const written = yield* Ref.get(outbound);
+      const sizeAfterTimeout = HashMap.size(yield* Ref.get(conn.s2cPending));
+
+      yield* Scope.close(scope, Exit.void);
+      return { exit, writtenLen: written.length, sizeAfterTimeout };
+    });
+
+    const { exit, writtenLen, sizeAfterTimeout } =
+      await Effect.runPromise(program);
+    expect(writtenLen).toBe(1);
+    expect(sizeAfterTimeout).toBe(0);
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const err = Cause.failureOption(exit.cause);
+      expect(err._tag).toBe("Some");
+      if (err._tag === "Some") {
+        expect(err.value._tag).toBe("TimeoutException");
+      }
+    }
   });
 });
 

--- a/packages/server/src/ws/connection.ts
+++ b/packages/server/src/ws/connection.ts
@@ -154,21 +154,42 @@ function nextS2cRequestId(
  * pool, no callback registry, no setTimeout retry loop):
  *
  *   1. Mint a fresh request id from the connection's counter.
- *   2. Allocate `Deferred<unknown, S2cRpcError>` and register it in
- *      `connection.s2cPending` keyed by the request id.
- *   3. Encode the `RequestFrame` with `direction: "s2c"` and write it via
- *      `connection.write`. Socket failures fail the Deferred with
- *      `S2cRpcSocketError` so the caller's await observes the failure
- *      rather than hanging.
- *   4. Return `Deferred.await` mapped through the typed error channel. The
- *      reader fiber resolves the Deferred when the matching s2c response
- *      arrives (`completeS2cResponse` below); the connection's `Scope`
- *      finalizer fails it on disconnect.
+ *   2. Allocate `Deferred<unknown, S2cRpcError>`.
+ *   3. `Effect.acquireUseRelease` around the pending-map pair:
+ *      - acquire: register the `{method, deferred}` entry in
+ *        `connection.s2cPending` keyed by the request id (atomic
+ *        `Ref.update`).
+ *      - use: encode the `RequestFrame` with `direction: "s2c"`, write
+ *        it via `connection.write`, then `Deferred.await`. Socket
+ *        failures fail the Deferred with `S2cRpcSocketError` so the
+ *        caller's await observes the failure rather than hanging.
+ *      - release: remove the entry from `s2cPending` (atomic
+ *        `Ref.update`). Fires on success, error, AND interrupt.
  *
- * Caller controls timeout via `Effect.timeout` at the call site — there is
- * NO schema-level cap. Result decoding from `unknown` to a typed verdict is
- * the caller's responsibility (Phase 1.1 / B.2 narrows this signature
- * generically against `S2cRpcMap` and folds decoding inside the function).
+ * Cleanup contract (Issue #310). The pending registry insert/remove are
+ * an `acquireUseRelease` pair; the entry is removed on success, error,
+ * AND interrupt. Interrupt paths covered:
+ *
+ *   - Caller fiber interrupt (e.g., `Effect.timeout` firing inside a
+ *     hook wrapper): release runs, entry removed before the inner exit
+ *     unwinds.
+ *   - Parent scope teardown mid-await: connection-Scope finalizer
+ *     (`drainPendingWithAppDisconnected`) drains the map and fails the
+ *     Deferred with `AppDisconnected`; the release then runs an
+ *     idempotent `HashMap.remove` (no-op).
+ *   - Normal completion via `completeS2cResponse`: removes the entry in
+ *     its own atomic `Ref.modify`; release re-removes (no-op).
+ *
+ * All three paths converge through atomic `Ref` ops on a single map, so
+ * no torn state. A late inbound response frame for a request whose
+ * caller was interrupted finds `Option.none()` in `completeS2cResponse`
+ * and is silently dropped (no panic, no Deferred re-resolve).
+ *
+ * Caller controls timeout via `Effect.timeout` at the call site — there
+ * is NO schema-level cap. Result decoding from `unknown` to a typed
+ * verdict is the caller's responsibility (Phase 1.1 / B.2 narrows this
+ * signature generically against `S2cRpcMap` and folds decoding inside
+ * the function).
  */
 export function sendRpcToClient(
   connection: MoltZapConnection,
@@ -178,14 +199,6 @@ export function sendRpcToClient(
   return Effect.gen(function* () {
     const requestId = yield* nextS2cRequestId(connection);
     const deferred = yield* Deferred.make<unknown, S2cRpcError>();
-
-    yield* Ref.update(connection.s2cPending, (m) =>
-      HashMap.set(m, requestId, {
-        method,
-        deferred,
-      } satisfies S2cPendingEntry<unknown>),
-    );
-
     const frame: RequestFrame = {
       jsonrpc: "2.0",
       type: "request",
@@ -196,34 +209,50 @@ export function sendRpcToClient(
     };
     const raw = JSON.stringify(frame);
 
-    // Write under `Effect.onError`-style cleanup: if write fails, drop the
-    // pending entry and fail the Deferred so the caller's `await` observes
-    // the typed socket error rather than hanging.
-    //
-    // Race note (intentional, benign): if a disconnect-finalizer fires
-    // between the pending insert above and the write attempt below, the
-    // finalizer drains the entry first and fails the Deferred with
-    // `AppDisconnected`. The cleanup branch then runs `HashMap.remove`
-    // (no-op on the already-empty map) and `Deferred.fail` with
-    // `S2cRpcSocketError` — which `Effect.ignore` swallows because the
-    // Deferred is already settled. Caller observes whichever completion
-    // landed first; both error tags are correct readings of the failure.
-    const writeOutcome = yield* Effect.either(connection.write(raw));
-    if (writeOutcome._tag === "Left") {
-      yield* Ref.update(connection.s2cPending, (m) =>
-        HashMap.remove(m, requestId),
-      );
-      const err = new S2cRpcSocketError({
-        connectionId: connection.id,
-        method,
-        requestId,
-        cause: writeOutcome.left,
-      });
-      yield* Deferred.fail(deferred, err).pipe(Effect.ignore);
-      return yield* Effect.fail<S2cRpcError>(err);
-    }
-
-    return yield* Deferred.await(deferred);
+    return yield* Effect.acquireUseRelease(
+      // acquire: register the pending entry. Atomic `Ref.update` —
+      // `completeS2cResponse` and the connection-Scope finalizer key
+      // off the same Ref, so all three writers serialize.
+      Ref.update(connection.s2cPending, (m) =>
+        HashMap.set(m, requestId, {
+          method,
+          deferred,
+        } satisfies S2cPendingEntry<unknown>),
+      ),
+      // use: write the frame, then await the Deferred. Socket failures
+      // settle the Deferred so a late inbound frame's `Deferred.succeed`
+      // is a no-op via `Effect.ignore` on an already-failed Deferred.
+      //
+      // Race note (intentional, benign): if the disconnect-finalizer
+      // fires between the acquire above and the write below, the
+      // finalizer drains the entry first and fails the Deferred with
+      // `AppDisconnected`. The write may then fail (socket already
+      // closed) and we attempt `Deferred.fail` with `S2cRpcSocketError`
+      // — `Effect.ignore` swallows the no-op on an already-settled
+      // Deferred. Caller observes whichever completion landed first;
+      // both error tags are correct readings of the failure.
+      () =>
+        Effect.gen(function* () {
+          const writeOutcome = yield* Effect.either(connection.write(raw));
+          if (writeOutcome._tag === "Left") {
+            const err = new S2cRpcSocketError({
+              connectionId: connection.id,
+              method,
+              requestId,
+              cause: writeOutcome.left,
+            });
+            yield* Deferred.fail(deferred, err).pipe(Effect.ignore);
+            return yield* Effect.fail<S2cRpcError>(err);
+          }
+          return yield* Deferred.await(deferred);
+        }),
+      // release: remove the entry. Idempotent — `HashMap.remove` on an
+      // already-removed key is a no-op, so this is safe whether
+      // `completeS2cResponse` already removed it (success/error path)
+      // or the connection-Scope finalizer drained it (disconnect path).
+      () =>
+        Ref.update(connection.s2cPending, (m) => HashMap.remove(m, requestId)),
+    );
   });
 }
 


### PR DESCRIPTION
Closes #310
Architect plan: https://github.com/chughtapan/moltzap/issues/309#issuecomment-4357132629
Parent epic: https://github.com/chughtapan/moltzap-arena/issues/198

## What changed

`sendRpcToClient` now wraps its `s2cPending` insert/remove pair in
`Effect.acquireUseRelease`. The release is guaranteed to fire on
success, error, AND interrupt — closing the orphan-entry leak that the
existing test at `connection.s2c.test.ts:346-384` pinned with
`expect(sizeAfterInterrupt).toBe(1)`. Public API unchanged. No caller
edits needed (B.3 `app-host.ts:1707`, B.7 `test-client.ts`).

The previous contract documented the gap rather than closed it:

```ts
// Interruption alone leaves the entry — primitive does not own
// cancellation cleanup. (Caller is expected to wrap with
// Effect.timeout or close the connection scope to drain.)
expect(sizeAfterInterrupt).toBe(1);
```

But Effect.timeout works by interrupting the inner fiber, so timeout
*is* the leaking path, not a workaround. Practical leak rate at the B.3
callsite: 100 hooks/s × 0.1% timeout × 1h ≈ 360 orphan entries per
connection, drained only at connection close.

## Plan anchors

| Change | Plan anchor |
|---|---|
| sendRpcToClient rewritten to use Effect.acquireUseRelease (acquire → insert; use → write + Deferred.await; release → remove) | Architect plan §"Primitive: Effect.acquireUseRelease around the registry pair"; acceptance #1 |
| TSDoc rewritten to spell out the cleanup contract: success / error / interrupt all converge through the same atomic Ref.update, idempotent vs completeS2cResponse and the connection-Scope finalizer | Plan §"Files to touch" connection.ts:150-172; acceptance #1 |
| Inverted expect(sizeAfterInterrupt).toBe(1) → toBe(0) and rewrote the inline comment to describe the new contract | Plan §"Files to touch" connection.s2c.test.ts:346-384; acceptance #2 |
| New test: late response after interrupt → completeS2cResponse returns Option.none(); the inbound response frame for that RequestId is silently dropped | Plan §"Tests that gate the contract" #3; acceptance #2.a |
| New test: scope close after interrupt is a clean no-op (no double-fail, no panic; fiber stays interrupted) | Plan §"Tests that gate the contract" #4; acceptance #2.b |
| New test: Effect.timeout firing removes the pending entry — the canonical B.3 callsite shape (wrapHookEffectWithEnvelope wrapping sendRpcToClient with Effect.timeout) | Plan §"Tests that gate the contract" #2; acceptance #2.c |

## Scope

- Modules touched: `packages/server/src/ws/connection.ts` + sibling test file. One module surface per the architect plan.
- Tier: architect classified as **senior** ("the reasoning is non-trivial: race analysis across 3 ref-mutation paths, interrupt semantics, Deferred settle-once invariant"). `safer-diff-scope` mechanical heuristics report `junior` (single module, no public surface changes, no new deps). The architect overrode the heuristic on reasoning load; tagging here so the next reviewer doesn't relabel.
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Tests

- Inverted: `connection.s2c.test.ts:346` — `sizeAfterInterrupt` flips from 1 → 0.
- Added: late response after interrupt (`Option.none` from `completeS2cResponse`).
- Added: scope close after interrupt is a clean no-op (`Exit.isInterrupted` on the fiber, `Exit.isSuccess` on the scope close).
- Added: `Effect.timeout` firing removes the pending entry (B.3 callsite shape).
- Unchanged: 5 pre-existing tests (happy-path round-trip, typed error response, scope-close drain, write-time SocketError cleanup, caller-side timeout exit type).

Local results:
- `pnpm --filter @moltzap/server-core test`: **145/145** pass.
- `pnpm --filter @moltzap/server-core test:integration`: **121/121** pass (33 files).
- `pnpm typecheck`: clean.
- `pnpm lint`: 0 warnings, 0 errors.
- `pnpm format:check`: all matched files formatted.
- `scripts/sloppy-code-guard.sh`: all guards passed.

## Confidence

**HIGH** — Architect plan was concrete down to the code shape. The implementation is structurally minimal (~10 LoC of behavioral change; the rest is TSDoc + 3 new tests). The 4 contract tests + the original 5 cover every interrupt path the plan named. `Fiber.interrupt` awaits the fiber's complete unwinding, so the post-interrupt size assertions are deterministic.

## Stamina precondition (per dispatch)

- `/simplify`: **no findings** — diff is plan-anchored, no extracted helpers needed; the new TSDoc, inverted test, and three new tests are each ~one logical block.
- `/safer:review-senior`: pending team-lead dispatch on this PR head.
- `/codex review`: pending team-lead dispatch on this PR head.
- `/safer:verify` runs before merge (per safer-by-default#241).
- CI must be GREEN on PR head before declaring DONE (per safer-by-default#244).