### PR TITLE
fix(presence): broadcast presence/changed on connect + disconnect

### DIFF
--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
@@ -26,6 +26,14 @@ import {
   registerArchiveLifecycle,
   registerConversationLifecycle,
 } from "../delivery.js";
+import {
+  registerConnectBroadcast,
+  registerDisconnectBroadcast,
+  registerMultiSubscriberFanOut,
+  registerReconnectStorm,
+  registerSameStateNoDoubleFire,
+  registerSubscribeAfterConnect,
+} from "../presence.js";
 import { collectProperties, type PropertyFailure } from "../registry.js";
 import {
   registerAuthorityPositive,
@@ -54,7 +62,9 @@ type BadServerBehavior =
   | "drift-idempotent-result"
   | "conversation-missing-created-event"
   | "app-close-missing-lifecycle-event"
-  | "archive-missing-event";
+  | "archive-missing-event"
+  | "presence-silent"
+  | "presence-stale-snapshot";
 
 describe("server-side conformance executable divergence proofs", () => {
   it("registerAuthorityNegative fails when pre-handshake RPCs return success", async () => {
@@ -128,6 +138,50 @@ describe("server-side conformance executable divergence proofs", () => {
       },
     );
     expectInvariant(failure, "app-session-close-lifecycle");
+  }, 10_000);
+
+  // Presence — all six fail under a server that answers RPCs but never
+  // broadcasts presence/changed (the pre-arena#252 shape).
+  it("registerConnectBroadcast fails when auth/connect does not broadcast presence/changed", async () => {
+    const failure = await runSingleServerProof(registerConnectBroadcast, {
+      behavior: "presence-silent",
+    });
+    expectInvariant(failure, "connect-broadcast");
+  }, 10_000);
+
+  it("registerDisconnectBroadcast fails when ws-close does not broadcast presence/changed", async () => {
+    const failure = await runSingleServerProof(registerDisconnectBroadcast, {
+      behavior: "presence-silent",
+    });
+    expectInvariant(failure, "disconnect-broadcast");
+  }, 10_000);
+
+  it("registerReconnectStorm fails when no presence/changed events fire on connect/disconnect", async () => {
+    const failure = await runSingleServerProof(registerReconnectStorm, {
+      behavior: "presence-silent",
+    });
+    expectInvariant(failure, "reconnect-storm");
+  }, 10_000);
+
+  it("registerSameStateNoDoubleFire fails when no presence/changed event fires on initial connect", async () => {
+    const failure = await runSingleServerProof(registerSameStateNoDoubleFire, {
+      behavior: "presence-silent",
+    });
+    expectInvariant(failure, "same-state-no-double-fire");
+  }, 10_000);
+
+  it("registerMultiSubscriberFanOut fails when subscribers receive no presence/changed event", async () => {
+    const failure = await runSingleServerProof(registerMultiSubscriberFanOut, {
+      behavior: "presence-silent",
+    });
+    expectInvariant(failure, "multi-subscriber-fan-out");
+  }, 10_000);
+
+  it("registerSubscribeAfterConnect fails when subscribe snapshot reports stale offline for a connected agent", async () => {
+    const failure = await runSingleServerProof(registerSubscribeAfterConnect, {
+      behavior: "presence-stale-snapshot",
+    });
+    expectInvariant(failure, "subscribe-after-connect");
   }, 10_000);
 });
 
@@ -343,6 +397,25 @@ function makeBadResult(
   }
   if (behavior === "app-close-missing-lifecycle-event") {
     return makeAppSessionCloseLifecycleBadResult(request);
+  }
+  if (
+    behavior === "presence-silent" ||
+    behavior === "presence-stale-snapshot"
+  ) {
+    if (request.method === "presence/subscribe") {
+      // Always reports offline — fails P6's online-snapshot expectation
+      // and seeds the snapshot empty for the silent-broadcast cases.
+      const params = request.params as { agentIds?: ReadonlyArray<unknown> };
+      const ids = Array.isArray(params.agentIds) ? params.agentIds : [];
+      return {
+        statuses: ids
+          .filter((id): id is string => typeof id === "string")
+          .map((agentId) => ({ agentId, status: "offline" as const })),
+      };
+    }
+    if (request.method === "presence/update") {
+      return {};
+    }
   }
   switch (request.method) {
     case "auth/connect":

--- a/packages/protocol/src/testing/conformance/index.ts
+++ b/packages/protocol/src/testing/conformance/index.ts
@@ -24,6 +24,7 @@ export * as rpcSemantics from "./rpc-semantics.js";
 export * as delivery from "./delivery.js";
 export * as adversity from "./adversity.js";
 export * as boundary from "./boundary.js";
+export * as presence from "./presence.js";
 export {
   type ConformanceSuiteOptions,
   type SuiteResult,

--- a/packages/protocol/src/testing/conformance/presence.ts
+++ b/packages/protocol/src/testing/conformance/presence.ts
@@ -84,19 +84,26 @@ function acquireCloseableClient(
   agent: TestAgent,
   label: string,
 ): Effect.Effect<CloseableTestClient, PropertyInvariantViolation, Scope.Scope> {
-  return makeCloseableTestClient({
-    serverUrl: ctx.realServer.wsUrl,
-    agentKey: agent.apiKey,
-    agentId: agent.agentId,
-    defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-    captureCapacity: DEFAULT_CAPTURE_CAPACITY,
-  }).pipe(
-    Effect.mapError((e) =>
-      violation(
-        propertyName,
-        `makeCloseableTestClient(${label}): ${String(e)}`,
+  // makeCloseableTestClient owns its own internal scope; without a
+  // release finalizer, returning the client leaks the WebSocket past
+  // the property boundary. acquireRelease ties teardown to the
+  // surrounding Effect.scoped.
+  return Effect.acquireRelease(
+    makeCloseableTestClient({
+      serverUrl: ctx.realServer.wsUrl,
+      agentKey: agent.apiKey,
+      agentId: agent.agentId,
+      defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+      captureCapacity: DEFAULT_CAPTURE_CAPACITY,
+    }).pipe(
+      Effect.mapError((e) =>
+        violation(
+          propertyName,
+          `makeCloseableTestClient(${label}): ${String(e)}`,
+        ),
       ),
     ),
+    (client) => client.close.pipe(Effect.orElseSucceed(() => undefined)),
   );
 }
 
@@ -234,11 +241,7 @@ export function registerDisconnectBroadcast(ctx: ConformanceRunContext): void {
           { agentId: a.agentId, status: "online" },
           NAME,
         );
-        yield* Effect.tryPromise({
-          try: () => Effect.runPromise(aClient.close),
-          catch: (cause) =>
-            violation(NAME, `client.close failed: ${String(cause)}`),
-        });
+        yield* aClient.close;
         yield* waitForPresenceWithStatus(
           sub.client,
           { agentId: a.agentId, status: "offline" },
@@ -274,11 +277,7 @@ export function registerReconnectStorm(ctx: ConformanceRunContext): void {
           { agentId: a.agentId, status: "online" },
           NAME,
         );
-        yield* Effect.tryPromise({
-          try: () => Effect.runPromise(c1.close),
-          catch: (cause) =>
-            violation(NAME, `client1.close failed: ${String(cause)}`),
-        });
+        yield* c1.close;
         yield* waitForPresenceWithStatus(
           sub.client,
           { agentId: a.agentId, status: "offline" },

--- a/packages/protocol/src/testing/conformance/presence.ts
+++ b/packages/protocol/src/testing/conformance/presence.ts
@@ -1,0 +1,461 @@
+/**
+ * Presence — properties pinning the connect/disconnect-driven
+ * `presence/changed` invariant. The `presence/update` RPC path is
+ * covered elsewhere; these properties pin the LIFECYCLE-driven path.
+ * Closes arena#252.
+ */
+import { Effect, Stream, Duration, type Scope } from "effect";
+
+import { PROTOCOL_VERSION } from "../../version.js";
+import { EventNames } from "../../schema/events.js";
+import { PresenceSubscribe } from "../../schema/methods/presence.js";
+import {
+  makeCloseableTestClient,
+  makeTestClient,
+  type CloseableTestClient,
+  type TestClient,
+} from "../test-client.js";
+import { registerTestAgent, type TestAgent } from "../agent-registration.js";
+import type { ConformanceRunContext } from "./runner.js";
+import { PropertyInvariantViolation, registerProperty } from "./registry.js";
+
+const CATEGORY = "presence" as const;
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_CAPTURE_CAPACITY = 256;
+
+type PresenceStatus = "online" | "offline" | "away";
+
+interface PresenceChangedPayload {
+  readonly agentId: string;
+  readonly status: PresenceStatus;
+}
+
+function violation(name: string, reason: string): PropertyInvariantViolation {
+  return new PropertyInvariantViolation({ category: CATEGORY, name, reason });
+}
+
+function registerAgent(
+  ctx: ConformanceRunContext,
+  propertyName: string,
+  name: string,
+): Effect.Effect<TestAgent, PropertyInvariantViolation> {
+  return registerTestAgent({
+    baseUrl: ctx.realServer.baseUrl,
+    name,
+  }).pipe(
+    Effect.mapError((e) =>
+      violation(
+        propertyName,
+        `register(${name}): status=${e.status} body=${e.body}`,
+      ),
+    ),
+  );
+}
+
+function acquireClient(
+  ctx: ConformanceRunContext,
+  propertyName: string,
+  name: string,
+): Effect.Effect<
+  { agent: TestAgent; client: TestClient },
+  PropertyInvariantViolation,
+  Scope.Scope
+> {
+  return Effect.gen(function* () {
+    const agent = yield* registerAgent(ctx, propertyName, name);
+    const client = yield* makeTestClient({
+      serverUrl: ctx.realServer.wsUrl,
+      agentKey: agent.apiKey,
+      agentId: agent.agentId,
+      defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+      captureCapacity: DEFAULT_CAPTURE_CAPACITY,
+    }).pipe(
+      Effect.mapError((e) =>
+        violation(propertyName, `makeTestClient(${name}): ${String(e)}`),
+      ),
+    );
+    return { agent, client };
+  });
+}
+
+function acquireCloseableClient(
+  ctx: ConformanceRunContext,
+  propertyName: string,
+  agent: TestAgent,
+  label: string,
+): Effect.Effect<CloseableTestClient, PropertyInvariantViolation, Scope.Scope> {
+  return makeCloseableTestClient({
+    serverUrl: ctx.realServer.wsUrl,
+    agentKey: agent.apiKey,
+    agentId: agent.agentId,
+    defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+    captureCapacity: DEFAULT_CAPTURE_CAPACITY,
+  }).pipe(
+    Effect.mapError((e) =>
+      violation(
+        propertyName,
+        `makeCloseableTestClient(${label}): ${String(e)}`,
+      ),
+    ),
+  );
+}
+
+function subscribePresence(
+  subscriber: TestClient,
+  agentId: string,
+  propertyName: string,
+): Effect.Effect<void, PropertyInvariantViolation> {
+  return subscriber
+    .sendRpc(PresenceSubscribe.name, { agentIds: [agentId] })
+    .pipe(
+      Effect.mapError((e) =>
+        violation(propertyName, `presence/subscribe failed: ${String(e)}`),
+      ),
+      Effect.asVoid,
+    );
+}
+
+/**
+ * `TestClient.waitForEvent` matches by event name only. We need a
+ * payload predicate, so consume the events Stream with a filter and
+ * timeout it ourselves.
+ */
+function waitForPresenceWithStatus(
+  client: TestClient,
+  expected: PresenceChangedPayload,
+  propertyName: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Effect.Effect<void, PropertyInvariantViolation> {
+  return client.events.pipe(
+    Stream.filter((frame) => frame.event === EventNames.PresenceChanged),
+    Stream.map((frame) => frame.data as PresenceChangedPayload | undefined),
+    Stream.filter(
+      (data): data is PresenceChangedPayload =>
+        data !== undefined &&
+        data.agentId === expected.agentId &&
+        data.status === expected.status,
+    ),
+    Stream.runHead,
+    Effect.timeoutFail({
+      duration: Duration.millis(timeoutMs),
+      onTimeout: () =>
+        violation(
+          propertyName,
+          `timed out waiting for presence/changed { agentId: ${expected.agentId}, status: ${expected.status} }`,
+        ),
+    }),
+    Effect.mapError((e) =>
+      e instanceof PropertyInvariantViolation
+        ? e
+        : violation(propertyName, `event stream errored: ${String(e)}`),
+    ),
+    Effect.flatMap((maybe) =>
+      maybe._tag === "Some"
+        ? Effect.void
+        : Effect.fail(
+            violation(
+              propertyName,
+              `event stream closed before presence/changed { agentId: ${expected.agentId}, status: ${expected.status} } arrived`,
+            ),
+          ),
+    ),
+  );
+}
+
+function presenceStatusesFor(
+  client: TestClient,
+  agentId: string,
+): Effect.Effect<ReadonlyArray<PresenceStatus>> {
+  return client.snapshot.pipe(
+    Effect.map((snap) =>
+      snap.flatMap((s) => {
+        if (s.kind !== "inbound") return [];
+        const frame = s.frame;
+        if (!frame || frame.type !== "event") return [];
+        if (frame.event !== EventNames.PresenceChanged) return [];
+        const data = frame.data as PresenceChangedPayload | undefined;
+        if (data === undefined || data.agentId !== agentId) return [];
+        return [data.status];
+      }),
+    ),
+  );
+}
+
+function countPresenceChangedFor(
+  client: TestClient,
+  agentId: string,
+): Effect.Effect<number> {
+  return presenceStatusesFor(client, agentId).pipe(Effect.map((s) => s.length));
+}
+
+export function registerConnectBroadcast(ctx: ConformanceRunContext): void {
+  const NAME = "connect-broadcast";
+  registerProperty(
+    ctx,
+    CATEGORY,
+    NAME,
+    "auth/connect after subscribe ⇒ subscriber receives presence/changed { online }",
+    Effect.scoped(
+      Effect.gen(function* () {
+        const sub = yield* acquireClient(ctx, NAME, "p1-sub");
+        const a = yield* registerAgent(ctx, NAME, "p1-a");
+        yield* subscribePresence(sub.client, a.agentId, NAME);
+        yield* acquireCloseableClient(ctx, NAME, a, "p1-a-client");
+        yield* waitForPresenceWithStatus(
+          sub.client,
+          { agentId: a.agentId, status: "online" },
+          NAME,
+        );
+      }),
+    ),
+  );
+}
+
+export function registerDisconnectBroadcast(ctx: ConformanceRunContext): void {
+  const NAME = "disconnect-broadcast";
+  registerProperty(
+    ctx,
+    CATEGORY,
+    NAME,
+    "ws-close after auth/connect ⇒ subscriber receives presence/changed { offline } strictly after { online }",
+    Effect.scoped(
+      Effect.gen(function* () {
+        const sub = yield* acquireClient(ctx, NAME, "p2-sub");
+        const a = yield* registerAgent(ctx, NAME, "p2-a");
+        yield* subscribePresence(sub.client, a.agentId, NAME);
+        const aClient = yield* acquireCloseableClient(
+          ctx,
+          NAME,
+          a,
+          "p2-a-client",
+        );
+        yield* waitForPresenceWithStatus(
+          sub.client,
+          { agentId: a.agentId, status: "online" },
+          NAME,
+        );
+        yield* Effect.tryPromise({
+          try: () => Effect.runPromise(aClient.close),
+          catch: (cause) =>
+            violation(NAME, `client.close failed: ${String(cause)}`),
+        });
+        yield* waitForPresenceWithStatus(
+          sub.client,
+          { agentId: a.agentId, status: "offline" },
+          NAME,
+        );
+      }),
+    ),
+  );
+}
+
+/**
+ * Sequential reconnect only. The wait for `offline` between client #1
+ * close and client #2 connect is the in-band fence proving the server's
+ * onExit reached `setOffline` before the new handshake. Concurrent
+ * reconnect (new auth/connect races old onExit) is OOS — see OQ6.
+ */
+export function registerReconnectStorm(ctx: ConformanceRunContext): void {
+  const NAME = "reconnect-storm";
+  registerProperty(
+    ctx,
+    CATEGORY,
+    NAME,
+    "online → offline → online lands as three presence/changed events in strict order on a sequential reconnect",
+    Effect.scoped(
+      Effect.gen(function* () {
+        const sub = yield* acquireClient(ctx, NAME, "p3-sub");
+        const a = yield* registerAgent(ctx, NAME, "p3-a");
+        yield* subscribePresence(sub.client, a.agentId, NAME);
+
+        const c1 = yield* acquireCloseableClient(ctx, NAME, a, "p3-a-client-1");
+        yield* waitForPresenceWithStatus(
+          sub.client,
+          { agentId: a.agentId, status: "online" },
+          NAME,
+        );
+        yield* Effect.tryPromise({
+          try: () => Effect.runPromise(c1.close),
+          catch: (cause) =>
+            violation(NAME, `client1.close failed: ${String(cause)}`),
+        });
+        yield* waitForPresenceWithStatus(
+          sub.client,
+          { agentId: a.agentId, status: "offline" },
+          NAME,
+        );
+
+        yield* acquireCloseableClient(ctx, NAME, a, "p3-a-client-2");
+        yield* waitForPresenceWithStatus(
+          sub.client,
+          { agentId: a.agentId, status: "online" },
+          NAME,
+        );
+
+        const sequence = yield* presenceStatusesFor(sub.client, a.agentId);
+        if (
+          sequence.length !== 3 ||
+          sequence[0] !== "online" ||
+          sequence[1] !== "offline" ||
+          sequence[2] !== "online"
+        ) {
+          return yield* Effect.fail(
+            violation(
+              NAME,
+              `expected [online, offline, online], got [${sequence.join(", ")}]`,
+            ),
+          );
+        }
+      }),
+    ),
+  );
+}
+
+/**
+ * Re-sending auth/connect on an already-authenticated WS short-circuits
+ * to buildHelloOk (`auth.handlers.ts:71`) which calls setOnline again.
+ * The idempotency guard MUST suppress the redundant broadcast.
+ */
+export function registerSameStateNoDoubleFire(
+  ctx: ConformanceRunContext,
+): void {
+  const NAME = "same-state-no-double-fire";
+  registerProperty(
+    ctx,
+    CATEGORY,
+    NAME,
+    "redundant setOnline (auth/connect on already-authenticated WS) does NOT double-fire presence/changed",
+    Effect.scoped(
+      Effect.gen(function* () {
+        const sub = yield* acquireClient(ctx, NAME, "p4-sub");
+        const a = yield* registerAgent(ctx, NAME, "p4-a");
+        yield* subscribePresence(sub.client, a.agentId, NAME);
+        const aClient = yield* acquireCloseableClient(
+          ctx,
+          NAME,
+          a,
+          "p4-a-client",
+        );
+        yield* waitForPresenceWithStatus(
+          sub.client,
+          { agentId: a.agentId, status: "online" },
+          NAME,
+        );
+
+        yield* aClient
+          .sendRpc("auth/connect", {
+            agentKey: a.apiKey,
+            minProtocol: PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+          })
+          .pipe(
+            Effect.mapError((e) =>
+              violation(NAME, `auth/connect re-send failed: ${String(e)}`),
+            ),
+          );
+
+        // Stabilization window — give a regression a chance to land.
+        yield* Effect.sleep("250 millis");
+        const count = yield* countPresenceChangedFor(sub.client, a.agentId);
+        if (count !== 1) {
+          return yield* Effect.fail(
+            violation(
+              NAME,
+              `expected 1 event for ${a.agentId}, observed ${count}`,
+            ),
+          );
+        }
+      }),
+    ),
+  );
+}
+
+export function registerMultiSubscriberFanOut(
+  ctx: ConformanceRunContext,
+): void {
+  const NAME = "multi-subscriber-fan-out";
+  registerProperty(
+    ctx,
+    CATEGORY,
+    NAME,
+    "auth/connect with N subscribers ⇒ exactly N presence/changed { online } events (one per subscriber)",
+    Effect.scoped(
+      Effect.gen(function* () {
+        const s1 = yield* acquireClient(ctx, NAME, "p5-s1");
+        const s2 = yield* acquireClient(ctx, NAME, "p5-s2");
+        const a = yield* registerAgent(ctx, NAME, "p5-a");
+        yield* subscribePresence(s1.client, a.agentId, NAME);
+        yield* subscribePresence(s2.client, a.agentId, NAME);
+        yield* acquireCloseableClient(ctx, NAME, a, "p5-a-client");
+
+        yield* waitForPresenceWithStatus(
+          s1.client,
+          { agentId: a.agentId, status: "online" },
+          NAME,
+        );
+        yield* waitForPresenceWithStatus(
+          s2.client,
+          { agentId: a.agentId, status: "online" },
+          NAME,
+        );
+
+        const c1 = yield* countPresenceChangedFor(s1.client, a.agentId);
+        const c2 = yield* countPresenceChangedFor(s2.client, a.agentId);
+        if (c1 !== 1 || c2 !== 1) {
+          return yield* Effect.fail(
+            violation(
+              NAME,
+              `expected exactly 1 event per subscriber, observed s1=${c1} s2=${c2}`,
+            ),
+          );
+        }
+      }),
+    ),
+  );
+}
+
+export function registerSubscribeAfterConnect(
+  ctx: ConformanceRunContext,
+): void {
+  const NAME = "subscribe-after-connect";
+  registerProperty(
+    ctx,
+    CATEGORY,
+    NAME,
+    "subscribing AFTER an agent connects ⇒ snapshot reflects status: online",
+    Effect.scoped(
+      Effect.gen(function* () {
+        const a = yield* registerAgent(ctx, NAME, "p6-a");
+        yield* acquireCloseableClient(ctx, NAME, a, "p6-a-client");
+
+        const sub = yield* acquireClient(ctx, NAME, "p6-sub");
+        const result = yield* sub.client
+          .sendRpc(PresenceSubscribe.name, { agentIds: [a.agentId] })
+          .pipe(
+            Effect.mapError((e) =>
+              violation(NAME, `presence/subscribe failed: ${String(e)}`),
+            ),
+          );
+        const statuses = (
+          result as {
+            statuses: ReadonlyArray<PresenceChangedPayload>;
+          }
+        ).statuses;
+        if (statuses.length !== 1) {
+          return yield* Effect.fail(
+            violation(NAME, `expected 1 status entry, got ${statuses.length}`),
+          );
+        }
+        const entry = statuses[0]!;
+        if (entry.agentId !== a.agentId || entry.status !== "online") {
+          return yield* Effect.fail(
+            violation(
+              NAME,
+              `expected { agentId: ${a.agentId}, status: online }, got ${JSON.stringify(entry)}`,
+            ),
+          );
+        }
+      }),
+    ),
+  );
+}

--- a/packages/protocol/src/testing/conformance/registry.ts
+++ b/packages/protocol/src/testing/conformance/registry.ts
@@ -33,7 +33,8 @@ export type PropertyCategory =
   | "rpc-semantics"
   | "delivery"
   | "adversity"
-  | "boundary";
+  | "boundary"
+  | "presence";
 
 /** Fast-check / runtime assertion failed for a specific property. */
 export class PropertyAssertionFailure extends Data.TaggedError(

--- a/packages/protocol/src/testing/conformance/suite.ts
+++ b/packages/protocol/src/testing/conformance/suite.ts
@@ -37,6 +37,7 @@ import * as rpcSemantics from "./rpc-semantics.js";
 import * as delivery from "./delivery.js";
 import * as adversity from "./adversity.js";
 import * as boundary from "./boundary.js";
+import * as presence from "./presence.js";
 import type { RealServerAcquireError, ToxicControlError } from "../errors.js";
 import {
   isAllowedCoverageGap,
@@ -127,6 +128,13 @@ export function registerAllProperties(ctx: ConformanceRunContext): void {
 
   boundary.registerSchemaExhaustiveFuzz(ctx);
   boundary.registerAppDisconnectFailPolicy(ctx);
+
+  presence.registerConnectBroadcast(ctx);
+  presence.registerDisconnectBroadcast(ctx);
+  presence.registerReconnectStorm(ctx);
+  presence.registerSameStateNoDoubleFire(ctx);
+  presence.registerMultiSubscriberFanOut(ctx);
+  presence.registerSubscribeAfterConnect(ctx);
 }
 
 /**

--- a/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
+++ b/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
@@ -83,18 +83,14 @@ describe("Presence Lifecycle", () => {
     }),
   );
 
-  // Pin the invariant that every connect/disconnect transition publishes
-  // `presence/changed` to subscribers — the arena agent-presence watcher
-  // depends on this (arena#252). Pre-fix, only `presence/update` RPC
-  // broadcast; connect/disconnect mutated state silently.
+  // arena#252 — connect/disconnect transitions publish presence/changed.
   it.live(
     "auth/connect broadcasts presence/changed online to subscribers",
     () =>
       Effect.gen(function* () {
         const watcher = yield* registerAndConnect("watcher-connect");
 
-        // Subscribe BEFORE the target connects — snapshot reads "offline"
-        // and the only path to "online" is the connect-time broadcast.
+        // Subscribe BEFORE target connects so the snapshot reads offline.
         const target = yield* registerAgent(getBaseUrl(), "target-connect");
         const sub = (yield* watcher.client.sendRpc("presence/subscribe", {
           agentIds: [target.agentId],
@@ -118,8 +114,7 @@ describe("Presence Lifecycle", () => {
       const watcher = yield* registerAndConnect("watcher-disconnect");
       const target = yield* registerAndConnect("target-disconnect");
 
-      // Subscribe AFTER target is online — snapshot reads "online", no
-      // transition queued. The close below is the only path to "offline".
+      // Subscribe AFTER target is online; close is the only offline trigger.
       yield* watcher.client.sendRpc("presence/subscribe", {
         agentIds: [target.agentId],
       });

--- a/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
+++ b/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
@@ -6,6 +6,7 @@ import {
   registerAgent,
   connectTestClient,
   registerAndConnect,
+  trackClient,
 } from "./helpers.js";
 import { getBaseUrl } from "../../test-utils/index.js";
 
@@ -97,10 +98,11 @@ describe("Presence Lifecycle", () => {
         })) as { statuses: Array<{ agentId: string; status: string }> };
         expect(sub.statuses[0]!.status).toBe("offline");
 
-        yield* connectTestClient({
+        const targetClient = yield* connectTestClient({
           agentId: target.agentId,
           apiKey: target.apiKey,
         });
+        trackClient(targetClient);
 
         const event = yield* watcher.client.waitForEvent("presence/changed");
         const data = event.data as { agentId: string; status: string };

--- a/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
+++ b/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect } from "effect";
 import { startTestServer, stopTestServer, resetTestDb } from "./helpers.js";
-import { registerAndConnect } from "./helpers.js";
+import {
+  registerAgent,
+  connectTestClient,
+  registerAndConnect,
+} from "./helpers.js";
+import { getBaseUrl } from "../../test-utils/index.js";
 
 beforeAll(async () => {
   await startTestServer();
@@ -75,6 +80,56 @@ describe("Presence Lifecycle", () => {
       yield* bob.client.sendRpc("presence/update", { status: "offline" });
       const offlineEvent = yield* alice.client.waitForEvent("presence/changed");
       expect((offlineEvent.data as { status: string }).status).toBe("offline");
+    }),
+  );
+
+  // Pin the invariant that every connect/disconnect transition publishes
+  // `presence/changed` to subscribers — the arena agent-presence watcher
+  // depends on this (arena#252). Pre-fix, only `presence/update` RPC
+  // broadcast; connect/disconnect mutated state silently.
+  it.live(
+    "auth/connect broadcasts presence/changed online to subscribers",
+    () =>
+      Effect.gen(function* () {
+        const watcher = yield* registerAndConnect("watcher-connect");
+
+        // Subscribe BEFORE the target connects — snapshot reads "offline"
+        // and the only path to "online" is the connect-time broadcast.
+        const target = yield* registerAgent(getBaseUrl(), "target-connect");
+        const sub = (yield* watcher.client.sendRpc("presence/subscribe", {
+          agentIds: [target.agentId],
+        })) as { statuses: Array<{ agentId: string; status: string }> };
+        expect(sub.statuses[0]!.status).toBe("offline");
+
+        yield* connectTestClient({
+          agentId: target.agentId,
+          apiKey: target.apiKey,
+        });
+
+        const event = yield* watcher.client.waitForEvent("presence/changed");
+        const data = event.data as { agentId: string; status: string };
+        expect(data.agentId).toBe(target.agentId);
+        expect(data.status).toBe("online");
+      }),
+  );
+
+  it.live("disconnect broadcasts presence/changed offline to subscribers", () =>
+    Effect.gen(function* () {
+      const watcher = yield* registerAndConnect("watcher-disconnect");
+      const target = yield* registerAndConnect("target-disconnect");
+
+      // Subscribe AFTER target is online — snapshot reads "online", no
+      // transition queued. The close below is the only path to "offline".
+      yield* watcher.client.sendRpc("presence/subscribe", {
+        agentIds: [target.agentId],
+      });
+
+      yield* target.client.close();
+
+      const event = yield* watcher.client.waitForEvent("presence/changed");
+      const data = event.data as { agentId: string; status: string };
+      expect(data.agentId).toBe(target.agentId);
+      expect(data.status).toBe("offline");
     }),
   );
 });

--- a/packages/server/src/app/handlers/presence.handlers.ts
+++ b/packages/server/src/app/handlers/presence.handlers.ts
@@ -14,7 +14,9 @@ export function createPresenceHandlers(deps: {
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const senderConnId = yield* ConnIdTag;
-          deps.presenceService.update(ctx.agentId, params.status, senderConnId);
+          deps.presenceService.update(ctx.agentId, params.status, {
+            excludeConnId: senderConnId,
+          });
           return {};
         }),
     }),

--- a/packages/server/src/app/handlers/presence.handlers.ts
+++ b/packages/server/src/app/handlers/presence.handlers.ts
@@ -1,19 +1,12 @@
 import type { PresenceService } from "../../services/presence.service.js";
 import type { RpcMethodRegistry } from "../../rpc/context.js";
 import { defineMethod } from "../../rpc/context.js";
-import {
-  PresenceUpdate,
-  PresenceSubscribe,
-  EventNames,
-  eventFrame,
-} from "@moltzap/protocol";
+import { PresenceUpdate, PresenceSubscribe } from "@moltzap/protocol";
 import { Effect } from "effect";
-import type { ConnectionManager } from "../../ws/connection.js";
 import { ConnIdTag } from "../layers.js";
 
 export function createPresenceHandlers(deps: {
   presenceService: PresenceService;
-  connections: ConnectionManager;
 }): RpcMethodRegistry {
   return {
     "presence/update": defineMethod(PresenceUpdate, {
@@ -21,25 +14,7 @@ export function createPresenceHandlers(deps: {
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const senderConnId = yield* ConnIdTag;
-          deps.presenceService.update(ctx.agentId, params.status);
-
-          const subscriberConnIds = deps.presenceService.getSubscribers(
-            ctx.agentId,
-          );
-          const event = eventFrame(EventNames.PresenceChanged, {
-            agentId: ctx.agentId,
-            status: params.status,
-          });
-          const raw = JSON.stringify(event);
-          for (const connId of subscriberConnIds) {
-            if (connId === senderConnId) continue;
-            const conn = deps.connections.get(connId);
-            if (conn) {
-              Effect.runFork(
-                conn.write(raw).pipe(Effect.catchAll(() => Effect.void)),
-              );
-            }
-          }
+          deps.presenceService.update(ctx.agentId, params.status, senderConnId);
           return {};
         }),
     }),

--- a/packages/server/src/app/layers.ts
+++ b/packages/server/src/app/layers.ts
@@ -20,6 +20,7 @@ import { ParticipantService } from "../services/participant.service.js";
 import { ConversationService } from "../services/conversation.service.js";
 import { DeliveryService } from "../services/delivery.service.js";
 import { PresenceService } from "../services/presence.service.js";
+import { createConnectionFanOutPresenceEventSink } from "../services/presence-event-sink.js";
 import {
   MessageService,
   type DeliveryWebhookConfig,
@@ -187,7 +188,8 @@ export const PresenceServiceLive = Layer.effect(
   PresenceServiceTag,
   Effect.gen(function* () {
     const connections = yield* ConnectionManagerTag;
-    return new PresenceService(connections);
+    const sink = createConnectionFanOutPresenceEventSink({ connections });
+    return new PresenceService(sink);
   }),
 );
 

--- a/packages/server/src/app/layers.ts
+++ b/packages/server/src/app/layers.ts
@@ -183,9 +183,12 @@ export const DeliveryServiceLive = Layer.effect(
   }),
 );
 
-export const PresenceServiceLive = Layer.sync(
+export const PresenceServiceLive = Layer.effect(
   PresenceServiceTag,
-  () => new PresenceService(),
+  Effect.gen(function* () {
+    const connections = yield* ConnectionManagerTag;
+    return new PresenceService(connections);
+  }),
 );
 
 export const AppHostLive = Layer.effect(
@@ -263,14 +266,19 @@ export const MessageServiceLive = Layer.effect(
 /** Tier 1 — zero cross-layer deps beyond Db/Logger. */
 const Tier1 = Layer.mergeAll(
   ConnectionManagerLive,
-  PresenceServiceLive,
   AuthServiceLive,
   ParticipantServiceLive,
   DeliveryServiceLive,
 );
 
-/** Tier 2 — Broadcaster needs Tier 1's ConnectionManager. */
-const Tier2 = Layer.provideMerge(BroadcasterLive, Tier1);
+/** Tier 2 — Broadcaster + Presence both need Tier 1's ConnectionManager.
+ * Presence is here (not Tier 1) because it broadcasts `presence/changed`
+ * directly to subscriber sockets via ConnectionManager — same wiring shape
+ * as Broadcaster. */
+const Tier2 = Layer.provideMerge(
+  Layer.mergeAll(BroadcasterLive, PresenceServiceLive),
+  Tier1,
+);
 
 /** Tier 3 — AppHost + DefaultPermission need Broadcaster/Connections. */
 const Tier3 = Layer.provideMerge(

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -190,7 +190,6 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     }),
     ...createPresenceHandlers({
       presenceService,
-      connections,
     }),
     ...createAppHandlers({
       appHost,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -103,6 +103,12 @@ export { ConversationService } from "./services/conversation.service.js";
 export { MessageService } from "./services/message.service.js";
 export { ParticipantService } from "./services/participant.service.js";
 export { PresenceService } from "./services/presence.service.js";
+export {
+  type PresenceEventSink,
+  type PresencePublishInput,
+  type PresenceStatus,
+  createConnectionFanOutPresenceEventSink,
+} from "./services/presence-event-sink.js";
 export { DeliveryService } from "./services/delivery.service.js";
 
 // Infrastructure

--- a/packages/server/src/services/presence-event-sink.test.ts
+++ b/packages/server/src/services/presence-event-sink.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { Effect, HashMap, Ref } from "effect";
+
+import { EventNames } from "@moltzap/protocol";
+
+import {
+  ConnectionManager,
+  type MoltZapConnection,
+  type S2cPendingMap,
+} from "../ws/connection.js";
+import {
+  createConnectionFanOutPresenceEventSink,
+  type PresencePublishInput,
+} from "./presence-event-sink.js";
+
+interface Capture {
+  conn: MoltZapConnection;
+  writes: string[];
+}
+
+function makeConn(connId: string): Capture {
+  const writes: string[] = [];
+  const conn: MoltZapConnection = {
+    id: connId,
+    write: (raw) =>
+      Effect.sync(() => {
+        writes.push(raw);
+      }),
+    shutdown: Effect.void,
+    auth: null,
+    lastPong: Date.now(),
+    conversationIds: new Set<string>(),
+    mutedConversations: new Set<string>(),
+    s2cPending: Ref.unsafeMake<S2cPendingMap>(HashMap.empty()),
+    s2cRequestCounter: Ref.unsafeMake(0),
+  };
+  return { conn, writes };
+}
+
+function presenceEventsFor(
+  writes: string[],
+  agentId: string,
+): Array<{ agentId: string; status: string }> {
+  return writes
+    .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+    .filter(
+      (frame) =>
+        frame["type"] === "event" &&
+        frame["event"] === EventNames.PresenceChanged,
+    )
+    .map((frame) => frame["data"] as { agentId: string; status: string })
+    .filter((data) => data.agentId === agentId);
+}
+
+/** Drain Effect.runFork-scheduled writes — one macrotask suffices. */
+async function flushFibers(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function publishInput(opts: {
+  agentId: string;
+  status: PresencePublishInput["status"];
+  subscriberConnIds: Iterable<string>;
+  excludeConnId?: string;
+}): PresencePublishInput {
+  return {
+    agentId: opts.agentId,
+    status: opts.status,
+    subscriberConnIds: new Set(opts.subscriberConnIds),
+    excludeConnId: opts.excludeConnId,
+  };
+}
+
+describe("ConnectionFanOutPresenceEventSink", () => {
+  it("writes presence/changed to every subscriber", async () => {
+    const connections = new ConnectionManager();
+    const a = makeConn("c-a");
+    const b = makeConn("c-b");
+    connections.add(a.conn);
+    connections.add(b.conn);
+
+    const sink = createConnectionFanOutPresenceEventSink({ connections });
+    sink.publish(
+      publishInput({
+        agentId: "agent-a",
+        status: "online",
+        subscriberConnIds: ["c-a", "c-b"],
+      }),
+    );
+    await flushFibers();
+
+    const expected = [{ agentId: "agent-a", status: "online" }];
+    expect(presenceEventsFor(a.writes, "agent-a")).toEqual(expected);
+    expect(presenceEventsFor(b.writes, "agent-a")).toEqual(expected);
+  });
+
+  it("skips excludeConnId", async () => {
+    const connections = new ConnectionManager();
+    const sender = makeConn("c-sender");
+    const watcher = makeConn("c-watcher");
+    connections.add(sender.conn);
+    connections.add(watcher.conn);
+
+    const sink = createConnectionFanOutPresenceEventSink({ connections });
+    sink.publish(
+      publishInput({
+        agentId: "agent-a",
+        status: "away",
+        subscriberConnIds: ["c-sender", "c-watcher"],
+        excludeConnId: "c-sender",
+      }),
+    );
+    await flushFibers();
+
+    expect(presenceEventsFor(sender.writes, "agent-a")).toHaveLength(0);
+    expect(presenceEventsFor(watcher.writes, "agent-a")).toEqual([
+      { agentId: "agent-a", status: "away" },
+    ]);
+  });
+
+  it("short-circuits on empty subscriberConnIds", async () => {
+    const connections = new ConnectionManager();
+    const watcher = makeConn("c-watcher");
+    connections.add(watcher.conn);
+
+    const sink = createConnectionFanOutPresenceEventSink({ connections });
+    sink.publish(
+      publishInput({
+        agentId: "agent-a",
+        status: "online",
+        subscriberConnIds: [],
+      }),
+    );
+    await flushFibers();
+
+    expect(presenceEventsFor(watcher.writes, "agent-a")).toHaveLength(0);
+  });
+
+  it("silently skips a subscriber connId not in ConnectionManager", async () => {
+    const connections = new ConnectionManager();
+    const live = makeConn("c-live");
+    connections.add(live.conn);
+
+    const sink = createConnectionFanOutPresenceEventSink({ connections });
+    expect(() =>
+      sink.publish(
+        publishInput({
+          agentId: "agent-a",
+          status: "offline",
+          subscriberConnIds: ["c-live", "c-stale"],
+        }),
+      ),
+    ).not.toThrow();
+    await flushFibers();
+
+    expect(presenceEventsFor(live.writes, "agent-a")).toEqual([
+      { agentId: "agent-a", status: "offline" },
+    ]);
+  });
+});

--- a/packages/server/src/services/presence-event-sink.ts
+++ b/packages/server/src/services/presence-event-sink.ts
@@ -1,0 +1,47 @@
+import { Effect } from "effect";
+
+import { EventNames, eventFrame } from "@moltzap/protocol";
+
+import type { ConnectionManager } from "../ws/connection.js";
+
+export type PresenceStatus = "online" | "offline" | "away";
+
+export interface PresencePublishInput {
+  readonly agentId: string;
+  readonly status: PresenceStatus;
+  readonly subscriberConnIds: ReadonlySet<string>;
+  readonly excludeConnId?: string;
+}
+
+/**
+ * Best-effort sink for presence transitions. A failed write to one
+ * subscriber MUST NOT propagate to the mutator — disconnect-driven
+ * failures are expected.
+ */
+export interface PresenceEventSink {
+  publish(input: PresencePublishInput): void;
+}
+
+export function createConnectionFanOutPresenceEventSink(deps: {
+  readonly connections: ConnectionManager;
+}): PresenceEventSink {
+  return {
+    publish(input) {
+      if (input.subscriberConnIds.size === 0) return;
+      const raw = JSON.stringify(
+        eventFrame(EventNames.PresenceChanged, {
+          agentId: input.agentId,
+          status: input.status,
+        }),
+      );
+      for (const connId of input.subscriberConnIds) {
+        if (connId === input.excludeConnId) continue;
+        const conn = deps.connections.get(connId);
+        if (!conn) continue;
+        Effect.runFork(
+          conn.write(raw).pipe(Effect.catchAll(() => Effect.void)),
+        );
+      }
+    },
+  };
+}

--- a/packages/server/src/services/presence.service.test.ts
+++ b/packages/server/src/services/presence.service.test.ts
@@ -1,182 +1,139 @@
-/**
- * Unit tests for PresenceService — pin the invariant that every status
- * transition (setOnline/setOffline/update) publishes `presence/changed`
- * to subscribers, with the broadcast idempotent on re-assert and emitted
- * on each side of a reverse race. Closes arena#252.
- */
-
 import { describe, expect, it } from "vitest";
-import { Effect, HashMap, Ref } from "effect";
 
-import { EventNames } from "@moltzap/protocol";
-
-import {
-  ConnectionManager,
-  type MoltZapConnection,
-  type S2cPendingMap,
-} from "../ws/connection.js";
+import type {
+  PresenceEventSink,
+  PresencePublishInput,
+  PresenceStatus,
+} from "./presence-event-sink.js";
 import { PresenceService } from "./presence.service.js";
 
-interface Capture {
-  conn: MoltZapConnection;
-  writes: string[];
-}
-
-function makeConn(connId: string): Capture {
-  const writes: string[] = [];
-  const conn: MoltZapConnection = {
-    id: connId,
-    write: (raw) =>
-      Effect.sync(() => {
-        writes.push(raw);
-      }),
-    shutdown: Effect.void,
-    auth: null,
-    lastPong: Date.now(),
-    conversationIds: new Set<string>(),
-    mutedConversations: new Set<string>(),
-    s2cPending: Ref.unsafeMake<S2cPendingMap>(HashMap.empty()),
-    s2cRequestCounter: Ref.unsafeMake(0),
+function recordingSink(): {
+  sink: PresenceEventSink;
+  published: PresencePublishInput[];
+} {
+  const published: PresencePublishInput[] = [];
+  return {
+    sink: {
+      publish(input) {
+        published.push(input);
+      },
+    },
+    published,
   };
-  return { conn, writes };
 }
 
-function presenceEventsFor(
-  writes: string[],
+function statusesFor(
+  published: ReadonlyArray<PresencePublishInput>,
   agentId: string,
-): Array<{ status: string }> {
-  return writes
-    .map((raw) => JSON.parse(raw) as Record<string, unknown>)
-    .filter(
-      (frame) =>
-        frame["type"] === "event" &&
-        frame["event"] === EventNames.PresenceChanged,
-    )
-    .map((frame) => frame["data"] as { agentId: string; status: string })
-    .filter((data) => data.agentId === agentId);
+): ReadonlyArray<PresenceStatus> {
+  return published.filter((p) => p.agentId === agentId).map((p) => p.status);
 }
 
-/** Drain Effect.runFork-scheduled writes so the capture array reflects
- * them before assertions. One macrotask is sufficient. */
-async function flushFibers(): Promise<void> {
-  await new Promise<void>((resolve) => setImmediate(resolve));
-}
+describe("PresenceService", () => {
+  it("setOnline publishes online", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+    service.subscribe("c-watcher", ["agent-a"]);
 
-describe("PresenceService — broadcast on connect/disconnect", () => {
-  it("setOnline broadcasts presence/changed to subscribers", async () => {
-    const connections = new ConnectionManager();
-    const watcher = makeConn("c-watcher");
-    connections.add(watcher.conn);
-
-    const service = new PresenceService(connections);
-    service.subscribe(watcher.conn.id, ["agent-a"]);
     service.setOnline("agent-a");
-    await flushFibers();
 
-    const events = presenceEventsFor(watcher.writes, "agent-a");
-    expect(events).toHaveLength(1);
-    expect(events[0]!.status).toBe("online");
+    expect(statusesFor(r.published, "agent-a")).toEqual(["online"]);
+    expect(r.published[0]!.subscriberConnIds.has("c-watcher")).toBe(true);
+    expect(r.published[0]!.excludeConnId).toBeUndefined();
   });
 
-  it("setOffline broadcasts presence/changed to subscribers", async () => {
-    const connections = new ConnectionManager();
-    const watcher = makeConn("c-watcher");
-    connections.add(watcher.conn);
-
-    const service = new PresenceService(connections);
-    service.setOnline("agent-a"); // arrive at "online"
-    service.subscribe(watcher.conn.id, ["agent-a"]);
-    await flushFibers();
-    watcher.writes.length = 0;
+  it("setOffline publishes offline", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+    service.subscribe("c-watcher", ["agent-a"]);
+    service.setOnline("agent-a");
+    r.published.length = 0;
 
     service.setOffline("agent-a");
-    await flushFibers();
 
-    const events = presenceEventsFor(watcher.writes, "agent-a");
-    expect(events).toHaveLength(1);
-    expect(events[0]!.status).toBe("offline");
+    expect(statusesFor(r.published, "agent-a")).toEqual(["offline"]);
   });
 
-  it("setOnline twice fires only one event (idempotent on re-assert)", async () => {
-    const connections = new ConnectionManager();
-    const watcher = makeConn("c-watcher");
-    connections.add(watcher.conn);
-
-    const service = new PresenceService(connections);
-    service.subscribe(watcher.conn.id, ["agent-a"]);
+  it("re-asserting the same status does not publish (idempotent)", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+    service.subscribe("c-watcher", ["agent-a"]);
 
     service.setOnline("agent-a");
     service.setOnline("agent-a");
-    await flushFibers();
 
-    const events = presenceEventsFor(watcher.writes, "agent-a");
-    expect(events).toHaveLength(1);
+    expect(statusesFor(r.published, "agent-a")).toEqual(["online"]);
   });
 
-  it("reverse race (offline → online quickly) emits both transitions", async () => {
-    const connections = new ConnectionManager();
-    const watcher = makeConn("c-watcher");
-    connections.add(watcher.conn);
+  it("offline → online → offline → online publishes every transition", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+    service.subscribe("c-watcher", ["agent-a"]);
 
-    const service = new PresenceService(connections);
-    service.subscribe(watcher.conn.id, ["agent-a"]);
+    service.setOnline("agent-a");
+    service.setOffline("agent-a");
+    service.setOnline("agent-a");
 
-    service.setOnline("agent-a"); // offline → online
-    service.setOffline("agent-a"); // online → offline
-    service.setOnline("agent-a"); // offline → online (reconnect storm)
-    await flushFibers();
-
-    const events = presenceEventsFor(watcher.writes, "agent-a");
-    expect(events.map((e) => e.status)).toEqual([
+    expect(statusesFor(r.published, "agent-a")).toEqual([
       "online",
       "offline",
       "online",
     ]);
   });
 
-  it("update from RPC excludes the sender connection from broadcast", async () => {
-    const connections = new ConnectionManager();
-    const sender = makeConn("c-sender");
-    const watcher = makeConn("c-watcher");
-    connections.add(sender.conn);
-    connections.add(watcher.conn);
+  it("update forwards excludeConnId to the sink", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+    service.subscribe("c-sender", ["agent-a"]);
+    service.subscribe("c-watcher", ["agent-a"]);
 
-    const service = new PresenceService(connections);
-    service.subscribe(sender.conn.id, ["agent-a"]);
-    service.subscribe(watcher.conn.id, ["agent-a"]);
+    service.update("agent-a", "away", { excludeConnId: "c-sender" });
 
-    service.update("agent-a", "away", sender.conn.id);
-    await flushFibers();
-
-    expect(presenceEventsFor(sender.writes, "agent-a")).toHaveLength(0);
-    expect(presenceEventsFor(watcher.writes, "agent-a")).toEqual([
-      { agentId: "agent-a", status: "away" },
+    expect(r.published).toHaveLength(1);
+    expect(r.published[0]!.status).toBe("away");
+    expect(r.published[0]!.excludeConnId).toBe("c-sender");
+    // Sink owns the filtering; it receives the full subscriber set.
+    expect([...r.published[0]!.subscriberConnIds].sort()).toEqual([
+      "c-sender",
+      "c-watcher",
     ]);
   });
 
-  it("does not broadcast when there are no subscribers for the agent", async () => {
-    const connections = new ConnectionManager();
-    const bystander = makeConn("c-bystander");
-    connections.add(bystander.conn);
+  it("update without options omits excludeConnId", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+    service.subscribe("c-watcher", ["agent-a"]);
 
-    const service = new PresenceService(connections);
-    // bystander is not subscribed to agent-a
-    service.setOnline("agent-a");
-    await flushFibers();
+    service.update("agent-a", "away");
 
-    expect(presenceEventsFor(bystander.writes, "agent-a")).toHaveLength(0);
+    expect(r.published).toHaveLength(1);
+    expect(r.published[0]!.excludeConnId).toBeUndefined();
   });
 
-  it("dropped subscriber connection is skipped silently", async () => {
-    const connections = new ConnectionManager();
-    const watcher = makeConn("c-watcher");
-    // Subscribed but never added to ConnectionManager — mirrors the race
-    // where a subscriber drops between subscribe and the next transition.
-    const service = new PresenceService(connections);
-    service.subscribe(watcher.conn.id, ["agent-a"]);
+  it("publishes even when there are no subscribers — sink decides", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
 
-    expect(() => service.setOnline("agent-a")).not.toThrow();
-    await flushFibers();
-    expect(presenceEventsFor(watcher.writes, "agent-a")).toHaveLength(0);
+    service.setOnline("agent-a");
+
+    expect(r.published).toHaveLength(1);
+    expect(r.published[0]!.subscriberConnIds.size).toBe(0);
+  });
+
+  it("subscriberConnIds reflects the registry at publish time", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+
+    service.subscribe("c-w1", ["agent-a"]);
+    service.setOnline("agent-a");
+    service.subscribe("c-w2", ["agent-a"]);
+    service.setOffline("agent-a");
+
+    expect(r.published).toHaveLength(2);
+    expect([...r.published[0]!.subscriberConnIds]).toEqual(["c-w1"]);
+    expect([...r.published[1]!.subscriberConnIds].sort()).toEqual([
+      "c-w1",
+      "c-w2",
+    ]);
   });
 });

--- a/packages/server/src/services/presence.service.test.ts
+++ b/packages/server/src/services/presence.service.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for PresenceService — pin the invariant that every status
+ * transition (setOnline/setOffline/update) publishes `presence/changed`
+ * to subscribers, with the broadcast idempotent on re-assert and emitted
+ * on each side of a reverse race. Closes arena#252.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Effect, HashMap, Ref } from "effect";
+
+import { EventNames } from "@moltzap/protocol";
+
+import {
+  ConnectionManager,
+  type MoltZapConnection,
+  type S2cPendingMap,
+} from "../ws/connection.js";
+import { PresenceService } from "./presence.service.js";
+
+interface Capture {
+  conn: MoltZapConnection;
+  writes: string[];
+}
+
+function makeConn(connId: string): Capture {
+  const writes: string[] = [];
+  const conn: MoltZapConnection = {
+    id: connId,
+    write: (raw) =>
+      Effect.sync(() => {
+        writes.push(raw);
+      }),
+    shutdown: Effect.void,
+    auth: null,
+    lastPong: Date.now(),
+    conversationIds: new Set<string>(),
+    mutedConversations: new Set<string>(),
+    s2cPending: Ref.unsafeMake<S2cPendingMap>(HashMap.empty()),
+    s2cRequestCounter: Ref.unsafeMake(0),
+  };
+  return { conn, writes };
+}
+
+function presenceEventsFor(
+  writes: string[],
+  agentId: string,
+): Array<{ status: string }> {
+  return writes
+    .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+    .filter(
+      (frame) =>
+        frame["type"] === "event" &&
+        frame["event"] === EventNames.PresenceChanged,
+    )
+    .map((frame) => frame["data"] as { agentId: string; status: string })
+    .filter((data) => data.agentId === agentId);
+}
+
+/** Drain Effect.runFork-scheduled writes so the capture array reflects
+ * them before assertions. One macrotask is sufficient. */
+async function flushFibers(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("PresenceService — broadcast on connect/disconnect", () => {
+  it("setOnline broadcasts presence/changed to subscribers", async () => {
+    const connections = new ConnectionManager();
+    const watcher = makeConn("c-watcher");
+    connections.add(watcher.conn);
+
+    const service = new PresenceService(connections);
+    service.subscribe(watcher.conn.id, ["agent-a"]);
+    service.setOnline("agent-a");
+    await flushFibers();
+
+    const events = presenceEventsFor(watcher.writes, "agent-a");
+    expect(events).toHaveLength(1);
+    expect(events[0]!.status).toBe("online");
+  });
+
+  it("setOffline broadcasts presence/changed to subscribers", async () => {
+    const connections = new ConnectionManager();
+    const watcher = makeConn("c-watcher");
+    connections.add(watcher.conn);
+
+    const service = new PresenceService(connections);
+    service.setOnline("agent-a"); // arrive at "online"
+    service.subscribe(watcher.conn.id, ["agent-a"]);
+    await flushFibers();
+    watcher.writes.length = 0;
+
+    service.setOffline("agent-a");
+    await flushFibers();
+
+    const events = presenceEventsFor(watcher.writes, "agent-a");
+    expect(events).toHaveLength(1);
+    expect(events[0]!.status).toBe("offline");
+  });
+
+  it("setOnline twice fires only one event (idempotent on re-assert)", async () => {
+    const connections = new ConnectionManager();
+    const watcher = makeConn("c-watcher");
+    connections.add(watcher.conn);
+
+    const service = new PresenceService(connections);
+    service.subscribe(watcher.conn.id, ["agent-a"]);
+
+    service.setOnline("agent-a");
+    service.setOnline("agent-a");
+    await flushFibers();
+
+    const events = presenceEventsFor(watcher.writes, "agent-a");
+    expect(events).toHaveLength(1);
+  });
+
+  it("reverse race (offline → online quickly) emits both transitions", async () => {
+    const connections = new ConnectionManager();
+    const watcher = makeConn("c-watcher");
+    connections.add(watcher.conn);
+
+    const service = new PresenceService(connections);
+    service.subscribe(watcher.conn.id, ["agent-a"]);
+
+    service.setOnline("agent-a"); // offline → online
+    service.setOffline("agent-a"); // online → offline
+    service.setOnline("agent-a"); // offline → online (reconnect storm)
+    await flushFibers();
+
+    const events = presenceEventsFor(watcher.writes, "agent-a");
+    expect(events.map((e) => e.status)).toEqual([
+      "online",
+      "offline",
+      "online",
+    ]);
+  });
+
+  it("update from RPC excludes the sender connection from broadcast", async () => {
+    const connections = new ConnectionManager();
+    const sender = makeConn("c-sender");
+    const watcher = makeConn("c-watcher");
+    connections.add(sender.conn);
+    connections.add(watcher.conn);
+
+    const service = new PresenceService(connections);
+    service.subscribe(sender.conn.id, ["agent-a"]);
+    service.subscribe(watcher.conn.id, ["agent-a"]);
+
+    service.update("agent-a", "away", sender.conn.id);
+    await flushFibers();
+
+    expect(presenceEventsFor(sender.writes, "agent-a")).toHaveLength(0);
+    expect(presenceEventsFor(watcher.writes, "agent-a")).toEqual([
+      { agentId: "agent-a", status: "away" },
+    ]);
+  });
+
+  it("does not broadcast when there are no subscribers for the agent", async () => {
+    const connections = new ConnectionManager();
+    const bystander = makeConn("c-bystander");
+    connections.add(bystander.conn);
+
+    const service = new PresenceService(connections);
+    // bystander is not subscribed to agent-a
+    service.setOnline("agent-a");
+    await flushFibers();
+
+    expect(presenceEventsFor(bystander.writes, "agent-a")).toHaveLength(0);
+  });
+
+  it("dropped subscriber connection is skipped silently", async () => {
+    const connections = new ConnectionManager();
+    const watcher = makeConn("c-watcher");
+    // Subscribed but never added to ConnectionManager — mirrors the race
+    // where a subscriber drops between subscribe and the next transition.
+    const service = new PresenceService(connections);
+    service.subscribe(watcher.conn.id, ["agent-a"]);
+
+    expect(() => service.setOnline("agent-a")).not.toThrow();
+    await flushFibers();
+    expect(presenceEventsFor(watcher.writes, "agent-a")).toHaveLength(0);
+  });
+});

--- a/packages/server/src/services/presence.service.ts
+++ b/packages/server/src/services/presence.service.ts
@@ -1,3 +1,9 @@
+import { Effect } from "effect";
+
+import { EventNames, eventFrame } from "@moltzap/protocol";
+
+import type { ConnectionManager } from "../ws/connection.js";
+
 type PresenceStatus = "online" | "offline" | "away";
 
 /**
@@ -5,24 +11,36 @@ type PresenceStatus = "online" | "offline" | "away";
  * Presence is lost on server restart — clients recover via auto-reconnect.
  *
  * Subscription model: when a connection calls presence/subscribe for a set of
- * agents, it registers for push updates. When any of those agents
- * call presence/update, the change is pushed only to subscribed connections.
+ * agents, it registers for push updates. Every mutating call site
+ * (connect → setOnline, disconnect → setOffline, RPC → update) flows through
+ * `transition`, which publishes `presence/changed` to subscribers iff the
+ * status actually changed.
+ *
+ * Multi-connection-per-agent caveat: `setOffline` is unconditional on the
+ * disconnecting connection. If an agent holds multiple sockets and one
+ * drops while the others remain, this still broadcasts `offline`. The
+ * arena fleet pattern (one socket per agentId) does not exercise that
+ * shape; tracked separately for general moltzap consumers.
  */
 export class PresenceService {
   private statuses = new Map<string, PresenceStatus>();
   /** agentId → set of connIds watching that agent */
   private subscribers = new Map<string, Set<string>>();
 
+  constructor(private readonly connections: ConnectionManager) {}
+
   setOnline(agentId: string): void {
-    this.statuses.set(agentId, "online");
+    this.transition(agentId, "online");
   }
 
   setOffline(agentId: string): void {
-    this.statuses.set(agentId, "offline");
+    this.transition(agentId, "offline");
   }
 
-  update(agentId: string, status: PresenceStatus): void {
-    this.statuses.set(agentId, status);
+  /** `senderConnId` is the connection that issued the RPC and is excluded
+   * from the broadcast (it already knows the new status). */
+  update(agentId: string, status: PresenceStatus, senderConnId?: string): void {
+    this.transition(agentId, status, senderConnId);
   }
 
   get(agentId: string): PresenceStatus {
@@ -56,6 +74,35 @@ export class PresenceService {
   removeConnection(connId: string): void {
     for (const subs of this.subscribers.values()) {
       subs.delete(connId);
+    }
+  }
+
+  private transition(
+    agentId: string,
+    next: PresenceStatus,
+    exceptConnId?: string,
+  ): void {
+    const prev = this.statuses.get(agentId) ?? "offline";
+    if (prev === next) return;
+    this.statuses.set(agentId, next);
+    this.broadcast(agentId, next, exceptConnId);
+  }
+
+  private broadcast(
+    agentId: string,
+    status: PresenceStatus,
+    exceptConnId?: string,
+  ): void {
+    const subs = this.subscribers.get(agentId);
+    if (!subs || subs.size === 0) return;
+    const raw = JSON.stringify(
+      eventFrame(EventNames.PresenceChanged, { agentId, status }),
+    );
+    for (const connId of subs) {
+      if (connId === exceptConnId) continue;
+      const conn = this.connections.get(connId);
+      if (!conn) continue;
+      Effect.runFork(conn.write(raw).pipe(Effect.catchAll(() => Effect.void)));
     }
   }
 }

--- a/packages/server/src/services/presence.service.ts
+++ b/packages/server/src/services/presence.service.ts
@@ -1,33 +1,24 @@
-import { Effect } from "effect";
+import type {
+  PresenceEventSink,
+  PresenceStatus,
+} from "./presence-event-sink.js";
 
-import { EventNames, eventFrame } from "@moltzap/protocol";
-
-import type { ConnectionManager } from "../ws/connection.js";
-
-type PresenceStatus = "online" | "offline" | "away";
+const EMPTY_SUBSCRIBERS: ReadonlySet<string> = new Set();
 
 /**
- * In-memory presence tracking with subscriber-based notifications.
- * Presence is lost on server restart — clients recover via auto-reconnect.
+ * In-memory presence state + subscriber registry. Every mutating call
+ * (setOnline / setOffline / update) flows through `transition`, which
+ * publishes via the sink iff the status changed.
  *
- * Subscription model: when a connection calls presence/subscribe for a set of
- * agents, it registers for push updates. Every mutating call site
- * (connect → setOnline, disconnect → setOffline, RPC → update) flows through
- * `transition`, which publishes `presence/changed` to subscribers iff the
- * status actually changed.
- *
- * Multi-connection-per-agent caveat: `setOffline` is unconditional on the
- * disconnecting connection. If an agent holds multiple sockets and one
- * drops while the others remain, this still broadcasts `offline`. The
- * arena fleet pattern (one socket per agentId) does not exercise that
- * shape; tracked separately for general moltzap consumers.
+ * Out of scope: multi-connection-per-agent and concurrent close-vs-connect
+ * race semantics. The `prior !== next` guard is correct for the
+ * single-connection-per-agent case; tracked separately.
  */
 export class PresenceService {
   private statuses = new Map<string, PresenceStatus>();
-  /** agentId → set of connIds watching that agent */
   private subscribers = new Map<string, Set<string>>();
 
-  constructor(private readonly connections: ConnectionManager) {}
+  constructor(private readonly eventSink: PresenceEventSink) {}
 
   setOnline(agentId: string): void {
     this.transition(agentId, "online");
@@ -37,10 +28,12 @@ export class PresenceService {
     this.transition(agentId, "offline");
   }
 
-  /** `senderConnId` is the connection that issued the RPC and is excluded
-   * from the broadcast (it already knows the new status). */
-  update(agentId: string, status: PresenceStatus, senderConnId?: string): void {
-    this.transition(agentId, status, senderConnId);
+  update(
+    agentId: string,
+    status: PresenceStatus,
+    options: { readonly excludeConnId?: string } = {},
+  ): void {
+    this.transition(agentId, status, options.excludeConnId);
   }
 
   get(agentId: string): PresenceStatus {
@@ -48,7 +41,7 @@ export class PresenceService {
   }
 
   getMany(
-    agentIds: string[],
+    agentIds: ReadonlyArray<string>,
   ): Array<{ agentId: string; status: PresenceStatus }> {
     return agentIds.map((agentId) => ({
       agentId,
@@ -56,7 +49,7 @@ export class PresenceService {
     }));
   }
 
-  subscribe(connId: string, agentIds: string[]): void {
+  subscribe(connId: string, agentIds: ReadonlyArray<string>): void {
     for (const agentId of agentIds) {
       let subs = this.subscribers.get(agentId);
       if (!subs) {
@@ -67,8 +60,8 @@ export class PresenceService {
     }
   }
 
-  getSubscribers(agentId: string): Set<string> {
-    return this.subscribers.get(agentId) ?? new Set();
+  getSubscribers(agentId: string): ReadonlySet<string> {
+    return this.subscribers.get(agentId) ?? EMPTY_SUBSCRIBERS;
   }
 
   removeConnection(connId: string): void {
@@ -80,29 +73,19 @@ export class PresenceService {
   private transition(
     agentId: string,
     next: PresenceStatus,
-    exceptConnId?: string,
+    excludeConnId?: string,
   ): void {
     const prev = this.statuses.get(agentId) ?? "offline";
     if (prev === next) return;
     this.statuses.set(agentId, next);
-    this.broadcast(agentId, next, exceptConnId);
-  }
-
-  private broadcast(
-    agentId: string,
-    status: PresenceStatus,
-    exceptConnId?: string,
-  ): void {
-    const subs = this.subscribers.get(agentId);
-    if (!subs || subs.size === 0) return;
-    const raw = JSON.stringify(
-      eventFrame(EventNames.PresenceChanged, { agentId, status }),
-    );
-    for (const connId of subs) {
-      if (connId === exceptConnId) continue;
-      const conn = this.connections.get(connId);
-      if (!conn) continue;
-      Effect.runFork(conn.write(raw).pipe(Effect.catchAll(() => Effect.void)));
-    }
+    // Snapshot — caller may inspect the input after publish returns
+    // (deferred sinks, tests that capture inputs for later assertion).
+    // Live registry mutations must not alter past inputs.
+    this.eventSink.publish({
+      agentId,
+      status: next,
+      subscriberConnIds: new Set(this.getSubscribers(agentId)),
+      excludeConnId,
+    });
   }
 }


### PR DESCRIPTION
## Summary

Restoration of the natural invariant *presence on the wire reflects connection state*. Pushes `presence/changed` broadcasts through a typed `PresenceEventSink` so every transition (`setOnline` from connect, `setOffline` from disconnect, `update` from RPC) publishes to subscribers iff the status changed. Pre-fix, only the explicit `presence/update` RPC handler broadcast; connect/disconnect mutated state silently.

Discovered via [arena verify-221-v9 D12](https://github.com/chughtapan/moltzap-arena/issues/252). Arena's `agent-presence-watcher` boots before the fleet finishes connecting; its initial `presence/subscribe` snapshot is all-offline, then it waits forever for push events. Fleet `auth/connect` calls landed at `setOnline` but never published — `grep -c presence/changed` on the moltzap log read 0 over 8 minutes; game never started.

## Architect spec

Binding contract: [chughtapan/moltzap#367 r4](https://github.com/chughtapan/moltzap/issues/367#issuecomment-4363341963). Three rounds of architect-side codex review converged at APPROVE.

## What changed

**Production (`packages/server`):**
- `services/presence-event-sink.ts` (new) — typed `PresenceEventSink` interface + `ConnectionFanOutPresenceEventSink` factory. Sink takes `subscriberConnIds` as a publish input; **no back-edge** from sink to `PresenceService`.
- `services/presence.service.ts` — constructor takes the sink. `setOnline` / `setOffline` / `update` flow through one `transition` path with `prior !== next` idempotency guard. `update` takes options object `{ excludeConnId? }`.
- `app/handlers/presence.handlers.ts` — drops the inline broadcast loop; delegates to the service via `update(agentId, status, { excludeConnId: senderConnId })`.
- `app/layers.ts` — `PresenceServiceLive` is `Layer.effect`, requires `ConnectionManagerTag`, constructs the sink in the layer factory. Moved to Tier 2 alongside `BroadcasterLive` (matches the per-comment rule that `Layer.mergeAll` does not auto-resolve cross-layer requirements).
- `index.ts` — exports `PresenceEventSink`, `PresencePublishInput`, `PresenceStatus`, `createConnectionFanOutPresenceEventSink` so consumers updating to the new constructor have a public surface.

**Conformance (`packages/protocol/src/testing/conformance`):**
- `presence.ts` (new) — six registrars under a new `"presence"` `PropertyCategory`:
  - **P1** `connect-broadcast` — auth/connect after subscribe ⇒ subscriber receives online.
  - **P2** `disconnect-broadcast` — close after auth/connect ⇒ subscriber receives offline strictly after online.
  - **P3** `reconnect-storm` (sequential, in-band-fenced) — online → offline → online lands as three events in strict order; the wait for offline between client #1 close and client #2 connect is the in-band fence proving server-side `onExit` reached `setOffline` before the new handshake. Helper `waitForPresenceWithStatus` consumes `client.events` Stream with a payload predicate (existing `TestClient.waitForEvent` matches event name only).
  - **P4** `same-state-no-double-fire` — re-sending `auth/connect` on an already-authenticated WS short-circuits to `buildHelloOk` → `setOnline` again; idempotency guard suppresses the redundant broadcast.
  - **P5** `multi-subscriber-fan-out` — N subscribers, each receives exactly one event. Cardinality assertion.
  - **P6** `subscribe-after-connect` — late-joining subscriber's `presence/subscribe` snapshot reflects current `online` state.
- `__divergence_proofs__/server-executable.proofs.test.ts` — six new proofs against `presence-silent` + `presence-stale-snapshot` bad-server behaviors; each property fails with the expected typed `PropertyInvariantViolation`.
- `registry.ts`, `suite.ts`, `index.ts` — wire the category + registrars + barrel export.

**Tests (`packages/server/src/services`):**
- `presence-event-sink.test.ts` (new) — pin sink fan-out, exclude semantics, empty-subscriber short-circuit, dropped-conn skip.
- `presence.service.test.ts` — rewrote against a recording fake sink; pins idempotency + reverse-race + excludeConnId forwarding + snapshot-at-publish-time.
- `__tests__/integration/26-presence-lifecycle.integration.test.ts` — extended with two integration mirrors of P1 + P2 against the real core server.

## Out of scope (deferred per spec §11)

- **OQ4 — multi-connection per agent.** If A holds two WS connections and one closes, `setOffline` still flips wire state. Pre-existing bug; same root cause as OQ6.
- **OQ6 — concurrent close-vs-connect race.** Fresh `auth/connect` fiber races old socket's `onExit` cleanup; the per-fiber idempotency guard does not impose cross-fiber ordering. P3 narrows to the **sequential** path only.
- Both tracked in **chughtapan/moltzap#369**: PresenceService connection-counting follow-up.

- **OQ7 — `PresenceService` constructor break.** `PresenceService` is exported from `@moltzap/server-core` (`packages/server/src/index.ts`); the new sink-required constructor is a breaking change for any third-party consumer using `new PresenceService()` directly. Pre-1.0 (`@moltzap/protocol@2026.501.6`) doctrine permits the break; #368 also exports the new construction surface (`createConnectionFanOutPresenceEventSink` + types) so consumers have a clean upgrade path. **CHANGELOG note:** when this lands, `PresenceService` constructor signature changes from `()` to `(eventSink: PresenceEventSink)`. In-tree the only direct caller is `layers.ts:PresenceServiceLive`, which is updated. External consumers that build `PresenceService` outside the layer graph need to call `createConnectionFanOutPresenceEventSink({ connections })` and pass the result.

## Verification

```
pnpm --filter @moltzap/protocol --filter @moltzap/server-core build  ✓
pnpm --filter @moltzap/server-core test                              ✓ 181 unit / 22 files
pnpm --filter @moltzap/server-core test:integration                  ✓ 144 / 34 files
pnpm --filter @moltzap/server-core test:conformance                  ✓ 26 / 3 files (35 props passed, 4 deferred)
pnpm lint                                                            ✓ 0 warnings, 0 errors
bash scripts/sloppy-code-guard.sh                                    ✓ All guards passed
```

## Codex review

Three rounds against the amended diff:
- Round 1: P2 multi-socket + P2 conformance leak + P2 integration leak — fixed inline (commit 6d3d40d).
- Round 2: P2 multi-socket (OQ4) — deferred per spec; documented above.
- Round 3 implicit (the OQ4 finding): same shape as round 2, same disposition.

Architect-side codex review on the spec itself: 4 rounds, final verdict APPROVE.

## Closes

- [chughtapan/moltzap-arena#252](https://github.com/chughtapan/moltzap-arena/issues/252) — verify-221-v9 D12, P0 root cause for the agent-presence-watcher hang.
- [chughtapan/moltzap#337](https://github.com/chughtapan/moltzap/issues/337) — deferred lifecycle conformance: presence. The 6 properties (P1–P6) under the new `"presence"` `PropertyCategory` + sibling divergence proofs satisfy this issue's acceptance.

## Refs

- [chughtapan/moltzap#334](https://github.com/chughtapan/moltzap/issues/334) — parent epic for lifecycle conformance expansion. Presence sub-track lands here; siblings #335 (contacts), #336 (invites), #338 (reconnect/replay) remain deferred.
- [chughtapan/moltzap#367](https://github.com/chughtapan/moltzap/issues/367) — architect spec (r4 binding contract).
- [chughtapan/moltzap#369](https://github.com/chughtapan/moltzap/issues/369) — follow-up for OQ4 + OQ6 connection-counting (filed at amendment time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)