### PR TITLE
[impl-senior] Phase 1.4: app-sdk handler surface + lifecycle methods

### DIFF
--- a/packages/app-sdk/src/app.handlers.test.ts
+++ b/packages/app-sdk/src/app.handlers.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Effect, Exit, Ref, HashMap } from "effect";
+import type {
+  BeforeDispatchContext,
+  BeforeMessageDeliveryContext,
+  OnSessionActiveContext,
+  OnJoinContext,
+  OnCloseContext,
+  DispatchAdmissionResult,
+  HookResult,
+} from "@moltzap/protocol";
+
+// Phase 1.4 / B.5 handler-surface tests.
+//
+// We mock `@moltzap/client` to expose `handleServerRpc` (the real client
+// keeps an internal `Ref<HashMap<method, handler>>`; we mirror that shape
+// using Effect's own `Ref` so the duplicate-registration test goes through
+// the same code path as production).  Each test drives an inbound s2c
+// admission request directly into the registered handler and asserts on
+// the outbound reply shape.
+//
+// `RpcServerError` is re-exported from the mock so the SDK's
+// `mapAttachError` `instanceof` check resolves correctly.
+
+// `vi.mock` is hoisted to the top of the file; classes referenced inside
+// the factory must be declared via `vi.hoisted` so they exist at hoist
+// time. See https://vitest.dev/api/vi.html#vi-hoisted.
+const { MockRpcServerError, MockDuplicateError } = vi.hoisted(() => {
+  class MockRpcServerError extends Error {
+    readonly _tag = "RpcServerError";
+    readonly code: number;
+    readonly data?: unknown;
+    constructor(args: { code: number; message: string; data?: unknown }) {
+      super(args.message);
+      this.code = args.code;
+      this.data = args.data;
+    }
+  }
+  class MockDuplicateError extends Error {
+    readonly _tag = "DuplicateServerRpcHandlerError";
+    constructor(public readonly method: string) {
+      super(`duplicate handler: ${method}`);
+    }
+  }
+  return { MockRpcServerError, MockDuplicateError };
+});
+
+type MockRpcServerErrorInstance = InstanceType<typeof MockRpcServerError>;
+
+interface InstalledHandler {
+  (params: unknown): Effect.Effect<unknown, MockRpcServerErrorInstance>;
+}
+
+vi.mock("@moltzap/client", async () => {
+  return {
+    MoltZapWsClient: vi.fn().mockImplementation(() => {
+      const handlers = Effect.runSync(
+        Ref.make<HashMap.HashMap<string, InstalledHandler>>(HashMap.empty()),
+      );
+      let attachShouldFail: {
+        error: MockRpcServerErrorInstance | Error;
+        isRpc: boolean;
+      } | null = null;
+
+      return {
+        // Capture-everything subscribe so app.start() succeeds if a test
+        // wires it up.  Most handler-surface tests skip start() entirely.
+        subscribe: vi.fn().mockImplementation(() =>
+          Effect.succeed({
+            id: "sub-mock",
+            unsubscribe: Effect.succeed(undefined),
+          }),
+        ),
+        connect: vi
+          .fn()
+          .mockImplementation(() => Effect.succeed({ agentId: "agent-1" })),
+        sendRpc: vi.fn().mockImplementation((method: string) => {
+          if (method === "apps/attachConversation") {
+            if (attachShouldFail !== null) {
+              const err = attachShouldFail.error;
+              attachShouldFail = null;
+              return Effect.fail(err);
+            }
+            return Effect.succeed({});
+          }
+          return Effect.succeed({});
+        }),
+        close: vi.fn().mockImplementation(() => Effect.succeed(undefined)),
+        disconnect: vi.fn().mockImplementation(() => Effect.succeed(undefined)),
+        handleServerRpc: vi
+          .fn()
+          .mockImplementation((method: string, handler: InstalledHandler) =>
+            Effect.gen(function* () {
+              const swapped = yield* Ref.modify(handlers, (m) => {
+                if (HashMap.has(m, method)) return [false, m];
+                return [true, HashMap.set(m, method, handler)];
+              });
+              if (!swapped) {
+                return yield* Effect.fail(new MockDuplicateError(method));
+              }
+            }),
+          ),
+        // Test helpers exposed via underscore prefix.
+        _invokeHandler(
+          method: string,
+          params: unknown,
+        ): Effect.Effect<unknown, MockRpcServerErrorInstance> {
+          const m = Effect.runSync(Ref.get(handlers));
+          const h = HashMap.get(m, method);
+          if (h._tag === "None") {
+            throw new Error(`no handler for ${method}`);
+          }
+          return h.value(params);
+        },
+        _hasHandler(method: string): boolean {
+          const m = Effect.runSync(Ref.get(handlers));
+          return HashMap.has(m, method);
+        },
+        _setAttachFailure(err: MockRpcServerErrorInstance | Error): void {
+          attachShouldFail = {
+            error: err,
+            isRpc: err instanceof MockRpcServerError,
+          };
+        },
+      };
+    }),
+    RpcServerError: MockRpcServerError,
+    DuplicateServerRpcHandlerError: MockDuplicateError,
+  };
+});
+
+// Import the SDK AFTER vi.mock so the mock is active.
+import { MoltZapApp } from "./app.js";
+import { AppError, AppHandlerError, AttachError } from "./errors.js";
+
+interface MockedWsClient {
+  _invokeHandler: (
+    method: string,
+    params: unknown,
+  ) => Effect.Effect<unknown, MockRpcServerErrorInstance>;
+  _hasHandler: (method: string) => boolean;
+  _setAttachFailure: (err: MockRpcServerErrorInstance | Error) => void;
+}
+
+// #ignore-sloppy-code-next-line[as-unknown-as]: mock boundary
+const asMock = (c: unknown): MockedWsClient => c as MockedWsClient;
+
+const baseDispatchCtx: BeforeDispatchContext = {
+  sessionId: "00000000-0000-0000-0000-000000000001",
+  appId: "test-app",
+  conversationId: "conv-1",
+  recipient: { agentId: "agent-r", ownerId: "owner-r" },
+  message: { id: "msg-1", senderAgentId: "agent-s" },
+  attempt: 0,
+};
+
+const baseDeliveryCtx: BeforeMessageDeliveryContext = {
+  sessionId: "00000000-0000-0000-0000-000000000001",
+  appId: "test-app",
+  conversationId: "conv-1",
+  sender: { agentId: "agent-s", ownerId: "owner-s" },
+  message: { parts: [{ type: "text", text: "hi" }] },
+};
+
+const baseSessionActiveCtx: OnSessionActiveContext = {
+  sessionId: "00000000-0000-0000-0000-000000000001",
+  appId: "test-app",
+  conversations: { default: "conv-1" },
+  admittedAgentIds: ["agent-1"],
+};
+
+const baseJoinCtx: OnJoinContext = {
+  sessionId: "00000000-0000-0000-0000-000000000001",
+  appId: "test-app",
+  conversations: { default: "conv-1" },
+  agent: { agentId: "agent-1", ownerId: "owner-1" },
+};
+
+const baseCloseCtx: OnCloseContext = {
+  sessionId: "00000000-0000-0000-0000-000000000001",
+  appId: "test-app",
+  conversations: { default: "conv-1" },
+  closedBy: { agentId: "agent-1", ownerId: "owner-1" },
+};
+
+describe("MoltZapApp — admission/lifecycle handler surface", () => {
+  let app: MoltZapApp;
+  let onErr: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new MoltZapApp({
+      serverUrl: "ws://localhost:3000",
+      agentKey: "test-key",
+      appId: "test-app",
+    });
+    onErr = vi.fn();
+    app.onError(onErr);
+  });
+
+  describe("onBeforeDispatch", () => {
+    it("registers a handler that wraps the verdict in { admission }", async () => {
+      app.onBeforeDispatch((ctx) =>
+        Effect.succeed<DispatchAdmissionResult>({
+          decision: "grant",
+          leaseId: `lease-${ctx.sessionId.slice(0, 4)}`,
+        }),
+      );
+      expect(asMock(app.client)._hasHandler("apps/onBeforeDispatch")).toBe(
+        true,
+      );
+
+      const reply = await Effect.runPromise(
+        asMock(app.client)._invokeHandler(
+          "apps/onBeforeDispatch",
+          baseDispatchCtx,
+        ),
+      );
+      expect(reply).toEqual({
+        admission: { decision: "grant", leaseId: "lease-0000" },
+      });
+    });
+
+    it("synthesizes deny with reason 'app_handler_error' on handler defect", async () => {
+      app.onBeforeDispatch(() =>
+        Effect.sync<DispatchAdmissionResult>(() => {
+          throw new Error("user code blew up");
+        }),
+      );
+      const reply = await Effect.runPromise(
+        asMock(app.client)._invokeHandler(
+          "apps/onBeforeDispatch",
+          baseDispatchCtx,
+        ),
+      );
+      expect(reply).toEqual({
+        admission: { decision: "deny", reason: "app_handler_error" },
+      });
+      expect(onErr).toHaveBeenCalledTimes(1);
+      const errArg = onErr.mock.calls[0]![0] as AppHandlerError;
+      expect(errArg).toBeInstanceOf(AppHandlerError);
+      expect(errArg.code).toBe("APP_HANDLER_ERROR");
+      expect(errArg.method).toBe("apps/onBeforeDispatch");
+    });
+
+    it("throws AppError DUPLICATE_HOOK_HANDLER on second registration", () => {
+      app.onBeforeDispatch(() =>
+        Effect.succeed<DispatchAdmissionResult>({ decision: "grant" }),
+      );
+      expect(() =>
+        app.onBeforeDispatch(() =>
+          Effect.succeed<DispatchAdmissionResult>({ decision: "grant" }),
+        ),
+      ).toThrow(AppError);
+      try {
+        app.onBeforeDispatch(() =>
+          Effect.succeed<DispatchAdmissionResult>({ decision: "grant" }),
+        );
+      } catch (e) {
+        expect((e as AppError).code).toBe("DUPLICATE_HOOK_HANDLER");
+      }
+    });
+  });
+
+  describe("onBeforeMessageDelivery", () => {
+    it("returns the user verdict verbatim on success", async () => {
+      const verdict: HookResult = {
+        block: false,
+        patch: { parts: [{ type: "text", text: "patched" }] },
+      };
+      app.onBeforeMessageDelivery(() => Effect.succeed(verdict));
+      const reply = await Effect.runPromise(
+        asMock(app.client)._invokeHandler(
+          "apps/onBeforeMessageDelivery",
+          baseDeliveryCtx,
+        ),
+      );
+      expect(reply).toEqual(verdict);
+    });
+
+    it("synthesizes block:true / reason:'app_handler_error' on defect", async () => {
+      app.onBeforeMessageDelivery(() =>
+        Effect.sync<HookResult>(() => {
+          throw new Error("kaboom");
+        }),
+      );
+      const reply = await Effect.runPromise(
+        asMock(app.client)._invokeHandler(
+          "apps/onBeforeMessageDelivery",
+          baseDeliveryCtx,
+        ),
+      );
+      expect(reply).toEqual({ block: true, reason: "app_handler_error" });
+      expect(onErr).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("lifecycle hooks (onSessionActive / onJoin / onClose)", () => {
+    it.each([
+      ["apps/onSessionActive", baseSessionActiveCtx, "onSessionActive"],
+      ["apps/onJoin", baseJoinCtx, "onJoin"],
+      ["apps/onClose", baseCloseCtx, "onClose"],
+    ] as const)(
+      "%s replies with empty result on success",
+      async (method, ctx, methodName) => {
+        const seen = vi.fn();
+        // dynamic dispatch via index — avoids 3 near-identical blocks
+        const register =
+          methodName === "onSessionActive"
+            ? app.onSessionActive.bind(app)
+            : methodName === "onJoin"
+              ? app.onJoin.bind(app)
+              : app.onClose.bind(app);
+        register((c: unknown) =>
+          Effect.sync(() => {
+            seen(c);
+          }),
+        );
+        const reply = await Effect.runPromise(
+          asMock(app.client)._invokeHandler(method, ctx),
+        );
+        expect(reply).toEqual({});
+        expect(seen).toHaveBeenCalledWith(ctx);
+      },
+    );
+
+    it("logs + replies void when the lifecycle handler defects (fail-open)", async () => {
+      app.onSessionActive(() =>
+        Effect.sync(() => {
+          throw new Error("kaboom");
+        }),
+      );
+      const reply = await Effect.runPromise(
+        asMock(app.client)._invokeHandler(
+          "apps/onSessionActive",
+          baseSessionActiveCtx,
+        ),
+      );
+      expect(reply).toEqual({});
+      expect(onErr).toHaveBeenCalledTimes(1);
+      const errArg = onErr.mock.calls[0]![0] as AppHandlerError;
+      expect(errArg.method).toBe("apps/onSessionActive");
+    });
+
+    it("each lifecycle hook rejects duplicate registration", () => {
+      app.onJoin(() => Effect.void);
+      expect(() => app.onJoin(() => Effect.void)).toThrow(AppError);
+    });
+  });
+
+  describe("attachConversation", () => {
+    it("succeeds when the RPC succeeds", async () => {
+      const result = await Effect.runPromise(
+        app.attachConversation(
+          "00000000-0000-0000-0000-000000000001",
+          "conv-2",
+        ),
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it.each([
+      ["SessionNotFound", "SessionNotFound" as const],
+      ["ConversationNotFound", "ConversationNotFound" as const],
+      ["NotAuthorized", "NotAuthorized" as const],
+    ])(
+      "maps RpcServerError data.code='%s' to AttachError code '%s'",
+      async (dataCode, expectedCode) => {
+        asMock(app.client)._setAttachFailure(
+          new MockRpcServerError({
+            code: -32099,
+            message: "rejected",
+            data: { code: dataCode },
+          }),
+        );
+        const exit = await Effect.runPromiseExit(
+          app.attachConversation(
+            "00000000-0000-0000-0000-000000000001",
+            "conv-2",
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const err = exit.cause._tag === "Fail" ? exit.cause.error : null;
+          expect(err).toBeInstanceOf(AttachError);
+          expect((err as AttachError).code).toBe(expectedCode);
+        }
+      },
+    );
+
+    it("falls back to AttachFailed for unknown RPC errors", async () => {
+      asMock(app.client)._setAttachFailure(
+        new MockRpcServerError({ code: -32099, message: "boom" }),
+      );
+      const exit = await Effect.runPromiseExit(
+        app.attachConversation(
+          "00000000-0000-0000-0000-000000000001",
+          "conv-2",
+        ),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const err = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(err).toBeInstanceOf(AttachError);
+        expect((err as AttachError).code).toBe("AttachFailed");
+      }
+    });
+  });
+
+  describe("type-narrowed handler signatures (compile-time)", () => {
+    // These tests are partly compile-time assertions; the bodies just
+    // ensure runtime registration succeeds.  If the type imports drift,
+    // tsc fails before vitest runs.
+    it("BeforeDispatchContext narrows correctly", () => {
+      const handler = (
+        ctx: BeforeDispatchContext,
+      ): Effect.Effect<DispatchAdmissionResult, never> =>
+        Effect.succeed({
+          decision: "grant" as const,
+          leaseId: ctx.message.id,
+        });
+      app.onBeforeDispatch(handler);
+      expect(asMock(app.client)._hasHandler("apps/onBeforeDispatch")).toBe(
+        true,
+      );
+    });
+
+    it("HookResult narrows correctly for delivery handler", () => {
+      const handler = (
+        _ctx: BeforeMessageDeliveryContext,
+      ): Effect.Effect<HookResult, never> => Effect.succeed({ block: false });
+      app.onBeforeMessageDelivery(handler);
+      expect(
+        asMock(app.client)._hasHandler("apps/onBeforeMessageDelivery"),
+      ).toBe(true);
+    });
+
+    it("OnSessionActiveContext narrows correctly", () => {
+      const handler = (
+        ctx: OnSessionActiveContext,
+      ): Effect.Effect<void, never> => Effect.sync(() => ctx.sessionId);
+      app.onSessionActive(handler);
+      expect(asMock(app.client)._hasHandler("apps/onSessionActive")).toBe(true);
+    });
+  });
+});

--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -1,4 +1,9 @@
-import { MoltZapWsClient } from "@moltzap/client";
+import {
+  MoltZapWsClient,
+  NotConnectedError,
+  RpcServerError,
+  RpcTimeoutError,
+} from "@moltzap/client";
 import type {
   WsClientLogger,
   MoltZapWsClientOptions,
@@ -16,13 +21,23 @@ import type {
   AppSkillChallengeEvent,
   AppParticipantAdmittedEvent,
   AppParticipantRejectedEvent,
+  BeforeDispatchContext,
+  BeforeMessageDeliveryContext,
+  OnSessionActiveContext,
+  OnJoinContext,
+  OnCloseContext,
+  DispatchAdmissionResult,
+  HookResult,
 } from "@moltzap/protocol";
 import { EventNames } from "@moltzap/protocol";
-import { Effect, Fiber } from "effect";
+import { Cause, Effect, Exit, Fiber } from "effect";
 import { AppSessionHandle } from "./session.js";
 import { HeartbeatManager } from "./heartbeat.js";
 import {
   AppError,
+  AppHandlerError,
+  AttachError,
+  type AttachErrorCode,
   AuthError,
   ManifestRegistrationError,
   SessionError,
@@ -30,29 +45,6 @@ import {
   ConversationKeyError,
   SendError,
 } from "./errors.js";
-
-// ── PHASE 1.4 STUB TYPE PLACEHOLDERS (B.0 architect) ────────────────────────
-// `BeforeDispatchContext` etc. live in `@moltzap/server`'s `app/hooks.ts`
-// today. Implementer (B.1) MOVES the context type *definitions* into
-// `@moltzap/protocol` (so app-sdk does not depend on server) and re-exports
-// them from app-sdk's `index.ts`. `AttachError` is a new tagged-error class
-// added by B.5 in `./errors.ts`.
-//
-// Local placeholder aliases below let the architect stubs typecheck without
-// requiring the moves to happen first. Implementer REPLACES these with real
-// imports from `@moltzap/protocol` in B.1.
-type _StubCtx = { readonly sessionId: string; readonly appId: string };
-type BeforeDispatchContext = _StubCtx;
-type BeforeMessageDeliveryContext = _StubCtx;
-type OnSessionActiveContext = _StubCtx;
-type OnJoinContext = _StubCtx;
-type OnCloseContext = _StubCtx;
-type DispatchAdmissionResult =
-  | { readonly decision: "grant"; readonly leaseId?: string }
-  | { readonly decision: "deny"; readonly reason?: string }
-  | { readonly decision: "hold"; readonly reason?: string };
-type HookResult = { readonly block: boolean };
-type AttachError = AppError;
 
 type MessageHandler = (message: Message) => void | Promise<void>;
 type SessionReadyHandler = (session: AppSessionHandle) => void | Promise<void>;
@@ -366,44 +358,46 @@ export class MoltZapApp {
     this.errorHandler = handler;
   }
 
-  // ── PHASE 1.4 STUBS — admission RPC handler surface (B.0 architect) ─────
+  // ── Admission + lifecycle handler surface (Phase 1.4 / B.5) ─────────────
   //
-  // These five handlers register against s2c admission RPC verbs from
-  // protocol/methods/apps.ts (B.1). The SDK auto-replies via
-  // `client.handleServerRpc(...)` from B.1's WS-client extension, decoding
-  // params with the corresponding TypeBox schema and encoding the verdict
-  // using `DispatchAdmissionResultSchema` / `HookResultSchema`.
+  // Each `onX(handler)` registers against the corresponding s2c admission
+  // RPC verb (`apps/onBeforeDispatch`, `apps/onBeforeMessageDelivery`,
+  // `apps/onSessionActive`, `apps/onJoin`, `apps/onClose`). The underlying
+  // `client.handleServerRpc` decodes inbound frames against the protocol
+  // schemas and writes the encoded reply back; the wrapper functions below
+  // shape the user handler's `Effect<Verdict, never>` into the SDK's
+  // fail-closed contract:
   //
-  // FAIL-CLOSED HANDLER ERRORS: the SDK wraps each user handler in
-  // `Effect.catchAll`. On thrown / failed handler:
-  //   - onBeforeDispatch    → reply { decision: "deny", reason: "app_handler_error" }
-  //   - onBeforeMessageDelivery → reply { block: true, reason: "app_handler_error" }
-  //   - onSessionActive / onJoin / onClose → reply void; SDK logs the error
-  //     via `logger`. The hook is treated as completed (the spec calls these
-  //     "awaitable void"; their failure must not leave the AppHost waiting).
+  //   - onBeforeDispatch         handler defect → `{decision: "deny", reason: "app_handler_error"}`
+  //   - onBeforeMessageDelivery  handler defect → `{block: true,  reason: "app_handler_error"}`
+  //   - on_session_active / on_join / on_close   handler defect → void; logged
   //
-  // CONTEXT TYPES re-exported from the protocol package by B.1:
-  //   `BeforeDispatchContext`, `BeforeMessageDeliveryContext`,
-  //   `OnSessionActiveContext`, `OnJoinContext`, `OnCloseContext`,
-  //   `DispatchAdmissionResult`, `HookResult`. Implementers MUST NOT redefine
-  //   these in app-sdk; they live in `@moltzap/protocol` and re-export from
-  //   the SDK's `index.ts` to give downstream apps direct IntelliSense.
-  // ────────────────────────────────────────────────────────────────────────
+  // Duplicate registration on the same hook surfaces synchronously as
+  // `AppError("DUPLICATE_HOOK_HANDLER")`.
 
   /**
-   * Register a `before_dispatch` admission handler.
+   * Register a `before_dispatch` admission handler. AppHost calls this
+   * before delivering an outbound message to a recipient; the handler
+   * returns a `DispatchAdmissionResult` (grant / deny / hold).
    *
-   * Implementer (B.5): wire via `client.handleServerRpc("apps/onBeforeDispatch",
-   * (params) => handler(decode(params)).pipe(Effect.catchAll(synthesizeDeny)))`.
-   * Multiple registrations on the same hook MUST throw at registration time —
-   * the manifest declares one handler per hook kind.
+   * The user Effect is invoked once per inbound RPC, the verdict is wrapped
+   * into the protocol's `{ admission }` envelope, and any defect synthesizes
+   * a fail-closed `deny`. Calling twice throws `AppError("DUPLICATE_HOOK_HANDLER")`.
    */
   onBeforeDispatch(
-    _handler: (
+    handler: (
       ctx: BeforeDispatchContext,
     ) => Effect.Effect<DispatchAdmissionResult, never>,
   ): void {
-    throw new Error("not implemented");
+    this.registerAdmissionHandler<
+      BeforeDispatchContext,
+      DispatchAdmissionResult
+    >(
+      "apps/onBeforeDispatch",
+      handler,
+      (decision) => ({ admission: decision }),
+      () => ({ admission: { decision: "deny", reason: "app_handler_error" } }),
+    );
   }
 
   /**
@@ -411,48 +405,151 @@ export class MoltZapApp {
    * `{ block: false }` allows; `{ block: true, reason }` drops; supplying
    * `patch.parts` mutates the recipient view; `feedback` emits an
    * observability hook.
+   *
+   * Handler defects synthesize fail-closed `{ block: true,
+   * reason: "app_handler_error" }`. Calling twice throws
+   * `AppError("DUPLICATE_HOOK_HANDLER")`.
    */
   onBeforeMessageDelivery(
-    _handler: (
+    handler: (
       ctx: BeforeMessageDeliveryContext,
     ) => Effect.Effect<HookResult, never>,
   ): void {
-    throw new Error("not implemented");
+    this.registerAdmissionHandler<BeforeMessageDeliveryContext, HookResult>(
+      "apps/onBeforeMessageDelivery",
+      handler,
+      (verdict) => verdict,
+      () => ({ block: true, reason: "app_handler_error" }),
+    );
   }
 
   /**
    * Register an awaitable `on_session_active` lifecycle handler. AppHost
    * gates `app/sessionReady` delivery on the handler completing (preserves
-   * 31-on-session-active.integration.test.ts:200-230 ordering).
+   * `31-on-session-active.integration.test.ts:200-230` ordering).
+   *
+   * Handler defects log + reply void; the lifecycle hook never blocks the
+   * session.
    */
   onSessionActive(
-    _handler: (ctx: OnSessionActiveContext) => Effect.Effect<void, never>,
+    handler: (ctx: OnSessionActiveContext) => Effect.Effect<void, never>,
   ): void {
-    throw new Error("not implemented");
+    this.registerLifecycleHandler<OnSessionActiveContext>(
+      "apps/onSessionActive",
+      handler,
+    );
   }
 
   /** Register an awaitable `on_join` lifecycle handler. */
-  onJoin(_handler: (ctx: OnJoinContext) => Effect.Effect<void, never>): void {
-    throw new Error("not implemented");
+  onJoin(handler: (ctx: OnJoinContext) => Effect.Effect<void, never>): void {
+    this.registerLifecycleHandler<OnJoinContext>("apps/onJoin", handler);
   }
 
   /** Register an awaitable `on_close` lifecycle handler. */
-  onClose(_handler: (ctx: OnCloseContext) => Effect.Effect<void, never>): void {
-    throw new Error("not implemented");
+  onClose(handler: (ctx: OnCloseContext) => Effect.Effect<void, never>): void {
+    this.registerLifecycleHandler<OnCloseContext>("apps/onClose", handler);
   }
 
   /**
    * Attach an existing conversation to a session for membership / role-DM
-   * purposes. Wraps the c2s RPC `apps/attachConversation` (B.1).
+   * purposes. Wraps the c2s RPC `apps/attachConversation`.
    *
-   * Errors: `AttachError` carries the underlying RPC code
-   * (SessionNotFound | ConversationNotFound | NotAuthorized).
+   * Errors map server response codes to `AttachError`:
+   *   - `SessionNotFound`, `ConversationNotFound`, `NotAuthorized` → typed
+   *   - any other RPC failure (timeout, transport) → `AttachFailed`
    */
   attachConversation(
-    _sessionId: string,
-    _conversationId: string,
+    sessionId: string,
+    conversationId: string,
   ): Effect.Effect<void, AttachError> {
-    throw new Error("not implemented");
+    return this.client
+      .sendRpc("apps/attachConversation", { sessionId, conversationId })
+      .pipe(
+        Effect.asVoid,
+        Effect.mapError((err) => mapAttachError(err)),
+      );
+  }
+
+  /**
+   * Wire a user-supplied admission handler against the SDK's WS client.
+   *
+   * `wrapVerdict` adapts the user verdict to the on-the-wire result shape
+   * (e.g. `{ admission }` for `before_dispatch`); `failClosedVerdict` is
+   * the wire-shape verdict synthesized when the user handler defects.
+   *
+   * `Effect.runSyncExit` is safe here: `handleServerRpc` mutates a `Ref`
+   * synchronously and only fails with `DuplicateServerRpcHandlerError`.
+   */
+  private registerAdmissionHandler<Ctx, Verdict>(
+    method: string,
+    handler: (ctx: Ctx) => Effect.Effect<Verdict, never>,
+    wrapVerdict: (verdict: Verdict) => unknown,
+    failClosedVerdict: () => unknown,
+  ): void {
+    const wrapped = (params: unknown): Effect.Effect<unknown, RpcServerError> =>
+      Effect.gen(this, function* () {
+        const ctx = params as Ctx;
+        const verdictExit = yield* Effect.exit(handler(ctx));
+        if (Exit.isSuccess(verdictExit)) {
+          return wrapVerdict(verdictExit.value);
+        }
+        // Fail-closed: log the underlying cause, synthesize the fail-closed
+        // verdict. Cause covers both typed failures (which are `never`-typed
+        // here so should not occur) and defects from `Effect.gen` throws.
+        const wrappedErr = new AppHandlerError(
+          method,
+          "handler failed; synthesizing fail-closed verdict",
+          causeToError(verdictExit.cause),
+        );
+        this.emitError(wrappedErr);
+        return failClosedVerdict();
+      });
+
+    this.installServerRpc(method, wrapped);
+  }
+
+  private registerLifecycleHandler<Ctx>(
+    method: string,
+    handler: (ctx: Ctx) => Effect.Effect<void, never>,
+  ): void {
+    const wrapped = (params: unknown): Effect.Effect<unknown, RpcServerError> =>
+      Effect.gen(this, function* () {
+        const ctx = params as Ctx;
+        const exit = yield* Effect.exit(handler(ctx));
+        if (Exit.isFailure(exit)) {
+          // Lifecycle hooks are awaitable-void: log and reply void so the
+          // server-side AppHost stops waiting. Never blocks session lifecycle.
+          this.emitError(
+            new AppHandlerError(
+              method,
+              "lifecycle handler failed; replying void",
+              causeToError(exit.cause),
+            ),
+          );
+        }
+        return {};
+      });
+
+    this.installServerRpc(method, wrapped);
+  }
+
+  private installServerRpc(
+    method: string,
+    wrapped: (params: unknown) => Effect.Effect<unknown, RpcServerError>,
+  ): void {
+    const exit = Effect.runSyncExit(
+      this.client.handleServerRpc(method, wrapped),
+    );
+    if (Exit.isFailure(exit)) {
+      // Only failure mode is `DuplicateServerRpcHandlerError`; surface as
+      // sync throw per architect plan §3.5 ("Multiple registrations for the
+      // same hook throw at registration time").
+      throw new AppError(
+        "DUPLICATE_HOOK_HANDLER",
+        `Handler already registered for ${method}`,
+        causeToError(exit.cause),
+      );
+    }
   }
 
   // ── Messaging ──────────────────────────────────────────────────────
@@ -823,4 +920,70 @@ export class MoltZapApp {
       this.logger.error(`[${error.code}] ${error.message}`);
     }
   }
+}
+
+// ── Module-private helpers ─────────────────────────────────────────────────
+
+/**
+ * Coerce an Effect `Cause` into a plain `Error` for error chaining. Defects
+ * carrying an `Error` are unwrapped; everything else is stringified.
+ */
+function causeToError(cause: Cause.Cause<unknown>): Error {
+  const failure = Cause.failureOption(cause);
+  if (failure._tag === "Some") {
+    return failure.value instanceof Error
+      ? failure.value
+      : new Error(String(failure.value));
+  }
+  const defect = Cause.dieOption(cause);
+  if (defect._tag === "Some") {
+    return defect.value instanceof Error
+      ? defect.value
+      : new Error(String(defect.value));
+  }
+  return new Error(Cause.pretty(cause));
+}
+
+/**
+ * Map a `client.sendRpc` failure for `apps/attachConversation` onto the
+ * SDK's typed `AttachError`. RPC server errors carry the server's reason
+ * code in `data.code` (or `message`); transport / timeout errors collapse
+ * to `AttachFailed`.
+ */
+type SendRpcError = NotConnectedError | RpcTimeoutError | RpcServerError;
+
+function mapAttachError(err: SendRpcError): AttachError {
+  if (err instanceof RpcServerError) {
+    const code = extractAttachCode(err);
+    return new AttachError(code, err.message, err);
+  }
+  // NotConnectedError or RpcTimeoutError — both extend Error via Data.TaggedError.
+  const cause = err instanceof Error ? err : undefined;
+  return new AttachError(
+    "AttachFailed",
+    `attachConversation failed: ${err.message}`,
+    cause,
+  );
+}
+
+function extractAttachCode(err: RpcServerError): AttachErrorCode {
+  // The server is expected to surface the reason as a string in `data.code`
+  // OR embed it in the message.  Prefer the structured `data.code` path.
+  const data = err.data;
+  if (data !== null && typeof data === "object" && "code" in data) {
+    const c = (data as { code: unknown }).code;
+    if (
+      c === "SessionNotFound" ||
+      c === "ConversationNotFound" ||
+      c === "NotAuthorized"
+    ) {
+      return c;
+    }
+  }
+  if (err.message.includes("SessionNotFound")) return "SessionNotFound";
+  if (err.message.includes("ConversationNotFound")) {
+    return "ConversationNotFound";
+  }
+  if (err.message.includes("NotAuthorized")) return "NotAuthorized";
+  return "AttachFailed";
 }

--- a/packages/app-sdk/src/errors.ts
+++ b/packages/app-sdk/src/errors.ts
@@ -1,6 +1,19 @@
 /**
  * Base error class for all App SDK errors.
- * Every error includes a machine-readable `code` and optional `cause`.
+ *
+ * Every error includes a machine-readable {@link code} so call sites can
+ * branch on the failure mode without parsing strings, plus an optional
+ * {@link cause} preserving the underlying error chain.
+ *
+ * Subclass for new error kinds; do not throw raw `AppError` instances
+ * unless the code does not warrant a dedicated subclass.
+ *
+ * @example
+ * ```ts
+ * import { AppError } from "@moltzap/app-sdk";
+ *
+ * throw new AppError("INVALID_CONFIG", "appId or manifest is required");
+ * ```
  */
 export class AppError extends Error {
   readonly code: string;
@@ -14,6 +27,27 @@ export class AppError extends Error {
   }
 }
 
+/**
+ * Authentication or initial connect failed: the agent key was rejected,
+ * the WebSocket could not open, or the protocol handshake failed.
+ *
+ * Surfaced from {@link MoltZapApp.start} when `auth/connect` fails.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { MoltZapApp, AuthError } from "@moltzap/app-sdk";
+ *
+ * const app = new MoltZapApp({ serverUrl, agentKey, appId: "my-app" });
+ * await Effect.runPromise(
+ *   app.start().pipe(
+ *     Effect.catchTag("AuthError", (err: AuthError) =>
+ *       Effect.sync(() => console.error("auth failed:", err.message)),
+ *     ),
+ *   ),
+ * );
+ * ```
+ */
 export class AuthError extends AppError {
   constructor(message: string, cause?: Error) {
     super("AUTH_FAILED", message, cause);
@@ -21,6 +55,25 @@ export class AuthError extends AppError {
   }
 }
 
+/**
+ * A session-scoped operation failed: create, recover, or operate on a
+ * session that the server rejected for non-closed reasons (validation,
+ * timeout, etc).
+ *
+ * Distinct from {@link SessionClosedError} — that fires only when a
+ * session has reached terminal `closed` or `failed` state.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await app.createSessionAsync(["agent-a", "agent-b"]);
+ * } catch (err) {
+ *   if (err instanceof SessionError) {
+ *     console.error(`[${err.code}] ${err.message}`);
+ *   }
+ * }
+ * ```
+ */
 export class SessionError extends AppError {
   constructor(message: string, cause?: Error) {
     super("SESSION_ERROR", message, cause);
@@ -28,6 +81,24 @@ export class SessionError extends AppError {
   }
 }
 
+/**
+ * The session has terminated and is no longer usable. Emitted via
+ * `onError` when the server announces a session closure or when a
+ * post-reconnect refresh finds the session in `closed` / `failed`.
+ *
+ * Handlers should drop session-scoped state and stop emitting messages
+ * for the affected session.
+ *
+ * @example
+ * ```ts
+ * app.onError((err) => {
+ *   if (err instanceof SessionClosedError) {
+ *     // session is gone; clean up local state
+ *     myCache.delete(currentSessionId);
+ *   }
+ * });
+ * ```
+ */
 export class SessionClosedError extends AppError {
   constructor(message: string, cause?: Error) {
     super("SESSION_CLOSED", message, cause);
@@ -35,6 +106,23 @@ export class SessionClosedError extends AppError {
   }
 }
 
+/**
+ * The server rejected the manifest at `apps/register`. Common causes:
+ * unknown permission, invalid conversation key, or a manifest field that
+ * fails the schema check.
+ *
+ * @example
+ * ```ts
+ * await Effect.runPromise(
+ *   app.start().pipe(
+ *     Effect.catchTag("ManifestRegistrationError", (err) => {
+ *       console.error("manifest rejected:", err.message);
+ *       return Effect.fail(err);
+ *     }),
+ *   ),
+ * );
+ * ```
+ */
 export class ManifestRegistrationError extends AppError {
   constructor(message: string, cause?: Error) {
     super("MANIFEST_REJECTED", message, cause);
@@ -42,6 +130,27 @@ export class ManifestRegistrationError extends AppError {
   }
 }
 
+/**
+ * `send(conversationKey, parts)` was called with a key that no active
+ * session declares. Either the manifest does not declare the key, or no
+ * session is currently active.
+ *
+ * Use {@link MoltZapApp.sendTo} (raw conversation id) when the key
+ * indirection is unwanted.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ *
+ * await Effect.runPromise(
+ *   app.send("typo-key", [{ type: "text", text: "hi" }]).pipe(
+ *     Effect.catchTag("UNKNOWN_CONVERSATION_KEY" as never, () =>
+ *       app.send("default", [{ type: "text", text: "hi" }]),
+ *     ),
+ *   ),
+ * );
+ * ```
+ */
 export class ConversationKeyError extends AppError {
   constructor(key: string) {
     super("UNKNOWN_CONVERSATION_KEY", `Unknown conversation key: "${key}"`);
@@ -49,9 +158,168 @@ export class ConversationKeyError extends AppError {
   }
 }
 
+/**
+ * `messages/send` failed at the transport or server-validation layer.
+ * The {@link cause} retains the underlying RPC error tag.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ *
+ * await Effect.runPromise(
+ *   app.sendTo(convId, [{ type: "text", text: "ping" }]).pipe(
+ *     Effect.catchTag("SendError", (err) =>
+ *       Effect.sync(() => console.warn("send failed:", err.message)),
+ *     ),
+ *   ),
+ * );
+ * ```
+ */
 export class SendError extends AppError {
   constructor(message: string, cause?: Error) {
     super("SEND_FAILED", message, cause);
     this.name = "SendError";
+  }
+}
+
+/**
+ * A user admission/lifecycle handler failed (defect or typed error). The
+ * SDK catches the failure to keep the AppHost RPC contract typed and
+ * synthesizes a fail-closed verdict for admission hooks (`deny` /
+ * `block: true`) or a no-op for void lifecycle hooks. The wrapped error
+ * is logged via the SDK logger and exposed here for observability.
+ *
+ * Code: `APP_HANDLER_ERROR`.
+ *
+ * @example
+ * ```ts
+ * // Internal: SDK wraps user handler failures in AppHandlerError before
+ * // logging.  Surface for tooling / tests:
+ * const wrapped = new AppHandlerError(
+ *   "apps/onBeforeDispatch",
+ *   "user handler threw",
+ *   originalError,
+ * );
+ * console.error(wrapped.code, wrapped.message, wrapped.cause);
+ * ```
+ */
+export class AppHandlerError extends AppError {
+  /** RPC method whose handler failed (e.g. `apps/onBeforeDispatch`). */
+  readonly method: string;
+
+  constructor(method: string, message: string, cause?: Error) {
+    super("APP_HANDLER_ERROR", `[${method}] ${message}`, cause);
+    this.name = "AppHandlerError";
+    this.method = method;
+  }
+}
+
+/**
+ * The server-side AppHost timed out waiting for the app's admission reply
+ * and synthesized a fail-closed verdict. The SDK exposes this class so
+ * test fixtures and instrumentation can model the timeout case
+ * symmetrically with the SDK's own typed errors.
+ *
+ * Code: `ADMISSION_TIMEOUT`.
+ *
+ * @example
+ * ```ts
+ * // In a test fixture asserting fail-closed semantics:
+ * const err = new AdmissionTimeoutError(
+ *   "apps/onBeforeDispatch",
+ *   30_000,
+ * );
+ * expect(err.code).toBe("ADMISSION_TIMEOUT");
+ * expect(err.timeoutMs).toBe(30_000);
+ * ```
+ */
+export class AdmissionTimeoutError extends AppError {
+  /** RPC method whose admission timed out. */
+  readonly method: string;
+  /** Manifest-declared timeout in ms. */
+  readonly timeoutMs: number;
+
+  constructor(method: string, timeoutMs: number, cause?: Error) {
+    super(
+      "ADMISSION_TIMEOUT",
+      `[${method}] admission timed out after ${timeoutMs}ms`,
+      cause,
+    );
+    this.name = "AdmissionTimeoutError";
+    this.method = method;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * SDK-side wrapper for the server's `AppDisconnected` failure. The
+ * inbound s2c admission RPC failed because the app's WebSocket dropped
+ * before the handler completed. Mirrors the runtime `AppDisconnected`
+ * error in `@moltzap/server`'s WS edge.
+ *
+ * Code: `APP_DISCONNECTED`.
+ *
+ * @example
+ * ```ts
+ * // Surfaced by runtime instrumentation when the s2c RPC's pending
+ * // Deferred is interrupted by the connection scope's finalizer:
+ * const err = new AppDisconnected("apps/onBeforeMessageDelivery");
+ * console.error(err.code, err.message);
+ * ```
+ */
+export class AppDisconnected extends AppError {
+  /** RPC method whose pending request was dropped. */
+  readonly method: string;
+
+  constructor(method: string, cause?: Error) {
+    super(
+      "APP_DISCONNECTED",
+      `[${method}] app disconnected before reply`,
+      cause,
+    );
+    this.name = "AppDisconnected";
+    this.method = method;
+  }
+}
+
+/**
+ * `attachConversation` failed. The {@link code} is one of:
+ *
+ * - `SessionNotFound` — session id does not refer to a session this app owns
+ * - `ConversationNotFound` — conversation id does not exist
+ * - `NotAuthorized` — the caller is not the session owner
+ * - `AttachFailed` — generic transport / server failure (timeout, network)
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ *
+ * await Effect.runPromise(
+ *   app.attachConversation(sessionId, conversationId).pipe(
+ *     Effect.catchTag("AttachError", (err: AttachError) => {
+ *       if (err.code === "SessionNotFound") {
+ *         return Effect.sync(() => console.warn("session is gone"));
+ *       }
+ *       return Effect.fail(err);
+ *     }),
+ *   ),
+ * );
+ * ```
+ */
+export type AttachErrorCode =
+  | "SessionNotFound"
+  | "ConversationNotFound"
+  | "NotAuthorized"
+  | "AttachFailed";
+
+export class AttachError extends AppError {
+  override readonly code: AttachErrorCode;
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "AttachError" as const;
+
+  constructor(code: AttachErrorCode, message: string, cause?: Error) {
+    super(code, message, cause);
+    this.name = "AttachError";
+    this.code = code;
   }
 }

--- a/packages/app-sdk/src/index.ts
+++ b/packages/app-sdk/src/index.ts
@@ -17,7 +17,12 @@ export {
   ManifestRegistrationError,
   ConversationKeyError,
   SendError,
+  AppHandlerError,
+  AdmissionTimeoutError,
+  AppDisconnected,
+  AttachError,
 } from "./errors.js";
+export type { AttachErrorCode } from "./errors.js";
 
 // Re-export common protocol types for convenience
 export type {
@@ -31,6 +36,16 @@ export type {
   FilePart,
   Message,
   EventFrame,
+  // Admission + lifecycle handler context types (Phase 1.4 / B.5).
+  // Surfaced here so app developers can import them directly from
+  // `@moltzap/app-sdk` without reaching into the protocol package.
+  BeforeDispatchContext,
+  BeforeMessageDeliveryContext,
+  OnSessionActiveContext,
+  OnJoinContext,
+  OnCloseContext,
+  HookResult,
+  DispatchAdmissionResult,
 } from "@moltzap/protocol";
 export { EventNames } from "@moltzap/protocol";
 

--- a/packages/protocol/src/schema/methods/apps.ts
+++ b/packages/protocol/src/schema/methods/apps.ts
@@ -1,4 +1,4 @@
-import { Type } from "@sinclair/typebox";
+import { Type, type Static } from "@sinclair/typebox";
 import { AgentId, ConversationId, MessageId } from "../primitives.js";
 import { AppManifestSchema, AppSessionSchema } from "../apps.js";
 import { PartSchema } from "../messages.js";
@@ -152,7 +152,14 @@ export const AppsListSessions = defineRpc({
   ),
 });
 
-const DispatchAdmissionDecision = Type.Union([
+/**
+ * Verdict from a `before_dispatch` admission handler. Discriminated by
+ * `decision`: `grant` (allow; optional lease for held delivery), `deny`
+ * (reject), `hold` (defer behind a lease the app will release later).
+ *
+ * Re-exported from `@moltzap/app-sdk` as `DispatchAdmissionResult`.
+ */
+export const DispatchAdmissionDecisionSchema = Type.Union([
   Type.Object(
     {
       decision: Type.Literal("grant"),
@@ -177,6 +184,10 @@ const DispatchAdmissionDecision = Type.Union([
     { additionalProperties: false },
   ),
 ]);
+
+export type DispatchAdmissionResult = Static<
+  typeof DispatchAdmissionDecisionSchema
+>;
 
 export const AppsAuthorizeDispatch = defineRpc({
   name: "apps/authorizeDispatch",
@@ -215,7 +226,7 @@ export const AppsAuthorizeDispatch = defineRpc({
   ),
   result: Type.Object(
     {
-      admission: DispatchAdmissionDecision,
+      admission: DispatchAdmissionDecisionSchema,
     },
     { additionalProperties: false },
   ),
@@ -231,7 +242,7 @@ export const AppsAuthorizeDispatch = defineRpc({
 // invariant — see `31-on-session-active.integration.test.ts:200-230`).
 //
 // Verdict shapes mirror `packages/server/src/app/hooks.ts` verbatim — the
-// `DispatchAdmissionDecision` constant defined above (and reused here) is the
+// `DispatchAdmissionDecisionSchema` constant defined above (and reused here) is the
 // same union, and `HookResultSchema` matches `HookResult` field-for-field.
 // Adding a new verdict tag is a protocol change; do it in the spec, not here.
 //
@@ -256,7 +267,14 @@ const HookFeedbackSchema = Type.Object(
   { additionalProperties: false },
 );
 
-const HookResultSchema = Type.Object(
+/**
+ * Verdict from a `before_message_delivery` admission handler. `block: true`
+ * drops the message; `block: false` allows. Optional `patch.parts` mutates
+ * the recipient view; optional `feedback` emits an observability hook.
+ *
+ * Re-exported from `@moltzap/app-sdk` as `HookResult`.
+ */
+export const HookResultSchema = Type.Object(
   {
     block: Type.Boolean(),
     reason: Type.Optional(Type.String()),
@@ -271,7 +289,13 @@ const HookResultSchema = Type.Object(
   { additionalProperties: false },
 );
 
-const BeforeDispatchContextSchema = Type.Object(
+export type HookResult = Static<typeof HookResultSchema>;
+
+/**
+ * Context passed to a `before_dispatch` admission handler. Mirrors the
+ * server-side `BeforeDispatchContext` minus runtime-only fields (`signal`).
+ */
+export const BeforeDispatchContextSchema = Type.Object(
   {
     sessionId: Type.String({ format: "uuid" }),
     appId: Type.String(),
@@ -313,7 +337,12 @@ const BeforeDispatchContextSchema = Type.Object(
   { additionalProperties: false },
 );
 
-const BeforeMessageDeliveryContextSchema = Type.Object(
+export type BeforeDispatchContext = Static<typeof BeforeDispatchContextSchema>;
+
+/**
+ * Context passed to a `before_message_delivery` admission handler.
+ */
+export const BeforeMessageDeliveryContextSchema = Type.Object(
   {
     sessionId: Type.String({ format: "uuid" }),
     appId: Type.String(),
@@ -331,6 +360,10 @@ const BeforeMessageDeliveryContextSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export type BeforeMessageDeliveryContext = Static<
+  typeof BeforeMessageDeliveryContextSchema
+>;
+
 const LifecycleAgentSchema = Type.Object(
   {
     agentId: AgentId,
@@ -339,7 +372,8 @@ const LifecycleAgentSchema = Type.Object(
   { additionalProperties: false },
 );
 
-const OnJoinContextSchema = Type.Object(
+/** Context passed to an `on_join` lifecycle handler. */
+export const OnJoinContextSchema = Type.Object(
   {
     sessionId: Type.String({ format: "uuid" }),
     appId: Type.String(),
@@ -349,7 +383,10 @@ const OnJoinContextSchema = Type.Object(
   { additionalProperties: false },
 );
 
-const OnCloseContextSchema = Type.Object(
+export type OnJoinContext = Static<typeof OnJoinContextSchema>;
+
+/** Context passed to an `on_close` lifecycle handler. */
+export const OnCloseContextSchema = Type.Object(
   {
     sessionId: Type.String({ format: "uuid" }),
     appId: Type.String(),
@@ -359,7 +396,10 @@ const OnCloseContextSchema = Type.Object(
   { additionalProperties: false },
 );
 
-const OnSessionActiveContextSchema = Type.Object(
+export type OnCloseContext = Static<typeof OnCloseContextSchema>;
+
+/** Context passed to an `on_session_active` lifecycle handler. */
+export const OnSessionActiveContextSchema = Type.Object(
   {
     sessionId: Type.String({ format: "uuid" }),
     appId: Type.String(),
@@ -369,6 +409,10 @@ const OnSessionActiveContextSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export type OnSessionActiveContext = Static<
+  typeof OnSessionActiveContextSchema
+>;
+
 /** Empty result envelope for awaitable-void s2c hooks. The reply still
  *  round-trips so AppHost can `Deferred.await` and apply manifest timeout. */
 const VoidHookResultSchema = Type.Object({}, { additionalProperties: false });
@@ -377,7 +421,7 @@ export const AppsOnBeforeDispatch = defineRpc({
   name: "apps/onBeforeDispatch",
   params: BeforeDispatchContextSchema,
   result: Type.Object(
-    { admission: DispatchAdmissionDecision },
+    { admission: DispatchAdmissionDecisionSchema },
     { additionalProperties: false },
   ),
 });


### PR DESCRIPTION
Closes #311
Architect plan: https://github.com/chughtapan/moltzap/issues/286 (§3.5)
Parent epic: https://github.com/chughtapan/moltzap-arena/issues/198 (decomposition row B.5)

## What changed

App developers can now register typed admission and lifecycle handlers on `MoltZapApp` against the five s2c RPC verbs landed in B.2. Each `onX(handler)` wires `client.handleServerRpc("apps/onX", wrapped)` so AppHost-initiated frames auto-reply without app code touching frame plumbing. Fail-closed semantics for admission hooks (`deny` / `block: true`) and fail-open void for lifecycle hooks are preserved per architect plan §3.4 invariants. `attachConversation` wraps the c2s verb with typed error mapping. Errors module gains `AppHandlerError`, `AdmissionTimeoutError`, `AppDisconnected`, `AttachError` and `@example` TSDoc on every error class.

## Plan anchors

| Change | Plan anchor |
|---|---|
| Export context + verdict schemas + Static types in `packages/protocol/src/schema/methods/apps.ts` | §3.5: "B.1 moves those types from `server/app/hooks.ts` into `protocol/src/schema/apps.ts` (or a new `schema/hooks.ts`) and the SDK re-exports them." (B.1 leftover; see "Cross-module note" below) |
| Implement `MoltZapApp.onBeforeDispatch` body | §3.5 admission handler surface — `client.handleServerRpc("apps/onBeforeDispatch", ...)` with `Effect.catchAll` synth deny |
| Implement `MoltZapApp.onBeforeMessageDelivery` body | §3.5 — fail-closed `{block: true, reason: "app_handler_error"}` |
| Implement `onSessionActive` / `onJoin` / `onClose` bodies | §3.5 lifecycle "log + return void (fail-open)"; preserves §3.4 awaitable-void contract |
| Duplicate registration throws sync `AppError("DUPLICATE_HOOK_HANDLER")` | §3.5: "Multiple registrations for the same hook throw at registration time" |
| Implement `MoltZapApp.attachConversation` body | §3.5 channel lifecycle — wraps `apps/attachConversation` c2s RPC |
| `AttachError("SessionNotFound" \| "ConversationNotFound" \| "NotAuthorized" \| "AttachFailed")` | §3.5: "errors carried over from the response code map to `AttachError`" |
| Add `AppHandlerError`, `AdmissionTimeoutError`, `AppDisconnected`, `AttachError` to `errors.ts` | B.5 task list: "errors added to `errors.ts`" |
| TSDoc `@example` on every error class (9 classes) | Sub-issue acceptance #5 (DX deliverable) |
| Re-export `BeforeDispatchContext` / `BeforeMessageDeliveryContext` / `OnSessionActiveContext` / `OnJoinContext` / `OnCloseContext` / `HookResult` / `DispatchAdmissionResult` from `app-sdk/src/index.ts` | Sub-issue acceptance #3 |
| New tests in `app.handlers.test.ts` (18 cases) | B.5 task list: "handler ergonomics test (registration + invocation success/error), attachConversation happy + error paths, type-narrowed handler signatures compile" |

## Cross-module note (B.1 prerequisite completed here)

Architect plan §3.5 explicitly assigned the protocol-side context-type export to B.1 (`"B.1 moves those types... and the SDK re-exports them"`). B.1 (PR #303) added the TypeBox schemas as locals in `protocol/src/schema/methods/apps.ts` but did not export them or derive `Static<>` type aliases, leaving the SDK with placeholder `_StubCtx` types and no path to satisfy this sub-issue's acceptance #3 ("re-export branded context types from protocol through app-sdk's `index.ts`"). I completed that prerequisite as part of this senior pass: renamed `DispatchAdmissionDecision` → `DispatchAdmissionDecisionSchema` (consistent with sibling `*Schema` naming), added `export` to the five context schemas + `HookResultSchema`, and added companion `export type` aliases. Net new public surface in protocol is exactly what the architect plan specifies; no new modules, no signature changes to existing exports.

## Scope

- Modules touched: `packages/app-sdk/src/`, `packages/protocol/src/schema/methods/apps.ts`
- Files touched: 5 (1 added: `app.handlers.test.ts`; 4 modified)
- Tier (per `git diff --stat`): senior
- New modules: 0
- New public signatures outside the plan: 0 (every export traces to plan §3.5 or sub-issue #311 acceptance)
- New deps: 0

## Tests

- `pnpm --filter @moltzap/app-sdk test`: **70 passed** (52 prior + 18 new)
- `pnpm --filter @moltzap/protocol test`: 130 passed
- `pnpm --filter @moltzap/client test`: 231 passed
- `pnpm typecheck`: clean (full repo, examples filter intact)
- `pnpm lint`: 0 warnings, 0 errors
- `pnpm format:check`: clean
- `bash scripts/sloppy-code-guard.sh`: all guards pass

New `app.handlers.test.ts` cases cover:
- registration round-trip (success path) — verdict wrapping for `before_dispatch`, verbatim for delivery, `{}` for void hooks
- handler defect → fail-closed verdict for both admission hooks
- handler defect → log + reply void for lifecycle hooks
- duplicate registration throws `AppError("DUPLICATE_HOOK_HANDLER")` (per hook)
- `attachConversation` happy path + 3 typed error paths + generic `AttachFailed` fallback
- type-narrowed handler signatures compile against re-exported context types

## Confidence

**HIGH** — all build/test/lint gates pass locally; every change traces to a specific plan line; `mapAttachError` matches the documented server response shape (`data.code` preferred, message-substring fallback). The B.1 leftover is documented above and matches the architect plan's exact wording.

## Pre-merge gates (per teammate customizations)

This PR is opened DRAFT and the team-lead-driven pipeline runs the customization stack before merge:
- `/safer:review-senior` (senior code review)
- `/codex review` (independent cross-model review)
- `/safer:verify` (test suite + acceptance check)
- CI green on PR head before declaring DONE (per safer-by-default#244)

🤖 Generated with [Claude Code](https://claude.com/claude-code)