### PR TITLE
[impl-senior] Stabilize client dispatch test and wire CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - run: pnpm --filter @moltzap/server-core build
       - run: pnpm --filter @moltzap/client build
       - run: pnpm --filter @moltzap/server-core test:integration
+      - run: pnpm --filter @moltzap/client test:integration
       # Openclaw integration suite skips at suite level via isImageAvailable()
       # when the openclaw container image is unavailable; the globalSetup itself
       # only requires Docker (Postgres testcontainer) and the built server.

--- a/packages/client/src/channel-core.test.ts
+++ b/packages/client/src/channel-core.test.ts
@@ -744,17 +744,21 @@ describe("MoltZapChannelCore", () => {
       fake.service.authorizeDispatch = () => Effect.never;
 
       fake.emit.message(buildMessage({ id: "msg-timeout-closed" }));
-      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      await vi.waitFor(
+        () =>
+          expect(warnSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              messageId: "msg-timeout-closed",
+              attempt: 0,
+            }),
+            "MoltZapChannelCore: dispatch admission failed closed",
+          ),
+        { timeout: 1_000 },
+      );
       await flushDispatchChain();
 
       expect(received).toHaveLength(0);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          messageId: "msg-timeout-closed",
-          attempt: 0,
-        }),
-        "MoltZapChannelCore: dispatch admission failed closed",
-      );
     });
 
     it("continues draining inbound work after a dispatch lease expires", async () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/chughtapan/moltzap/issues/297
Fixes https://github.com/chughtapan/moltzap/issues/313

- Replace the fixed 5ms sleep in the channel-core dispatch admission timeout test with `vi.waitFor` on the observable fail-closed warning.
- Add `pnpm --filter @moltzap/client test:integration` to the GitHub Actions `test-integration` job after the client build.

## Safer Artifacts

- #297 investigation writeup: https://github.com/chughtapan/moltzap/issues/297#issuecomment-4357369085
- `safer-diff-scope --head HEAD`: `senior` (`files=2`, `modules=2`, `exports=0`, `new_deps=0`) because this PR intentionally covers the client test and CI workflow issues together.

## Validation

- `pnpm --filter @moltzap/protocol build`
- `pnpm --filter @moltzap/client build`
- `pnpm --filter @moltzap/server-core build`
- `pnpm --dir packages/client exec vitest run src/channel-core.test.ts -t "fails closed when dispatch admission hangs" --reporter=dot` repeated 100 times: `passes=100 fails=0`
- `pnpm --filter @moltzap/client test`
- `pnpm --filter @moltzap/client test:integration`
- `pnpm format:check`
- commit hook: `pnpm lint`, `pnpm format:check`, full workspace `pnpm typecheck`, type safety/effect/bare-catch/test-integrity guardrails

## Notes

#313 acceptance item 2 requires CI green on a PR with no other changes. This draft PR is opened so GitHub Actions can provide that evidence.