### PR TITLE
chore: thorough-pass — strengthen messages.test.ts fixture (followup to #379)

### DIFF
--- a/packages/client/src/cli/commands/messages.test.ts
+++ b/packages/client/src/cli/commands/messages.test.ts
@@ -53,10 +53,14 @@ describe("messages list", () => {
   afterEach(() => stdout.mockRestore());
 
   it("calls messages/list with { conversationId, limit? } and emits one line per message", async () => {
+    // Fixture mirrors the wire shape produced by the server's `mapMessage`:
+    // every `MessageSchema` field is present (including `conversationId`)
+    // plus the server-computed `senderName` the CLI displays.
     const { calls, transport } = makeFakeTransport(() => ({
       messages: [
         {
           id: "m1",
+          conversationId: "c1",
           senderId: "a1",
           senderName: "alice",
           createdAt: "2026-04-24T00:00:00Z",
@@ -64,6 +68,7 @@ describe("messages list", () => {
         },
         {
           id: "m2",
+          conversationId: "c1",
           senderId: "b1",
           senderName: "bob",
           createdAt: "2026-04-24T00:00:01Z",

--- a/packages/client/src/cli/commands/messages.test.ts
+++ b/packages/client/src/cli/commands/messages.test.ts
@@ -57,7 +57,6 @@ describe("messages list", () => {
       messages: [
         {
           id: "m1",
-          seq: 1,
           senderId: "a1",
           senderName: "alice",
           createdAt: "2026-04-24T00:00:00Z",
@@ -65,7 +64,6 @@ describe("messages list", () => {
         },
         {
           id: "m2",
-          seq: 2,
           senderId: "b1",
           senderName: "bob",
           createdAt: "2026-04-24T00:00:01Z",
@@ -84,6 +82,12 @@ describe("messages list", () => {
       params: { conversationId: "c1", limit: 50 },
     });
     expect(stdout).toHaveBeenCalledTimes(2);
+    // Regression #216: first column is `createdAt`, never `undefined`.
+    // MessageSchema has no `seq` field; the previous output stringified
+    // `m.seq` as the literal "undefined" in the leading column.
+    const firstLine = String(stdout.mock.calls[0]?.[0] ?? "");
+    expect(firstLine.startsWith("undefined\t")).toBe(false);
+    expect(firstLine).toBe("2026-04-24T00:00:00Z\talice\thello");
   });
 
   it("omits limit when absent", async () => {

--- a/packages/client/src/cli/commands/messages.ts
+++ b/packages/client/src/cli/commands/messages.ts
@@ -48,7 +48,6 @@ export interface MessagesListArgs {
 
 interface WireMessage {
   readonly id: string;
-  readonly seq: number;
   readonly senderId: string;
   readonly senderName?: string;
   readonly createdAt: string;
@@ -78,7 +77,7 @@ export const messagesListHandler = (
       for (const m of result.messages) {
         const text = m.parts.find((p) => p.type === "text")?.text ?? "";
         const sender = m.senderName ?? m.senderId;
-        console.log(`${m.seq}\t${sender}\t${text}`);
+        console.log(`${m.createdAt}\t${sender}\t${text}`);
       }
       if (result.hasMore) {
         console.log("... more messages available");

--- a/packages/protocol/src/helpers.test.ts
+++ b/packages/protocol/src/helpers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
+import { FormatRegistry, Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
 import { stringEnum, brandedId, DateTimeString } from "./helpers.js";
 
 const ajv = addFormats(new Ajv({ strict: true }));
@@ -51,5 +53,40 @@ describe("DateTimeString", () => {
   it("rejects non-datetime strings", () => {
     const validate = ajv.compile(DateTimeString);
     expect(validate("not-a-date")).toBe(false);
+  });
+});
+
+/**
+ * Regression #370: importing `@moltzap/protocol` (or any of its helpers)
+ * must register the `uuid`, `date-time`, and `uri` formats with TypeBox's
+ * `FormatRegistry` as a side effect. Otherwise `Value.Decode` against any
+ * schema using these formats fails with "Unknown format <name>" and every
+ * frame is rejected.
+ */
+describe("TypeBox FormatRegistry side-effect registration", () => {
+  it("registers uuid", () => {
+    expect(FormatRegistry.Has("uuid")).toBe(true);
+    const schema = brandedId("AgentId");
+    expect(Value.Check(schema, "550e8400-e29b-41d4-a716-446655440000")).toBe(
+      true,
+    );
+    expect(Value.Check(schema, "not-a-uuid")).toBe(false);
+  });
+
+  it("registers date-time", () => {
+    expect(FormatRegistry.Has("date-time")).toBe(true);
+    expect(Value.Check(DateTimeString, "2026-03-14T12:00:00.000Z")).toBe(true);
+    expect(Value.Check(DateTimeString, "not-a-date")).toBe(false);
+    // Shape-valid but semantically impossible — must reject.
+    expect(Value.Check(DateTimeString, "2026-99-99T99:99:99Z")).toBe(false);
+  });
+
+  it("registers uri", () => {
+    expect(FormatRegistry.Has("uri")).toBe(true);
+    const uriSchema = Type.String({ format: "uri" });
+    expect(Value.Check(uriSchema, "https://example.com/path")).toBe(true);
+    expect(Value.Check(uriSchema, "moltzap:foo/bar")).toBe(true);
+    expect(Value.Check(uriSchema, "not a uri")).toBe(false);
+    expect(Value.Check(uriSchema, "://missing-scheme")).toBe(false);
   });
 });

--- a/packages/protocol/src/helpers.ts
+++ b/packages/protocol/src/helpers.ts
@@ -1,4 +1,47 @@
-import { Type, type TString } from "@sinclair/typebox";
+import { FormatRegistry, Type, type TString } from "@sinclair/typebox";
+
+/**
+ * Register the string formats this protocol uses with TypeBox's
+ * `FormatRegistry` as a side effect at module load. Without this,
+ * `Value.Decode` against any schema that uses `format: "uuid"` (and friends)
+ * fails with `Unknown format uuid` and every frame is rejected — see #370.
+ *
+ * Registering here makes downstream consumers correct by construction:
+ * importing anything from `@moltzap/protocol` registers the formats, even
+ * via dynamic-import paths that never reach a bin entrypoint.
+ *
+ * `FormatRegistry` is a process-global, so we gate on `Has(...)` to avoid
+ * clobbering a consumer-provided stricter validator that ran before us.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Shape filter for RFC 3339 / ISO 8601. We pair it with `Date.parse` so
+// values like "2026-99-99T99:99:99Z" — shape-valid but semantically
+// impossible — also reject.
+const DATE_TIME_RE =
+  /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+// Liberal URI matcher: scheme + ":" + non-whitespace remainder. Tighter
+// validation (e.g., authority parsing) lives in the consumer if needed.
+const URI_RE = /^[A-Za-z][A-Za-z0-9+.-]*:\S+$/;
+
+if (!FormatRegistry.Has("uuid")) {
+  FormatRegistry.Set(
+    "uuid",
+    (value) => typeof value === "string" && UUID_RE.test(value),
+  );
+}
+if (!FormatRegistry.Has("date-time")) {
+  FormatRegistry.Set("date-time", (value) => {
+    if (typeof value !== "string" || !DATE_TIME_RE.test(value)) return false;
+    return Number.isFinite(Date.parse(value));
+  });
+}
+if (!FormatRegistry.Has("uri")) {
+  FormatRegistry.Set(
+    "uri",
+    (value) => typeof value === "string" && URI_RE.test(value),
+  );
+}
 
 /**
  * Creates a string enum schema without producing anyOf (which some validators reject).

--- a/packages/server/src/runtime-surface/config.test.ts
+++ b/packages/server/src/runtime-surface/config.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import { loadRuntimeProcessConfig } from "./config.js";
+
+/**
+ * Regression: `withPatchedProcessEnv(processEnv, …)` was called with
+ * `processEnv === process.env` from `loadRuntimeProcessConfig`. The previous
+ * implementation deleted every key from `process.env` and then iterated
+ * `Object.entries(next)` over the now-empty same reference — leaving
+ * `process.env` empty for the duration of the YAML load. Compose-style
+ * `${VAR}` interpolation in moltzap.yaml then reported the var missing
+ * even when it was set in the container's env.
+ *
+ * This test pins the fix: passing `process.env` directly must preserve every
+ * key both during the load (so YAML interpolation works) and after.
+ */
+
+let tmpDir: string;
+const ENV_KEY = "MOLTZAP_TEST_PATCH_KEY";
+const ENV_VALUE = "regression-352-value";
+const TOUCHED_KEYS = [ENV_KEY, "MOLTZAP_DEV_MODE"] as const;
+let savedEnv: Map<string, string | undefined>;
+
+function writeYaml(path: string, body: string): void {
+  writeFileSync(path, body, "utf-8");
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "moltzap-runtime-config-"));
+  // Save prior values so afterEach restores rather than blindly deletes —
+  // otherwise we could erase a caller-provided env value or leak across
+  // tests that share these keys.
+  savedEnv = new Map(TOUCHED_KEYS.map((k) => [k, process.env[k]]));
+  process.env[ENV_KEY] = ENV_VALUE;
+  process.env["MOLTZAP_DEV_MODE"] = "true";
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  for (const key of TOUCHED_KEYS) {
+    const prior = savedEnv.get(key);
+    if (prior === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = prior;
+    }
+  }
+});
+
+describe("loadRuntimeProcessConfig — env patching", () => {
+  it("does not lose keys when processEnv === process.env (regression #352)", async () => {
+    const configPath = join(tmpDir, "moltzap.yaml");
+    writeYaml(configPath, `registration:\n  secret: \${${ENV_KEY}}\n`);
+
+    const beforeKeys = Object.keys(process.env).length;
+
+    const result = await Effect.runPromise(
+      loadRuntimeProcessConfig({
+        configPath: configPath as Parameters<
+          typeof loadRuntimeProcessConfig
+        >[0]["configPath"],
+        // Critical: same reference as process.env reproduces the bug.
+        processEnv: process.env,
+      }),
+    );
+
+    expect(result.app.registration?.secret).toBe(ENV_VALUE);
+    // process.env survives the load (no keys lost).
+    expect(process.env[ENV_KEY]).toBe(ENV_VALUE);
+    expect(Object.keys(process.env).length).toBe(beforeKeys);
+  });
+
+  it("still works when processEnv is a separate snapshot", async () => {
+    const configPath = join(tmpDir, "moltzap.yaml");
+    writeYaml(configPath, `registration:\n  secret: \${${ENV_KEY}}\n`);
+
+    // Spread to break reference identity with process.env.
+    const snapshot = { ...process.env };
+    const result = await Effect.runPromise(
+      loadRuntimeProcessConfig({
+        configPath: configPath as Parameters<
+          typeof loadRuntimeProcessConfig
+        >[0]["configPath"],
+        processEnv: snapshot,
+      }),
+    );
+
+    expect(result.app.registration?.secret).toBe(ENV_VALUE);
+    expect(process.env[ENV_KEY]).toBe(ENV_VALUE);
+  });
+});

--- a/packages/server/src/runtime-surface/config.ts
+++ b/packages/server/src/runtime-surface/config.ts
@@ -80,10 +80,14 @@ function resolveRuntimeConfigPath(
 }
 
 function replaceProcessEnv(next: ProcessEnvSnapshot): void {
+  // Snapshot before mutation: when `next === process.env`, deleting keys
+  // from process.env would also empty `next`, leaving the iteration over
+  // entries empty and process.env wiped. Copy first, then delete-and-replace.
+  const snapshot = { ...next };
   for (const key of Object.keys(process.env)) {
     delete process.env[key];
   }
-  for (const [key, value] of Object.entries(next)) {
+  for (const [key, value] of Object.entries(snapshot)) {
     if (value !== undefined) {
       process.env[key] = value;
     }


### PR DESCRIPTION
Followup to merged PR #379. Per team-lead's "be thorough" directive after the original PR landed, this picks up the one remaining loose end from the codex review pass.

## What changed

`packages/client/src/cli/commands/messages.test.ts` — adds the required `conversationId` field to the `messages/list` fake transport fixture so the test reflects the real wire shape produced by the server's `mapMessage`. Codex flagged the fixture as missing this `MessageSchema`-required field during the original PR review; was deferred as pre-existing. Now in scope per the thoroughness directive.

## Adjacent-issue sweep summary

This PR also serves as the audit log for the broader sweep:

- **#352 area** — `delete process.env`/`Object.keys(process.env)` mutator survey: only one in the codebase (`runtime-surface/config.ts`). No other self-aliasing risk found.
- **#216 area** — every CLI command's `console.log` formatting verified against its actual schema:
  - `apps list` → `AppSession` (id/appId/status all required) ✓
  - `agents list` / `agents lookup` → `AgentCard` (optional fields gated with `if`) ✓
  - `conversations list` → `ConversationSummary` (`name ?? type` fallback, `lastMessagePreview` gated) ✓
  - `permissions list` → all required fields ✓
  - `messages list` → fixed in #379 ✓
- **#370 area** — every `Value.Decode` / `Value.Check` consumer in the repo lives inside `@moltzap/protocol` itself; the side-effect import in helpers.ts covers all of them. Server `config/schema.ts` uses Ajv directly with separate format support.
- **#208 / #213** — re-verified clean: `pnpm typecheck` passes; `examples/mountains-or-beaches` builds cleanly.

## Pre-existing concern flagged (NOT addressed — out of junior scope)

`packages/client/src/cli/commands/conversations.ts` exports `historyCommand` that calls `request("history", …)`, but no `history` RPC is defined in `@moltzap/protocol` or registered on the server. Stale dead-code path. Filing this as a separate issue is the right next step — fixing it requires either deleting the command surface (CLI architectural decision) or adding a server handler (architect-tier).

## Verification

- `pnpm build` — clean
- `pnpm typecheck` — clean
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm format:check` — clean
- `pnpm test` — all passing (messages.test.ts: 3 passed)
- `./scripts/sloppy-code-guard.sh` — all guards passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)