### PR TITLE
fix(server-core): direct conversations honor contact policy (closes #361)

### DIFF
--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -468,6 +468,17 @@ export class AppHost {
     this.contactService = checker;
   }
 
+  /**
+   * Read-side accessor used by peer services (notably
+   * {@link ConversationService}) that must consult the same contact policy
+   * AppHost uses for app-session admission. Returns `null` when no policy
+   * is wired — callers treat that as "allow all" to preserve dev-mode
+   * defaults.
+   */
+  getContactService(): ContactService | null {
+    return this.contactService;
+  }
+
   setPermissionService(handler: PermissionService): void {
     this.permissionService = handler;
   }

--- a/packages/server/src/app/layers.ts
+++ b/packages/server/src/app/layers.ts
@@ -170,8 +170,20 @@ export const ConversationServiceLive = Layer.effect(
     const participants = yield* ParticipantServiceTag;
     const connections = yield* ConnectionManagerTag;
     const appHost = yield* AppHostTag;
-    return new ConversationService(db, participants, connections, (convId) =>
-      appHost.isAttachedToActiveSession(convId),
+    return new ConversationService(
+      db,
+      participants,
+      connections,
+      (convId) => appHost.isAttachedToActiveSession(convId),
+      // Lazy: AppHost.contactService is wired post-construction in
+      // standalone.ts (`app.setContactService(...)`) AFTER this Layer has
+      // already produced its ConversationService instance, so capturing
+      // a snapshot here would always be `null`.
+      () => {
+        const cs = appHost.getContactService();
+        if (!cs) return null;
+        return (a, b) => cs.areInContact(a, b);
+      },
     );
   }),
 );

--- a/packages/server/src/runtime/errors.ts
+++ b/packages/server/src/runtime/errors.ts
@@ -47,6 +47,16 @@ export const rateLimited = (
   message = "Please wait before trying again",
 ): RpcFailure => new RpcFailure({ code: ErrorCodes.RateLimited, message });
 
+/**
+ * Direct/group communication blocked because the policy held by
+ * `ContactService` does not allow the two parties to talk. Carries the
+ * dedicated `NotInContacts` code so clients can distinguish a contact-policy
+ * denial from a generic `Forbidden`.
+ */
+export const notInContacts = (
+  message = "Not allowed by contact policy",
+): RpcFailure => new RpcFailure({ code: ErrorCodes.NotInContacts, message });
+
 /** Boundary validation error — raised when an AJV validator rejects `params`. */
 export class InvalidParamsError extends Data.TaggedError("InvalidParamsError")<{
   readonly message: string;

--- a/packages/server/src/runtime/index.ts
+++ b/packages/server/src/runtime/index.ts
@@ -10,6 +10,7 @@ export {
   internalError,
   blocked,
   rateLimited,
+  notInContacts,
 } from "./errors.js";
 export { validateParams, type Validator } from "./validator.js";
 export { coalesce, drainCoalesceMap } from "./coalesce.js";

--- a/packages/server/src/services/conversation.service.test.ts
+++ b/packages/server/src/services/conversation.service.test.ts
@@ -17,7 +17,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { Effect } from "effect";
+import { Cause, Effect, Exit } from "effect";
+import { ErrorCodes } from "@moltzap/protocol";
+import { RpcFailure } from "../runtime/index.js";
 import type { Kysely } from "kysely";
 import { KyselyPGlite } from "kysely-pglite";
 import { readFileSync } from "node:fs";
@@ -86,11 +88,28 @@ function makeConn(connId: string, agentId: string): MoltZapConnection {
 async function seedAgent(
   authService: AuthService,
   name: string,
+  ownerUserId?: string,
 ): Promise<string> {
   const { agentId } = await Effect.runPromise(
-    authService.registerAgent({ name }),
+    authService.registerAgent({ name }, ownerUserId),
   );
   return agentId;
+}
+
+/** Extract the underlying RpcFailure so tests can assert on wire-level codes. */
+function expectRpcFailure<A>(exit: Exit.Exit<A, RpcFailure>): RpcFailure {
+  if (Exit.isSuccess(exit)) {
+    throw new Error(
+      `Expected RpcFailure, got success: ${JSON.stringify(exit.value)}`,
+    );
+  }
+  const failure = Cause.failureOption(exit.cause);
+  if (failure._tag !== "Some") {
+    throw new Error(
+      `Expected tagged failure, got: ${Cause.pretty(exit.cause)}`,
+    );
+  }
+  return failure.value;
 }
 
 describe("ConversationService.create auto-subscribes participants", () => {
@@ -296,5 +315,196 @@ describe("ConversationService.create — archived DM lookup (issue #372)", () =>
     );
 
     expect(second.id).toBe(first.id);
+  });
+});
+
+/**
+ * Regression for moltzap#361: direct conversation creation must consult
+ * the contact policy. When `ConversationService.create("dm", ...)` ran
+ * without the gate, two agents whose owners had no contact edge could
+ * still open a DM (and `messages/send { to }` would auto-create one
+ * through `createDmByAgentName`).
+ *
+ * The contact policy is exposed as a lazy resolver because in production
+ * it is registered on AppHost AFTER ConversationService has been
+ * constructed (`app.setContactService(...)` in `standalone.ts`). These
+ * tests inject the resolver directly to keep the contract pinned at the
+ * service boundary.
+ */
+describe("ConversationService.create enforces contact policy on DMs", () => {
+  beforeEach(freshDb, dbHookTimeoutMs);
+  afterEach(async () => {
+    await pglite?.close();
+  });
+
+  it("denies DM creation when owners are not in contact (NotInContacts)", async () => {
+    const calls: Array<[string, string]> = [];
+    const policy = (a: string, b: string) =>
+      Effect.sync(() => {
+        calls.push([a, b]);
+        return false;
+      });
+
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(
+      db,
+      participants,
+      connections,
+      undefined,
+      () => policy,
+    );
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(
+      authService,
+      "alice",
+      "00000000-0000-0000-0000-0000000000a1",
+    );
+    const bob = await seedAgent(
+      authService,
+      "bob",
+      "00000000-0000-0000-0000-0000000000b2",
+    );
+
+    const exit = await Effect.runPromiseExit(
+      service.create("dm", undefined, [bob], alice),
+    );
+    const failure = expectRpcFailure(exit);
+
+    expect(failure.code).toBe(ErrorCodes.NotInContacts);
+    expect(failure.message).toMatch(/contact policy/i);
+    expect(calls).toEqual([
+      [
+        "00000000-0000-0000-0000-0000000000a1",
+        "00000000-0000-0000-0000-0000000000b2",
+      ],
+    ]);
+  });
+
+  it("creates the DM when owners are in contact", async () => {
+    const policy = () => Effect.succeed(true);
+
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(
+      db,
+      participants,
+      connections,
+      undefined,
+      () => policy,
+    );
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(
+      authService,
+      "alice",
+      "00000000-0000-0000-0000-0000000000a1",
+    );
+    const bob = await seedAgent(
+      authService,
+      "bob",
+      "00000000-0000-0000-0000-0000000000b2",
+    );
+
+    const aliceConn = makeConn("c-alice", alice);
+    const bobConn = makeConn("c-bob", bob);
+    connections.add(aliceConn);
+    connections.add(bobConn);
+
+    const conv = await Effect.runPromise(
+      service.create("dm", undefined, [bob], alice),
+    );
+
+    expect(conv.type).toBe("dm");
+    expect(aliceConn.conversationIds.has(conv.id)).toBe(true);
+    expect(bobConn.conversationIds.has(conv.id)).toBe(true);
+  });
+
+  it("denies the DM when either agent has no owner_user_id", async () => {
+    const policy = () => Effect.succeed(true); // would allow if reached
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(
+      db,
+      participants,
+      connections,
+      undefined,
+      () => policy,
+    );
+    const authService = new AuthService(db);
+
+    // Alice has an owner; Bob is owner-less. The policy can't evaluate
+    // the edge → fail closed with NotInContacts (matches AppHost's
+    // checkIdentity stance for app-session admission).
+    const alice = await seedAgent(
+      authService,
+      "alice",
+      "00000000-0000-0000-0000-0000000000a1",
+    );
+    const bob = await seedAgent(authService, "bob");
+
+    const exit = await Effect.runPromiseExit(
+      service.create("dm", undefined, [bob], alice),
+    );
+    const failure = expectRpcFailure(exit);
+    expect(failure.code).toBe(ErrorCodes.NotInContacts);
+  });
+
+  it("permits DMs when no policy is configured (default behavior preserved)", async () => {
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(db, participants, connections);
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(authService, "alice");
+    const bob = await seedAgent(authService, "bob");
+
+    const conv = await Effect.runPromise(
+      service.create("dm", undefined, [bob], alice),
+    );
+    expect(conv.type).toBe("dm");
+  });
+
+  it("returns the existing DM without re-checking policy (idempotent)", async () => {
+    const calls: Array<[string, string]> = [];
+    const policy = (a: string, b: string) =>
+      Effect.sync(() => {
+        calls.push([a, b]);
+        return true;
+      });
+
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(
+      db,
+      participants,
+      connections,
+      undefined,
+      () => policy,
+    );
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(
+      authService,
+      "alice",
+      "00000000-0000-0000-0000-0000000000a1",
+    );
+    const bob = await seedAgent(
+      authService,
+      "bob",
+      "00000000-0000-0000-0000-0000000000b2",
+    );
+
+    const first = await Effect.runPromise(
+      service.create("dm", undefined, [bob], alice),
+    );
+    const second = await Effect.runPromise(
+      service.create("dm", undefined, [bob], alice),
+    );
+
+    expect(second.id).toBe(first.id);
+    // Policy invoked exactly once — for the create that actually inserted.
+    expect(calls.length).toBe(1);
   });
 });

--- a/packages/server/src/services/conversation.service.ts
+++ b/packages/server/src/services/conversation.service.ts
@@ -12,6 +12,7 @@ import {
   forbidden,
   conflict,
   invalidParams,
+  notInContacts,
 } from "../runtime/index.js";
 import { ErrorCodes } from "@moltzap/protocol";
 import { ParticipantService } from "./participant.service.js";
@@ -27,6 +28,24 @@ import {
 
 const MAX_GROUP_PARTICIPANTS = 256;
 const PREVIEW_CACHE_MAX = 2000;
+
+/**
+ * Policy gate consulted before a direct conversation is created. Returns
+ * `true` to allow the DM, `false` to deny it. The `Effect<_, never>` shape
+ * mirrors {@link ContactService.areInContact} on AppHost — implementations
+ * absorb webhook failures internally and surface a boolean verdict.
+ *
+ * Passed as a lazy lookup (not a captured reference) because the
+ * underlying service is registered on AppHost AFTER ConversationService is
+ * constructed via `app.setContactService(...)` in `standalone.ts`.
+ */
+export type ContactPolicyCheck = (
+  ownerUserIdA: string,
+  ownerUserIdB: string,
+) => Effect.Effect<boolean, never>;
+
+/** Lazy resolver — `null` means "no policy configured, allow all". */
+export type ContactPolicyResolver = () => ContactPolicyCheck | null;
 
 interface ListRow {
   id: string;
@@ -57,6 +76,14 @@ export class ConversationService {
     private connections: ConnectionManager,
     private isAttachedToActiveSession: (convId: string) => boolean = () =>
       false,
+    /**
+     * Lazy lookup for the active contact policy. Returns `null` when no
+     * policy is wired (default for unit tests + dev mode), in which case
+     * direct conversation creation is unrestricted. Returning a check
+     * function gates direct conversation creation: both agents must have
+     * `owner_user_id` set and the owners must be in contact.
+     */
+    private resolveContactPolicy: ContactPolicyResolver = () => null,
   ) {}
 
   /** Write-through: called from MessageService.send() with plaintext parts before encryption */
@@ -77,16 +104,22 @@ export class ConversationService {
   ): Effect.Effect<Conversation, RpcFailure> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
-        if (agentIds.length > 0) {
-          const found = yield* this.db
-            .selectFrom("agents")
-            .select("id")
-            .where("id", "in", agentIds);
-          const foundIds = new Set(found.map((r) => r.id));
-          for (const agentId of agentIds) {
-            if (!foundIds.has(agentId)) {
-              return yield* Effect.fail(notFound(`Agent ${agentId} not found`));
-            }
+        // Owner-id is read in the same query as the existence check so the
+        // DM contact-policy gate below doesn't issue a second round-trip.
+        const agentRows =
+          agentIds.length > 0
+            ? yield* this.db
+                .selectFrom("agents")
+                .select(["id", "owner_user_id"])
+                .where("id", "in", agentIds)
+            : [];
+        const ownerByAgentId = new Map<string, string | null>();
+        for (const row of agentRows) {
+          ownerByAgentId.set(row.id, row.owner_user_id);
+        }
+        for (const agentId of agentIds) {
+          if (!ownerByAgentId.has(agentId)) {
+            return yield* Effect.fail(notFound(`Agent ${agentId} not found`));
           }
         }
 
@@ -105,6 +138,23 @@ export class ConversationService {
           );
           if (existingDm) {
             return existingDm;
+          }
+
+          // Contact-policy gate: only enforced when a policy is wired
+          // (production via `WebhookContactService` in standalone.ts;
+          // dev/tests default to "no policy = allow all"). DMs are a
+          // direct edge between two agent owners, so a missing
+          // `owner_user_id` on either side cannot be evaluated against
+          // the policy and is treated as a denial — same fail-closed
+          // shape AppHost.checkIdentity uses for app-session admission.
+          const policy = this.resolveContactPolicy();
+          if (policy) {
+            yield* this.requireDirectAllowed(
+              creatorAgentId,
+              agentIds[0]!,
+              ownerByAgentId.get(agentIds[0]!) ?? null,
+              policy,
+            );
           }
         }
 
@@ -699,6 +749,62 @@ export class ConversationService {
         }
         if (!allowedRoles.includes(rowOpt.value.role)) {
           return yield* Effect.fail(forbidden("Insufficient permissions"));
+        }
+      }),
+    );
+  }
+
+  /**
+   * Enforce contact policy for a brand-new direct conversation. Loads the
+   * creator's `owner_user_id` (the target's was already read in the
+   * existence-check query above) and consults the policy. Both agents must
+   * have an owner; otherwise the DM is denied with the same `NotInContacts`
+   * code the policy itself uses, so callers see one error shape regardless
+   * of which precondition failed.
+   */
+  private requireDirectAllowed(
+    creatorAgentId: string,
+    targetAgentId: string,
+    targetOwnerUserId: string | null,
+    policy: ContactPolicyCheck,
+  ): Effect.Effect<void, RpcFailure> {
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        const creatorOpt = yield* takeFirstOption(
+          this.db
+            .selectFrom("agents")
+            .select(["owner_user_id"])
+            .where("id", "=", creatorAgentId),
+        );
+        if (Option.isNone(creatorOpt)) {
+          return yield* Effect.fail(
+            notFound(`Agent ${creatorAgentId} not found`),
+          );
+        }
+        const creatorOwner = creatorOpt.value.owner_user_id;
+        if (!creatorOwner || !targetOwnerUserId) {
+          return yield* Effect.fail(
+            notInContacts(
+              "Direct conversation requires both agents to have an owner",
+            ),
+          );
+        }
+
+        const allowed = yield* policy(creatorOwner, targetOwnerUserId);
+        if (!allowed) {
+          yield* Effect.logInfo(
+            "Direct conversation denied by contact policy",
+          ).pipe(
+            Effect.annotateLogs({
+              creatorAgentId,
+              targetAgentId,
+              creatorOwner,
+              targetOwner: targetOwnerUserId,
+            }),
+          );
+          return yield* Effect.fail(
+            notInContacts("Direct conversation not allowed by contact policy"),
+          );
         }
       }),
     );


### PR DESCRIPTION
## Summary

`ConversationService.create("dm", ...)` (and the `messages/send { to: "agent:<name>" }` path through `createDmByAgentName`) was inserting DM participants without consulting the contact-policy `ContactService` that AppHost already uses for app-session admission. Two agents whose owners had no allowed-contact edge could open a DM and exchange messages — bypassing the experiment's communication topology.

Closes #361.

## What changed

- **`AppHost.getContactService()`** (new) exposes the post-construction `setContactService(...)` value to peer services so the policy is defined in one place.
- **`ConversationServiceLive`** wires a *lazy* resolver into the service — lazy because `app.setContactService(...)` runs in `standalone.ts` AFTER the layer has already produced its instance, so a captured snapshot would always be `null`.
- **`ConversationService.create`** now reads `owner_user_id` for each participant in the existing existence-check query (no extra round-trip), and for `type === "dm"` calls the policy after `findExistingDm` (so previously-created DMs stay accessible — idempotent semantics preserved).
- **Typed errors** (Principle 3): failures use `RpcFailure` with the dedicated `ErrorCodes.NotInContacts` code via the new `notInContacts(...)` factory in `runtime/errors.ts`. Missing `owner_user_id` on either side fails closed with the same code, matching `AppHost.checkIdentity`'s stance for app-session admission.

## Behavior matrix

| Scenario                                          | Before        | After                        |
| ------------------------------------------------- | ------------- | ---------------------------- |
| No policy configured (dev/local)                  | DM created    | DM created (unchanged)       |
| Policy set, owners NOT in contact                 | **DM created (bug)** | **`NotInContacts` denial**   |
| Policy set, owners in contact                     | DM created    | DM created                   |
| Policy set, either agent owner-less               | DM created    | `NotInContacts` denial       |
| Existing DM (idempotent re-create)                | Returned      | Returned (policy not re-run) |

## Tests

New PGlite-backed unit tests in `conversation.service.test.ts` lock the contract at the service boundary (per the existing test docstring's pattern):

- DENY when policy returns `false` — asserts `NotInContacts` code + policy invocation args
- SUCCESS when policy returns `true` — DM created, sockets subscribed
- DENY when either agent is owner-less
- ALLOW when no policy is configured (preserves dev-mode default)
- IDEMPOTENT — second create returns the existing DM without re-invoking the policy

## Scope notes

This PR addresses the **direct conversation creation** path called out in the issue (`conversations/create` of `type: "dm"` and the `messages/send { to }` auto-create that funnels through it). The other gates the issue's spec questions raise — `conversations/add-participant`, group creation, app-session conversations — remain follow-ups; the spec on #361 is the place to settle which ones get gated and how. The new `ContactPolicyResolver` plumbing is reusable for those follow-ups.

## Test plan

- [x] `pnpm --filter @moltzap/server-core test` — 186/186 passing
- [x] `pnpm --filter @moltzap/server-core build` — clean
- [x] `pnpm lint` — 0/0
- [x] `pnpm format:check` — clean
- [x] `scripts/sloppy-code-guard.sh` — passes
- [x] Pre-commit hook (lint + typecheck) — passes
- [ ] Integration tests: continue to pass (no contact policy configured in their YAML, so default-allow path preserved). Worth running in CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)