### PR TITLE
fix: add .dockerignore to keep moltzap-server build context hermetic

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+**/node_modules
+dist
+**/dist
+.git


### PR DESCRIPTION
Closes #353

## Why

Without a `.dockerignore` at the repo root, `packages/server/Dockerfile`'s `COPY . .` ships the host's `lib/moltzap/` tree — including its already-installed `node_modules` (~1.77GB) — into the build context whenever a parent repo (e.g. `chughtapan/moltzap-arena`) consumes this submodule and runs `pnpm install` at its root. pnpm inside the container then detects the foreign modules and wipes-and-reinstalls; the resulting hoisting layout breaks `@types/node` resolution and tsc fails with TS2688:

```
#10 [builder 5/6] RUN pnpm --filter @moltzap/protocol build && pnpm --filter @moltzap/server-core build
#10 2.388 > @moltzap/protocol@2026.501.4 build /app/packages/protocol
#10 2.388 > tsc
#10 6.194 error TS2688: Cannot find type definition file for 'node'.
#10 6.194   The file is in the program because:
#10 6.194     Entry point of type library 'node' specified in compilerOptions
#10 6.249  ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @moltzap/protocol@2026.501.4 build: `tsc`
#10 ERROR: process "/bin/sh -c pnpm --filter @moltzap/protocol build && pnpm --filter @moltzap/server-core build" did not complete successfully: exit code: 2
```

Quoted from #353. Same symptom blocked `chughtapan/moltzap-arena#221` (the arena Phase 2 rewrite) at the verify-221-v3 4-player game gate.

## What

Add `.dockerignore` at the repo root excluding `node_modules`, `**/node_modules`, `dist`, `**/dist`, `.git`. This makes `COPY . .` hermetic: pnpm installs from `pnpm-lock.yaml` in a clean container and `@types/node` lands where `--filter @moltzap/protocol build` expects it.

## Verification

Reproduced verify-221-v3's exact failure mode in `/tmp/junior-353-arena` (clone of moltzap-arena at PR #221 head `35c750e`, submodule pointed at this branch, `pnpm install` at the arena root populating `lib/moltzap/packages/*/node_modules` to recreate contamination). Then ran the gate command:

```
docker compose --env-file .env.compose -f compose.yml build moltzap-network
```

Before fix (per #353): build context 1.77GB, TS2688 at builder 5/6.

After fix:
- `#4 [internal] load .dockerignore` → `transferring context: 87B done` (was 2B / missing)
- `#6 [internal] load build context` → `transferring context: 3.63MB` (was 1.77GB — 488× reduction)
- All 6 builder stages: 1/6 through 6/6 — all `DONE`
- TS2688 occurrences: **0**
- ` Image junior-353-arena-moltzap-network Built`

## Scope

- Module: repo root build hygiene
- Tier (from safer-diff-scope): junior — single 5-line file added
- New exported signatures: none
- New deps: none
- No source code touched, no Dockerfile touched

## Confidence

HIGH — direct reproduction of the failure mode, single hermetic fix, exit code 0 against contaminated host context.