### PR TITLE
[impl-junior] B.4 follow-up: drop manifest 30s cap on hooks.timeout_ms

### DIFF
--- a/packages/protocol/src/schema/apps.test.ts
+++ b/packages/protocol/src/schema/apps.test.ts
@@ -94,6 +94,34 @@ describe("AppManifestSchema", () => {
     expect(validateManifest(manifest)).toBe(true);
   });
 
+  it("accepts hook timeouts above 30s (no upper cap)", () => {
+    // Werewolf Phase 2 declares `before_dispatch: 900_000ms` (15 min) for the
+    // player-input waiter pattern. The schema-level 30s `maximum` was removed
+    // in B.4 follow-up (#324) per architect plan §8.1; AppHost enforces the
+    // declared timeout via `Effect.timeout(manifestMs)`.
+    const manifest = {
+      appId: "werewolf",
+      name: "Werewolf",
+      permissions: { required: [], optional: [] },
+      hooks: {
+        before_dispatch: { timeout_ms: 900_000 },
+      },
+    };
+    expect(validateManifest(manifest)).toBe(true);
+  });
+
+  it("rejects non-positive hook timeouts", () => {
+    const manifest = {
+      appId: "werewolf",
+      name: "Werewolf",
+      permissions: { required: [], optional: [] },
+      hooks: {
+        before_dispatch: { timeout_ms: 0 },
+      },
+    };
+    expect(validateManifest(manifest)).toBe(false);
+  });
+
   it("rejects additional properties on hook entries", () => {
     const manifest = {
       appId: "test",

--- a/packages/protocol/src/schema/apps.ts
+++ b/packages/protocol/src/schema/apps.ts
@@ -33,9 +33,7 @@ export const AppManifestConversationSchema = Type.Object(
  */
 const HookEntrySchema = Type.Object(
   {
-    timeout_ms: Type.Optional(
-      Type.Integer({ default: 5000, minimum: 100, maximum: 30000 }),
-    ),
+    timeout_ms: Type.Optional(Type.Integer({ default: 5000, minimum: 1 })),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
Closes #324

## Plan anchor

Architect plan §8.1 (issue #286, comment): "The schema-level `timeout_ms` `maximum: 30000` cap is REMOVED alongside the webhook fields." Also §3.4 invariant: "Manifest-level `timeout_ms` enforced via `Effect.timeout(manifestMs)` at AppHost call site (NOT at the schema level)."

B.4 (PR #306) deleted the webhook fields but did not remove the cap. Discovered by senior-320 in B.13 docs sweep (PR #323) when trying to write "schema 30s cap removed" in the migration guide.

## Why now

Pre-Phase-2 unblock. Werewolf Phase 2 manifest declares `before_dispatch: 900_000ms` (15 min) for the player-input waiter pattern. The 30s cap rejects this manifest at validation. **Phase 2 E.1 cannot land without this fix.** Phase 1 max declared timeout is 10s, so nothing in Phase 1 breaks.

## Schema change

`packages/protocol/src/schema/apps.ts`, `HookEntrySchema.timeout_ms`:

```diff
-      Type.Integer({ default: 5000, minimum: 100, maximum: 30000 }),
+      Type.Integer({ default: 5000, minimum: 1 }),
```

`minimum: 1` matches the dispatch briefing's wording ("positive integer ms, unbounded above"). `default: 5000` retained — JSON-Schema-level documentation; AppHost has independent `?? 5000` fallbacks at 1444, 1506, 1565, 1615, 1667.

## AppHost no-op verify

B.3 already wires `Effect.timeout(\`${opts.timeoutMs} millis\`)` at `packages/server/src/app/app-host.ts:1404`, fed by `manifest?.hooks?.<hook>?.timeout_ms ?? 5000` at every hook site (1444 `before_dispatch`, 1506 `before_message_delivery`, 1565 `on_session_active`, 1615 `on_join`, 1667 `on_close`). No code change needed; honors whatever the manifest declares.

## Tests

- `accepts hook timeouts above 30s (no upper cap)` — validates `before_dispatch: 900_000`, locking in the new contract for Werewolf Phase 2.
- `rejects non-positive hook timeouts` — pins the `minimum: 1` floor.

No existing test asserted the 30s ceiling (acceptance criterion #3 was a no-op in this tree).

## Scope

- Module: `packages/protocol/src/schema/apps.ts` (+ co-located `apps.test.ts`)
- Files: 2
- LOC: +29 / -3
- Exported signature changes: none
- New deps: none

## Confidence

HIGH — schema constraint removal is a pure relaxation; AppHost's manifest-honoring timeout enforcement was already verified by B.3; positive test exercises Werewolf's actual Phase 2 value.