### PR TITLE
chore: clean up stale messages TSDoc + pin Has-guard test (closes #383)

### DIFF
--- a/packages/client/src/cli/commands/messages.ts
+++ b/packages/client/src/cli/commands/messages.ts
@@ -57,7 +57,11 @@ interface WireMessage {
 // ─── Handlers ──────────────────────────────────────────────────────────────
 
 /**
- * Wraps `messages/list`. Emits one message per line (seq, senderName, text).
+ * Wraps `messages/list`. Emits one message per line, tab-separated:
+ * `<createdAt>\t<senderName ?? senderId>\t<text>`. `seq` was removed
+ * from the wire shape in PR #379 — only `id`, `senderId`, optional
+ * `senderName`, `createdAt`, and `parts` survive.
+ *
  * `--json` is a stretch flag added by impl if consistent with
  * `conversations list` output style (not fixed by spec).
  */

--- a/packages/protocol/src/helpers.test.ts
+++ b/packages/protocol/src/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import { FormatRegistry, Type } from "@sinclair/typebox";
@@ -89,4 +89,70 @@ describe("TypeBox FormatRegistry side-effect registration", () => {
     expect(Value.Check(uriSchema, "not a uri")).toBe(false);
     expect(Value.Check(uriSchema, "://missing-scheme")).toBe(false);
   });
+});
+
+/**
+ * Regression #383: `helpers.ts` gates each `FormatRegistry.Set(...)` on
+ * `FormatRegistry.Has(...)` precisely so that a downstream consumer who
+ * pre-registers a stricter (or otherwise customized) validator is NOT
+ * silently overwritten when `@moltzap/protocol`'s side-effect import
+ * runs after them.
+ *
+ * Pin the contract for every format helpers.ts touches: pre-register a
+ * sentinel validator that accepts ONLY one specific value, force a
+ * re-execution of the helpers module body via `vi.resetModules()` +
+ * dynamic import, and assert the sentinel is still the active validator
+ * — i.e. helpers.ts's default validator (which would also accept a
+ * separate "default-valid" sample) did NOT clobber it. Removing any of
+ * the three `Has(...)` guards in helpers.ts fails the matching case.
+ */
+describe("FormatRegistry Has-guard preserves consumer-registered formats", () => {
+  const cases: ReadonlyArray<{
+    format: "uuid" | "date-time" | "uri";
+    sentinel: string;
+    defaultValid: string;
+  }> = [
+    {
+      format: "uuid",
+      sentinel: "00000000-0000-0000-0000-000000000001",
+      defaultValid: "550e8400-e29b-41d4-a716-446655440000",
+    },
+    {
+      format: "date-time",
+      sentinel: "2099-01-01T00:00:00.000Z",
+      defaultValid: "2026-03-14T12:00:00.000Z",
+    },
+    {
+      format: "uri",
+      sentinel: "moltzap:sentinel",
+      defaultValid: "https://example.com/path",
+    },
+  ];
+
+  for (const { format, sentinel, defaultValid } of cases) {
+    it(`does not overwrite a pre-registered ${format} validator on re-import`, async () => {
+      const original = FormatRegistry.Get(format);
+      expect(original).toBeDefined();
+      try {
+        // Pre-register a sentinel that accepts ONLY one value, so we can
+        // distinguish it from helpers.ts's default validator.
+        FormatRegistry.Set(format, (value) => value === sentinel);
+
+        // Force helpers.ts to re-execute its top-level side effects.
+        vi.resetModules();
+        await import("./helpers.js");
+
+        const schema = Type.String({ format });
+        // Sentinel must still be in place — Has-guard skipped re-registration.
+        expect(Value.Check(schema, sentinel)).toBe(true);
+        // A value the default validator would accept must now be rejected,
+        // proving the sentinel — not helpers.ts's validator — is active.
+        expect(Value.Check(schema, defaultValid)).toBe(false);
+      } finally {
+        // Restore the original validator so subsequent tests in this process
+        // see the helpers.ts-installed format.
+        if (original) FormatRegistry.Set(format, original);
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
Two NITs from the PR #379 codex review (issue #383). Issue #385 is **not** included — see below.

- **#383(1) — stale TSDoc:** `packages/client/src/cli/commands/messages.ts:60` said the handler emits `(seq, senderName, text)` but `seq` was removed from the wire shape in PR #379. Replaced with the actual tab-separated format `<createdAt>\t<senderName ?? senderId>\t<text>` and a one-line note on what `WireMessage` actually contains now.
- **#383(2) — Has-guard regression test:** `packages/protocol/src/helpers.ts` gates each `FormatRegistry.Set(...)` on `Has(...)` so a downstream consumer that pre-registered a stricter validator is not silently overwritten by `@moltzap/protocol`'s side-effect import. Added a parameterized regression suite (`uuid` / `date-time` / `uri`) that pre-registers a sentinel validator, forces a re-execution of the helpers module body via `vi.resetModules()` + dynamic import, and asserts the sentinel survived. **Verified by mutation:** removing any of the three `Has(...)` guards in `helpers.ts` fails the matching case (uuid, date-time, and uri tests each fail in isolation when their guard is dropped).

## Why #385 is **not** in this PR

Issue #385 says `historyCommand` calls `request("history", ...)` but "no `history` RPC exists in protocol or server" — and recommends deleting the CLI surface as dead code.

The premise is **incorrect**. The `history` "RPC" IS real — but it's a **local Unix-socket RPC handled by the client daemon**, not a wire-protocol RPC handled by the MoltZap server:

- Client daemon dispatch: `packages/client/src/service.ts:486-505` (`handleSocketRequestEffect`) routes the `"history"` method to `handleHistoryRequest`, which composes `messages/list` + agent name lookup + conversation meta + `lastRead` / `lastNotified` tracking — strictly richer than `messages/list` alone.
- Heavily covered by `packages/client/src/__tests__/service.integration.test.ts` (12+ `socketRequest("history", ...)` invocations).

Deleting `historyCommand` and `historySubcommand` would delete working CLI functionality. This is **architect-tier**: the right move is probably to either (a) close #385 as "premise wrong, no action needed", or (b) refile as "rename the daemon socket method so it doesn't share a name with a non-existent server RPC" — but that's a senior-tier rename, not a junior delete. Reporting back to the team lead per the dispatch instructions.

## Test plan
- [x] `pnpm --filter @moltzap/protocol test` — 148 passed (was 146 before; +2 net new tests after dropping the original single-format case for the parameterized 3)
- [x] `pnpm --filter @moltzap/client test` — 277 passed
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — clean
- [x] Mutation test: each of the three `Has(...)` guards in `helpers.ts` was removed in isolation; the matching parameterized case failed each time, confirming the test pins the contract per-format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)