### PR TITLE
fix(husky): build before typecheck in pre-commit (closes #392)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,5 +8,6 @@ if ! git diff --quiet; then
 fi
 
 pnpm check
+pnpm build
 pnpm typecheck
 ./scripts/sloppy-code-guard.sh

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 pnpm exec oxfmt .
 if ! git diff --quiet; then


### PR DESCRIPTION
## Summary

This PR contains two commits:

1. **build-before-typecheck (original)**: Pre-commit hook now runs `pnpm typecheck` after `pnpm build`, matching CI's sequence and preventing module-not-found errors on workspace package updates.
2. **set -e enforcement (new)**: Pre-commit hook now includes `set -e` at the top to actually enforce all checks. Without it, exit codes from `pnpm check`, `pnpm build`, and `pnpm typecheck` were silently swallowed — only `sloppy-code-guard.sh` was gating commits.

## Impact

**Perf cost:** ~45 seconds per commit (full `pnpm build`). This is now justified because:
- The hook actually enforces the full check sequence (was decorative before)
- Developers no longer need `git commit --no-verify` on workspace-touching changes
- CI and pre-commit are now fully synchronized

## Root cause (vs. issue framing)

Issue #392 attributed the failure to "pre-existing TS errors in
`packages/nanoclaw-channel/src/channels/moltzap.ts` and `src/test-support.ts`."
Investigation showed the source files are typed correctly — every error
is downstream of missing dist artifacts:

- Each `@moltzap/*` package's `package.json` points `types` to `./dist/*.d.ts`.
- On a fresh clone (no dist), workspace consumers fail with `TS2307 Cannot
  find module '@moltzap/protocol'` / `'@moltzap/client'`.
- That cascades into `TS7006`/`TS7019` implicit-any errors on callbacks
  whose parameter types come from the missing imports (e.g. `core.onInbound((msg) => …)`
  in `nanoclaw-channel/src/channels/moltzap.ts:76`).

After `pnpm build`, `pnpm typecheck` exits 0 with no source changes — confirming
no real type errors in nanoclaw-channel.

## Fix

Two changes to `.husky/pre-commit`:
1. Add `set -e` at the top to enforce exit codes
2. Add `pnpm build` before `pnpm typecheck` to match CI's order

This removes the need for `--no-verify` on workspace-touching commits.

## Why not the alternatives in the issue

- **Add type annotations / fix imports in the two files**: doesn't help.
  The TS2307 errors are about modules that don't exist on disk yet; explicit
  annotations can't paper over a missing module.
- **Exclude nanoclaw-channel from pre-commit**: hides the rot — and the same
  failure mode hits `packages/server`, `packages/client`, `packages/app-sdk`,
  `packages/openclaw-channel`, and `packages/claude-code-channel` too.

## Verification

```
$ rm -rf packages/*/dist
$ sh .husky/pre-commit
… pnpm check OK …
… pnpm build OK …
… pnpm typecheck OK …
… sloppy-code-guard OK …
$ echo $?
0
```

Commit itself was made without `--no-verify`.

**New verification (set -e enforcement):** Synthetic test confirms that introducing `false` before sloppy-guard now correctly blocks commits with exit code 1.

## Test plan

- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — all packages pass (protocol 145, server 201, client 277+6todo, app-sdk 89, nanoclaw-channel 19, openclaw-channel 79, claude-code-channel 47, runtimes 37)
- [x] Pre-commit hook passes from a clean state (no dist) without `--no-verify`
- [x] Codex review passed
- [x] `set -e` verified to enforce early exit on failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)