### PR TITLE
fix: enforce archived conversation lifecycle

### DIFF
--- a/packages/client/src/__tests__/service.integration.test.ts
+++ b/packages/client/src/__tests__/service.integration.test.ts
@@ -9,6 +9,11 @@ import {
 import { it } from "@effect/vitest";
 import { Effect, Either } from "effect";
 import {
+  ConversationsArchive,
+  ConversationsCreate,
+  ErrorCodes,
+} from "@moltzap/protocol";
+import {
   startCoreTestServer,
   stopCoreTestServer,
   resetCoreTestDb,
@@ -255,6 +260,55 @@ describe("Connection & Core API", () => {
       yield* regA.client.close();
       yield* regB.client.close();
     }),
+  );
+
+  it.live(
+    "conversation archive events purge service state and block late sends",
+    () =>
+      Effect.gen(function* () {
+        const regOwner = yield* registerAgent("archive-owner");
+        const regReceiver = yield* registerAgent("archive-receiver");
+
+        yield* regOwner.client.connect();
+        const service = yield* connectService(regReceiver.apiKey);
+
+        const conv = (yield* regOwner.client.sendRpc(ConversationsCreate.name, {
+          type: "dm",
+          participants: [{ type: "agent", id: regReceiver.agentId }],
+        })) as { conversation: { id: string } };
+        const convId = conv.conversation.id;
+
+        yield* sendAndSettle(regOwner.client, convId, "before archive");
+        expect(service.getHistory(convId)).toHaveLength(1);
+
+        const archivedEvents: unknown[] = [];
+        service.on("conversationArchived", (data) => archivedEvents.push(data));
+
+        yield* regOwner.client.sendRpc(ConversationsArchive.name, {
+          conversationId: convId,
+        });
+        yield* Effect.sleep("500 millis");
+
+        expect(archivedEvents).toHaveLength(1);
+        expect(service.isConversationArchived(convId)).toBe(true);
+        expect(service.getConversation(convId)).toBeUndefined();
+        expect(service.getHistory(convId)).toEqual([]);
+
+        const lateSend = yield* Effect.either(
+          service.send(convId, "after archive"),
+        );
+        expect(Either.isLeft(lateSend)).toBe(true);
+        if (Either.isLeft(lateSend)) {
+          expect(lateSend.left).toMatchObject({
+            code: ErrorCodes.ConversationArchived,
+            message: "Conversation is archived",
+          });
+        }
+
+        service.close();
+        yield* regOwner.client.close();
+        yield* regReceiver.client.close();
+      }),
   );
 });
 

--- a/packages/client/src/channel-core.test.ts
+++ b/packages/client/src/channel-core.test.ts
@@ -577,6 +577,41 @@ describe("MoltZapChannelCore", () => {
       expect(received[0]!.dispatchLeaseId).toBe("lease-den");
     });
 
+    it("purges held and queued dispatch work when a conversation is archived", async () => {
+      const { fake, received, infoSpy } = customSetup();
+      fake.state.setConversation("conv-1", { type: "group", participants: [] });
+      fake.state.setAgentName("agent-alice", "Alice");
+      let calls = 0;
+      fake.service.authorizeDispatch = () =>
+        Effect.sync(() => {
+          calls += 1;
+          return { _tag: "hold" as const, reason: "waiting" };
+        });
+
+      fake.emit.message(buildMessage({ id: "msg-held" }));
+      await flushDispatchChain();
+
+      fake.emit.conversationArchived({ conversationId: "conv-1" });
+      fake.emit.message(buildMessage({ id: "msg-after-archive" }));
+      await flushDispatchChain();
+
+      expect(calls).toBe(1);
+      expect(received).toHaveLength(0);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: "conv-1",
+        }),
+        "MoltZapChannelCore: closed conversation dispatch work purged",
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: "msg-after-archive",
+          conversationId: "conv-1",
+        }),
+        "MoltZapChannelCore: dropping inbound message for closed conversation",
+      );
+    });
+
     it("keeps blocked authorization head-of-line and coalesces same-conversation backlog on grant", async () => {
       const { fake, received } = customSetup();
       fake.state.setConversation("conv-1", { type: "group", participants: [] });
@@ -1099,6 +1134,25 @@ describe("MoltZapChannelCore", () => {
       await Effect.runPromise(core.sendReply("conv-42", "hello there"));
       expect(fake.state.sent).toEqual([
         { convId: "conv-42", text: "hello there" },
+      ]);
+    });
+
+    it("drops replies locally after the conversation is archived", async () => {
+      fake.emit.conversationArchived({ conversationId: "conv-42" });
+
+      await Effect.runPromise(core.sendReply("conv-42", "hello there"));
+
+      expect(fake.state.sent).toEqual([]);
+    });
+
+    it("resumes replies after the conversation is unarchived", async () => {
+      fake.emit.conversationArchived({ conversationId: "conv-42" });
+      fake.emit.conversationUnarchived({ conversationId: "conv-42" });
+
+      await Effect.runPromise(core.sendReply("conv-42", "hello again"));
+
+      expect(fake.state.sent).toEqual([
+        { convId: "conv-42", text: "hello again" },
       ]);
     });
   });

--- a/packages/client/src/channel-core.ts
+++ b/packages/client/src/channel-core.ts
@@ -96,6 +96,14 @@ export interface ChannelService {
   on(event: "disconnect", handler: () => void): void;
   on(event: "reconnect", handler: () => void): void;
   on(
+    event: "conversationArchived",
+    handler: (data: { conversationId: string }) => void,
+  ): void;
+  on(
+    event: "conversationUnarchived",
+    handler: (data: { conversationId: string }) => void,
+  ): void;
+  on(
     event: "permissionRequired",
     handler: (data: PermissionsRequiredEvent) => void,
   ): void;
@@ -106,6 +114,7 @@ export interface ChannelService {
     text: string,
     opts?: { dispatchLeaseId?: string },
   ): Effect.Effect<void, ServiceRpcError>;
+  isConversationArchived?(conversationId: string): boolean;
   getConversation(
     convId: string,
   ): { type: string; name?: string; participants: string[] } | undefined;
@@ -205,6 +214,7 @@ export class MoltZapChannelCore {
   private connected = false;
   private inboundHandler: InboundHandler<unknown> | null = null;
   private activeDispatchLeaseId: string | undefined;
+  private readonly closedConversationIds = new Set<string>();
   private readonly logicalClocks = new Map<
     string,
     { epoch: number; vector: Record<string, number> }
@@ -231,6 +241,16 @@ export class MoltZapChannelCore {
       opts.dispatchAdmissionTimeoutMs ?? DEFAULT_DISPATCH_ADMISSION_TIMEOUT_MS;
 
     this.service.on("message", (message) => {
+      if (this.closedConversationIds.has(message.conversationId)) {
+        this.logger.info(
+          {
+            messageId: message.id,
+            conversationId: message.conversationId,
+          },
+          "MoltZapChannelCore: dropping inbound message for closed conversation",
+        );
+        return;
+      }
       Queue.unsafeOffer(this.inboundQueue, {
         message,
         attempt: 0,
@@ -280,6 +300,14 @@ export class MoltZapChannelCore {
       if (this.permissionRequiredHandler) {
         this.permissionRequiredHandler(data);
       }
+    });
+
+    this.service.on("conversationArchived", ({ conversationId }) => {
+      this.closeConversation(conversationId);
+    });
+
+    this.service.on("conversationUnarchived", ({ conversationId }) => {
+      this.closedConversationIds.delete(conversationId);
     });
   }
 
@@ -345,9 +373,45 @@ export class MoltZapChannelCore {
     text: string,
     opts?: { dispatchLeaseId?: string },
   ): Effect.Effect<void, ServiceRpcError> {
+    if (
+      this.closedConversationIds.has(conversationId) ||
+      this.service.isConversationArchived?.(conversationId)
+    ) {
+      return Effect.sync(() =>
+        this.logger.info(
+          { conversationId },
+          "MoltZapChannelCore: dropping reply for closed conversation",
+        ),
+      );
+    }
     return this.service.send(conversationId, text, {
       dispatchLeaseId: opts?.dispatchLeaseId ?? this.activeDispatchLeaseId,
     });
+  }
+
+  private closeConversation(conversationId: string): void {
+    this.closedConversationIds.add(conversationId);
+    this.parkedByConversation.delete(conversationId);
+
+    const queued = Chunk.toReadonlyArray(
+      Effect.runSync(Queue.takeAll(this.inboundQueue)),
+    );
+    let droppedQueued = 0;
+    for (const work of queued) {
+      if (work.message.conversationId === conversationId) {
+        droppedQueued += 1;
+      } else {
+        Queue.unsafeOffer(this.inboundQueue, work);
+      }
+    }
+
+    this.logger.info(
+      {
+        conversationId,
+        droppedQueued,
+      },
+      "MoltZapChannelCore: closed conversation dispatch work purged",
+    );
   }
 
   private observeMessage(message: Message): LogicalClock {
@@ -461,6 +525,19 @@ export class MoltZapChannelCore {
   ): Effect.Effect<void, unknown> {
     return Effect.gen(this, function* () {
       const current = this.takeDispatchCandidate(work);
+      if (this.closedConversationIds.has(current.message.conversationId)) {
+        yield* Effect.sync(() =>
+          this.logger.info(
+            {
+              messageId: current.message.id,
+              conversationId: current.message.conversationId,
+              attempt: current.attempt,
+            },
+            "MoltZapChannelCore: dropping dispatch for closed conversation",
+          ),
+        );
+        return;
+      }
       const decision = yield* this.dispatchAdmission(current);
       if (decision._tag === "grant") {
         const messages = this.service.authorizeDispatch

--- a/packages/client/src/service.test.ts
+++ b/packages/client/src/service.test.ts
@@ -1,9 +1,16 @@
 import * as path from "node:path";
 import * as os from "node:os";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Effect } from "effect";
+import { Effect, Either } from "effect";
 import type { Message } from "@moltzap/protocol";
-import { EventNames } from "@moltzap/protocol";
+import {
+  AppsAuthorizeDispatch,
+  ConversationsGet,
+  ErrorCodes,
+  EventNames,
+  MessagesSend,
+  eventFrame,
+} from "@moltzap/protocol";
 import { sanitizeForSystemReminder } from "./service.js";
 import { FakeMoltZapService } from "./test-utils/fake-service.js";
 
@@ -200,7 +207,7 @@ describe("sanitizeForSystemReminder", () => {
 describe("MoltZapService.authorizeDispatch", () => {
   it("uses the long app-dispatch RPC timeout instead of the generic RPC timeout", async () => {
     const service = new FakeMoltZapService();
-    service.setResponse("apps/authorizeDispatch", {
+    service.setResponse(AppsAuthorizeDispatch.name, {
       admission: {
         decision: "grant",
         leaseId: "lease-1",
@@ -237,7 +244,7 @@ describe("MoltZapService.authorizeDispatch", () => {
     });
     expect(service.calls).toHaveLength(1);
     expect(service.calls[0]).toMatchObject({
-      method: "apps/authorizeDispatch",
+      method: AppsAuthorizeDispatch.name,
       opts: { timeoutMs: 900_000 },
     });
   });
@@ -674,6 +681,92 @@ describe("MoltZapService.on('permissionRequired')", () => {
     );
 
     expect(received).toHaveLength(0);
+  });
+});
+
+describe("MoltZapService conversation archive lifecycle", () => {
+  it("purges local state, fires conversationArchived, and locally rejects sends", async () => {
+    const service = new FakeMoltZapService();
+    service.setResponse(ConversationsGet.name, {
+      conversation: {
+        id: "conv-archived",
+        type: "group",
+        name: "Archived",
+        createdBy: "agent-self",
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      },
+      participants: [],
+    });
+    service.setResponse(MessagesSend.name, {
+      message: {
+        id: "msg-unreachable",
+        conversationId: "conv-archived",
+        senderId: "agent-self",
+        parts: [{ type: "text", text: "unreachable" }],
+        createdAt: "2026-05-01T00:00:00.000Z",
+      } as Message,
+    });
+
+    service.emitEvent(
+      eventFrame(EventNames.ConversationCreated, {
+        conversation: {
+          id: "conv-archived",
+          type: "group",
+          name: "Archived",
+          createdBy: "agent-self",
+          createdAt: "2026-05-01T00:00:00.000Z",
+          updatedAt: "2026-05-01T00:00:00.000Z",
+        },
+      }),
+    );
+    service.addMessage("conv-archived", {
+      id: "msg-1",
+      conversationId: "conv-archived",
+      senderId: "agent-other",
+      parts: [{ type: "text", text: "old" }],
+      createdAt: "2026-05-01T00:00:00.000Z",
+    } as Message);
+
+    const archivedEvents: unknown[] = [];
+    const unarchivedEvents: unknown[] = [];
+    service.on("conversationArchived", (data) => archivedEvents.push(data));
+    service.on("conversationUnarchived", (data) => unarchivedEvents.push(data));
+
+    const archivedEvent = eventFrame(EventNames.ConversationArchived, {
+      conversationId: "conv-archived",
+      archivedAt: "2026-05-01T00:01:00.000Z",
+      by: "agent-gm",
+    });
+    service.emitEvent(archivedEvent);
+
+    expect(service.isConversationArchived("conv-archived")).toBe(true);
+    expect(service.getConversation("conv-archived")).toBeUndefined();
+    expect(service.getHistory("conv-archived")).toEqual([]);
+    expect(archivedEvents).toEqual([archivedEvent.data]);
+
+    const lateSend = await run(
+      Effect.either(service.send("conv-archived", "should not hit rpc")),
+    );
+    expect(Either.isLeft(lateSend)).toBe(true);
+    if (Either.isLeft(lateSend)) {
+      expect(lateSend.left).toMatchObject({
+        code: ErrorCodes.ConversationArchived,
+        message: "Conversation is archived",
+      });
+    }
+    expect(service.calls.filter((c) => c.method === MessagesSend.name)).toEqual(
+      [],
+    );
+
+    const unarchivedEvent = eventFrame(EventNames.ConversationUnarchived, {
+      conversationId: "conv-archived",
+      by: "agent-gm",
+    });
+    service.emitEvent(unarchivedEvent);
+
+    expect(service.isConversationArchived("conv-archived")).toBe(false);
+    expect(unarchivedEvents).toEqual([unarchivedEvent.data]);
   });
 });
 

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -3,14 +3,25 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import {
+  AgentsLookup,
+  AgentsLookupByName,
+  AppsAuthorizeDispatch,
+  ConversationsCreate,
+  ConversationsGet,
   type EventFrame,
   type Message,
   type Part,
   type MessageReceivedEvent,
   type ConversationCreatedEvent,
   type ConversationUpdatedEvent,
+  type ConversationArchivedEvent,
+  type ConversationUnarchivedEvent,
   type PermissionsRequiredEvent,
+  ErrorCodes,
   EventNames,
+  MessagesList,
+  MessagesSend,
+  PermissionsGrant,
 } from "@moltzap/protocol";
 import { Effect, HashMap, Match, Option, Ref } from "effect";
 import {
@@ -219,11 +230,16 @@ export class MoltZapService {
       HashMap.empty<string, HashMap.HashMap<string, ReadonlySet<string>>>(),
     ),
   );
+  private readonly archivedConversationIds = new Set<string>();
   private messageHandlers: EventHandler<Message>[] = [];
   private rawEventHandlers: EventHandler<EventFrame>[] = [];
   private disconnectHandlers: EventHandler<void>[] = [];
   private reconnectHandlers: EventHandler<HelloOk>[] = [];
   private permissionRequiredHandlers: EventHandler<PermissionsRequiredEvent>[] =
+    [];
+  private conversationArchivedHandlers: EventHandler<ConversationArchivedEvent>[] =
+    [];
+  private conversationUnarchivedHandlers: EventHandler<ConversationUnarchivedEvent>[] =
     [];
 
   private _ownAgentId: string | undefined;
@@ -299,6 +315,7 @@ export class MoltZapService {
         Ref.set(this.lastReadRef, HashMap.empty()),
       ]),
     );
+    this.archivedConversationIds.clear();
     // Handlers are preserved across close()/connect() cycles. MoltZapChannelCore
     // subscribes once in its constructor; clearing handlers here would silently
     // drop inbound/reconnect dispatch on any subsequent reconnect of the same
@@ -502,7 +519,7 @@ export class MoltZapService {
       const convId = params.conversationId;
       const limit = (params.limit as number) ?? 10;
       const sessionKey = params.sessionKey as string | undefined;
-      const result = (yield* this.sendRpc("messages/list", {
+      const result = (yield* this.sendRpc(MessagesList.name, {
         conversationId: convId,
         limit,
       })) as { messages: Message[]; hasMore: boolean };
@@ -515,7 +532,7 @@ export class MoltZapService {
 
       const lookupEff =
         unknownAgentIds.length > 0
-          ? this.sendRpc("agents/lookup", { agentIds: unknownAgentIds }).pipe(
+          ? this.sendRpc(AgentsLookup.name, { agentIds: unknownAgentIds }).pipe(
               Effect.tap((res) => {
                 const agents = (
                   res as { agents: Array<{ id: string; name: string }> }
@@ -533,7 +550,7 @@ export class MoltZapService {
             )
           : Effect.void;
 
-      const metaEff = this.sendRpc("conversations/get", {
+      const metaEff = this.sendRpc(ConversationsGet.name, {
         conversationId: convId,
       }).pipe(
         Effect.map(
@@ -622,6 +639,10 @@ export class MoltZapService {
     );
   }
 
+  isConversationArchived(convId: string): boolean {
+    return this.archivedConversationIds.has(convId);
+  }
+
   getConversations(): ConversationMeta[] {
     return [...HashMap.values(snapshot(this.conversationsRef))];
   }
@@ -658,7 +679,9 @@ export class MoltZapService {
       );
       if (cached !== undefined) return cached;
 
-      return yield* this.sendRpc("agents/lookup", { agentIds: [agentId] }).pipe(
+      return yield* this.sendRpc(AgentsLookup.name, {
+        agentIds: [agentId],
+      }).pipe(
         Effect.flatMap((result) => {
           const agent = (
             result as { agents: Array<{ id: string; name: string }> }
@@ -687,8 +710,16 @@ export class MoltZapService {
     text: string,
     opts?: { replyTo?: string; dispatchLeaseId?: string },
   ): Effect.Effect<void, ServiceRpcError> {
+    if (this.isConversationArchived(convId)) {
+      return Effect.fail(
+        new RpcServerError({
+          code: ErrorCodes.ConversationArchived,
+          message: "Conversation is archived",
+        }),
+      );
+    }
     return Effect.asVoid(
-      this.sendRpc("messages/send", {
+      this.sendRpc(MessagesSend.name, {
         conversationId: convId,
         parts: [{ type: "text", text }],
         ...(opts?.replyTo ? { replyToId: opts.replyTo } : {}),
@@ -703,7 +734,7 @@ export class MoltZapService {
     request: DispatchAdmissionRequest,
   ): Effect.Effect<DispatchAdmissionDecision, ServiceRpcError> {
     return this.sendRpc(
-      "apps/authorizeDispatch",
+      AppsAuthorizeDispatch.name,
       {
         conversationId: request.conversationId,
         messageId: request.message.id,
@@ -764,14 +795,14 @@ export class MoltZapService {
       const cache = yield* Ref.get(this.agentConversationCacheRef);
       let conversationId = Option.getOrUndefined(HashMap.get(cache, agentName));
       if (!conversationId) {
-        const lookupResult = (yield* this.sendRpc("agents/lookupByName", {
+        const lookupResult = (yield* this.sendRpc(AgentsLookupByName.name, {
           names: [agentName],
         })) as { agents: Array<{ id: string; name: string }> };
         const agent = lookupResult.agents[0];
         if (!agent) {
           return yield* Effect.fail(new AgentNotFoundError({ agentName }));
         }
-        const createResult = (yield* this.sendRpc("conversations/create", {
+        const createResult = (yield* this.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: agent.id }],
         })) as { conversation: { id: string } };
@@ -987,12 +1018,22 @@ export class MoltZapService {
     handler: EventHandler<PermissionsRequiredEvent>,
   ): void;
   on(
+    event: "conversationArchived",
+    handler: EventHandler<ConversationArchivedEvent>,
+  ): void;
+  on(
+    event: "conversationUnarchived",
+    handler: EventHandler<ConversationUnarchivedEvent>,
+  ): void;
+  on(
     event:
       | "message"
       | "rawEvent"
       | "disconnect"
       | "reconnect"
-      | "permissionRequired",
+      | "permissionRequired"
+      | "conversationArchived"
+      | "conversationUnarchived",
     handler: EventHandler<any>,
   ): void {
     switch (event) {
@@ -1011,6 +1052,16 @@ export class MoltZapService {
       case "permissionRequired":
         this.permissionRequiredHandlers.push(
           handler as EventHandler<PermissionsRequiredEvent>,
+        );
+        break;
+      case "conversationArchived":
+        this.conversationArchivedHandlers.push(
+          handler as EventHandler<ConversationArchivedEvent>,
+        );
+        break;
+      case "conversationUnarchived":
+        this.conversationUnarchivedHandlers.push(
+          handler as EventHandler<ConversationUnarchivedEvent>,
         );
         break;
     }
@@ -1037,7 +1088,7 @@ export class MoltZapService {
     resource: string;
     access: string[];
   }): Effect.Effect<void, ServiceRpcError> {
-    return Effect.asVoid(this.sendRpc("permissions/grant", params));
+    return Effect.asVoid(this.sendRpc(PermissionsGrant.name, params));
   }
 
   // --- Internals ---
@@ -1050,7 +1101,7 @@ export class MoltZapService {
   private refreshConversationParticipants(
     conversationId: string,
   ): Effect.Effect<void, never> {
-    return this.sendRpc("conversations/get", { conversationId }).pipe(
+    return this.sendRpc(ConversationsGet.name, { conversationId }).pipe(
       Effect.tap((res) => {
         const typed = res as {
           conversation: { id: string; type: string; name?: string };
@@ -1064,6 +1115,9 @@ export class MoltZapService {
             (p) => `${p.participant.type}:${p.participant.id}`,
           ),
         };
+        if (this.archivedConversationIds.has(conversationId)) {
+          return Effect.void;
+        }
         return Ref.update(this.conversationsRef, (m) =>
           HashMap.set(m, conversationId, meta),
         );
@@ -1081,6 +1135,7 @@ export class MoltZapService {
       Ref.update(this.conversationsRef, (m) => {
         let next = m;
         for (const conv of incoming) {
+          this.archivedConversationIds.delete(conv.id);
           next = HashMap.set(next, conv.id, {
             id: conv.id,
             type: conv.type,
@@ -1103,6 +1158,10 @@ export class MoltZapService {
     const conversation = isPlainRecord(eventData["conversation"])
       ? eventData["conversation"]
       : undefined;
+    const eventConversationId =
+      typeof eventData["conversationId"] === "string"
+        ? eventData["conversationId"]
+        : undefined;
     appendClientEventTrace({
       ts: new Date().toISOString(),
       agentId: this._ownAgentId ?? "unknown",
@@ -1110,7 +1169,7 @@ export class MoltZapService {
       messageId: message?.["id"],
       messageConversationId: message?.["conversationId"],
       messageSenderId: message?.["senderId"],
-      conversationId: conversation?.["id"],
+      conversationId: conversation?.["id"] ?? eventConversationId,
       conversationName: conversation?.["name"],
     });
 
@@ -1144,6 +1203,7 @@ export class MoltZapService {
         const { conversation } = event.data as
           | ConversationCreatedEvent
           | ConversationUpdatedEvent;
+        this.archivedConversationIds.delete(conversation.id);
         Effect.runSync(
           Ref.update(this.conversationsRef, (m) => {
             const existing = Option.getOrUndefined(
@@ -1168,7 +1228,67 @@ export class MoltZapService {
         }
         break;
       }
+      case EventNames.ConversationArchived: {
+        const data = event.data as ConversationArchivedEvent;
+        this.markConversationArchived(data.conversationId);
+        fanout(this.conversationArchivedHandlers, data, this.opts.logger);
+        break;
+      }
+      case EventNames.ConversationUnarchived: {
+        const data = event.data as ConversationUnarchivedEvent;
+        this.archivedConversationIds.delete(data.conversationId);
+        fanout(this.conversationUnarchivedHandlers, data, this.opts.logger);
+        break;
+      }
     }
+  }
+
+  private markConversationArchived(conversationId: string): void {
+    this.archivedConversationIds.add(conversationId);
+    Effect.runSync(
+      Effect.all([
+        Ref.update(this.conversationsRef, (m) =>
+          HashMap.remove(m, conversationId),
+        ),
+        Ref.update(this.messagesRef, (m) => HashMap.remove(m, conversationId)),
+        Ref.update(this.agentConversationCacheRef, (m) => {
+          let next = HashMap.empty<string, string>();
+          for (const [agentName, convId] of HashMap.entries(m)) {
+            if (convId !== conversationId) {
+              next = HashMap.set(next, agentName, convId);
+            }
+          }
+          return next;
+        }),
+        Ref.update(this.lastNotifiedRef, (outer) => {
+          let next = HashMap.empty<string, HashMap.HashMap<string, string>>();
+          for (const [viewConvId, markers] of HashMap.entries(outer)) {
+            if (viewConvId !== conversationId) {
+              next = HashMap.set(
+                next,
+                viewConvId,
+                HashMap.remove(markers, conversationId),
+              );
+            }
+          }
+          return next;
+        }),
+        Ref.update(this.lastReadRef, (outer) => {
+          let next = HashMap.empty<
+            string,
+            HashMap.HashMap<string, ReadonlySet<string>>
+          >();
+          for (const [sessionKey, perConv] of HashMap.entries(outer)) {
+            next = HashMap.set(
+              next,
+              sessionKey,
+              HashMap.remove(perConv, conversationId),
+            );
+          }
+          return next;
+        }),
+      ]),
+    );
   }
 
   private storeMessage(msg: Message): void {

--- a/packages/client/src/test-utils/channel-service-fixture.ts
+++ b/packages/client/src/test-utils/channel-service-fixture.ts
@@ -12,6 +12,8 @@ import type {
 type MessageHandler = (msg: Message) => void;
 type VoidHandler = () => void;
 type PermissionRequiredHandler = (data: PermissionsRequiredEvent) => void;
+type ConversationArchivedHandler = (data: { conversationId: string }) => void;
+type ConversationUnarchivedHandler = (data: { conversationId: string }) => void;
 
 interface FixtureConversationMeta {
   type: string;
@@ -25,6 +27,8 @@ export interface ChannelServiceEmit {
   disconnect(): void;
   reconnect(): void;
   permissionRequired(data: PermissionsRequiredEvent): void;
+  conversationArchived(data: { conversationId: string }): void;
+  conversationUnarchived(data: { conversationId: string }): void;
 }
 
 export interface ChannelServiceState {
@@ -64,12 +68,15 @@ export function createFakeChannelService(
   const disconnectHandlers: VoidHandler[] = [];
   const reconnectHandlers: VoidHandler[] = [];
   const permissionRequiredHandlers: PermissionRequiredHandler[] = [];
+  const conversationArchivedHandlers: ConversationArchivedHandler[] = [];
+  const conversationUnarchivedHandlers: ConversationUnarchivedHandler[] = [];
 
   const conversations = new Map<string, FixtureConversationMeta>();
   const agentNames = new Map<string, string>();
   const contextEntriesByConv = new Map<string, CrossConversationEntry[]>();
   const fullMessagesByConv = new Map<string, CrossConvMessage[]>();
   const resolveFailures = new Map<string, Error>();
+  const archivedConversationIds = new Set<string>();
   const resolveCalls: string[] = [];
   const sent: Array<{
     convId: string;
@@ -87,8 +94,19 @@ export function createFakeChannelService(
     },
 
     on(
-      event: "message" | "disconnect" | "reconnect" | "permissionRequired",
-      handler: MessageHandler | VoidHandler | PermissionRequiredHandler,
+      event:
+        | "message"
+        | "disconnect"
+        | "reconnect"
+        | "permissionRequired"
+        | "conversationArchived"
+        | "conversationUnarchived",
+      handler:
+        | MessageHandler
+        | VoidHandler
+        | PermissionRequiredHandler
+        | ConversationArchivedHandler
+        | ConversationUnarchivedHandler,
     ): void {
       if (event === "message") {
         messageHandlers.push(handler as MessageHandler);
@@ -98,6 +116,14 @@ export function createFakeChannelService(
         reconnectHandlers.push(handler as VoidHandler);
       } else if (event === "permissionRequired") {
         permissionRequiredHandlers.push(handler as PermissionRequiredHandler);
+      } else if (event === "conversationArchived") {
+        conversationArchivedHandlers.push(
+          handler as ConversationArchivedHandler,
+        );
+      } else if (event === "conversationUnarchived") {
+        conversationUnarchivedHandlers.push(
+          handler as ConversationUnarchivedHandler,
+        );
       }
     },
 
@@ -136,6 +162,10 @@ export function createFakeChannelService(
 
     getAgentName(agentId: string) {
       return agentNames.get(agentId);
+    },
+
+    isConversationArchived(convId: string) {
+      return archivedConversationIds.has(convId);
     },
 
     resolveAgentName(agentId: string) {
@@ -181,6 +211,15 @@ export function createFakeChannelService(
     },
     permissionRequired(data) {
       for (const h of permissionRequiredHandlers) h(data);
+    },
+    conversationArchived(data) {
+      archivedConversationIds.add(data.conversationId);
+      conversations.delete(data.conversationId);
+      for (const h of conversationArchivedHandlers) h(data);
+    },
+    conversationUnarchived(data) {
+      archivedConversationIds.delete(data.conversationId);
+      for (const h of conversationUnarchivedHandlers) h(data);
     },
   };
 

--- a/packages/client/src/test-utils/fake-service.ts
+++ b/packages/client/src/test-utils/fake-service.ts
@@ -22,7 +22,12 @@
  *       keep working. Prefer `setResponse` in new code.
  */
 
-import type { Message, RpcMap, RpcMethodName } from "@moltzap/protocol";
+import type {
+  EventFrame,
+  Message,
+  RpcMap,
+  RpcMethodName,
+} from "@moltzap/protocol";
 import { Effect, HashMap, Option, Ref } from "effect";
 import { MoltZapService, type ServiceRpcError } from "../service.js";
 import type { RpcCallOptions } from "../ws-client.js";
@@ -134,6 +139,14 @@ export class FakeMoltZapService extends MoltZapService {
         );
         return HashMap.set(m, convId, [...existing, msg]);
       }),
+    );
+  }
+
+  /** Deliver a protocol event through the real service event handler. */
+  emitEvent(event: EventFrame): void {
+    (Reflect.get(this, "handleEvent") as (frame: EventFrame) => void).call(
+      this,
+      event,
     );
   }
 

--- a/packages/protocol/scripts/check-divergence-proofs.sh
+++ b/packages/protocol/scripts/check-divergence-proofs.sh
@@ -2,16 +2,18 @@
 #
 # Executable divergence-proof gate.
 #
-# The old gate accepted `describe.skip(...)` comment placeholders. That
-# made CI report skipped tests instead of proving the properties reject
-# bad implementations. This gate now requires real Vitest proof files and
-# fails if any skipped divergence-proof placeholder comes back.
+# Any registrar wired into the server or client conformance suites must
+# have an executable proof unless it is explicitly listed in the legacy
+# exemption table below. This prevents new conformance properties from
+# landing with only happy-path coverage.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROTOCOL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROOFS_DIR="$PROTOCOL_DIR/src/testing/conformance/__divergence_proofs__"
+SERVER_SUITE="$PROTOCOL_DIR/src/testing/conformance/suite.ts"
+CLIENT_SUITE="$PROTOCOL_DIR/src/testing/conformance/client/suite.ts"
 
 if [ ! -d "$PROOFS_DIR" ]; then
   echo "ERROR: $PROOFS_DIR not found" >&2
@@ -29,37 +31,90 @@ if grep -R --line-number -E 'describe\.skip|it\.skip|test\.skip' "$PROOFS_DIR"; 
   exit 1
 fi
 
-required_registrars=(
-  registerEventWellFormednessClient
-  registerMalformedFrameHandlingClient
-  registerFanOutCardinalityClient
-  registerPayloadOpacityClient
-  registerTaskBoundaryIsolationClient
-  registerSchemaExhaustiveFuzzClient
-  registerModelEquivalenceClient
-  registerRequestIdUniquenessClient
-  registerRequestWellFormedness
-  registerRpcMapCoverage
-  registerAuthorityNegative
-  registerAuthorityPositive
-  registerModelEquivalence
-  registerRequestIdUniqueness
-  registerIdempotence
+# Existing properties that predate the executable-proof gate. Keep this
+# list small and intentional: new suite registrars should normally get a
+# proof, not a new exemption.
+legacy_exempt_registrars=(
+  registerEventWellFormedness
+  registerRoundTripIdentity
+  registerMalformedFrameHandling
+  registerS2cRequestRoundTripIdentity
+  registerS2cResponseValidation
+  registerS2cMalformedRequestHandling
+  registerDualDirectionIdCollision
+  registerFanOutCardinality
+  registerStoreAndReplay
+  registerPayloadOpacity
+  registerTaskBoundaryIsolation
+  registerHookGatedDelivery
+  registerMultiAppFifoShortCircuit
+  registerLatencyResilience
+  registerBackpressure
+  registerSlicerFraming
+  registerResetPeerRecovery
+  registerTimeoutSurface
+  registerSlowCloseCleanup
+  registerSpuriousS2cFrameHandling
+  registerCallerControlledS2cTimeout
+  registerSchemaExhaustiveFuzz
+  registerAppDisconnectFailPolicy
+  registerLatencyResilienceClient
+  registerSlicerFramingClient
+  registerResetPeerRecoveryClient
+  registerTimeoutSurfaceClient
+  registerSlowCloseCleanupClient
+)
+
+is_legacy_exempt() {
+  local registrar="$1"
+  local exempt
+  for exempt in "${legacy_exempt_registrars[@]}"; do
+    if [ "$registrar" = "$exempt" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+extract_suite_registrars() {
+  local suite_file="$1"
+  grep -Eo 'register[A-Za-z0-9_]+\(ctx\);' "$suite_file" \
+    | sed 's/(ctx);//' \
+    | grep -Ev '^registerAll(Client)?Properties$' \
+    | sort -u
+}
+
+mapfile -t suite_registrars < <(
+  {
+    extract_suite_registrars "$SERVER_SUITE"
+    extract_suite_registrars "$CLIENT_SUITE"
+  } | sort -u
 )
 
 missing=()
-for registrar in "${required_registrars[@]}"; do
+for registrar in "${suite_registrars[@]}"; do
+  if is_legacy_exempt "$registrar"; then
+    continue
+  fi
   if ! grep -R -q "$registrar" "${executable_proofs[@]}"; then
     missing+=("$registrar")
   fi
 done
 
 if [ "${#missing[@]}" -gt 0 ]; then
-  echo "Divergence-proof gate: FAIL — missing executable proofs for:" >&2
+  echo "Divergence-proof gate: FAIL — missing executable proofs for suite registrars:" >&2
   for registrar in "${missing[@]}"; do
     echo "  - $registrar" >&2
   done
+  echo "Add a proof under $PROOFS_DIR or explicitly document a legacy exemption." >&2
   exit 1
 fi
 
-echo "Divergence-proof gate: OK (${#required_registrars[@]} executable proof cases, no skipped placeholders)"
+proved=0
+for registrar in "${suite_registrars[@]}"; do
+  if ! is_legacy_exempt "$registrar"; then
+    proved=$((proved + 1))
+  fi
+done
+
+echo "Divergence-proof gate: OK ($proved suite registrars proof-required, ${#legacy_exempt_registrars[@]} legacy exemptions, no skipped placeholders)"

--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/client-executable.proofs.test.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/client-executable.proofs.test.ts
@@ -5,6 +5,7 @@ import type {
   RequestFrame,
   ResponseFrame,
 } from "../../../schema/frames.js";
+import { EventNames } from "../../../schema/events.js";
 import type { TestServer, TestServerConnection } from "../../test-server.js";
 import { makeCaptureBuffer, recordFrame } from "../../captures.js";
 import { encodeFrame } from "../../codec.js";
@@ -18,6 +19,7 @@ import {
   registerFanOutCardinalityClient,
   registerPayloadOpacityClient,
   registerTaskBoundaryIsolationClient,
+  registerArchiveLifecycleClient,
   registerSchemaExhaustiveFuzzClient,
 } from "../client/index.js";
 import type {
@@ -42,6 +44,7 @@ type EventBehavior =
   | "strip-required-field"
   | "rewrite-payload"
   | "rewrite-conversation-id"
+  | "swap-archive-lifecycle"
   | "close-on-malformed"
   | "close-on-untagged-fuzz";
 
@@ -92,6 +95,13 @@ describe("client-side conformance executable divergence proofs", () => {
       { eventBehavior: "rewrite-conversation-id" },
     );
     expectInvariant(failure, "task-boundary-isolation-client");
+  });
+
+  it("registerArchiveLifecycleClient fails when archive lifecycle order is wrong", async () => {
+    const failure = await runSingleClientProof(registerArchiveLifecycleClient, {
+      eventBehavior: "swap-archive-lifecycle",
+    });
+    expectInvariant(failure, "archive-lifecycle-client");
   });
 
   it("registerSchemaExhaustiveFuzzClient fails when post-fuzz liveness is poisoned", async () => {
@@ -184,7 +194,9 @@ function makeBadClientContext(
                   ? rewriteEventData(frame, {
                       conversationId: "cross-wired-task",
                     })
-                  : frame;
+                  : behavior === "swap-archive-lifecycle"
+                    ? swapArchiveLifecycleEvent(frame)
+                    : frame;
         const encoded = new TextEncoder().encode(JSON.stringify(surfaceFrame));
         yield* Ref.update(eventsRef, (events) => [
           ...events,
@@ -356,4 +368,14 @@ function stripEventName(frame: EventFrame): EventFrame {
   const withoutEvent: Partial<EventFrame> = { ...frame };
   delete withoutEvent.event;
   return withoutEvent as EventFrame;
+}
+
+function swapArchiveLifecycleEvent(frame: EventFrame): EventFrame {
+  if (frame.event === EventNames.ConversationArchived) {
+    return { ...frame, event: EventNames.ConversationUnarchived };
+  }
+  if (frame.event === EventNames.ConversationUnarchived) {
+    return { ...frame, event: EventNames.ConversationArchived };
+  }
+  return frame;
 }

--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
@@ -5,9 +5,17 @@ import { Effect, Ref, Scope } from "effect";
 import * as NodeSocketServer from "@effect/platform-node/NodeSocketServer";
 import type { RequestFrame, ResponseFrame } from "../../../schema/frames.js";
 import { ErrorCodes } from "../../../schema/errors.js";
+import { responseFrame } from "../../../helpers.js";
+import {
+  ConversationsArchive,
+  ConversationsCreate,
+  ConversationsUnarchive,
+} from "../../../schema/methods/conversations.js";
+import { MessagesSend } from "../../../schema/methods/messages.js";
 import { decodeFrame, encodeFrame } from "../../codec.js";
 import type { ConformanceArtifact } from "../runner.js";
 import type { ConformanceRunContext, RealServerHandle } from "../runner.js";
+import { registerArchiveLifecycle } from "../delivery.js";
 import { collectProperties, type PropertyFailure } from "../registry.js";
 import {
   registerAuthorityPositive,
@@ -33,7 +41,8 @@ type BadServerBehavior =
   | "drop-sampled-response"
   | "reject-confident-model-call"
   | "reject-authorized"
-  | "drift-idempotent-result";
+  | "drift-idempotent-result"
+  | "archive-missing-event";
 
 describe("server-side conformance executable divergence proofs", () => {
   it("registerAuthorityNegative fails when pre-handshake RPCs return success", async () => {
@@ -84,6 +93,13 @@ describe("server-side conformance executable divergence proofs", () => {
     });
     expectInvariant(failure, "rpc-map-coverage");
   });
+
+  it("registerArchiveLifecycle fails when archive does not broadcast lifecycle", async () => {
+    const failure = await runSingleServerProof(registerArchiveLifecycle, {
+      behavior: "archive-missing-event",
+    });
+    expectInvariant(failure, "archive-lifecycle");
+  }, 10_000);
 });
 
 async function runSingleServerProof(
@@ -273,24 +289,16 @@ function makeBadResponse(
     (behavior === "reject-authorized" &&
       request.method === "conversations/list")
   ) {
-    return {
-      jsonrpc: "2.0",
-      type: "response",
-      direction: "c2s",
-      id: request.id,
+    return responseFrame("c2s", request.id, {
       error: {
         code: ErrorCodes.InternalError,
         message: "bad server rejects model-ok call",
       },
-    };
+    });
   }
-  return {
-    jsonrpc: "2.0",
-    type: "response",
-    direction: "c2s",
-    id: request.id,
+  return responseFrame("c2s", request.id, {
     result: makeBadResult(request, behavior, ordinal),
-  };
+  });
 }
 
 function makeBadResult(
@@ -298,6 +306,9 @@ function makeBadResult(
   behavior: BadServerBehavior,
   ordinal: number,
 ): unknown {
+  if (behavior === "archive-missing-event") {
+    return makeArchiveLifecycleBadResult(request);
+  }
   switch (request.method) {
     case "auth/connect":
       return {};
@@ -310,4 +321,33 @@ function makeBadResult(
     default:
       return {};
   }
+}
+
+function makeArchiveLifecycleBadResult(request: RequestFrame): unknown {
+  if (request.method === ConversationsCreate.name) {
+    return {
+      conversation: {
+        id: "00000000-0000-4000-8000-000000000001",
+      },
+    };
+  }
+  if (
+    request.method === ConversationsArchive.name ||
+    request.method === ConversationsUnarchive.name
+  ) {
+    return {};
+  }
+  if (request.method === MessagesSend.name) {
+    const params = request.params as { conversationId?: unknown };
+    return {
+      message: {
+        id: "00000000-0000-4000-8000-000000000002",
+        conversationId:
+          typeof params.conversationId === "string"
+            ? params.conversationId
+            : "00000000-0000-4000-8000-000000000001",
+      },
+    };
+  }
+  return {};
 }

--- a/packages/protocol/src/testing/conformance/client/delivery.ts
+++ b/packages/protocol/src/testing/conformance/client/delivery.ts
@@ -20,6 +20,8 @@
  */
 import { Effect } from "effect";
 import * as fc from "fast-check";
+import { eventFrame } from "../../../helpers.js";
+import { EventNames } from "../../../schema/events.js";
 import type { EventFrame } from "../../../schema/frames.js";
 import { arbitraryEventFrame } from "../../arbitraries/frames.js";
 import type { ClientConformanceRunContext } from "./runner.js";
@@ -310,6 +312,75 @@ export function registerTaskBoundaryIsolationClient(
               ),
             );
           }
+        }
+      }),
+    ),
+  );
+}
+
+/**
+ * Archive lifecycle client — TestServer emits archive then unarchive
+ * lifecycle events. The real client subscriber must surface both in
+ * emission order.
+ */
+export function registerArchiveLifecycleClient(
+  ctx: ClientConformanceRunContext,
+): void {
+  const name = "archive-lifecycle-client";
+  registerProperty(
+    ctx,
+    CATEGORY,
+    name,
+    "archive/unarchive lifecycle events surface on the real client in order",
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fx = yield* acquireFixture(ctx, CATEGORY, name);
+        yield* subscribeAll(fx.handle);
+
+        const conversationId = "00000000-0000-4000-8000-000000000001";
+        const tag = yield* fx.window.freshEmissionTag;
+        yield* fx.window.emitTaggedEvent({
+          connection: fx.connection,
+          base: eventFrame(EventNames.ConversationArchived, {
+            conversationId,
+            archivedAt: new Date(0).toISOString(),
+            by: fx.handle.agentId,
+          }),
+          emissionTag: tag,
+        });
+        yield* fx.window.emitTaggedEvent({
+          connection: fx.connection,
+          base: eventFrame(EventNames.ConversationUnarchived, {
+            conversationId,
+            by: fx.handle.agentId,
+          }),
+          emissionTag: tag,
+        });
+
+        const observed = yield* collectTagged(fx.handle, (t) => t === tag, {
+          expected: 2,
+          budgetMs: PROPERTY_BUDGET_MS,
+        });
+        if (observed.length !== 2) {
+          return yield* Effect.fail(
+            invariant(
+              CATEGORY,
+              name,
+              `expected 2 lifecycle observations, got ${observed.length}`,
+            ),
+          );
+        }
+        if (
+          observed[0]?.eventName !== EventNames.ConversationArchived ||
+          observed[1]?.eventName !== EventNames.ConversationUnarchived
+        ) {
+          return yield* Effect.fail(
+            invariant(
+              CATEGORY,
+              name,
+              `lifecycle order mismatch: ${observed.map((o) => o.eventName).join(",")}`,
+            ),
+          );
         }
       }),
     ),

--- a/packages/protocol/src/testing/conformance/client/index.ts
+++ b/packages/protocol/src/testing/conformance/client/index.ts
@@ -38,6 +38,7 @@ export {
   registerRequestIdUniquenessClient,
 } from "./rpc-semantics.js";
 export {
+  registerArchiveLifecycleClient,
   registerFanOutCardinalityClient,
   registerPayloadOpacityClient,
   registerTaskBoundaryIsolationClient,

--- a/packages/protocol/src/testing/conformance/client/suite.ts
+++ b/packages/protocol/src/testing/conformance/client/suite.ts
@@ -54,6 +54,7 @@ import {
   registerRequestIdUniquenessClient,
 } from "./rpc-semantics.js";
 import {
+  registerArchiveLifecycleClient,
   registerFanOutCardinalityClient,
   registerPayloadOpacityClient,
   registerTaskBoundaryIsolationClient,
@@ -99,7 +100,7 @@ export interface ClientConformanceSuiteOptions {
 
 /**
  * Register every client-side property (A2, A4, B1, B4, C1, C3, C4, D1,
- * D3, D4, D5, D6, E2 — 13 total per spec amendment #200 §5) against
+ * D3, D4, D5, D6, E2 plus archive lifecycle — 14 total) against
  * `ctx`. Property files in `conformance/client/*.ts` each export one
  * `registerXxxClient` per spec-amendment registrar; this helper is the
  * single call site.
@@ -114,6 +115,7 @@ export function registerAllClientProperties(
   registerFanOutCardinalityClient(ctx);
   registerPayloadOpacityClient(ctx);
   registerTaskBoundaryIsolationClient(ctx);
+  registerArchiveLifecycleClient(ctx);
   registerSchemaExhaustiveFuzzClient(ctx);
   registerLatencyResilienceClient(ctx);
   registerSlicerFramingClient(ctx);

--- a/packages/protocol/src/testing/conformance/delivery.ts
+++ b/packages/protocol/src/testing/conformance/delivery.ts
@@ -10,6 +10,14 @@
  */
 import * as fc from "fast-check";
 import { Effect, Ref, type Scope } from "effect";
+import { ErrorCodes } from "../../schema/errors.js";
+import { EventNames } from "../../schema/events.js";
+import {
+  ConversationsArchive,
+  ConversationsCreate,
+  ConversationsUnarchive,
+} from "../../schema/methods/conversations.js";
+import { MessagesSend } from "../../schema/methods/messages.js";
 import { makeTestClient, type TestClient } from "../test-client.js";
 import { registerTestAgent, type TestAgent } from "../agent-registration.js";
 import type { ConformanceRunContext } from "./runner.js";
@@ -26,6 +34,7 @@ const CATEGORY = "delivery" as const;
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_CAPTURE_CAPACITY = 256;
 const MAX_N = 4;
+const ARCHIVE_LIFECYCLE_PROPERTY = "archive-lifecycle";
 
 interface ConversationFixture {
   readonly owner: { agent: TestAgent; client: TestClient };
@@ -34,6 +43,158 @@ interface ConversationFixture {
     client: TestClient;
   }>;
   readonly conversationId: string;
+}
+
+type ConversationActor = {
+  readonly agent: TestAgent;
+  readonly client: TestClient;
+};
+
+type ArchiveEventData = {
+  readonly conversationId?: unknown;
+  readonly archivedAt?: unknown;
+  readonly by?: unknown;
+};
+
+type UnarchiveEventData = {
+  readonly conversationId?: unknown;
+  readonly by?: unknown;
+};
+
+function violation(name: string, reason: string): PropertyInvariantViolation {
+  return new PropertyInvariantViolation({ category: CATEGORY, name, reason });
+}
+
+function acquirePropertyConversation(
+  ctx: ConformanceRunContext,
+  propertyName: string,
+  namePrefix: string,
+): Effect.Effect<ConversationFixture, PropertyInvariantViolation, Scope.Scope> {
+  return acquireConversation(ctx, 1, namePrefix).pipe(
+    Effect.mapError((e) => violation(propertyName, `fixture: ${e}`)),
+  );
+}
+
+function firstParticipant(
+  fixture: ConversationFixture,
+  propertyName: string,
+): Effect.Effect<ConversationActor, PropertyInvariantViolation> {
+  const participant = fixture.participants[0];
+  return participant === undefined
+    ? Effect.fail(violation(propertyName, "fixture missing participant"))
+    : Effect.succeed(participant);
+}
+
+function sendText(
+  actor: ConversationActor,
+  conversationId: string,
+  text: string,
+) {
+  return actor.client.sendRpc(MessagesSend.name, {
+    conversationId,
+    parts: [{ type: "text", text }],
+  });
+}
+
+function archiveConversation(actor: ConversationActor, conversationId: string) {
+  return actor.client.sendRpc(ConversationsArchive.name, { conversationId });
+}
+
+function unarchiveConversation(
+  actor: ConversationActor,
+  conversationId: string,
+) {
+  return actor.client.sendRpc(ConversationsUnarchive.name, { conversationId });
+}
+
+function waitForArchivedEvent(
+  observer: ConversationActor,
+  conversationId: string,
+  byAgentId: string,
+  propertyName: string,
+): Effect.Effect<void, PropertyInvariantViolation> {
+  return Effect.gen(function* () {
+    const event = yield* observer.client
+      .waitForEvent(EventNames.ConversationArchived, DEFAULT_TIMEOUT_MS)
+      .pipe(
+        Effect.mapError((e) =>
+          violation(propertyName, `archive event missing: ${e.message}`),
+        ),
+      );
+    const data = event.data as ArchiveEventData | undefined;
+    if (
+      data?.conversationId !== conversationId ||
+      typeof data.archivedAt !== "string" ||
+      data.by !== byAgentId
+    ) {
+      return yield* Effect.fail(
+        violation(
+          propertyName,
+          `bad archive event payload: ${JSON.stringify(event.data)}`,
+        ),
+      );
+    }
+  });
+}
+
+function waitForUnarchivedEvent(
+  observer: ConversationActor,
+  conversationId: string,
+  byAgentId: string,
+  propertyName: string,
+): Effect.Effect<void, PropertyInvariantViolation> {
+  return Effect.gen(function* () {
+    const event = yield* observer.client
+      .waitForEvent(EventNames.ConversationUnarchived, DEFAULT_TIMEOUT_MS)
+      .pipe(
+        Effect.mapError((e) =>
+          violation(propertyName, `unarchive event missing: ${e.message}`),
+        ),
+      );
+    const data = event.data as UnarchiveEventData | undefined;
+    if (data?.conversationId !== conversationId || data.by !== byAgentId) {
+      return yield* Effect.fail(
+        violation(
+          propertyName,
+          `bad unarchive event payload: ${JSON.stringify(event.data)}`,
+        ),
+      );
+    }
+  });
+}
+
+function assertConversationRejectsMessages(
+  actor: ConversationActor,
+  conversationId: string,
+  propertyName: string,
+): Effect.Effect<void, PropertyInvariantViolation> {
+  return Effect.gen(function* () {
+    const outcome = yield* sendText(
+      actor,
+      conversationId,
+      "must-fail-while-archived",
+    ).pipe(Effect.either);
+    if (outcome._tag === "Right") {
+      return yield* Effect.fail(
+        violation(propertyName, "messages/send succeeded while archived"),
+      );
+    }
+    if (
+      outcome.left._tag !== "TestingRpcResponseError" ||
+      outcome.left.code !== ErrorCodes.ConversationArchived
+    ) {
+      const errorLabel =
+        outcome.left._tag === "TestingRpcResponseError"
+          ? `${outcome.left._tag}/${outcome.left.code}`
+          : outcome.left._tag;
+      return yield* Effect.fail(
+        violation(
+          propertyName,
+          `messages/send returned ${errorLabel}, expected ConversationArchived`,
+        ),
+      );
+    }
+  });
 }
 
 function acquireClient(
@@ -74,7 +235,7 @@ function acquireConversation(
       { concurrency: clamped },
     );
     const createResult = yield* owner.client
-      .sendRpc("conversations/create", {
+      .sendRpc(ConversationsCreate.name, {
         type: "group",
         name: `${namePrefix}-conv`,
         participants: participants.map((p) => ({
@@ -126,7 +287,7 @@ export function registerFanOutCardinality(ctx: ConformanceRunContext): void {
                   Effect.mapError((e) => new Error(e)),
                 );
                 const send = yield* fixture.owner.client
-                  .sendRpc("messages/send", {
+                  .sendRpc(MessagesSend.name, {
                     conversationId: fixture.conversationId,
                     parts: [{ type: "text", text: "fan-out-ping" }],
                   })
@@ -225,7 +386,7 @@ export function registerStoreAndReplay(ctx: ConformanceRunContext): void {
         const sent = 3;
         for (let i = 0; i < sent; i++) {
           yield* fixture.owner.client
-            .sendRpc("messages/send", {
+            .sendRpc(MessagesSend.name, {
               conversationId: fixture.conversationId,
               parts: [{ type: "text", text: `sr-${i}` }],
             })
@@ -280,7 +441,7 @@ export function registerPayloadOpacity(ctx: ConformanceRunContext): void {
                   const participant = fixture.participants[0];
                   if (participant === undefined) return false;
                   yield* fixture.owner.client
-                    .sendRpc("messages/send", {
+                    .sendRpc(MessagesSend.name, {
                       conversationId: fixture.conversationId,
                       parts: [{ type: "text", text }],
                     })
@@ -552,7 +713,7 @@ export function registerTaskBoundaryIsolation(
           ),
         );
         yield* fxA.owner.client
-          .sendRpc("messages/send", {
+          .sendRpc(MessagesSend.name, {
             conversationId: fxA.conversationId,
             parts: [{ type: "text", text: "iso-leak-canary" }],
           })
@@ -571,6 +732,93 @@ export function registerTaskBoundaryIsolation(
               name: "task-boundary-isolation",
               reason: `conversation ${fxA.conversationId} leaked into outsider ${outsider.agent.agentId}`,
             }),
+          );
+        }
+      }),
+    ),
+  );
+}
+
+/**
+ * Archive lifecycle — archival is observable and enforced:
+ *   - conversations/archive broadcasts conversations/archived
+ *   - messages/send to the archived conversation returns the typed
+ *     ConversationArchived error
+ *   - conversations/unarchive broadcasts conversations/unarchived
+ *   - messages/send succeeds again after unarchive
+ */
+export function registerArchiveLifecycle(ctx: ConformanceRunContext): void {
+  registerProperty(
+    ctx,
+    CATEGORY,
+    ARCHIVE_LIFECYCLE_PROPERTY,
+    "archive/unarchive emits lifecycle events and gates messages/send",
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* acquirePropertyConversation(
+          ctx,
+          ARCHIVE_LIFECYCLE_PROPERTY,
+          "arch",
+        );
+        const participant = yield* firstParticipant(
+          fixture,
+          ARCHIVE_LIFECYCLE_PROPERTY,
+        );
+
+        const archive = yield* archiveConversation(
+          fixture.owner,
+          fixture.conversationId,
+        ).pipe(Effect.either);
+        if (archive._tag === "Left") {
+          return yield* Effect.fail(
+            violation(
+              ARCHIVE_LIFECYCLE_PROPERTY,
+              `archive failed: ${archive.left._tag}`,
+            ),
+          );
+        }
+        yield* waitForArchivedEvent(
+          participant,
+          fixture.conversationId,
+          fixture.owner.agent.agentId,
+          ARCHIVE_LIFECYCLE_PROPERTY,
+        );
+        yield* assertConversationRejectsMessages(
+          participant,
+          fixture.conversationId,
+          ARCHIVE_LIFECYCLE_PROPERTY,
+        );
+
+        const unarchive = yield* unarchiveConversation(
+          fixture.owner,
+          fixture.conversationId,
+        ).pipe(Effect.either);
+        if (unarchive._tag === "Left") {
+          return yield* Effect.fail(
+            violation(
+              ARCHIVE_LIFECYCLE_PROPERTY,
+              `unarchive failed: ${unarchive.left._tag}`,
+            ),
+          );
+        }
+        yield* waitForUnarchivedEvent(
+          participant,
+          fixture.conversationId,
+          fixture.owner.agent.agentId,
+          ARCHIVE_LIFECYCLE_PROPERTY,
+        );
+
+        const resumedSend = yield* sendText(
+          participant,
+          fixture.conversationId,
+          "must-succeed-after-unarchive",
+        ).pipe(Effect.either);
+        if (resumedSend._tag === "Left") {
+          return yield* Effect.fail(
+            violation(
+              ARCHIVE_LIFECYCLE_PROPERTY,
+              `messages/send failed after unarchive: ${resumedSend.left._tag}`,
+            ),
           );
         }
       }),

--- a/packages/protocol/src/testing/conformance/suite.ts
+++ b/packages/protocol/src/testing/conformance/suite.ts
@@ -114,6 +114,7 @@ export function registerAllProperties(ctx: ConformanceRunContext): void {
   delivery.registerTaskBoundaryIsolation(ctx);
   delivery.registerHookGatedDelivery(ctx);
   delivery.registerMultiAppFifoShortCircuit(ctx);
+  delivery.registerArchiveLifecycle(ctx);
 
   adversity.registerLatencyResilience(ctx);
   adversity.registerBackpressure(ctx); // tombstoned — #186

--- a/packages/server/src/__tests__/integration/31-session-close.integration.test.ts
+++ b/packages/server/src/__tests__/integration/31-session-close.integration.test.ts
@@ -9,7 +9,13 @@ import {
   getKyselyDb,
 } from "./helpers.js";
 import type { CoreApp } from "../../app/types.js";
-import { ErrorCodes } from "@moltzap/protocol";
+import {
+  AppsAuthorizeDispatch,
+  AppsCloseSession,
+  AppsCreate,
+  ErrorCodes,
+  EventNames,
+} from "@moltzap/protocol";
 import type { ConnectedAgent } from "../../test-utils/helpers.js";
 import { expectRpcFailure } from "../../test-utils/index.js";
 
@@ -349,6 +355,45 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
         }),
     );
 
+    it.live("broadcasts conversations/archived before app/sessionClosed", () =>
+      Effect.gen(function* () {
+        const initiator = yield* registerAppAgent("close-archive-init");
+        const invitee = yield* registerAppAgent("close-archive-inv");
+
+        registerTestApp(coreApp, "close-archive-app");
+        coreApp.onAppJoin("close-archive-app", () => {});
+
+        const session = (yield* initiator.client.sendRpc(AppsCreate.name, {
+          appId: "close-archive-app",
+          invitedAgentIds: [invitee.agentId],
+        })) as {
+          session: { id: string; conversations: Record<string, string> };
+        };
+        const convId = session.session.conversations["main"]!;
+
+        yield* invitee.client.waitForEvent("app/participantAdmitted", 5000);
+
+        yield* initiator.client.sendRpc(AppsCloseSession.name, {
+          sessionId: session.session.id,
+        });
+
+        const archived = yield* invitee.client.waitForEvent(
+          EventNames.ConversationArchived,
+          3000,
+        );
+        expect(
+          (archived.data as { conversationId: string }).conversationId,
+        ).toBe(convId);
+        const closed = yield* invitee.client.waitForEvent(
+          EventNames.AppSessionClosed,
+          3000,
+        );
+        expect((closed.data as { sessionId: string }).sessionId).toBe(
+          session.session.id,
+        );
+      }),
+    );
+
     it.live("rejects messages to archived conversations", () =>
       Effect.gen(function* () {
         const agent = yield* registerAppAgent("archived-msg");
@@ -376,6 +421,50 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
           ErrorCodes.ConversationArchived,
         );
       }),
+    );
+
+    it.live(
+      "denies dispatch authorization for archived app conversations",
+      () =>
+        Effect.gen(function* () {
+          const agent = yield* registerAppAgent("archived-dispatch");
+
+          registerTestApp(coreApp, "archived-dispatch-app");
+
+          const session = (yield* agent.client.sendRpc(AppsCreate.name, {
+            appId: "archived-dispatch-app",
+            invitedAgentIds: [],
+          })) as {
+            session: { id: string; conversations: Record<string, string> };
+          };
+          const convId = session.session.conversations["main"]!;
+
+          yield* agent.client.sendRpc(AppsCloseSession.name, {
+            sessionId: session.session.id,
+          });
+
+          const result = yield* agent.client.sendRpc(
+            AppsAuthorizeDispatch.name,
+            {
+              conversationId: convId,
+              messageId: crypto.randomUUID(),
+              senderAgentId: agent.agentId,
+              attempt: 0,
+              receivedAt: new Date().toISOString(),
+              clock: {
+                domainId: convId,
+                epoch: 1,
+                vector: { [agent.agentId]: 1 },
+              },
+              pending: [],
+            },
+          );
+
+          expect(result.admission).toEqual({
+            decision: "deny",
+            reason: "conversation_archived",
+          });
+        }),
     );
 
     it.live("excludes archived conversations from conversations/list", () =>

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -467,7 +467,22 @@ export class AppHost {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
         const session = this.conversationToSession.get(conversationId);
-        if (!session) return { decision: "grant" as const };
+        if (!session) {
+          const conversationOpt = yield* takeFirstOption(
+            this.db
+              .selectFrom("conversations")
+              .select("archived_at")
+              .where("id", "=", conversationId),
+          );
+          const conversation = Option.getOrNull(conversationOpt);
+          if (conversation?.archived_at) {
+            return {
+              decision: "deny" as const,
+              reason: "conversation_archived",
+            };
+          }
+          return { decision: "grant" as const };
+        }
 
         const isRemote = this.remoteRegistrations.has(session.appId);
         const appHooks = this.hooks.get(session.appId);
@@ -895,11 +910,23 @@ export class AppHost {
         }
 
         const convIdArray = [...convIds];
+        const archivedAt = new Date();
         if (convIdArray.length > 0) {
           yield* this.db
             .updateTable("conversations")
-            .set({ archived_at: new Date() })
+            .set({ archived_at: archivedAt })
             .where("id", "in", convIdArray);
+        }
+
+        for (const convId of convIdArray) {
+          this.broadcaster.broadcastToConversation(
+            convId,
+            eventFrame(EventNames.ConversationArchived, {
+              conversationId: convId,
+              archivedAt: archivedAt.toISOString(),
+              by: callerAgentId,
+            }),
+          );
         }
 
         for (const convId of convIdArray) {


### PR DESCRIPTION
## Summary
- archive app conversations on session close and reject archived app dispatch even after session mapping is removed
- purge archived conversation state in MoltZapClientService and MoltZapChannelCore, then resume cleanly on unarchive
- add archive lifecycle server/client conformance coverage and executable divergence proofs
- make the divergence-proof gate derive required proofs from the conformance suites so new registrars are checked as part of test:conformance

## Verification
- bash packages/protocol/scripts/check-divergence-proofs.sh
- pnpm --filter @moltzap/protocol exec vitest run src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts src/testing/conformance/__divergence_proofs__/client-executable.proofs.test.ts
- pnpm --filter @moltzap/client test:conformance
- pnpm --filter @moltzap/server-core test:conformance
- pnpm typecheck
- pnpm check
