### PR TITLE
fix(runtimes): resolve OpenClaw channel deps via require.resolve (closes #285)

### DIFF
--- a/packages/runtimes/src/channel-plugin-install.test.ts
+++ b/packages/runtimes/src/channel-plugin-install.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the channel-plugin install helpers.
+ *
+ * Specifically guards the regression in moltzap#285: the OpenClaw adapter
+ * used to assume runtime deps lived under `<channelPackage>/dist/node_modules/`.
+ * That layout only exists in some published artifacts; in workspace dev
+ * mode `pnpm install` puts the dep at `<channelPackage>/node_modules/` (or
+ * hoists it to the repo root).
+ *
+ * `resolveChannelDependency` should walk Node's standard module resolution
+ * starting from the channel package's `package.json`, so it finds the dep
+ * whether it's per-package, hoisted to a parent `node_modules`, or any
+ * other layout Node would normally walk to — none of which require
+ * `dist/node_modules` to exist.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  installChannelPlugin,
+  resolveChannelDependency,
+} from "./channel-plugin-install.js";
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), "channel-plugin-install-"));
+});
+
+afterEach(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("resolveChannelDependency", () => {
+  it("resolves a dep installed at the channel package's own node_modules (no dist/node_modules required)", () => {
+    const channelPkg = path.join(workDir, "openclaw-channel");
+    const depPkg = path.join(channelPkg, "node_modules", "effect");
+    seedPackage(channelPkg, { name: "@moltzap/openclaw-channel" });
+    seedPackage(depPkg, { name: "effect", version: "3.21.0" });
+
+    const resolved = resolveChannelDependency(channelPkg, "effect");
+
+    expect(resolved).toBe(depPkg);
+    expect(resolved).not.toContain("dist/node_modules");
+  });
+
+  it("resolves a dep hoisted to a parent (workspace-root) node_modules", () => {
+    const channelPkg = path.join(workDir, "packages", "openclaw-channel");
+    const hoistedDep = path.join(workDir, "node_modules", "effect");
+    seedPackage(channelPkg, { name: "@moltzap/openclaw-channel" });
+    seedPackage(hoistedDep, { name: "effect", version: "3.21.0" });
+
+    const resolved = resolveChannelDependency(channelPkg, "effect");
+
+    expect(resolved).toBe(hoistedDep);
+  });
+
+  it("returns null when the channel package has no package.json", () => {
+    const channelPkg = path.join(workDir, "openclaw-channel");
+    fs.mkdirSync(channelPkg, { recursive: true });
+    expect(resolveChannelDependency(channelPkg, "effect")).toBeNull();
+  });
+
+  it("returns null when the dep cannot be found anywhere in the resolution chain", () => {
+    const channelPkg = path.join(workDir, "openclaw-channel");
+    seedPackage(channelPkg, { name: "@moltzap/openclaw-channel" });
+    // A purposefully-improbable scoped name keeps Node's parent-walking
+    // resolution from accidentally finding a real install (workDir lives
+    // under `/tmp`, which on dev machines can sit beneath populated
+    // node_modules trees).
+    expect(
+      resolveChannelDependency(channelPkg, "@moltzap/__nonexistent-dep-285__"),
+    ).toBeNull();
+  });
+
+  it("returns the package root (not a dist subpath) for packages whose main lives under dist/", () => {
+    const channelPkg = path.join(workDir, "openclaw-channel");
+    const depPkg = path.join(channelPkg, "node_modules", "fancy-dep");
+    seedPackage(channelPkg, { name: "@moltzap/openclaw-channel" });
+    seedPackage(depPkg, {
+      name: "fancy-dep",
+      version: "1.0.0",
+      main: "dist/index.js",
+    });
+
+    const resolved = resolveChannelDependency(channelPkg, "fancy-dep");
+
+    expect(resolved).toBe(depPkg);
+  });
+});
+
+describe("installChannelPlugin (workspace layout, no dist/node_modules)", () => {
+  it("symlinks an extraSymlink dep from the workspace node_modules when dist/node_modules is absent", () => {
+    // Mirror real workspace layout: a channel package with its built dist/
+    // and a sibling node_modules containing the runtime dep — exactly the
+    // shape `pnpm install --frozen-lockfile && pnpm -r build` produces and
+    // the shape that triggered #285.
+    const repoRoot = workDir;
+    const channelPkg = path.join(repoRoot, "packages", "openclaw-channel");
+    const channelDist = path.join(channelPkg, "dist");
+    const channelDepDir = path.join(channelPkg, "node_modules", "effect");
+    const protocolPkg = path.join(repoRoot, "packages", "protocol");
+    const clientPkg = path.join(repoRoot, "packages", "client");
+    const stateDir = path.join(repoRoot, ".state");
+
+    seedPackage(channelPkg, { name: "@moltzap/openclaw-channel" });
+    fs.mkdirSync(channelDist, { recursive: true });
+    fs.writeFileSync(path.join(channelDist, "openclaw-entry.js"), "// stub\n");
+    seedPackage(channelDepDir, { name: "effect", version: "3.21.0" });
+    seedPackage(protocolPkg, { name: "@moltzap/protocol" });
+    seedPackage(clientPkg, { name: "@moltzap/client" });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const channelPackageDir = path.dirname(channelDist);
+    const effectResolved = resolveChannelDependency(
+      channelPackageDir,
+      "effect",
+    );
+    expect(effectResolved).toBe(channelDepDir);
+
+    const extDir = installChannelPlugin({
+      stateDir,
+      channelDistDir: channelDist,
+      repoRoot,
+      extName: "openclaw-channel",
+      extraSymlinks: [
+        {
+          linkPath: "effect",
+          candidates: [
+            ...(effectResolved === null ? [] : [effectResolved]),
+            // Legacy fallback path that does NOT exist in this layout —
+            // kept here intentionally so the test proves the resolver
+            // candidate wins over the bundled fallback.
+            path.join(channelDist, "node_modules", "effect"),
+          ],
+        },
+      ],
+    });
+
+    const symlinkPath = path.join(extDir, "node_modules", "effect");
+    expect(fs.lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(symlinkPath)).toBe(channelDepDir);
+  });
+});
+
+function seedPackage(
+  pkgDir: string,
+  pkgJson: Readonly<Record<string, unknown>>,
+): void {
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, "package.json"),
+    JSON.stringify(pkgJson, null, 2),
+  );
+}

--- a/packages/runtimes/src/channel-plugin-install.ts
+++ b/packages/runtimes/src/channel-plugin-install.ts
@@ -19,6 +19,7 @@
  * now that two live adapters consume it.
  */
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as path from "node:path";
 import type { SpawnInput } from "./runtime.js";
 
@@ -156,4 +157,45 @@ function symlinkPreferring(
   throw new Error(
     `channel-plugin-install: none of the candidate paths exist for ${target}: ${candidates.join(", ")}`,
   );
+}
+
+/**
+ * Resolve a runtime dependency the channel package imports, using
+ * Node's standard module resolution anchored at the channel package's
+ * `package.json`. Walks `node_modules` parent-ward, so it finds the
+ * dep regardless of whether it lives at:
+ *   - `<channelPackage>/node_modules/<dep>` (per-package install)
+ *   - `<repoRoot>/node_modules/<dep>`       (workspace hoist)
+ *   - any other ancestor `node_modules/<dep>` Node would walk to
+ *
+ * Returns the absolute path to the dep's package directory, or `null`
+ * when the resolver can't find the dep from this anchor (missing
+ * package.json, dep not installed, etc.). Callers can chain it with
+ * legacy candidate paths so existing layouts (e.g. a bundled
+ * `dist/node_modules/<dep>`) keep working as a fallback.
+ *
+ * Resolves `<dep>/package.json` rather than the package's main entry
+ * so the returned path is always the package root, not a `dist/` file
+ * inside it. (`exports`-restricted packages can hide the main entry
+ * but virtually always expose `./package.json`.)
+ */
+export function resolveChannelDependency(
+  channelPackageDir: string,
+  packageName: string,
+): string | null {
+  const anchor = path.join(channelPackageDir, "package.json");
+  if (!fs.existsSync(anchor)) {
+    return null;
+  }
+  try {
+    const requireFromAnchor = createRequire(anchor);
+    const pkgJsonPath = requireFromAnchor.resolve(
+      `${packageName}/package.json`,
+    );
+    return path.dirname(pkgJsonPath);
+    // #ignore-sloppy-code-next-line[bare-catch]: best-effort resolver — surface "not found" as null and let caller try fallback candidates
+  } catch (_err) {
+    void _err;
+    return null;
+  }
 }

--- a/packages/runtimes/src/claude-code-adapter.ts
+++ b/packages/runtimes/src/claude-code-adapter.ts
@@ -43,6 +43,7 @@ import type {
 import { SpawnFailed } from "./errors.js";
 import {
   installChannelPlugin,
+  resolveChannelDependency,
   seedWorkspaceFiles,
 } from "./channel-plugin-install.js";
 import { writeClaudeCodeMcpConfig } from "./claude-code-process.js";
@@ -235,21 +236,37 @@ export class ClaudeCodeAdapter implements Runtime {
 
       yield* tryStep(() => seedWorkspaceFiles(stateDir, input.workspaceFiles));
 
+      // cc-channel resolves @modelcontextprotocol/sdk + effect at
+      // MCP-load time; symlink them into the per-agent ext dir. Use
+      // Node's standard module resolution (anchored at the channel
+      // package's package.json) as the primary path so per-package and
+      // workspace-hoisted layouts both work without hardcoded candidate
+      // paths (#285). The explicit fallbacks keep the historical
+      // resolution order for consumers without a discoverable
+      // `package.json`.
+      const channelPackageDir = path.dirname(this.deps.channelDistDir);
+      const mcpSdkResolved = resolveChannelDependency(
+        channelPackageDir,
+        "@modelcontextprotocol/sdk",
+      );
+      const effectResolved = resolveChannelDependency(
+        channelPackageDir,
+        "effect",
+      );
       const extDir = yield* tryStep(() =>
         installChannelPlugin({
           stateDir,
           channelDistDir: this.deps.channelDistDir,
           repoRoot: this.deps.repoRoot,
           extName: "claude-code-channel",
-          // cc-channel resolves @modelcontextprotocol/sdk + effect at
-          // MCP-load time; symlink them into the per-agent ext dir.
           extraSymlinks: [
             {
               linkPath: "@modelcontextprotocol/sdk",
               candidates: [
+                ...(mcpSdkResolved === null ? [] : [mcpSdkResolved]),
                 path.join(
-                  this.deps.channelDistDir,
-                  "../node_modules/@modelcontextprotocol/sdk",
+                  channelPackageDir,
+                  "node_modules/@modelcontextprotocol/sdk",
                 ),
                 path.join(
                   this.deps.repoRoot,
@@ -260,7 +277,8 @@ export class ClaudeCodeAdapter implements Runtime {
             {
               linkPath: "effect",
               candidates: [
-                path.join(this.deps.channelDistDir, "../node_modules/effect"),
+                ...(effectResolved === null ? [] : [effectResolved]),
+                path.join(channelPackageDir, "node_modules/effect"),
                 path.join(this.deps.repoRoot, "node_modules/effect"),
               ],
             },

--- a/packages/runtimes/src/openclaw-adapter.ts
+++ b/packages/runtimes/src/openclaw-adapter.ts
@@ -16,6 +16,7 @@ import type {
 import { SpawnFailed } from "./errors.js";
 import {
   installChannelPlugin as installSharedChannelPlugin,
+  resolveChannelDependency,
   seedWorkspaceFiles as seedSharedWorkspaceFiles,
 } from "./channel-plugin-install.js";
 
@@ -415,6 +416,15 @@ function installChannelPlugin(
   channelDistDir: string,
   repoRoot: string,
 ): void {
+  const channelPackageDir = path.dirname(channelDistDir);
+  // OpenClaw's plugin imports `effect` at load time. Resolve it the way
+  // Node would when the channel package itself imported it (#285) — that
+  // walks parent `node_modules` directories, so it handles both per-pkg
+  // installs (`<pkg>/node_modules/effect`) and workspace hoists
+  // (`<repoRoot>/node_modules/effect`). The legacy `dist/node_modules`
+  // candidate is kept as a fallback for any consumer that still ships a
+  // bundled artifact in that layout.
+  const effectResolved = resolveChannelDependency(channelPackageDir, "effect");
   installSharedChannelPlugin({
     stateDir,
     channelDistDir,
@@ -423,13 +433,13 @@ function installChannelPlugin(
     // OpenClaw discovers channels via `openclaw.plugin.json` in the
     // package root; cc-channel has no equivalent manifest.
     extraPackageFiles: ["openclaw.plugin.json"],
-    // OpenClaw's plugin imports `effect` at load time. Match the
-    // pre-refactor sourcing exactly (single candidate inside the
-    // channel's bundled node_modules).
     extraSymlinks: [
       {
         linkPath: "effect",
-        candidates: [path.join(channelDistDir, "node_modules", "effect")],
+        candidates: [
+          ...(effectResolved === null ? [] : [effectResolved]),
+          path.join(channelDistDir, "node_modules", "effect"),
+        ],
       },
     ],
   });


### PR DESCRIPTION
## Summary

- The OpenClaw runtime adapter's `installChannelPlugin()` only looked for the `effect` runtime dep at `<channelPackage>/dist/node_modules/effect` — a layout that exists only in some published artifacts. After a normal `pnpm install --frozen-lockfile && pnpm -r build`, `effect` lives at `<channelPackage>/node_modules/effect`, so spawning agents from a clean workspace failed with `channel-plugin-install: none of the candidate paths exist for ...openclaw-channel/node_modules/effect`.
- Add `resolveChannelDependency(channelPackageDir, packageName)` to `channel-plugin-install.ts`. It anchors `createRequire` at the channel package's `package.json` and resolves `<dep>/package.json`, which walks parent `node_modules` directories the way Node would if the channel package itself imported the dep — so per-package, workspace-hoisted, and any other ancestor layout all work without hardcoded candidate paths.
- Wire it into both adapters with the legacy paths kept as last-resort fallbacks: `OpenClawAdapter` for `effect`; `ClaudeCodeAdapter` for `effect` + `@modelcontextprotocol/sdk` (also drops the obscure `"../node_modules/..."` candidates in favor of the cleaner `path.join(channelPackageDir, ...)` form).

Closes #285.

## Test plan

- [x] `pnpm -r build` — green
- [x] `pnpm test` — green (37/37 in `@moltzap/runtimes`, including 6 new unit tests in `channel-plugin-install.test.ts`)
- [x] `pnpm lint` / `pnpm format:check` — clean
- [x] `scripts/sloppy-code-guard.sh` — clean
- New tests cover: per-package install (asserts no `dist/node_modules` in path), workspace-hoisted, missing `package.json` → null, missing dep → null, dist-main package returns the package root (not the file inside `dist/`), and an end-to-end `installChannelPlugin` symlink that proves the resolver candidate beats the legacy bundled fallback.
- [ ] Re-run the original repro from the issue (`PLAYER_COUNTS=8 AGENT_RUNTIME=openclaw ... ./scripts/run-real-game-sweep.sh` from a fresh moltzap-arena checkout pointing at this submodule SHA) — needs Docker + an OpenClaw runtime, not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)