### PR TITLE
[impl-junior] B.9 follow-up: extend extractAttachCode fallback paths for AlreadyAttached

### DIFF
--- a/packages/app-sdk/src/app.handlers.test.ts
+++ b/packages/app-sdk/src/app.handlers.test.ts
@@ -396,6 +396,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       ["SessionNotFound", "SessionNotFound" as const],
       ["ConversationNotFound", "ConversationNotFound" as const],
       ["NotAuthorized", "NotAuthorized" as const],
+      ["AlreadyAttached", "AlreadyAttached" as const],
     ])(
       "maps RpcServerError data.code='%s' to AttachError code '%s'",
       async (dataCode, expectedCode) => {
@@ -420,6 +421,33 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
         }
       },
     );
+
+    // Substring-fallback path: when the server emits a text-only RPC error
+    // (no numeric -32003, no structured `data.code`), the SDK matches the
+    // canonical server message — see
+    // `packages/server/src/app/app-host.ts` ("Conversation X is already
+    // attached to session Y") — and routes to AttachError('AlreadyAttached').
+    it("maps 'already attached' message substring to AttachError code 'AlreadyAttached'", async () => {
+      asMock(app.client)._setAttachFailure(
+        new MockRpcServerError({
+          code: -32099,
+          message:
+            "Conversation conv-2 is already attached to session 00000000-0000-0000-0000-000000000099",
+        }),
+      );
+      const exit = await Effect.runPromiseExit(
+        app.attachConversation(
+          "00000000-0000-0000-0000-000000000001",
+          "conv-2",
+        ),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const err = exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(err).toBeInstanceOf(AttachError);
+        expect((err as AttachError).code).toBe("AlreadyAttached");
+      }
+    });
 
     it("falls back to AttachFailed for unknown RPC errors", async () => {
       asMock(app.client)._setAttachFailure(

--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -1000,18 +1000,24 @@ function extractAttachCode(err: RpcServerError): AttachErrorCode {
     if (
       c === "SessionNotFound" ||
       c === "ConversationNotFound" ||
-      c === "NotAuthorized"
+      c === "NotAuthorized" ||
+      c === "AlreadyAttached"
     ) {
       return c;
     }
   }
 
   // 3. Last-ditch substring fallback for legacy text-only RPC errors.
+  //    The "already attached" check mirrors the canonical server message
+  //    emitted on Conflict (-32003) — see
+  //    `packages/server/src/app/app-host.ts` ("Conversation X is already
+  //    attached to session Y").
   if (err.message.includes("SessionNotFound")) return "SessionNotFound";
   if (err.message.includes("ConversationNotFound")) {
     return "ConversationNotFound";
   }
   if (err.message.includes("NotAuthorized")) return "NotAuthorized";
+  if (err.message.includes("already attached")) return "AlreadyAttached";
 
   return "AttachFailed";
 }


### PR DESCRIPTION
Closes #343.

## What changed

`extractAttachCode` in `packages/app-sdk/src/app.ts` had three lookup paths but only path 1 (numeric `-32003`) covered `AlreadyAttached` (PR #341). Extended paths 2 and 3:

- **Path 2** (structured `data.code`): added `"AlreadyAttached"` to the disjunction at `app.ts:997-1014`.
- **Path 3** (substring fallback on `error.message`): added `.includes("already attached")`, mirroring the canonical server message in `packages/server/src/app/app-host.ts:1100,1154` (`"Conversation X is already attached to session Y"`).

Tests in `packages/app-sdk/src/app.handlers.test.ts`:
- Extended the `data.code` `it.each` table to include `["AlreadyAttached", "AlreadyAttached"]`.
- Added a standalone `"maps 'already attached' message substring to AttachError code 'AlreadyAttached'"` test.

## Scope

- Module: `packages/app-sdk/src/` (app.ts + its test file)
- Tier: junior — 1 module, +35 LOC, no exported signature change, no new deps
- `AttachErrorCode` already includes `"AlreadyAttached"` from PR #341; no public-surface change here

## Tests

- 89 app-sdk unit tests pass (prev 87, +2 from this PR)
- `pnpm build`, `pnpm lint`, `pnpm format:check` clean

## Confidence

HIGH — acceptance criteria 1:1 from sub-issue body; canonical server message string traced to source; existing data.code test pattern extended; all suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)