### PR TITLE
[impl-senior] B.9 follow-ups: AttachError ConversationNotFound + AlreadyAttached coverage (stacked on #326)

### DIFF
--- a/packages/app-sdk/src/app.handlers.test.ts
+++ b/packages/app-sdk/src/app.handlers.test.ts
@@ -405,6 +405,38 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
         expect((err as AttachError).code).toBe("AttachFailed");
       }
     });
+
+    // Numeric-code path: `extractAttachCode` consults the wire-level
+    // `err.code` first (NumericCodeToAttach), falling back to structured
+    // `data.code` only on miss. Mirrors the integration test in
+    // `30-app-hooks-rpc.integration.test.ts` ("Conflict (-32003) →
+    // AttachError('AlreadyAttached')"). Keeps the SDK-side numeric map
+    // honest without booting the real server.
+    it.each([
+      [-32021, "SessionNotFound" as const],
+      [-32002, "ConversationNotFound" as const],
+      [-32001, "NotAuthorized" as const],
+      [-32003, "AlreadyAttached" as const],
+    ])(
+      "maps numeric err.code=%s to AttachError code '%s' via NumericCodeToAttach",
+      async (numericCode, expectedCode) => {
+        asMock(app.client)._setAttachFailure(
+          new MockRpcServerError({ code: numericCode, message: "rejected" }),
+        );
+        const exit = await Effect.runPromiseExit(
+          app.attachConversation(
+            "00000000-0000-0000-0000-000000000001",
+            "conv-2",
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const err = exit.cause._tag === "Fail" ? exit.cause.error : null;
+          expect(err).toBeInstanceOf(AttachError);
+          expect((err as AttachError).code).toBe(expectedCode);
+        }
+      },
+    );
   });
 
   describe("type-narrowed handler signatures (compile-time)", () => {

--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -980,6 +980,7 @@ const NumericCodeToAttach: Record<number, AttachErrorCode> = {
   [-32021]: "SessionNotFound", // ErrorCodes.SessionNotFound
   [-32002]: "ConversationNotFound", // ErrorCodes.NotFound (used for missing convId)
   [-32001]: "NotAuthorized", // ErrorCodes.Forbidden
+  [-32003]: "AlreadyAttached", // ErrorCodes.Conflict (1:1 cross-session collision)
 };
 
 function extractAttachCode(err: RpcServerError): AttachErrorCode {

--- a/packages/app-sdk/src/errors.ts
+++ b/packages/app-sdk/src/errors.ts
@@ -288,6 +288,8 @@ export class AppDisconnected extends AppError {
  * - `SessionNotFound` — session id does not refer to a session this app owns
  * - `ConversationNotFound` — conversation id does not exist
  * - `NotAuthorized` — the caller is not the session owner
+ * - `AlreadyAttached` — the conversation is already attached to a different
+ *   session (the 1:1 cross-session invariant on `AppHost.conversationToSession`)
  * - `AttachFailed` — generic transport / server failure (timeout, network)
  *
  * @example
@@ -297,8 +299,8 @@ export class AppDisconnected extends AppError {
  * await Effect.runPromise(
  *   app.attachConversation(sessionId, conversationId).pipe(
  *     Effect.catchTag("AttachError", (err: AttachError) => {
- *       if (err.code === "SessionNotFound") {
- *         return Effect.sync(() => console.warn("session is gone"));
+ *       if (err.code === "SessionNotFound" || err.code === "AlreadyAttached") {
+ *         return Effect.sync(() => console.warn(err.code));
  *       }
  *       return Effect.fail(err);
  *     }),
@@ -310,6 +312,7 @@ export type AttachErrorCode =
   | "SessionNotFound"
   | "ConversationNotFound"
   | "NotAuthorized"
+  | "AlreadyAttached"
   | "AttachFailed";
 
 export class AttachError extends AppError {

--- a/packages/server/src/__tests__/integration/30-app-hooks-rpc.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-app-hooks-rpc.integration.test.ts
@@ -68,6 +68,7 @@ const NUMERIC_TO_ATTACH_TAG: Record<number, string> = {
   [ErrorCodes.SessionNotFound]: "SessionNotFound",
   [ErrorCodes.NotFound]: "ConversationNotFound",
   [ErrorCodes.Forbidden]: "NotAuthorized",
+  [ErrorCodes.Conflict]: "AlreadyAttached",
 };
 
 function expectedAttachTagFor(numericCode: number): string {
@@ -1001,6 +1002,99 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           );
           expect(rpcErr.code).toBe(ErrorCodes.Forbidden);
           expect(expectedAttachTagFor(rpcErr.code)).toBe("NotAuthorized");
+        }),
+    );
+
+    it.live(
+      "ConversationNotFound (-32002) → SDK maps to AttachError('ConversationNotFound') for missing convId",
+      () =>
+        Effect.gen(function* () {
+          const userAgent = yield* registerAppAgent("att-cnf-user");
+
+          coreApp.registerApp({
+            appId: "att-cnf-app",
+            name: "Att CNF",
+            permissions: { required: [], optional: [] },
+            conversations: [
+              { key: "main", name: "Main", participantFilter: "all" },
+            ],
+          });
+
+          const session = (yield* userAgent.client.sendRpc("apps/create", {
+            appId: "att-cnf-app",
+            invitedAgentIds: [],
+          })) as { session: { id: string } };
+
+          // Well-formed UUID that does not exist in `conversations`.
+          // Without the pre-check (issue #328), this falls through to a
+          // PG FK violation on `app_session_conversations.conversation_id`
+          // and surfaces as an internal error / `AttachFailed`. With the
+          // pre-check, the typed `NotFound` (-32002) round-trips to the
+          // SDK as `AttachError('ConversationNotFound')`.
+          const rpcErr = yield* expectRpcFailure(
+            userAgent.client.sendRpc("apps/attachConversation", {
+              sessionId: session.session.id,
+              conversationId: crypto.randomUUID(),
+            }),
+            ErrorCodes.NotFound,
+          );
+          expect(rpcErr.code).toBe(ErrorCodes.NotFound);
+          expect(expectedAttachTagFor(rpcErr.code)).toBe(
+            "ConversationNotFound",
+          );
+        }),
+    );
+
+    it.live(
+      "Conflict (-32003) → SDK maps to AttachError('AlreadyAttached') when convId is already attached to another session",
+      () =>
+        Effect.gen(function* () {
+          const userAgent = yield* registerAppAgent("att-aa-user");
+          const peer = yield* registerAppAgent("att-aa-peer");
+
+          coreApp.registerApp({
+            appId: "att-aa-app",
+            name: "Att AA",
+            permissions: { required: [], optional: [] },
+            conversations: [
+              { key: "main", name: "Main", participantFilter: "all" },
+            ],
+          });
+
+          // Two sessions owned by the same initiator so auth checks pass
+          // for both attach calls; the collision under test is the 1:1
+          // `AppHost.conversationToSession` invariant, not authorization.
+          const sessionA = (yield* userAgent.client.sendRpc("apps/create", {
+            appId: "att-aa-app",
+            invitedAgentIds: [],
+          })) as { session: { id: string } };
+          const sessionB = (yield* userAgent.client.sendRpc("apps/create", {
+            appId: "att-aa-app",
+            invitedAgentIds: [],
+          })) as { session: { id: string } };
+
+          const dm = (yield* userAgent.client.sendRpc("conversations/create", {
+            type: "dm",
+            participants: [{ type: "agent", id: peer.agentId }],
+          })) as { conversation: { id: string } };
+
+          // First attach: succeeds, binds dm.conversation.id → sessionA.
+          yield* userAgent.client.sendRpc("apps/attachConversation", {
+            sessionId: sessionA.session.id,
+            conversationId: dm.conversation.id,
+          });
+
+          // Second attach for the same convId against sessionB collides
+          // with the cross-session map; AppHost emits Conflict (-32003).
+          const rpcErr = yield* expectRpcFailure(
+            userAgent.client.sendRpc("apps/attachConversation", {
+              sessionId: sessionB.session.id,
+              conversationId: dm.conversation.id,
+            }),
+            ErrorCodes.Conflict,
+          );
+          expect(rpcErr.code).toBe(ErrorCodes.Conflict);
+          expect(expectedAttachTagFor(rpcErr.code)).toBe("AlreadyAttached");
         }),
     );
   });

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -977,6 +977,30 @@ export class AppHost {
           );
         }
 
+        // ConversationNotFound pre-check (architect plan §3.2 / §3.5):
+        // surface a typed `ConversationNotFound` (-32002) when the convId
+        // does not refer to any row in `conversations`. Without this the
+        // bogus convId would fall through to the `app_session_conversations`
+        // FK violation and surface to the SDK as the generic
+        // `AttachError("AttachFailed")`, losing the structured tag.
+        // Race-deleted conversations between this SELECT and the INSERT
+        // below still surface as `AttachFailed` via FK violation; the
+        // pre-check is best-effort, not a serializable invariant.
+        const conversationOpt = yield* takeFirstOption(
+          this.db
+            .selectFrom("conversations")
+            .select(["id"])
+            .where("id", "=", conversationId),
+        );
+        if (Option.isNone(conversationOpt)) {
+          return yield* Effect.fail(
+            new RpcFailure({
+              code: ErrorCodes.NotFound,
+              message: "Conversation not found",
+            }),
+          );
+        }
+
         // Cross-session collision: a convId can only belong to one session's
         // hook pipeline at a time (AppHost.conversationToSession is 1:1).
         const crossSession = this.conversationToSession.get(conversationId);


### PR DESCRIPTION
Closes #328
Closes #329

**Stacked on:** PR #326 (`senior/318-server-integration-rpc-admission`). Base auto-flips to `main` when #326 merges.

Architect plan: https://github.com/chughtapan/moltzap/issues/286 §3.2 / §3.5
Parent epic: https://github.com/chughtapan/moltzap-arena/issues/198 (B.9 row)

## What changed

Two B.9 review-326 follow-ups land structured `AttachError` handling:

1. **#328 — `ConversationNotFound` pre-check.** `AppHost.attachConversation` now SELECTs `conversations.id` before any membership write. Missing convId fails with `RpcFailure(ErrorCodes.NotFound /* -32002 */, "Conversation not found")`, which round-trips on the SDK side to `AttachError("ConversationNotFound")` via the existing `NumericCodeToAttach[-32002]` entry. Without the pre-check, bogus convIds fell through to a PG FK violation and surfaced as the generic `AttachError("AttachFailed")`, losing the typed tag named in architect plan §3.2.
2. **#329 — `Conflict (-32003)` extension.** Widens `AttachErrorCode` with `"AlreadyAttached"` and adds `[-32003]: "AlreadyAttached"` to `NumericCodeToAttach`. Cross-session 1:1 collisions on `AppHost.conversationToSession` now round-trip as a structured tag instead of `AttachFailed`. TSDoc on `AttachError` updated to list the new tag.

## Plan anchors

| Change | Plan / sub-issue anchor |
|---|---|
| `app-host.ts:attachConversation` pre-check on `conversations.id` (lines ~979-1001) | Architect plan §3.2 (`apps/attachConversation` typed errors); sub-issue #328 Option 1 |
| `errors.ts:AttachErrorCode` widened with `"AlreadyAttached"` | Sub-issue #329 Option 1 acceptance |
| `app.ts:NumericCodeToAttach` adds `[-32003]: "AlreadyAttached"` | Sub-issue #329 Option 1 acceptance |
| `30-app-hooks-rpc.integration.test.ts`: ConversationNotFound (-32002) wire case | Sub-issue #328 acceptance bullet 1 |
| `30-app-hooks-rpc.integration.test.ts`: Conflict (-32003) → AlreadyAttached wire case | Sub-issue #329 acceptance bullet 1 |
| `app.handlers.test.ts`: numeric-code unit-test mirror covering -32021/-32002/-32001/-32003 | Sub-issue #329 acceptance bullet 4 |
| TSDoc on `AttachError` lists `"AlreadyAttached"` | Sub-issue #329 acceptance bullet 5 |
| `NUMERIC_TO_ATTACH_TAG` mirror map (test-side) extended with `Conflict → AlreadyAttached` | Drift-detector parity with SDK map |

## Scope

- Modules touched: `@moltzap/server-core` (1 file: `app-host.ts`), `@moltzap/server-core` integration tests (1 file), `@moltzap/app-sdk` (3 files: `app.ts`, `errors.ts`, `app.handlers.test.ts`).
- Tier: senior (cross-module: server pre-check ↔ SDK numeric-code map ↔ both test layers).
- New modules: 0
- New public signatures outside the plan: `AttachErrorCode` widens by one tag (`"AlreadyAttached"`) — this is a public-surface widening of `@moltzap/app-sdk`, but is the explicit acceptance criterion in #329 Option 1 (sub-issue is the plan-extension authority for this single tag). Architect plan §3.5 named the original three tags; #329 is the user-approved sub-issue extending it.
- New deps: 0 (no `package.json` or lockfile changes).

## Tests

- `pnpm typecheck` — clean across all packages.
- `pnpm --filter @moltzap/app-sdk test` — 74 passing (was 70; +4 from new numeric-code unit cases).
- `pnpm --filter @moltzap/server-core test` — 169 passing.
- `pnpm --filter @moltzap/server-core test:integration -- src/__tests__/integration/30-app-hooks-rpc.integration.test.ts` — 139 passing across 34 files (16 in this scenario; was 14, +2 from new attachConversation cases).
- `pnpm lint` — 0 errors / 0 warnings.
- `pnpm format:check` — clean.
- `bash scripts/sloppy-code-guard.sh` — all guards passed.

New wire-level cases verified by name in test runner output:
- `Scenario 30b > apps/attachConversation (c2s wire round-trip) > ConversationNotFound (-32002) → SDK maps to AttachError('ConversationNotFound') for missing convId`
- `Scenario 30b > apps/attachConversation (c2s wire round-trip) > Conflict (-32003) → SDK maps to AttachError('AlreadyAttached') when convId is already attached to another session`

## Pre-PR checks

- `/simplify`: errored — sub-skill nesting limitation when invoked from `/safer:implement-senior` (same friction senior-318 hit). Manual self-review against PRINCIPLES.md substituted: pre-check uses existing `takeFirstOption` + `Option.isNone` pattern (no new helpers); typed error channel preserved (`Effect<void, RpcFailure>`); `NumericCodeToAttach` is a `Record` lookup (no switch needing `absurd`); test mirrors the existing `it.each` + numeric-code path style.
- `/review`: same sub-skill nesting limitation — substituted manual self-review.
- `/codex review`: skipped — codex CLI not invoked from teammate context. Recommend codex-cross-model pass at `/safer:review-senior` time.

## Confidence

HIGH — every acceptance bullet from #328 and #329 is met with executable evidence (passing integration test for the typed wire codes; passing SDK unit-test mirror; TSDoc updated). Pre-check race-deletion edge (convId deleted between SELECT and INSERT) still falls through to FK violation / `AttachFailed`; called out inline in the pre-check comment as best-effort.

## Concerns

- `AttachErrorCode` widening is a public-surface change. Architect plan §3.5 named only `SessionNotFound | ConversationNotFound | NotAuthorized`; the union extension is authorized by sub-issue #329 Option 1 (user-approved acceptance path) but technically extends the plan's named error channel. Flagged here so reviewer can confirm the sub-issue-as-plan-extension delegation, or escalate to architect if not.