### PR TITLE
revert: drop loader-boundary seed: rejection guard per user override (#391 follow-up)

### DIFF
--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -203,26 +203,4 @@ server:
     expect(err.kind).toBe("yaml");
     expect(err.message).toMatch(/top-level value must be a mapping/);
   });
-
-  // Retired-field guard. Effect's `Config.all` ignores unknown top-level
-  // keys, so without an explicit check at the loader boundary a stale
-  // `seed:` block in a pre-existing moltzap.yaml would boot silently and
-  // the operator's intent (seed alice/bob at startup) would just vanish.
-  // The schema.ts negative test only covers the dev-time validateConfig()
-  // path, not the runtime loader path.
-  it("rejects retired top-level `seed:` field with migration guidance", async () => {
-    vi.mocked(readFileSync).mockReturnValue(`
-database:
-  url: postgres://localhost:5432/moltzap
-seed:
-  agents:
-    - name: alice
-`);
-
-    const exit = await Effect.runPromiseExit(loadConfigFromFile("test.yaml"));
-    const err = expectConfigLoadError(exit);
-    expect(err.kind).toBe("validation");
-    expect(err.message).toMatch(/retired field "seed"/);
-    expect(err.message).toMatch(/admin\/register-agent/);
-  });
 });

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -94,36 +94,6 @@ function interpolateEnvVars(
 }
 
 /**
- * Top-level fields that used to be valid in `moltzap.yaml` but have
- * been removed. Effect's `Config.all` ignores unknown keys, so an
- * operator with a stale field would boot silently with the field's
- * intent lost. Surface it as a hard error with migration guidance
- * instead.
- */
-const RETIRED_TOP_LEVEL_FIELDS: ReadonlyArray<{
-  readonly key: string;
-  readonly guidance: string;
-}> = [
-  {
-    key: "seed",
-    guidance:
-      'remove this block. Boot-time agent seeding was dropped; mint your first agent via POST /api/v1/admin/register-agent (idempotent) or POST /api/v1/auth/register. See README "Get Started" / CHANGELOG.',
-  },
-];
-
-function findRetiredTopLevelField(
-  obj: unknown,
-): { readonly key: string; readonly guidance: string } | null {
-  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
-    return null;
-  }
-  for (const entry of RETIRED_TOP_LEVEL_FIELDS) {
-    if (entry.key in obj) return entry;
-  }
-  return null;
-}
-
-/**
  * Load and validate a MoltZap config YAML file.
  *
  * Resolves the path with the same precedence as before: explicit arg ->
@@ -174,22 +144,6 @@ export const loadConfigFromFile = (
 
     const interp = interpolateEnvVars(decoded.right, configPath);
     if (!interp.ok) return yield* Effect.fail(interp.error);
-
-    // Reject retired top-level fields up-front. Effect's `Config.all`
-    // silently ignores unknown keys, so without this check a stale
-    // `seed:` block in a pre-existing moltzap.yaml would boot
-    // successfully and silently no-op (the seed task that consumed
-    // it is gone). Surface the migration explicitly instead.
-    const retiredField = findRetiredTopLevelField(interp.value);
-    if (retiredField !== null) {
-      return yield* Effect.fail(
-        new ConfigLoadError({
-          kind: "validation",
-          path: configPath,
-          message: `Invalid config in "${configPath}": retired field "${retiredField.key}" — ${retiredField.guidance}`,
-        }),
-      );
-    }
 
     // `fromJson` walks the nested object and produces flat paths that
     // `Config.all(...)` / `Config.nested(...)` / `Config.array(...)` consume.


### PR DESCRIPTION
## Summary

Per user comment on #391 ("User override: adding rejection guard is unnecessary"), this PR removes the `findRetiredTopLevelField` hard-error guard from the config loader boundary.

User intended behavior: stale `seed:` keys in moltzap.yaml should silently work (via `Config.all` ignoring unknown keys) rather than trigger a loader-boundary hard-error with migration guidance.

## What's removed

- `findRetiredTopLevelField` function in `packages/server/src/config/loader.ts`
- The call site that validates stale `seed:` keys before `ConfigProvider.fromJson`
- The associated test at `loader.test.ts:213` ("rejects retired top-level `seed:` field with migration guidance")

## What's preserved

- ✅ The seedAgentsEffect removal from the original PR #391
- ✅ TypeBox-level `additionalProperties: false` rejection in `validateConfig` (SDK-consumer side guard, pre-existing, still fires for schema violations)
- ✅ The `schema.test.ts:52` test (tests TypeBox-level rejection, not loader-boundary rejection)
- ✅ All README, CHANGELOG, and YAML example updates from PR #391

## Behavior change

**Before:** stale `seed:` keys in `moltzap.yaml` triggered a loader-boundary hard-error with explicit migration guidance.

**After:** stale `seed:` keys silently work (Config.all ignores them). The only guardrail is TypeBox-level rejection in the schema validation layer (`validateConfig`), which still fires for SDK consumers.

## Verification

- ✅ `pnpm build` — all packages build clean
- ✅ `pnpm test` — 200+ unit tests pass
- ✅ `pnpm lint` — 0 warnings, 0 errors
- ✅ `pnpm format` — all files formatted
- ✅ `scripts/sloppy-code-guard.sh` — all guards passed
- ✅ Codex review completed

---

🤖 Generated with /safer:implement-junior