### PR TITLE
feat(auth): reentrant /admin/register-agent (#373)

### DIFF
--- a/packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts
+++ b/packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect } from "effect";
 import type { Kysely } from "kysely";
-import type { AppManifest } from "@moltzap/protocol";
+import { PROTOCOL_VERSION, type AppManifest } from "@moltzap/protocol";
 import type { Database } from "../../db/database.js";
+import { parseApiKey } from "../../auth/agent-auth.js";
 import {
   startTestServer,
   stopTestServer,
@@ -12,6 +13,7 @@ import {
   getTestCoreApp,
   trackClient,
   connectTestClient,
+  registerAgent,
 } from "./helpers.js";
 
 const REGISTRATION_SECRET = "admin-test-secret-zxcv";
@@ -19,6 +21,7 @@ const REGISTRATION_SECRET = "admin-test-secret-zxcv";
 // schema has no users table; this UUID is just a label that satisfies the
 // AppHost null check on `agents.owner_user_id`.
 const SYSTEM_USER_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_USER_ID = "00000000-0000-4000-8000-000000000002";
 
 const ADMIN_TEST_MANIFEST: AppManifest = {
   appId: "admin-register-test-app",
@@ -68,6 +71,15 @@ async function postAdmin(
   // The endpoint always returns JSON (success or error envelopes).
   const json: unknown = await res.json();
   return { status: res.status, json };
+}
+
+/** Effect-lifted POST to the admin route with `inviteCode` pre-applied. */
+function adminRegister(
+  body: Record<string, unknown>,
+): Effect.Effect<{ status: number; json: unknown }, Error> {
+  return Effect.tryPromise(() =>
+    postAdmin({ inviteCode: REGISTRATION_SECRET, ...body }),
+  );
 }
 
 describe("/api/v1/admin/register-agent — secret-gated ownerUserId", () => {
@@ -209,6 +221,225 @@ describe("/api/v1/admin/register-agent — secret-gated ownerUserId", () => {
         );
         // devModeUserId is not configured in this test harness, so owner is null.
         expect(row.owner_user_id).toBeNull();
+      }),
+  );
+
+  // ───────────────────────── reentrant upsert (#373) ─────────────────────────
+
+  it.live(
+    "re-register same (name, ownerUserId): same agentId, fresh apiKey, status 200",
+    () =>
+      Effect.gen(function* () {
+        const first = yield* adminRegister({
+          name: "rotating-agent",
+          ownerUserId: SYSTEM_USER_ID,
+        });
+        expect(first.status).toBe(201);
+        const firstBody = first.json as AdminRegisterResponse;
+
+        const second = yield* adminRegister({
+          name: "rotating-agent",
+          ownerUserId: SYSTEM_USER_ID,
+        });
+        expect(second.status).toBe(200);
+        const secondBody = second.json as AdminRegisterResponse;
+
+        expect(secondBody.agentId).toBe(firstBody.agentId);
+        expect(secondBody.apiKey).not.toBe(firstBody.apiKey);
+        expect(secondBody.apiKey).toMatch(/^moltzap_agent_/);
+      }),
+  );
+
+  it.live("old apiKey is rejected by auth/connect after re-register", () =>
+    Effect.gen(function* () {
+      const first = yield* adminRegister({
+        name: "rotated-key-rejection",
+        ownerUserId: SYSTEM_USER_ID,
+      });
+      expect(first.status).toBe(201);
+      const oldKey = (first.json as AdminRegisterResponse).apiKey;
+
+      const second = yield* adminRegister({
+        name: "rotated-key-rejection",
+        ownerUserId: SYSTEM_USER_ID,
+      });
+      expect(second.status).toBe(200);
+      const rotated = second.json as AdminRegisterResponse;
+      expect(rotated.apiKey).not.toBe(oldKey);
+
+      // Old key's api_key_id no longer matches any row → auth/connect fails.
+      const staleClient = yield* connectTestClient({
+        wsUrl,
+        agentId: rotated.agentId,
+        apiKey: oldKey,
+        autoConnect: false,
+      });
+      trackClient(staleClient);
+      const staleResult = yield* Effect.exit(
+        staleClient.sendRpc("auth/connect", {
+          agentKey: oldKey,
+          minProtocol: PROTOCOL_VERSION,
+          maxProtocol: PROTOCOL_VERSION,
+        }),
+      );
+      expect(staleResult._tag).toBe("Failure");
+
+      const freshClient = yield* connectTestClient({
+        wsUrl,
+        agentId: rotated.agentId,
+        apiKey: rotated.apiKey,
+        autoConnect: false,
+      });
+      trackClient(freshClient);
+      const hello = (yield* freshClient.sendRpc("auth/connect", {
+        agentKey: rotated.apiKey,
+        minProtocol: PROTOCOL_VERSION,
+        maxProtocol: PROTOCOL_VERSION,
+      })) as { agentId: string };
+      expect(hello.agentId).toBe(rotated.agentId);
+    }),
+  );
+
+  it.live("re-register with mismatched ownerUserId returns 409", () =>
+    Effect.gen(function* () {
+      const first = yield* adminRegister({
+        name: "owner-mismatch-agent",
+        ownerUserId: SYSTEM_USER_ID,
+      });
+      expect(first.status).toBe(201);
+
+      const second = yield* adminRegister({
+        name: "owner-mismatch-agent",
+        ownerUserId: OTHER_USER_ID,
+      });
+      expect(second.status).toBe(409);
+      expect((second.json as { code?: string }).code).toBe(
+        "REGISTRATION_CONFLICT",
+      );
+    }),
+  );
+
+  it.live(
+    "re-register without ownerUserId on a row that has one returns 409",
+    () =>
+      Effect.gen(function* () {
+        const first = yield* adminRegister({
+          name: "drop-owner-agent",
+          ownerUserId: SYSTEM_USER_ID,
+        });
+        expect(first.status).toBe(201);
+
+        // IS NOT DISTINCT FROM treats NULL ≠ <uuid>; upsert is rejected.
+        const second = yield* adminRegister({ name: "drop-owner-agent" });
+        expect(second.status).toBe(409);
+      }),
+  );
+
+  it.live(
+    "re-register on a suspended agent returns 409 (does not silently re-arm)",
+    () =>
+      Effect.gen(function* () {
+        const first = yield* adminRegister({
+          name: "suspended-agent",
+          ownerUserId: SYSTEM_USER_ID,
+        });
+        expect(first.status).toBe(201);
+        const firstBody = first.json as AdminRegisterResponse;
+
+        yield* Effect.tryPromise(() =>
+          db
+            .updateTable("agents")
+            .set({ status: "suspended" })
+            .where("id", "=", firstBody.agentId)
+            .execute(),
+        );
+
+        const second = yield* adminRegister({
+          name: "suspended-agent",
+          ownerUserId: SYSTEM_USER_ID,
+        });
+        expect(second.status).toBe(409);
+
+        const row = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("agents")
+            .select(["status"])
+            .where("id", "=", firstBody.agentId)
+            .executeTakeFirstOrThrow(),
+        );
+        expect(row.status).toBe("suspended");
+      }),
+  );
+
+  it.live(
+    "concurrent re-register: both calls succeed, both return same agentId",
+    () =>
+      Effect.gen(function* () {
+        // Seed the row so both concurrent calls hit the UPDATE branch
+        // (where row-lock serialization matters). Two concurrent INSERTs
+        // with no prior row race on the unique constraint and one would
+        // fail — that race isn't the contract under test.
+        const seed = yield* adminRegister({
+          name: "concurrent-rotate-agent",
+          ownerUserId: SYSTEM_USER_ID,
+        });
+        expect(seed.status).toBe(201);
+        const seedBody = seed.json as AdminRegisterResponse;
+
+        const [a, b] = yield* Effect.all(
+          [
+            adminRegister({
+              name: "concurrent-rotate-agent",
+              ownerUserId: SYSTEM_USER_ID,
+            }),
+            adminRegister({
+              name: "concurrent-rotate-agent",
+              ownerUserId: SYSTEM_USER_ID,
+            }),
+          ],
+          { concurrency: "unbounded" },
+        );
+        expect(a.status).toBe(200);
+        expect(b.status).toBe(200);
+        const aBody = a.json as AdminRegisterResponse;
+        const bBody = b.json as AdminRegisterResponse;
+
+        expect(aBody.agentId).toBe(seedBody.agentId);
+        expect(bBody.agentId).toBe(seedBody.agentId);
+        expect(aBody.apiKey).not.toBe(bBody.apiKey);
+
+        // Whichever transaction committed last is the live key — Postgres
+        // row-lock ordering is non-deterministic, so we only assert that
+        // the live key matches one of the two callers (not which one).
+        const liveRow = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("agents")
+            .select(["api_key_id"])
+            .where("id", "=", seedBody.agentId)
+            .executeTakeFirstOrThrow(),
+        );
+        const aKeyId = parseApiKey(aBody.apiKey)?.keyId;
+        const bKeyId = parseApiKey(bBody.apiKey)?.keyId;
+        expect([aKeyId, bKeyId]).toContain(liveRow.api_key_id);
+      }),
+  );
+
+  it.live(
+    "regression: public /auth/register stays insert-only (duplicate name fails)",
+    () =>
+      // Architect spec #373 decision 5: reentrancy on the public route
+      // would let any REGISTRATION_SECRET holder rotate any existing
+      // agent's apiKey. The public route has no owner-match WHERE.
+      Effect.gen(function* () {
+        yield* registerAgent(baseUrl, "public-route-insert-only", {
+          inviteCode: REGISTRATION_SECRET,
+        });
+        const dup = yield* Effect.exit(
+          registerAgent(baseUrl, "public-route-insert-only", {
+            inviteCode: REGISTRATION_SECRET,
+          }),
+        );
+        expect(dup._tag).toBe("Failure");
       }),
   );
 });

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -326,22 +326,34 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       }
 
       const exit = yield* Effect.exit(
-        authService.registerAgent(
-          registerBody as Parameters<typeof authService.registerAgent>[0],
+        authService.upsertAgent(
+          registerBody as Parameters<typeof authService.upsertAgent>[0],
           // Explicit body owner wins; dev-mode auto-owner is the fallback.
           resolvedOwnerUserId ?? config.devModeUserId,
         ),
       );
-      if (Exit.isSuccess(exit)) {
-        return HttpServerResponse.unsafeJson(exit.value, { status: 201 });
+      if (Exit.isFailure(exit)) {
+        logger.error(
+          { cause: Cause.pretty(exit.cause) },
+          "Admin upsert failed",
+        );
+        return HttpServerResponse.unsafeJson(
+          { error: "Registration failed" },
+          { status: 500 },
+        );
       }
-      logger.error(
-        { cause: Cause.pretty(exit.cause) },
-        "Admin registration failed",
-      );
+      const result = exit.value;
+      if ("_tag" in result) {
+        return HttpServerResponse.unsafeJson(
+          { error: "Registration conflict", code: "REGISTRATION_CONFLICT" },
+          { status: 409 },
+        );
+      }
+      // 200 = rotated existing row, 201 = newly inserted. The status code
+      // is the on-the-wire `rotated` signal; body shape stays unchanged.
       return HttpServerResponse.unsafeJson(
-        { error: "Registration failed" },
-        { status: 500 },
+        { agentId: result.agentId, apiKey: result.apiKey },
+        { status: result.rotated ? 200 : 201 },
       );
     }),
   );

--- a/packages/server/src/services/auth.service.ts
+++ b/packages/server/src/services/auth.service.ts
@@ -1,4 +1,5 @@
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
+import { sql } from "kysely";
 import type { Db } from "../db/client.js";
 import type { Register, Static } from "@moltzap/protocol";
 import { AgentId, UserId } from "../app/types.js";
@@ -15,7 +16,12 @@ import {
   takeFirstOption,
   takeFirstOrFail,
 } from "../db/effect-kysely-toolkit.js";
-import { Option } from "effect";
+
+export const REGISTRATION_CONFLICT = "RegistrationConflict" as const;
+
+export type UpsertAgentResult =
+  | { agentId: AgentId; apiKey: string; rotated: boolean }
+  | { _tag: typeof REGISTRATION_CONFLICT };
 
 export class AuthService {
   constructor(private db: Db) {}
@@ -55,6 +61,76 @@ export class AuthService {
         );
 
         return { agentId, apiKey };
+      }),
+    );
+  }
+
+  /**
+   * Reentrant register. INSERT new row, or rotate api_key_id /
+   * api_key_secret_hash on an existing row when `(name)` matches AND the
+   * existing owner matches AND the row is not suspended. Otherwise return
+   * `RegistrationConflict`.
+   *
+   * Atomic on `agents.name UNIQUE` — concurrent callers serialize on the
+   * row lock and second-write wins (most-recent admin upsert is source of
+   * truth). Public `/auth/register` stays insert-only: reentrancy without
+   * an owner-match WHERE would let any `REGISTRATION_SECRET` holder mint a
+   * fresh apiKey for any existing agent.
+   */
+  upsertAgent(
+    params: RegisterParams,
+    ownerUserId?: string,
+  ): Effect.Effect<UpsertAgentResult, never> {
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        const { apiKey, keyId, secretHash } = generateApiKey();
+
+        const rowOpt = yield* takeFirstOption(
+          this.db
+            .insertInto("agents")
+            .values({
+              name: params.name,
+              description: params.description ?? null,
+              api_key_id: keyId,
+              api_key_secret_hash: secretHash,
+              claim_token: generateClaimToken(),
+              status: "active",
+              owner_user_id: ownerUserId ?? null,
+            })
+            .onConflict((oc) =>
+              oc
+                .column("name")
+                .doUpdateSet({
+                  api_key_id: keyId,
+                  api_key_secret_hash: secretHash,
+                })
+                // WHERE failure → no UPDATE → RETURNING yields zero rows,
+                // which maps to RegistrationConflict.
+                .where(
+                  sql<boolean>`agents.owner_user_id IS NOT DISTINCT FROM EXCLUDED.owner_user_id AND agents.status != 'suspended'`,
+                ),
+            )
+            // `xmax = 0` distinguishes a fresh INSERT from a conflict
+            // UPDATE; PG system column with no Kysely abstraction.
+            .returning(["id", sql<boolean>`(xmax = 0)`.as("inserted")]),
+        );
+
+        if (Option.isNone(rowOpt)) {
+          yield* Effect.logInfo("Agent upsert conflict").pipe(
+            Effect.annotateLogs({ name: params.name }),
+          );
+          return { _tag: REGISTRATION_CONFLICT } as const;
+        }
+
+        const { id, inserted } = rowOpt.value;
+        const agentId = AgentId(id);
+        const rotated = !inserted;
+
+        yield* Effect.logInfo("Agent upserted").pipe(
+          Effect.annotateLogs({ agentId, name: params.name, rotated }),
+        );
+
+        return { agentId, apiKey, rotated };
       }),
     );
   }


### PR DESCRIPTION
## Summary

Make `/api/v1/admin/register-agent` idempotent on `(name, owner_user_id)` so production deploys don't crash on `agents.name UNIQUE` against a persistent PGlite. Closes #373; unblocks the arena-fleet Railway crash-loop in chughtapan/moltzap-arena.

- New `AuthService.upsertAgent()`: single `INSERT ... ON CONFLICT(name) DO UPDATE SET api_key_id, api_key_secret_hash WHERE owner_user_id IS NOT DISTINCT FROM EXCLUDED.owner_user_id AND status != 'suspended' RETURNING (xmax = 0)`. Atomic, race-safe, second-write-wins.
- Admin route returns `200` on rotation, `201` on insert, `409` (`code: REGISTRATION_CONFLICT`) on owner mismatch / suspended row. Body shape unchanged: `{ agentId, apiKey }`.
- Public `/auth/register` stays insert-only (architect spec #373 decision 5 — without an owner-match WHERE, reentrancy on a secret-gated endpoint becomes credential takeover).

Per-architect spec; no protocol changes; no schema migration; no new deps.

## Implementation notes

| File | Change |
|---|---|
| `packages/server/src/services/auth.service.ts` | New `upsertAgent` + `REGISTRATION_CONFLICT` const + `UpsertAgentResult` discriminated union (Principle 3: typed errors). |
| `packages/server/src/app/server.ts` | Admin route swaps `registerAgent` → `upsertAgent`; adds 200/201/409 mapping. |
| `packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts` | 7 new test cases (the architect-prescribed ones). |

## Architect-spec coverage

- [x] Decision 1: extend existing admin route (no new endpoint, no flag).
- [x] Decision 2: mint-fresh + invalidate-old apiKey rotation.
- [x] Decision 3: atomic INSERT...ON CONFLICT, no app-level lock.
- [x] Decision 4: zero schema migration.
- [x] Decision 5: public route stays insert-only.
- [x] Decision 6: 7 integration tests in `41-admin-register-agent.integration.test.ts`.

## Test plan

- [x] `pnpm --filter @moltzap/server-core build` — clean.
- [x] `pnpm --filter @moltzap/server-core test` — 181/181 unit pass.
- [x] `pnpm --filter @moltzap/server-core test:integration -- 41-admin` — 151/151 (incl. 7 new) pass.
- [x] `pnpm lint` — 0 warnings, 0 errors.
- [x] `pnpm format` / `pnpm format:check` — clean.
- [x] `scripts/sloppy-code-guard.sh` — 0 violations.
- [x] `pnpm typecheck` — clean (full repo).
- [ ] Post-merge arena-side: bump submodule, redeploy, verify fleet boots without `FLEET_SUFFIX` rotation.

## Concurrency test note

The concurrent-rotate test (test 6) seeds the row first so both racing calls hit the UPDATE branch. The two concurrent INSERTs case (no prior row) would race the unique constraint with one losing — that race is not the architect-defined contract under test ("most-recent admin upsert is source of truth" applies to repeated deploys, where the row already exists). The test asserts that the final live `api_key_id` matches one of the two callers (Postgres row-lock ordering is non-deterministic, so we don't pin which one). Deterministic in CI.

## Deviations from architect spec

None functional. Two presentation polish items:

1. The discriminator constant `REGISTRATION_CONFLICT = "RegistrationConflict" as const` is exported alongside `UpsertAgentResult` so the route handler doesn't carry the string literal twice. Spec called out the `_tag` shape; the const is implementation-internal.
2. Comments on the SQL are trimmed to "WHY only" — the architect spec's full rationale (decisions 3, 5, the `xmax = 0` derivation) is not duplicated in code; reviewers should consult #373 for the design history.

## Reviewer attention

**Codex flagged a P1 trade-off** during review that the architect already explicitly considered in spec decision 5: in deployments where `REGISTRATION_SECRET` is shared with non-operators, this admin route lets any holder rotate an existing agent's apiKey by passing the matching `ownerUserId` (or omitting it for un-owned agents). The architect's decision: in arena's deployment `REGISTRATION_SECRET` is operator-only, so this is acceptable. This PR ships that trade-off as-is. If reviewer wants stricter admin-only auth (a separate `ADMIN_SECRET`, or signed requests), that's a follow-up issue and out of scope here. Re-raising for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)