### PR TITLE
chore: B.14 docs cleanup (closes #346 #347 #348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Effect<Verdict, never>` regardless of source (in-process or remote).
 - Manifest hook timeout (`manifest.hooks.<name>.timeout_ms`) is now
   enforced at the AppHost call site via `Effect.timeout(manifestMs)`.
-  Schema bounds (100ms-30000ms) remain.
 
 ### Removed
 
@@ -84,6 +83,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `app-disconnect-fail-policy` property that asserts pending s2c
   admissions fail with `AppDisconnected` and AppHost applies
   fail-closed verdicts when the app's WS is severed.
+- 30s upper bound on `hooks.<name>.timeout_ms` (B.4 follow-up #324).
+  The schema in `packages/protocol/src/schema/apps.ts` now reads
+  `Type.Integer({ default: 5000, minimum: 1 })` — no `maximum`.
 
 ### Migration
 

--- a/docs/development/contributing.mdx
+++ b/docs/development/contributing.mdx
@@ -18,6 +18,23 @@ description: Contribution guidelines and conventions
 
 MoltZap uses date-based versioning: `YYYY.MDD.patch` (e.g., `2026.407.0`). Versions are auto-bumped by the publish workflow.
 
+## Releases
+
+Releases land as `chore(release): @<pkg>@<version>` commits with the matching `package.json` bump. The npm publish workflow keys off those commits; downstream consumers that pin by commit SHA continue to work as-is.
+
+To make releases easier to reference symbolically (cross-repo submodule pins, `git describe`, GitHub release pages keyed off tags), tag each release commit with an **annotated** git tag.
+
+### Tag convention
+
+- **Per-package tags** that match the commit message format:
+  ```bash
+  git tag -a "@moltzap/server-core@2026.501.6" -m "@moltzap/server-core@2026.501.6"
+  git push origin "@moltzap/server-core@2026.501.6"
+  ```
+- Always use `git tag -a` (annotated) — never `git tag <name>` (lightweight). Annotated tags are first-class git objects: they carry a tagger, date, message, and an optional GPG signature, and `git describe` will only walk to them by default.
+- Tag against the `chore(release):` commit that bumped the version.
+- Do **not** retroactively tag historical release commits — adopt the convention going forward only.
+
 ## Branch conventions
 
 - `main` — stable, all tests pass

--- a/docs/guides/app-hooks-rpc.mdx
+++ b/docs/guides/app-hooks-rpc.mdx
@@ -186,7 +186,7 @@ the legacy webhook surface, this table is the port.
 | **Reply shape** | HTTP 200 with verdict JSON in the body | `Effect<HookResult>` (or `DispatchAdmissionResult`) returned from the handler |
 | **Retries** | Server retried on non-2xx | No retry. The AppHost fails closed on the first failure (deny / block). Intentional — admission must not double-fire. |
 | **Timeout** | `manifest.hooks.X.timeout_ms_remote_only` (separate from in-process timeout) | `manifest.hooks.X.timeout_ms` — single value, applied via `Effect.timeout` at the AppHost. |
-| **Schema-level cap** | 30s `maximum` constraint on `timeout_ms` | Cap retained at 30s today; the AppHost enforces it via `Effect.timeout(manifestMs)` per call. |
+| **Schema-level cap** | 30s `maximum` constraint on `timeout_ms` | No cap (B.4 follow-up #324 dropped the 30s `maximum`); the schema is `Type.Integer({ default: 5000, minimum: 1 })` and the AppHost enforces the manifest's declared value via `Effect.timeout(manifestMs)` per call. |
 | **Failure mode** | Non-2xx → server retried, then fail-closed | App disconnect mid-admission → fail-closed via the connection's Scope finalizer |
 | **Observability** | HTTP request log on your endpoint | `app/hookTimeout` event when a handler exceeds `timeout_ms`; SDK logger captures handler errors |
 

--- a/docs/migration/webhook-to-rpc.mdx
+++ b/docs/migration/webhook-to-rpc.mdx
@@ -24,9 +24,10 @@ The manifest schema rejects all three:
 - `hooks.<name>.timeout_ms_remote_only` — the remote-specific timeout
   override
 
-`hooks.<name>.timeout_ms` keeps its current bounds (100ms-30000ms).
-Per-call enforcement moves into the AppHost via
-`Effect.timeout(manifestMs)`.
+`hooks.<name>.timeout_ms` survives. The schema is now
+`Type.Integer({ default: 5000, minimum: 1 })` — no upper bound (the 30s
+`maximum` was removed in B.4 follow-up #324). Per-call enforcement moves
+into the AppHost via `Effect.timeout(manifestMs)`.
 
 The `WebhookClient.call(...)` hook-delivery code in `adapters/webhook.ts`
 is also gone. The `WebhookClient` class and `signWebhookPayload` helper

--- a/packages/app-sdk/src/errors.ts
+++ b/packages/app-sdk/src/errors.ts
@@ -369,11 +369,11 @@ export class AppHandlerError extends AppError {
  * external input that never arrived; misconfigured (too tight)
  * timeout for a legitimately slow workload.
  *
- * **Recovery:** raise `manifest.hooks.<name>.timeout_ms` (bounded to
- * the schema's current 100ms-30000ms range); cache the slow lookup;
- * or short-circuit fast inside the handler when the answer is already
- * known. The AppHost has already issued the fail-closed verdict; this
- * class is for observability.
+ * **Recovery:** raise `manifest.hooks.<name>.timeout_ms` (the schema is
+ * `Type.Integer({ default: 5000, minimum: 1 })` — no upper bound since
+ * B.4 follow-up #324); cache the slow lookup; or short-circuit fast
+ * inside the handler when the answer is already known. The AppHost has
+ * already issued the fail-closed verdict; this class is for observability.
  *
  * @example
  * ```ts

--- a/packages/server/src/app/hooks.ts
+++ b/packages/server/src/app/hooks.ts
@@ -53,7 +53,8 @@ const PartArraySchema = Schema.declare(
   { identifier: "PartArray" },
 );
 
-/** Wire schema for `HookResult` webhook responses. Single-layer `as`
+/** Wire schema for the `HookResult` RPC response from
+ *  `apps/onBeforeMessageDelivery` (s2c admission verb). Single-layer `as`
  *  reconciles effect-schema's encoded-type inference (which mirrors the
  *  Struct shape) with the caller's `Schema.Schema<_, unknown>` slot. */
 export const HookResultSchema = Schema.Struct({


### PR DESCRIPTION
## Summary

Three B.14 Phase 1 verify follow-ups (#344) bundled in one docs-only PR, plus an in-scope mop-up of adjacent stale references caught on a thorough sweep.

### Tracked issues
- **#346 — CHANGELOG drift**: drop the stale `Schema bounds (100ms-30000ms) remain` line from the Manifest hook timeout entry; add a `Removed` entry recording that the 30s upper bound on `hooks.<name>.timeout_ms` is gone (B.4 follow-up #324). Schema in `packages/protocol/src/schema/apps.ts` is `Type.Integer({ default: 5000, minimum: 1 })` — no `maximum`.
- **#347 — `packages/server/src/app/hooks.ts`**: rewrite the `HookResultSchema` doc comment from `webhook responses` (pre-#306 wording) to name the actual surface — `apps/onBeforeMessageDelivery` s2c RPC. Singular, because `apps/onBeforeDispatch` uses `BeforeDispatchRpcResultSchema` instead.
- **#348 — `docs/development/contributing.mdx`**: add a Releases section documenting the convention that release commits get **annotated** git tags (`git tag -a "@<pkg>@<version>"`) matching the `chore(release):` commit message. Going forward only — no retroactive tagging of historical release commits.

### Adjacent stale references (in-scope mop-up, second commit)

The sweep that caught #346 also surfaced three more places that still claimed the 30s upper bound exists. All fixed in the same PR:
- `docs/migration/webhook-to-rpc.mdx` — was: `keeps its current bounds (100ms-30000ms)`.
- `docs/guides/app-hooks-rpc.mdx` — was: `Cap retained at 30s today` row in the Webhook→RPC migration table.
- `packages/app-sdk/src/errors.ts` — was: `bounded to the schema's current 100ms-30000ms range` in the `AdmissionTimeoutError` Recovery JSDoc.

All three now reference the actual schema (`Type.Integer({ default: 5000, minimum: 1 })`) and B.4 follow-up #324. Other webhook references in the repo (`WebhookContactService`, `WebhookPermissionService`, `MessageService.deliveryWebhook`, `services.contacts/permissions/users` YAML, `WebhookClient` for surviving non-hook surfaces) were verified intentional — those are server-level integration surfaces that the CHANGELOG `Migration` block explicitly preserves.

## Pre-PR checks

- `pnpm build` — clean (all packages, both rounds)
- `pnpm --filter @moltzap/server-core test --run` — 181/181 (round 1)
- `pnpm --filter @moltzap/app-sdk test --run` — 89/89 (round 2; errors.ts JSDoc-only change)
- `pnpm lint` — 0/0 across 363 files
- Pre-commit hook (`pnpm typecheck` + Type Safety / Effect / Bare Catch / Test Integrity guards) — pass on both commits
- `codex exec -c model_reasoning_effort=high` review on each commit:
  - Commit 1: FAIL → fixed → PASS (overclaimed about npm publish/`gh release view` requiring tags; used plural `admission verbs` for `HookResultSchema`).
  - Commit 2: PASS first round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)