### PR TITLE
fix(conversations): findExistingDm filters archived_at IS NULL (closes #372)

### DIFF
--- a/packages/server/src/services/conversation.service.test.ts
+++ b/packages/server/src/services/conversation.service.test.ts
@@ -234,3 +234,44 @@ describe("ConversationService.addParticipant auto-subscribes the new member", ()
     expect(bobConn.conversationIds.has(conv.id)).toBe(true);
   });
 });
+
+/**
+ * Regression for arena#372: archived DMs must not be reused by
+ * conversations/create. Before this fix, `findExistingDm` returned any DM
+ * between the two agents — including archived ones. After closeSession
+ * archives a DM, the next conversations/create would hand back the archived
+ * conversation, but messages/send rejects writes to archived conversations,
+ * so the agent ended up with a "live" DM id it could never write to.
+ */
+describe("ConversationService.create — archived DM lookup (issue #372)", () => {
+  beforeEach(freshDb, dbHookTimeoutMs);
+  afterEach(async () => {
+    await pglite?.close();
+  });
+
+  it("does not reuse an archived DM — creates a fresh conversation instead", async () => {
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(db, participants, connections);
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(authService, "alice");
+    const bob = await seedAgent(authService, "bob");
+
+    // 1. Create a DM between alice and bob.
+    const first = await Effect.runPromise(
+      service.create("dm", undefined, [bob], alice),
+    );
+
+    // 2. Archive it (alice is the creator/owner, so archive is permitted).
+    await Effect.runPromise(service.archive(first.id, alice));
+
+    // 3. Create a DM again with the same participants.
+    const second = await Effect.runPromise(
+      service.create("dm", undefined, [bob], alice),
+    );
+
+    // 4. The new DM must be a fresh row — not the archived one.
+    expect(second.id).not.toBe(first.id);
+  });
+});

--- a/packages/server/src/services/conversation.service.test.ts
+++ b/packages/server/src/services/conversation.service.test.ts
@@ -274,4 +274,27 @@ describe("ConversationService.create — archived DM lookup (issue #372)", () =>
     // 4. The new DM must be a fresh row — not the archived one.
     expect(second.id).not.toBe(first.id);
   });
+
+  it("still dedupes live DMs — repeat create returns the existing live DM", async () => {
+    // Positive guard: the archived_at filter must not over-filter and break
+    // the dedupe contract for live DMs. Without this guard, a future tweak
+    // that turns the filter into `archived_at IS NOT NULL` (or removes the
+    // EXISTS subqueries) would silently regress dedupe.
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(db, participants, connections);
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(authService, "alice");
+    const bob = await seedAgent(authService, "bob");
+
+    const first = await Effect.runPromise(
+      service.create("dm", undefined, [bob], alice),
+    );
+    const second = await Effect.runPromise(
+      service.create("dm", undefined, [bob], alice),
+    );
+
+    expect(second.id).toBe(first.id);
+  });
 });

--- a/packages/server/src/services/conversation.service.ts
+++ b/packages/server/src/services/conversation.service.ts
@@ -715,6 +715,7 @@ export class ConversationService {
           sql<ConversationColumns>`
             SELECT c.* FROM conversations c
             WHERE c.type = 'dm'
+            AND c.archived_at IS NULL
             AND EXISTS (
               SELECT 1 FROM conversation_participants cp
               WHERE cp.conversation_id = c.id


### PR DESCRIPTION
## Summary

Fixes [arena#372](https://github.com/chughtapan/moltzap/issues/372) — `conversations/create` returned an archived DM and reused it. After `closeSession` archives a DM, the next `conversations/create` for the same pair returned the archived row, but writes to it (`messages/send`) are rejected on archived conversations. The caller ended up with a conversation id it could never write to.

**Fix (Option A):** `findExistingDm` filters `c.archived_at IS NULL` in the SQL lookup. Archived DMs are dead — a fresh conversation is created for the next pairing instead.

This matches the repo's existing convention: `archived_at IS NULL` means live, non-NULL means archived (see the `archive`/`list` paths in the same service).

## Test plan

Added `ConversationService.create — archived DM lookup (issue #372)` in `conversation.service.test.ts`:

- [x] Creates a DM between alice and bob
- [x] Archives it
- [x] Creates a DM again with the same participants
- [x] Asserts the new DM has a different id (not the archived one)
- [x] All 6 tests in `conversation.service.test.ts` pass against PGlite
- [x] `pnpm build` clean
- [x] `pnpm lint` 0 warnings, 0 errors
- [x] `pnpm format` clean
- [x] `scripts/sloppy-code-guard.sh` passes
- [x] Codex review: pass (verified the SQL filter is correct and the test covers the regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)