### PR TITLE
fix(protocol): make stringEnum decode-compatible (D14)

### DIFF
--- a/packages/protocol/src/helpers.ts
+++ b/packages/protocol/src/helpers.ts
@@ -1,11 +1,14 @@
-import { Type } from "@sinclair/typebox";
+import { Type, type TString } from "@sinclair/typebox";
 
 /**
  * Creates a string enum schema without producing anyOf (which some validators reject).
+ * Uses Type.String + enum constraint (Kind="String") so TypeBox's Value.Decode
+ * visitor handles the node — Type.Unsafe has no Kind tag and trips
+ * `ValueCheckUnknownTypeError: Unknown type` on consumer-side decoders.
  * Matches OpenClaw's stringEnum pattern.
  */
 export function stringEnum<T extends string[]>(values: [...T]) {
-  return Type.Unsafe<T[number]>({ type: "string", enum: values });
+  return Type.String({ enum: values }) as TString & { static: T[number] };
 }
 
 /**


### PR DESCRIPTION
## Summary

`stringEnum<T>(values)` previously returned `Type.Unsafe<T[number]>({type:"string",enum:values})`. `Type.Unsafe` has no `Kind` symbol, so TypeBox 0.34.49's `Value.Decode → Visit` throws `ValueCheckUnknownTypeError: Unknown type` on every node built from this helper.

This blocks arena's `agent-presence` watcher (chughtapan/moltzap-arena PR #221, sub-issue #254) — `presence/changed.status` field uses `stringEnum(["online","offline"])`, so every presence frame is rejected at the decode boundary, the watcher never reaches roster threshold, no game ever starts.

Sister bug to chughtapan/moltzap-arena#253 (D13 — uuid format registration). Subsumes #370.

## Fix

Use `Type.String({ enum: values })` (Kind="String") + cast for the literal-typed Static. JSON Schema output is still `{type:"string", enum:[...]}` — same wire format. No anyOf.

```ts
export function stringEnum<T extends string[]>(values: [...T]) {
  return Type.String({ enum: values }) as TString & { static: T[number] };
}
```

## Test plan

- [x] `pnpm -r build` clean
- [x] Repro: `Value.Decode(PresenceChangedEventSchema, {agentId, status:"online"})` returns successfully (was throwing pre-fix)
- [x] `pnpm test` all green (147 protocol unit + 89 app-sdk + 277 client + 79 openclaw + 47 claude-code-channel + 31 runtimes + 19 nanoclaw)
- [x] `pnpm --filter @moltzap/server-core test:conformance` green (35 properties + 4 deferred + divergence proofs, 26 test files)
- [x] `pnpm --filter @moltzap/server-core test:integration` green (144 tests across 34 files)
- [x] `pnpm lint` clean (0 warnings, 0 errors)
- [x] `pnpm format` applied
- [x] Static type narrowing preserved: `Static<ReturnType<typeof stringEnum<["a","b"]>>>` is `"a"|"b"` not `string` (verified via tsc)

## Closes

chughtapan/moltzap-arena#254