### PR TITLE
[impl-senior] B.9 follow-ups: AttachError ConversationNotFound + AlreadyAttached coverage (re-opened from #331)

### DIFF
--- a/packages/app-sdk/src/app.handlers.test.ts
+++ b/packages/app-sdk/src/app.handlers.test.ts
@@ -438,6 +438,38 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
         expect((err as AttachError).code).toBe("AttachFailed");
       }
     });
+
+    // Numeric-code path: `extractAttachCode` consults the wire-level
+    // `err.code` first (NumericCodeToAttach), falling back to structured
+    // `data.code` only on miss. Mirrors the integration test in
+    // `30-app-hooks-rpc.integration.test.ts` ("Conflict (-32003) →
+    // AttachError('AlreadyAttached')"). Keeps the SDK-side numeric map
+    // honest without booting the real server.
+    it.each([
+      [-32021, "SessionNotFound" as const],
+      [-32002, "ConversationNotFound" as const],
+      [-32001, "NotAuthorized" as const],
+      [-32003, "AlreadyAttached" as const],
+    ])(
+      "maps numeric err.code=%s to AttachError code '%s' via NumericCodeToAttach",
+      async (numericCode, expectedCode) => {
+        asMock(app.client)._setAttachFailure(
+          new MockRpcServerError({ code: numericCode, message: "rejected" }),
+        );
+        const exit = await Effect.runPromiseExit(
+          app.attachConversation(
+            "00000000-0000-0000-0000-000000000001",
+            "conv-2",
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const err = exit.cause._tag === "Fail" ? exit.cause.error : null;
+          expect(err).toBeInstanceOf(AttachError);
+          expect((err as AttachError).code).toBe(expectedCode);
+        }
+      },
+    );
   });
 
   describe("type-narrowed handler signatures (compile-time)", () => {

--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -980,6 +980,7 @@ const NumericCodeToAttach: Record<number, AttachErrorCode> = {
   [-32021]: "SessionNotFound", // ErrorCodes.SessionNotFound
   [-32002]: "ConversationNotFound", // ErrorCodes.NotFound (used for missing convId)
   [-32001]: "NotAuthorized", // ErrorCodes.Forbidden
+  [-32003]: "AlreadyAttached", // ErrorCodes.Conflict (1:1 cross-session collision)
 };
 
 function extractAttachCode(err: RpcServerError): AttachErrorCode {

--- a/packages/app-sdk/src/errors.ts
+++ b/packages/app-sdk/src/errors.ts
@@ -463,6 +463,8 @@ export class AppDisconnected extends AppError {
  * - `SessionNotFound` — session id does not refer to a session this app owns
  * - `ConversationNotFound` — conversation id does not exist
  * - `NotAuthorized` — the caller is not the session owner
+ * - `AlreadyAttached` — the conversation is already attached to a different
+ *   session (the 1:1 cross-session invariant on `AppHost.conversationToSession`)
  * - `AttachFailed` — generic transport / server failure (timeout, network)
  *
  * **Triggered by:** {@link MoltZapApp.attachConversation} resolving
@@ -499,6 +501,10 @@ export class AppDisconnected extends AppError {
  *         case "SessionNotFound":
  *         case "ConversationNotFound":
  *           return Effect.sync(() => console.warn(`gone: ${err.code}`));
+ *         case "AlreadyAttached":
+ *           return Effect.sync(() =>
+ *             console.warn("convId already bound to another session"),
+ *           );
  *         case "NotAuthorized":
  *           return Effect.fail(err); // programming error; surface it
  *         case "AttachFailed":
@@ -513,6 +519,7 @@ export type AttachErrorCode =
   | "SessionNotFound"
   | "ConversationNotFound"
   | "NotAuthorized"
+  | "AlreadyAttached"
   | "AttachFailed";
 
 export class AttachError extends AppError {

--- a/packages/server/src/__tests__/integration/30-app-hooks-rpc.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-app-hooks-rpc.integration.test.ts
@@ -68,6 +68,7 @@ const NUMERIC_TO_ATTACH_TAG: Record<number, string> = {
   [ErrorCodes.SessionNotFound]: "SessionNotFound",
   [ErrorCodes.NotFound]: "ConversationNotFound",
   [ErrorCodes.Forbidden]: "NotAuthorized",
+  [ErrorCodes.Conflict]: "AlreadyAttached",
 };
 
 function expectedAttachTagFor(numericCode: number): string {
@@ -1115,6 +1116,99 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
               .execute(),
           );
           expect(rows).toHaveLength(0);
+        }),
+    );
+
+    it.live(
+      "ConversationNotFound (-32002) → SDK maps to AttachError('ConversationNotFound') for missing convId",
+      () =>
+        Effect.gen(function* () {
+          const userAgent = yield* registerAppAgent("att-cnf-user");
+
+          coreApp.registerApp({
+            appId: "att-cnf-app",
+            name: "Att CNF",
+            permissions: { required: [], optional: [] },
+            conversations: [
+              { key: "main", name: "Main", participantFilter: "all" },
+            ],
+          });
+
+          const session = (yield* userAgent.client.sendRpc("apps/create", {
+            appId: "att-cnf-app",
+            invitedAgentIds: [],
+          })) as { session: { id: string } };
+
+          // Well-formed UUID that does not exist in `conversations`.
+          // Without the pre-check (issue #328), this falls through to a
+          // PG FK violation on `app_session_conversations.conversation_id`
+          // and surfaces as an internal error / `AttachFailed`. With the
+          // pre-check, the typed `NotFound` (-32002) round-trips to the
+          // SDK as `AttachError('ConversationNotFound')`.
+          const rpcErr = yield* expectRpcFailure(
+            userAgent.client.sendRpc("apps/attachConversation", {
+              sessionId: session.session.id,
+              conversationId: crypto.randomUUID(),
+            }),
+            ErrorCodes.NotFound,
+          );
+          expect(rpcErr.code).toBe(ErrorCodes.NotFound);
+          expect(expectedAttachTagFor(rpcErr.code)).toBe(
+            "ConversationNotFound",
+          );
+        }),
+    );
+
+    it.live(
+      "Conflict (-32003) → SDK maps to AttachError('AlreadyAttached') when convId is already attached to another session",
+      () =>
+        Effect.gen(function* () {
+          const userAgent = yield* registerAppAgent("att-aa-user");
+          const peer = yield* registerAppAgent("att-aa-peer");
+
+          coreApp.registerApp({
+            appId: "att-aa-app",
+            name: "Att AA",
+            permissions: { required: [], optional: [] },
+            conversations: [
+              { key: "main", name: "Main", participantFilter: "all" },
+            ],
+          });
+
+          // Two sessions owned by the same initiator so auth checks pass
+          // for both attach calls; the collision under test is the 1:1
+          // `AppHost.conversationToSession` invariant, not authorization.
+          const sessionA = (yield* userAgent.client.sendRpc("apps/create", {
+            appId: "att-aa-app",
+            invitedAgentIds: [],
+          })) as { session: { id: string } };
+          const sessionB = (yield* userAgent.client.sendRpc("apps/create", {
+            appId: "att-aa-app",
+            invitedAgentIds: [],
+          })) as { session: { id: string } };
+
+          const dm = (yield* userAgent.client.sendRpc("conversations/create", {
+            type: "dm",
+            participants: [{ type: "agent", id: peer.agentId }],
+          })) as { conversation: { id: string } };
+
+          // First attach: succeeds, binds dm.conversation.id → sessionA.
+          yield* userAgent.client.sendRpc("apps/attachConversation", {
+            sessionId: sessionA.session.id,
+            conversationId: dm.conversation.id,
+          });
+
+          // Second attach for the same convId against sessionB collides
+          // with the cross-session map; AppHost emits Conflict (-32003).
+          const rpcErr = yield* expectRpcFailure(
+            userAgent.client.sendRpc("apps/attachConversation", {
+              sessionId: sessionB.session.id,
+              conversationId: dm.conversation.id,
+            }),
+            ErrorCodes.Conflict,
+          );
+          expect(rpcErr.code).toBe(ErrorCodes.Conflict);
+          expect(expectedAttachTagFor(rpcErr.code)).toBe("AlreadyAttached");
         }),
     );
   });

--- a/packages/server/src/__tests__/integration/30-app-hooks-rpc.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-app-hooks-rpc.integration.test.ts
@@ -1123,30 +1123,36 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
       "ConversationNotFound (-32002) → SDK maps to AttachError('ConversationNotFound') for missing convId",
       () =>
         Effect.gen(function* () {
-          const userAgent = yield* registerAppAgent("att-cnf-user");
-
-          coreApp.registerApp({
-            appId: "att-cnf-app",
-            name: "Att CNF",
-            permissions: { required: [], optional: [] },
-            conversations: [
-              { key: "main", name: "Main", participantFilter: "all" },
-            ],
+          // Mirrors the happy-path setup: remote-app of record (via
+          // `registerAppClient`) creates the session, then attempts to
+          // attach a UUID that doesn't exist in `conversations`. Without
+          // the pre-check (issue #328) the bogus convId falls through to
+          // a PG FK violation on `app_session_conversations.conversation_id`
+          // and surfaces as an internal error / `AttachFailed`. With the
+          // pre-check, the typed `NotFound` (-32002) round-trips to the
+          // SDK as `AttachError('ConversationNotFound')`.
+          const app = yield* registerAppClient({
+            name: "att-cnf-app-agent",
+            manifest: manifestFor("att-cnf-app"),
+            handlers: {},
           });
 
-          const session = (yield* userAgent.client.sendRpc("apps/create", {
+          const db = getKyselyDb();
+          yield* Effect.tryPromise(() =>
+            db
+              .updateTable("agents")
+              .set({ owner_user_id: crypto.randomUUID() })
+              .where("id", "=", app.appAgentId)
+              .execute(),
+          );
+
+          const session = (yield* app.client.sendRpc("apps/create", {
             appId: "att-cnf-app",
             invitedAgentIds: [],
           })) as { session: { id: string } };
 
-          // Well-formed UUID that does not exist in `conversations`.
-          // Without the pre-check (issue #328), this falls through to a
-          // PG FK violation on `app_session_conversations.conversation_id`
-          // and surfaces as an internal error / `AttachFailed`. With the
-          // pre-check, the typed `NotFound` (-32002) round-trips to the
-          // SDK as `AttachError('ConversationNotFound')`.
           const rpcErr = yield* expectRpcFailure(
-            userAgent.client.sendRpc("apps/attachConversation", {
+            app.client.sendRpc("apps/attachConversation", {
               sessionId: session.session.id,
               conversationId: crypto.randomUUID(),
             }),
@@ -1163,37 +1169,42 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
       "Conflict (-32003) → SDK maps to AttachError('AlreadyAttached') when convId is already attached to another session",
       () =>
         Effect.gen(function* () {
-          const userAgent = yield* registerAppAgent("att-aa-user");
+          // Two sessions owned by the same remote-app of record so the
+          // app-of-record auth check passes on both attach calls; the
+          // collision under test is the 1:1 `AppHost.conversationToSession`
+          // invariant, not authorization.
           const peer = yield* registerAppAgent("att-aa-peer");
-
-          coreApp.registerApp({
-            appId: "att-aa-app",
-            name: "Att AA",
-            permissions: { required: [], optional: [] },
-            conversations: [
-              { key: "main", name: "Main", participantFilter: "all" },
-            ],
+          const app = yield* registerAppClient({
+            name: "att-aa-app-agent",
+            manifest: manifestFor("att-aa-app"),
+            handlers: {},
           });
 
-          // Two sessions owned by the same initiator so auth checks pass
-          // for both attach calls; the collision under test is the 1:1
-          // `AppHost.conversationToSession` invariant, not authorization.
-          const sessionA = (yield* userAgent.client.sendRpc("apps/create", {
+          const db = getKyselyDb();
+          yield* Effect.tryPromise(() =>
+            db
+              .updateTable("agents")
+              .set({ owner_user_id: crypto.randomUUID() })
+              .where("id", "=", app.appAgentId)
+              .execute(),
+          );
+
+          const sessionA = (yield* app.client.sendRpc("apps/create", {
             appId: "att-aa-app",
             invitedAgentIds: [],
           })) as { session: { id: string } };
-          const sessionB = (yield* userAgent.client.sendRpc("apps/create", {
+          const sessionB = (yield* app.client.sendRpc("apps/create", {
             appId: "att-aa-app",
             invitedAgentIds: [],
           })) as { session: { id: string } };
 
-          const dm = (yield* userAgent.client.sendRpc("conversations/create", {
+          const dm = (yield* app.client.sendRpc("conversations/create", {
             type: "dm",
             participants: [{ type: "agent", id: peer.agentId }],
           })) as { conversation: { id: string } };
 
           // First attach: succeeds, binds dm.conversation.id → sessionA.
-          yield* userAgent.client.sendRpc("apps/attachConversation", {
+          yield* app.client.sendRpc("apps/attachConversation", {
             sessionId: sessionA.session.id,
             conversationId: dm.conversation.id,
           });
@@ -1201,7 +1212,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           // Second attach for the same convId against sessionB collides
           // with the cross-session map; AppHost emits Conflict (-32003).
           const rpcErr = yield* expectRpcFailure(
-            userAgent.client.sendRpc("apps/attachConversation", {
+            app.client.sendRpc("apps/attachConversation", {
               sessionId: sessionB.session.id,
               conversationId: dm.conversation.id,
             }),

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -1066,6 +1066,30 @@ export class AppHost {
           );
         }
 
+        // ConversationNotFound pre-check (architect plan §3.2 / §3.5):
+        // surface a typed `ConversationNotFound` (-32002) when the convId
+        // does not refer to any row in `conversations`. Without this the
+        // bogus convId would fall through to the `app_session_conversations`
+        // FK violation and surface to the SDK as the generic
+        // `AttachError("AttachFailed")`, losing the structured tag.
+        // Race-deleted conversations between this SELECT and the INSERT
+        // below still surface as `AttachFailed` via FK violation; the
+        // pre-check is best-effort, not a serializable invariant.
+        const conversationOpt = yield* takeFirstOption(
+          this.db
+            .selectFrom("conversations")
+            .select(["id"])
+            .where("id", "=", conversationId),
+        );
+        if (Option.isNone(conversationOpt)) {
+          return yield* Effect.fail(
+            new RpcFailure({
+              code: ErrorCodes.NotFound,
+              message: "Conversation not found",
+            }),
+          );
+        }
+
         // Cross-session collision: a convId can only belong to one session's
         // hook pipeline at a time (AppHost.conversationToSession is 1:1).
         const crossSession = this.conversationToSession.get(conversationId);


### PR DESCRIPTION
**Re-opened from #331** — that PR auto-closed when its base branch (`senior/318-server-integration-rpc-admission`, PR #326) was deleted on merge with `--delete-branch`. GitHub blocked retargeting + reopen on the closed PR; this is the same content rebased onto `main` and pushed fresh.

## Closes

- Closes #328 — `ConversationNotFound` pre-check on `apps/attachConversation`
- Closes #329 — `Conflict (-32003)` → `AttachError("AlreadyAttached")` map extension

## Stamina chain on the prior PR #331 (carries the substance)

- review-senior APPROVE: https://github.com/chughtapan/moltzap/pull/331#pullrequestreview-4209972866
- codex-331 APPROVE (one P2 nit on `extractAttachCode` fallbacks; non-blocking)
- verify-senior SHIP-deferred: https://github.com/chughtapan/moltzap/pull/331#issuecomment-4357872749

Re-engaging review/codex/verify on this fresh PR is the orchestrator's call.

## What changed

Two B.9 review-326 follow-ups land structured `AttachError` handling:

1. **#328 — `ConversationNotFound` pre-check.** `AppHost.attachConversation` now SELECTs `conversations.id` before any membership write. Missing convId fails with `RpcFailure(ErrorCodes.NotFound /* -32002 */, "Conversation not found")`, which round-trips on the SDK side to `AttachError("ConversationNotFound")` via the existing `NumericCodeToAttach[-32002]` entry. Without the pre-check, bogus convIds fell through to a PG FK violation and surfaced as the generic `AttachError("AttachFailed")`, losing the typed tag named in architect plan §3.2.
2. **#329 — `Conflict (-32003)` extension.** Widens `AttachErrorCode` with `"AlreadyAttached"` and adds `[-32003]: "AlreadyAttached"` to `NumericCodeToAttach`. Cross-session 1:1 collisions on `AppHost.conversationToSession` now round-trip as a structured tag instead of `AttachFailed`. TSDoc on `AttachError` updated to list the new tag.

## Plan anchors

| Change | Plan / sub-issue anchor |
|---|---|
| `app-host.ts:attachConversation` pre-check on `conversations.id` | Architect plan §3.2 (`apps/attachConversation` typed errors); sub-issue #328 Option 1 |
| `errors.ts:AttachErrorCode` widened with `"AlreadyAttached"` | Sub-issue #329 Option 1 acceptance |
| `app.ts:NumericCodeToAttach` adds `[-32003]: "AlreadyAttached"` | Sub-issue #329 Option 1 acceptance |
| `30-app-hooks-rpc.integration.test.ts`: ConversationNotFound (-32002) wire case | Sub-issue #328 acceptance bullet 1 |
| `30-app-hooks-rpc.integration.test.ts`: Conflict (-32003) → AlreadyAttached wire case | Sub-issue #329 acceptance bullet 1 |
| `app.handlers.test.ts`: numeric-code unit-test mirror covering -32021/-32002/-32001/-32003 | Sub-issue #329 acceptance bullet 4 |
| TSDoc on `AttachError` lists `"AlreadyAttached"` (new switch arm in `@example`) | Sub-issue #329 acceptance bullet 5 |
| `NUMERIC_TO_ATTACH_TAG` mirror map (test-side) extended with `Conflict → AlreadyAttached` | Drift-detector parity with SDK map |

## Rebase notes (post-#326-merge)

Rebasing onto main produced two semantic conflicts beyond the textual ones git resolved:
- `errors.ts` `@example` JSDoc — main has senior-318's expanded TSDoc with a switch over `AttachErrorCode`; resolved by adding an `AlreadyAttached` arm to the existing switch (instead of the original PR's narrower `if`).
- `30-app-hooks-rpc.integration.test.ts` — both PRs added cases to the `apps/attachConversation` describe block. Resolved by placing senior-318's cross-tenant guard test first (per its merge order), then my two new cases. The new cases were rewritten to use `registerAppClient` (post-#326 pattern: remote-app of record on the same WS connection as the initiator) since `coreApp.registerApp` no longer satisfies `requireSessionAppOfRecord`.

## Scope

- Modules touched: `@moltzap/server-core` (1 file: `app-host.ts`) + 1 integration test file; `@moltzap/app-sdk` (3 files: `app.ts`, `errors.ts`, `app.handlers.test.ts`).
- Tier: senior (cross-module: server pre-check ↔ SDK numeric-code map ↔ both test layers).
- New modules: 0
- New public signatures outside the plan: `AttachErrorCode` widens by one tag (`"AlreadyAttached"`) per sub-issue #329 Option 1 (user-approved acceptance path).
- New deps: 0 (no `package.json` or lockfile changes).

## Tests

- `pnpm typecheck` — clean across all packages.
- `pnpm --filter @moltzap/app-sdk test` — 87 passing (errors.test added cases for the post-#326 `_tag` discrimination + my 4 new numeric-code unit cases).
- `pnpm --filter @moltzap/server-core test` — 169 passing.
- `pnpm --filter @moltzap/server-core test:integration -- src/__tests__/integration/30-app-hooks-rpc.integration.test.ts` — 142 passing across 34 files (16 in scenario 30b, was 14, +2 from this PR; the cross-tenant guard from #326 lives next to the typed-error cases).
- `pnpm lint` — 0 errors / 0 warnings.
- `pnpm format:check` — clean.
- `bash scripts/sloppy-code-guard.sh` — all guards passed.

## Confidence

HIGH — every acceptance bullet from #328 and #329 is met with executable evidence (passing integration test for the typed wire codes; passing SDK unit-test mirror; TSDoc updated). Pre-check race-deletion edge (convId deleted between SELECT and INSERT) still falls through to FK violation / `AttachFailed`; called out inline in the pre-check comment as best-effort.

## Concerns

- Public-surface widening: `AttachErrorCode` extends architect plan §3.5's named error channel (`SessionNotFound | ConversationNotFound | NotAuthorized`) by one tag. Authorized via sub-issue #329 Option 1 (user-approved); flagged for review-senior to confirm sub-issue-as-plan-extension delegation.
- Stacked-PR-on-base-deletion incident (process feedback for orchestrate doctrine): PR #331 closed because PR #326 was merged with `--delete-branch`. The orchestrator should either skip `--delete-branch` when stacked PRs depend on the merging branch, or warn the operator. Recovery cost ~3 minutes of runtime + a rebase round + the post-rebase test rewrite.