### PR TITLE
[impl-junior] B.10 Phase 1.9: SDK unit tests + _tag fix on error classes

### DIFF
--- a/packages/app-sdk/src/app.handlers.test.ts
+++ b/packages/app-sdk/src/app.handlers.test.ts
@@ -221,6 +221,39 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       });
     });
 
+    it("does not impose its own timeout on a long-running handler (AppHost owns timeout)", async () => {
+      // Architect plan §3.4: "Timeout policy moves into AppHost, not the
+      // schema."  The SDK must not abort or shorten a user handler — the
+      // server-side AppHost wraps the s2c RPC in `Effect.timeout(manifestMs)`.
+      // This test pins the contract: while the WS is healthy, a slow handler
+      // returns its verdict verbatim, no SDK-side cancellation.
+      app.onBeforeDispatch((ctx) =>
+        Effect.sleep("50 millis").pipe(
+          Effect.as<DispatchAdmissionResult>({
+            decision: "grant",
+            leaseId: `slow-${ctx.sessionId.slice(0, 4)}`,
+          }),
+        ),
+      );
+      const start = Date.now();
+      const reply = await Effect.runPromise(
+        asMock(app.client)._invokeHandler(
+          "apps/onBeforeDispatch",
+          baseDispatchCtx,
+        ),
+      );
+      const elapsed = Date.now() - start;
+      expect(reply).toEqual({
+        admission: { decision: "grant", leaseId: "slow-0000" },
+      });
+      // Lower bound: the handler actually waited.  Upper bound is loose
+      // (CI variance) — the assertion is "at least the sleep ran", not
+      // "exactly 50ms".
+      expect(elapsed).toBeGreaterThanOrEqual(40);
+      // No fail-closed verdict was synthesized → onError must not have fired.
+      expect(onErr).not.toHaveBeenCalled();
+    });
+
     it("synthesizes deny with reason 'app_handler_error' on handler defect", async () => {
       app.onBeforeDispatch(() =>
         Effect.sync<DispatchAdmissionResult>(() => {

--- a/packages/app-sdk/src/app.test.ts
+++ b/packages/app-sdk/src/app.test.ts
@@ -210,6 +210,32 @@ describe("MoltZapApp", () => {
       expect(app.client.close).toHaveBeenCalledTimes(1);
     });
 
+    it("succeeds even when apps/closeSession fails (failure is swallowed by Effect.ignore)", async () => {
+      await Effect.runPromise(app.start());
+
+      // After start, the next sendRpc("apps/closeSession") must fail. The
+      // mock's default sendRpc handles that method with Effect.succeed —
+      // override it for the closeSession call only so the apps/closeSession
+      // path goes down the error branch.
+      const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
+      sendRpc.mockImplementationOnce((method: string) => {
+        if (method === "apps/closeSession") {
+          return Effect.fail(new Error("server rejected closeSession"));
+        }
+        return Effect.succeed({});
+      });
+
+      // stop() must still complete cleanly. The contract is "best-effort
+      // cleanup" — a closeSession failure on shutdown should not propagate.
+      const exit = await Effect.runPromiseExit(app.stop());
+      expect(Exit.isSuccess(exit)).toBe(true);
+
+      expect(app.client.sendRpc).toHaveBeenCalledWith("apps/closeSession", {
+        sessionId: "session-1",
+      });
+      expect(app.client.close).toHaveBeenCalledTimes(1);
+    });
+
     it("unsubscribes the event subscription on shutdown", async () => {
       const subscribe = app.client.subscribe as ReturnType<typeof vi.fn>;
       let unsubscribeCalled = false;

--- a/packages/app-sdk/src/errors.test.ts
+++ b/packages/app-sdk/src/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Effect } from "effect";
 import {
   AppError,
   AuthError,
@@ -7,6 +8,10 @@ import {
   ManifestRegistrationError,
   ConversationKeyError,
   SendError,
+  AppHandlerError,
+  AdmissionTimeoutError,
+  AppDisconnected,
+  AttachError,
 } from "./errors.js";
 
 describe("AppError hierarchy", () => {
@@ -65,5 +70,139 @@ describe("AppError hierarchy", () => {
     expect(err.code).toBe("SEND_FAILED");
     expect(err.name).toBe("SendError");
     expect(err).toBeInstanceOf(AppError);
+  });
+});
+
+// `Effect.catchTag` discriminates on `_tag`. The 10 error subclasses each
+// carry a `readonly _tag = "<ClassName>" as const`, so the @example blocks
+// in `errors.ts` that pipe failures through `Effect.catchTag` actually
+// catch at runtime. This block is the runtime proof: each test fails the
+// effect with one error class, catches the matching tag, and asserts the
+// recovery handler ran exactly once. If a subclass loses its `_tag`, the
+// catchTag silently misses → the recovery never runs → the test fails.
+describe("error _tag discrimination via Effect.catchTag", () => {
+  it("AuthError is caught by catchTag('AuthError')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(new AuthError("bad creds")).pipe(
+        Effect.catchTag("AuthError", (err) => Effect.succeed(err.code)),
+      ),
+    );
+    expect(recovered).toBe("AUTH_FAILED");
+  });
+
+  it("SessionError is caught by catchTag('SessionError')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(new SessionError("gone")).pipe(
+        Effect.catchTag("SessionError", (err) => Effect.succeed(err.code)),
+      ),
+    );
+    expect(recovered).toBe("SESSION_ERROR");
+  });
+
+  it("SessionClosedError is caught by catchTag('SessionClosedError')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(new SessionClosedError("closed")).pipe(
+        Effect.catchTag("SessionClosedError", (err) =>
+          Effect.succeed(err.code),
+        ),
+      ),
+    );
+    expect(recovered).toBe("SESSION_CLOSED");
+  });
+
+  it("ManifestRegistrationError is caught by catchTag('ManifestRegistrationError')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(new ManifestRegistrationError("bad manifest")).pipe(
+        Effect.catchTag("ManifestRegistrationError", (err) =>
+          Effect.succeed(err.code),
+        ),
+      ),
+    );
+    expect(recovered).toBe("MANIFEST_REJECTED");
+  });
+
+  it("ConversationKeyError is caught by catchTag('ConversationKeyError')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(new ConversationKeyError("typo-key")).pipe(
+        Effect.catchTag("ConversationKeyError", (err) =>
+          Effect.succeed(err.code),
+        ),
+      ),
+    );
+    expect(recovered).toBe("UNKNOWN_CONVERSATION_KEY");
+  });
+
+  it("SendError is caught by catchTag('SendError')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(new SendError("send failed")).pipe(
+        Effect.catchTag("SendError", (err) => Effect.succeed(err.code)),
+      ),
+    );
+    expect(recovered).toBe("SEND_FAILED");
+  });
+
+  it("AppHandlerError is caught by catchTag('AppHandlerError')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(
+        new AppHandlerError("apps/onBeforeDispatch", "user threw"),
+      ).pipe(
+        Effect.catchTag("AppHandlerError", (err) => Effect.succeed(err.method)),
+      ),
+    );
+    expect(recovered).toBe("apps/onBeforeDispatch");
+  });
+
+  it("AdmissionTimeoutError is caught by catchTag('AdmissionTimeoutError')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(
+        new AdmissionTimeoutError("apps/onBeforeDispatch", 30_000),
+      ).pipe(
+        Effect.catchTag("AdmissionTimeoutError", (err) =>
+          Effect.succeed(err.timeoutMs),
+        ),
+      ),
+    );
+    expect(recovered).toBe(30_000);
+  });
+
+  it("AppDisconnected is caught by catchTag('AppDisconnected')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(new AppDisconnected("apps/onBeforeMessageDelivery")).pipe(
+        Effect.catchTag("AppDisconnected", (err) => Effect.succeed(err.method)),
+      ),
+    );
+    expect(recovered).toBe("apps/onBeforeMessageDelivery");
+  });
+
+  it("AttachError is caught by catchTag('AttachError')", async () => {
+    const recovered = await Effect.runPromise(
+      Effect.fail(new AttachError("SessionNotFound", "session is gone")).pipe(
+        Effect.catchTag("AttachError", (err) => Effect.succeed(err.code)),
+      ),
+    );
+    expect(recovered).toBe("SessionNotFound");
+  });
+
+  // Belt-and-suspenders: the literal `_tag` field on each instance must
+  // equal the class name. catchTag is a thin wrapper over this property,
+  // but a direct assertion catches any future drift (e.g. a copy-paste
+  // bug where two classes share the same `_tag`).
+  it("each error class exposes a _tag matching its class name", () => {
+    expect(new AuthError("x")._tag).toBe("AuthError");
+    expect(new SessionError("x")._tag).toBe("SessionError");
+    expect(new SessionClosedError("x")._tag).toBe("SessionClosedError");
+    expect(new ManifestRegistrationError("x")._tag).toBe(
+      "ManifestRegistrationError",
+    );
+    expect(new ConversationKeyError("x")._tag).toBe("ConversationKeyError");
+    expect(new SendError("x")._tag).toBe("SendError");
+    expect(new AppHandlerError("apps/onJoin", "x")._tag).toBe(
+      "AppHandlerError",
+    );
+    expect(new AdmissionTimeoutError("apps/onJoin", 1)._tag).toBe(
+      "AdmissionTimeoutError",
+    );
+    expect(new AppDisconnected("apps/onJoin")._tag).toBe("AppDisconnected");
+    expect(new AttachError("SessionNotFound", "x")._tag).toBe("AttachError");
   });
 });

--- a/packages/app-sdk/src/errors.ts
+++ b/packages/app-sdk/src/errors.ts
@@ -49,6 +49,9 @@ export class AppError extends Error {
  * ```
  */
 export class AuthError extends AppError {
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "AuthError" as const;
+
   constructor(message: string, cause?: Error) {
     super("AUTH_FAILED", message, cause);
     this.name = "AuthError";
@@ -75,6 +78,9 @@ export class AuthError extends AppError {
  * ```
  */
 export class SessionError extends AppError {
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "SessionError" as const;
+
   constructor(message: string, cause?: Error) {
     super("SESSION_ERROR", message, cause);
     this.name = "SessionError";
@@ -100,6 +106,9 @@ export class SessionError extends AppError {
  * ```
  */
 export class SessionClosedError extends AppError {
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "SessionClosedError" as const;
+
   constructor(message: string, cause?: Error) {
     super("SESSION_CLOSED", message, cause);
     this.name = "SessionClosedError";
@@ -124,6 +133,9 @@ export class SessionClosedError extends AppError {
  * ```
  */
 export class ManifestRegistrationError extends AppError {
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "ManifestRegistrationError" as const;
+
   constructor(message: string, cause?: Error) {
     super("MANIFEST_REJECTED", message, cause);
     this.name = "ManifestRegistrationError";
@@ -152,6 +164,9 @@ export class ManifestRegistrationError extends AppError {
  * ```
  */
 export class ConversationKeyError extends AppError {
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "ConversationKeyError" as const;
+
   constructor(key: string) {
     super("UNKNOWN_CONVERSATION_KEY", `Unknown conversation key: "${key}"`);
     this.name = "ConversationKeyError";
@@ -176,6 +191,9 @@ export class ConversationKeyError extends AppError {
  * ```
  */
 export class SendError extends AppError {
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "SendError" as const;
+
   constructor(message: string, cause?: Error) {
     super("SEND_FAILED", message, cause);
     this.name = "SendError";
@@ -204,6 +222,8 @@ export class SendError extends AppError {
  * ```
  */
 export class AppHandlerError extends AppError {
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "AppHandlerError" as const;
   /** RPC method whose handler failed (e.g. `apps/onBeforeDispatch`). */
   readonly method: string;
 
@@ -234,6 +254,8 @@ export class AppHandlerError extends AppError {
  * ```
  */
 export class AdmissionTimeoutError extends AppError {
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "AdmissionTimeoutError" as const;
   /** RPC method whose admission timed out. */
   readonly method: string;
   /** Manifest-declared timeout in ms. */
@@ -268,6 +290,8 @@ export class AdmissionTimeoutError extends AppError {
  * ```
  */
 export class AppDisconnected extends AppError {
+  /** Tag used for `Effect.catchTag` discrimination. */
+  readonly _tag = "AppDisconnected" as const;
   /** RPC method whose pending request was dropped. */
   readonly method: string;
 


### PR DESCRIPTION
Closes #319

## Plan-anchor table

| Plan §           | Acceptance                                                                              | Implemented |
|------------------|-----------------------------------------------------------------------------------------|-------------|
| #319 (1)         | onBeforeDispatch — handler returning Effect (success path)                              | `app.handlers.test.ts` (existing, kept) |
| #319 (1)         | onBeforeDispatch — handler throwing → SDK synthesizes deny `app_handler_error`          | `app.handlers.test.ts` (existing, kept) |
| #319 (1)         | Long-running handler while WS healthy → AppHost respects manifest timeout (not SDK)     | `app.handlers.test.ts` — new test pins architect §3.4 contract: SDK does not impose its own timeout |
| #319 (2)         | `app.attachConversation` happy + error paths                                            | `app.handlers.test.ts` (existing, kept) — covers happy + 3 typed `RpcServerError data.code` mappings + `AttachFailed` fallback |
| #319 (3)         | `app.closeSession` happy + error paths                                                  | `app.test.ts` — happy at L207 (existing); new error-path test verifies `stop()` succeeds when apps/closeSession fails (Effect.ignore swallow contract) |
| review-316 cross-module | Add `readonly _tag = "<ClassName>"` to every error class so `@example` `Effect.catchTag` blocks fire at runtime | `errors.ts` — 9 subclasses gain `_tag`; AttachError already had it |
| review-316 cross-module | Unit test per class proving `@example` actually catches via `Effect.catchTag`         | `errors.test.ts` — 10 catchTag tests + 1 uniform `_tag === ClassName` literal check |

## What changed

`packages/app-sdk/src/errors.ts` — added `readonly _tag = "<ClassName>" as const` to AuthError, SessionError, SessionClosedError, ManifestRegistrationError, ConversationKeyError, SendError, AppHandlerError, AdmissionTimeoutError, AppDisconnected. AttachError was already tagged. Tests in `errors.test.ts` prove every documented `Effect.catchTag` `@example` actually fires. New tests in `app.handlers.test.ts` and `app.test.ts` cover the §1.9 acceptance criteria not previously exercised: long-running handler timeout-respect contract and closeSession error swallow.

## Scope

- Module: `packages/app-sdk/src/` (4 files)
- Tier (from safer-diff-scope): junior (`tier: junior, files: 4, modules: 1, exports: 0, new_deps: 0`)
- New exported signatures: none (`_tag` is a runtime field; types are unchanged at the SDK boundary aside from each class gaining a discriminator member)
- New deps: none
- No `package.json` / lockfile changes

## Tests

- 11 new `errors.test.ts` tests — one `Effect.catchTag` test per class (10) + one uniform `_tag` literal check
- 1 new `app.handlers.test.ts` test — long-running handler verdict round-trips, no SDK-side cancellation
- 1 new `app.test.ts` test — stop() succeeds when apps/closeSession fails

`pnpm --filter @moltzap/app-sdk test` → 83/83 passing (was 70).
`pnpm test` (full repo) → all packages green.
`pnpm lint` → 0 warnings, 0 errors.
`pnpm typecheck` → clean.

## Confidence

HIGH — the `_tag` fix is a single-line addition per class with TSDoc; the new tests run real `Effect.catchTag` against real instances (no mocks at the assertion). The long-handler test uses a real `Effect.sleep("50 millis")` with a loose lower bound (40ms) to avoid CI flake. The closeSession-error test follows the existing `mockImplementationOnce` pattern from sibling tests.

## Coordination note

B.9 (#318, `safer:implement-senior`) is open with no PR yet. If B.9 lands first and changes `app-sdk/src/app.ts` `mapAttachError` mapping, this PR's `app.handlers.test.ts` `attachConversation` block (existing tests, kept) may need a trivial rebase. No conflict on `errors.ts` — that file is owned by this sub-issue per dispatch.