### PR TITLE
feat: add app SDK observability and replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on the app-sdk surface. Each `onX` registers a handler against the
   matching s2c RPC verb; duplicate registration throws
   `AppError("DUPLICATE_HOOK_HANDLER")`.
+- App SDK observability: optional OpenTelemetry tracing, hook replay
+  recording, `onSessionSnapshot`, `exportSession`, and `writeTranscript`
+  for arena-compatible `{ meta, gameplay, traceEvents }` output.
 - Typed errors in `@moltzap/app-sdk`: `AppHandlerError`,
   `AdmissionTimeoutError`, `AppDisconnected`, `AttachError`.
 - `POST /api/v1/auth/register-admin` admin endpoint. Accepts a required
@@ -39,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   migration table) and
   [`docs/migration/webhook-to-rpc.mdx`](docs/migration/webhook-to-rpc.mdx)
   (step-by-step port for existing webhook code).
+- New observability guide and local Jaeger compose example:
+  [`docs/guides/observability.mdx`](docs/guides/observability.mdx) and
+  [`examples/observability-compose/compose.yml`](examples/observability-compose/compose.yml).
 
 ### Changed
 
@@ -59,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Effect<Verdict, never>` regardless of source (in-process or remote).
 - Manifest hook timeout (`manifest.hooks.<name>.timeout_ms`) is now
   enforced at the AppHost call site via `Effect.timeout(manifestMs)`.
+- `RequestFrameSchema` accepts optional W3C `traceparent`; server s2c
+  sends include it when an Effect span is active, and app-sdk hook spans
+  use it as their parent.
 
 ### Removed
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
               "guides/presence-typing",
               "guides/building-apps",
               "guides/app-hooks-rpc",
+              "guides/observability",
               "guides/custom-identity-provider",
               "guides/custom-contacts",
               "guides/user-agent-communication"

--- a/docs/guides/observability.mdx
+++ b/docs/guides/observability.mdx
@@ -1,0 +1,155 @@
+---
+title: App Observability
+description: Trace app hooks, export replay bundles, and write arena-compatible transcripts
+---
+
+# App Observability
+
+`@moltzap/app-sdk` can record two operator-facing artifacts for app sessions:
+
+- Effect spans for SDK lifecycle calls and app hook handlers
+- replay bundles keyed by session id, exportable as `traceEvents`
+
+Tracing is opt-in. Replay recording is opt-in. Existing apps run unchanged
+when both are omitted.
+
+## Enable tracing
+
+Install the optional tracing dependencies. They are optional peers so apps
+that do not enable tracing can omit them.
+
+```bash
+pnpm add @effect/opentelemetry@0.63.0 @effect/platform@0.96.0 \
+  @opentelemetry/api@1.9.1 \
+  @opentelemetry/core@2.7.1 \
+  @opentelemetry/exporter-trace-otlp-http@0.216.0 \
+  @opentelemetry/resources@2.7.1 \
+  @opentelemetry/sdk-logs@0.216.0 \
+  @opentelemetry/sdk-metrics@2.7.1 \
+  @opentelemetry/sdk-trace-base@2.7.1 \
+  @opentelemetry/sdk-trace-node@2.7.1 \
+  @opentelemetry/sdk-trace-web@2.7.1 \
+  @opentelemetry/semantic-conventions@1.40.0
+```
+
+Set the OTLP HTTP endpoint before starting the app:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+```
+
+Then enable tracing in the app options:
+
+```typescript
+import { MoltZapApp } from "@moltzap/app-sdk";
+
+const app = new MoltZapApp({
+  serverUrl: "ws://localhost:41973",
+  agentKey: process.env.MOLTZAP_AGENT_KEY,
+  appId: "werewolf-arena",
+  observability: {
+    tracing: {
+      enabled: true,
+      serviceName: "werewolf-arena-app",
+      shutdownTimeoutMs: 5_000,
+    },
+  },
+});
+```
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, tracing resolves to a no-op
+Layer. When the endpoint is set, `app.start()` initializes the
+OpenTelemetry exporter and `app.stop()` closes the Layer scope so spans flush.
+
+Server-initiated app hook frames may carry W3C `traceparent`. The SDK uses it
+as the parent for hook spans. Invalid `traceparent` values are reported through
+`app.onError(...)` as `ObservabilityError`, then the hook still runs as a root
+span.
+
+## Enable replay bundles
+
+Replay recording captures one `ReplayEvent` per app hook invocation. It stores
+the method, request id, session id, timing, params, and the resulting verdict.
+
+```typescript
+const app = new MoltZapApp({
+  serverUrl: "ws://localhost:41973",
+  agentKey: process.env.MOLTZAP_AGENT_KEY,
+  appId: "werewolf-arena",
+  observability: {
+    replay: {
+      enabled: true,
+      bufferLimit: 10_000,
+      maxSessions: 50,
+      softWarnThreshold: 8_000,
+    },
+  },
+});
+```
+
+Attach app-specific state with one snapshot callback:
+
+```typescript
+import { Effect } from "effect";
+
+app.onSessionSnapshot((sessionId) =>
+  Effect.succeed({
+    sessionId,
+    winner: "villagers",
+    rounds: 4,
+  }),
+);
+```
+
+Export the bundle after the session:
+
+```typescript
+import type { SessionId } from "@moltzap/app-sdk";
+
+const bundle = await app.exportSessionAsync(session.id as SessionId);
+```
+
+`bundle.traceEvents` is the SDK-owned replay stream. `bundle.appData` is the
+snapshot returned by `onSessionSnapshot`.
+
+## Write transcripts
+
+`writeTranscript` writes the same top-level shape used by arena live captures:
+
+```json
+{
+  "meta": {},
+  "gameplay": {},
+  "traceEvents": []
+}
+```
+
+For arena-style output:
+
+```typescript
+await app.writeTranscriptAsync(
+  session.id as SessionId,
+  {
+    kind: "arena-live",
+    model: "gpt-5.5",
+    playerCount: 7,
+    gameNumber: 42,
+    status: "complete",
+  },
+  "packages/evals/artifacts/arena/live",
+);
+```
+
+The writer creates a directory named like
+`arena-live-42-gpt-5.5-2026-05-03T00-01-00.000Z/transcript.json`.
+
+## Local collector
+
+The repo includes a local Jaeger compose file:
+
+```bash
+docker compose -f examples/observability-compose/compose.yml up
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+```
+
+Open `http://localhost:16686` to inspect spans.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,7 +25,13 @@ export default [
     },
     rules: {
       ...guard.configs.recommended.rules,
-      "@typescript-eslint/no-magic-numbers": "warn",
+      "@typescript-eslint/no-magic-numbers": [
+        "warn",
+        {
+          ignore: [-1, 0, 1],
+          ignoreArrayIndexes: true,
+        },
+      ],
       "@typescript-eslint/no-unused-vars": "error",
       "sonarjs/no-duplicate-string": ["warn", { threshold: 4 }],
     },

--- a/examples/observability-compose/README.md
+++ b/examples/observability-compose/README.md
@@ -1,0 +1,24 @@
+# Observability Compose
+
+Local Jaeger for testing app-sdk tracing.
+
+```bash
+docker compose -f examples/observability-compose/compose.yml up
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+```
+
+Then start an app with:
+
+```typescript
+const app = new MoltZapApp({
+  serverUrl: "ws://localhost:41973",
+  agentKey: process.env.MOLTZAP_AGENT_KEY,
+  appId: "observed-app",
+  observability: {
+    tracing: { enabled: true },
+    replay: { enabled: true },
+  },
+});
+```
+
+Jaeger UI: <http://localhost:16686>

--- a/examples/observability-compose/compose.yml
+++ b/examples/observability-compose/compose.yml
@@ -1,0 +1,11 @@
+name: moltzap-observability
+
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.65.0
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"

--- a/packages/app-sdk/package.json
+++ b/packages/app-sdk/package.json
@@ -28,6 +28,48 @@
     "@moltzap/protocol": "workspace:*",
     "effect": "3.21.0"
   },
+  "peerDependencies": {
+    "@effect/opentelemetry": "0.63.0",
+    "@effect/platform": "0.96.0",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/core": "2.7.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.216.0",
+    "@opentelemetry/resources": "2.7.1",
+    "@opentelemetry/sdk-logs": "0.216.0",
+    "@opentelemetry/sdk-metrics": "2.7.1",
+    "@opentelemetry/sdk-trace-base": "2.7.1",
+    "@opentelemetry/sdk-trace-node": "2.7.1",
+    "@opentelemetry/sdk-trace-web": "2.7.1",
+    "@opentelemetry/semantic-conventions": "1.40.0"
+  },
+  "peerDependenciesMeta": {
+    "@effect/opentelemetry": { "optional": true },
+    "@effect/platform": { "optional": true },
+    "@opentelemetry/api": { "optional": true },
+    "@opentelemetry/core": { "optional": true },
+    "@opentelemetry/exporter-trace-otlp-http": { "optional": true },
+    "@opentelemetry/resources": { "optional": true },
+    "@opentelemetry/sdk-logs": { "optional": true },
+    "@opentelemetry/sdk-metrics": { "optional": true },
+    "@opentelemetry/sdk-trace-base": { "optional": true },
+    "@opentelemetry/sdk-trace-node": { "optional": true },
+    "@opentelemetry/sdk-trace-web": { "optional": true },
+    "@opentelemetry/semantic-conventions": { "optional": true }
+  },
+  "optionalDependencies": {
+    "@effect/opentelemetry": "0.63.0",
+    "@effect/platform": "0.96.0",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/core": "2.7.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.216.0",
+    "@opentelemetry/resources": "2.7.1",
+    "@opentelemetry/sdk-logs": "0.216.0",
+    "@opentelemetry/sdk-metrics": "2.7.1",
+    "@opentelemetry/sdk-trace-base": "2.7.1",
+    "@opentelemetry/sdk-trace-node": "2.7.1",
+    "@opentelemetry/sdk-trace-web": "2.7.1",
+    "@opentelemetry/semantic-conventions": "1.40.0"
+  },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "typescript": "^5.7.0",

--- a/packages/app-sdk/src/app.handlers.test.ts
+++ b/packages/app-sdk/src/app.handlers.test.ts
@@ -47,8 +47,17 @@ const { MockRpcServerError, MockDuplicateError } = vi.hoisted(() => {
 
 type MockRpcServerErrorInstance = InstanceType<typeof MockRpcServerError>;
 
+interface MockServerRpcContext {
+  readonly requestId: string;
+  readonly method: string;
+  readonly traceparent?: string;
+}
+
 interface InstalledHandler {
-  (params: unknown): Effect.Effect<unknown, MockRpcServerErrorInstance>;
+  (
+    params: unknown,
+    ctx: MockServerRpcContext,
+  ): Effect.Effect<unknown, MockRpcServerErrorInstance>;
 }
 
 vi.mock("@moltzap/client", async () => {
@@ -104,13 +113,18 @@ vi.mock("@moltzap/client", async () => {
         _invokeHandler(
           method: string,
           params: unknown,
+          traceparent?: string,
         ): Effect.Effect<unknown, MockRpcServerErrorInstance> {
           const m = Effect.runSync(Ref.get(handlers));
           const h = HashMap.get(m, method);
           if (h._tag === "None") {
             throw new Error(`no handler for ${method}`);
           }
-          return h.value(params);
+          return h.value(params, {
+            requestId: `req-${method}`,
+            method,
+            ...(traceparent !== undefined ? { traceparent } : {}),
+          });
         },
         _hasHandler(method: string): boolean {
           const m = Effect.runSync(Ref.get(handlers));
@@ -131,12 +145,18 @@ vi.mock("@moltzap/client", async () => {
 
 // Import the SDK AFTER vi.mock so the mock is active.
 import { MoltZapApp } from "./app.js";
-import { AppError, AppHandlerError, AttachError } from "./errors.js";
+import {
+  AppError,
+  AppHandlerError,
+  AttachError,
+  ObservabilityError,
+} from "./errors.js";
 
 interface MockedWsClient {
   _invokeHandler: (
     method: string,
     params: unknown,
+    traceparent?: string,
   ) => Effect.Effect<unknown, MockRpcServerErrorInstance>;
   _hasHandler: (method: string) => boolean;
   _setAttachFailure: (err: MockRpcServerErrorInstance | Error) => void;
@@ -273,6 +293,24 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       expect(errArg).toBeInstanceOf(AppHandlerError);
       expect(errArg.code).toBe("APP_HANDLER_ERROR");
       expect(errArg.method).toBe("apps/onBeforeDispatch");
+    });
+
+    it("logs malformed inbound traceparent and still runs the handler as a root span", async () => {
+      app.onBeforeDispatch(() =>
+        Effect.succeed<DispatchAdmissionResult>({ decision: "grant" }),
+      );
+
+      const reply = await Effect.runPromise(
+        asMock(app.client)._invokeHandler(
+          "apps/onBeforeDispatch",
+          baseDispatchCtx,
+          "not-a-traceparent",
+        ),
+      );
+
+      expect(reply).toEqual({ admission: { decision: "grant" } });
+      expect(onErr).toHaveBeenCalledTimes(1);
+      expect(onErr.mock.calls[0]![0]).toBeInstanceOf(ObservabilityError);
     });
 
     it("throws AppError DUPLICATE_HOOK_HANDLER on second registration", () => {

--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -8,6 +8,7 @@ import type {
   WsClientLogger,
   MoltZapWsClientOptions,
   EventSubscription,
+  ServerRpcContext,
 } from "@moltzap/client";
 import type {
   AppManifest,
@@ -30,7 +31,8 @@ import type {
   HookResult,
 } from "@moltzap/protocol";
 import { EventNames } from "@moltzap/protocol";
-import { Cause, Effect, Exit, Fiber } from "effect";
+import { Cause, Duration, Effect, Exit, Fiber, Layer, Scope } from "effect";
+import { env as hostEnv } from "node:process";
 import { AppSessionHandle } from "./session.js";
 import { HeartbeatManager } from "./heartbeat.js";
 import {
@@ -44,7 +46,28 @@ import {
   SessionClosedError,
   ConversationKeyError,
   SendError,
+  ConfigValidationError,
+  ObservabilityError,
+  SessionNotFoundError,
 } from "./errors.js";
+import {
+  externalParentFromTraceparent,
+  makeReplayRecorder,
+  makeTracerLayer,
+  makeTranscriptWriter,
+  type BufferLimitInput,
+  type HookMethod,
+  type ReplayBundle,
+  type ReplayEvent,
+  type ReplayRecorder,
+  type ReplayStore,
+  type ReplayStoreIoError,
+  type SessionId,
+  type SnapshotCallback,
+  type TranscriptMeta,
+  type TranscriptWriterError,
+  type VerdictTag,
+} from "./observability/index.js";
 
 type MessageHandler = (message: Message) => void | Promise<void>;
 type SessionReadyHandler = (session: AppSessionHandle) => void | Promise<void>;
@@ -61,12 +84,34 @@ export interface MoltZapAppOptions {
   heartbeatIntervalMs?: number;
   /** Agents to invite when start() is called */
   invitedAgentIds?: string[];
+  readonly observability?: {
+    readonly tracing?: {
+      readonly enabled: boolean;
+      readonly serviceName?: string;
+      readonly shutdownTimeoutMs?: number;
+    };
+    readonly replay?: {
+      readonly enabled: boolean;
+      readonly bufferLimit?: BufferLimitInput;
+      readonly maxSessions?: BufferLimitInput;
+      readonly softWarnThreshold?: number;
+      readonly store?: ReplayStore;
+    };
+  };
 }
 
-export type StartError = AuthError | ManifestRegistrationError | SessionError;
+export type StartError =
+  | AuthError
+  | ManifestRegistrationError
+  | SessionError
+  | ObservabilityError
+  | ConfigValidationError;
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const NO_BACKGROUND_FIBERS = 0;
+const DEFAULT_TRACER_SHUTDOWN_TIMEOUT_MS = 5_000;
+const CLOSE_SESSION_EVENT_LOSS_CLEANUP_MS = 5_000;
+const CLOSE_SESSIONS_CONCURRENCY = 8;
 
 /**
  * MoltZapApp — main class for building MoltZap apps.
@@ -83,8 +128,13 @@ export class MoltZapApp {
   private readonly heartbeatIntervalMs: number;
   private readonly invitedAgentIds: string[];
   private readonly logger: WsClientLogger;
+  private readonly observability?: MoltZapAppOptions["observability"];
 
   private sessions = new Map<string, AppSessionHandle>();
+  private sessionLifetimes = new Map<
+    string,
+    { readonly startedAt: string; finishedAt: string | null }
+  >();
   /** Reverse map: conversationId -> conversation key */
   private reverseConvMap = new Map<string, string>();
   /** Sessions for which sessionReady handlers have fired (dedup across start() + event) */
@@ -104,6 +154,14 @@ export class MoltZapApp {
   private backgroundFibers = new Set<Fiber.RuntimeFiber<unknown, unknown>>();
   /** Session IDs currently being recovered after reconnect; prevents duplicate recovery fibers on flapping networks. */
   private recoveringSessions = new Set<string>();
+  /** Self-initiated closes in flight; makes closeSession idempotent. */
+  private closingSessions = new Set<string>();
+  /** Closed events for self-initiated closes should not surface as onError. */
+  private suppressedClosedSessions = new Set<string>();
+  private replayRecorder: ReplayRecorder | null = null;
+  private pendingSnapshotCallback: SnapshotCallback | null = null;
+  private observabilityLayer: Layer.Layer<never, never, never> | null = null;
+  private observabilityScope: Scope.CloseableScope | null = null;
 
   private started = false;
   /** Handle from the `{}` event subscription registered in `start()`. Stored so
@@ -131,6 +189,7 @@ export class MoltZapApp {
     this.heartbeatIntervalMs =
       options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
     this.invitedAgentIds = options.invitedAgentIds ?? [];
+    this.observability = options.observability;
     this.logger = options.logger ?? {
       info: () => {},
       warn: () => {},
@@ -159,84 +218,94 @@ export class MoltZapApp {
 
   start(): Effect.Effect<AppSessionHandle, StartError> {
     return Effect.gen(this, function* () {
-      // Spec #222 OQ-4 deletion: per-event `onEvent` callback is gone.
-      // Replacement: register a `{}` filter subscription before
-      // `connect()` so every inbound event still reaches `handleEvent`.
-      const sub = yield* this.client
-        .subscribe({}, (event) => Effect.sync(() => this.handleEvent(event)))
-        .pipe(
-          Effect.mapError(
-            (err) =>
-              new AuthError(
-                "Failed to register event subscription",
-                err instanceof Error ? err : undefined,
+      yield* this.initializeObservability();
+      return yield* this.withAppSpan(
+        "app.start",
+        { appId: this.manifest.appId },
+        Effect.gen(this, function* () {
+          // Spec #222 OQ-4 deletion: per-event `onEvent` callback is gone.
+          // Replacement: register a `{}` filter subscription before
+          // `connect()` so every inbound event still reaches `handleEvent`.
+          const sub = yield* this.client
+            .subscribe({}, (event) =>
+              Effect.sync(() => this.handleEvent(event)),
+            )
+            .pipe(
+              Effect.mapError(
+                (err) =>
+                  new AuthError(
+                    "Failed to register event subscription",
+                    err instanceof Error ? err : undefined,
+                  ),
               ),
-          ),
-        );
+            );
 
-      // Track the handle so stop() can unsubscribe, and so tapError below
-      // can clean up if a later step fails (preventing subscription leaks).
-      this.activeSubscription = sub;
+          // Track the handle so stop() can unsubscribe, and so tapError below
+          // can clean up if a later step fails (preventing subscription leaks).
+          this.activeSubscription = sub;
 
-      yield* this.client
-        .connect()
-        .pipe(
-          Effect.mapError(
-            (err) =>
-              new AuthError(
-                "Failed to connect and authenticate",
-                err instanceof Error ? err : undefined,
+          yield* this.client
+            .connect()
+            .pipe(
+              Effect.mapError(
+                (err) =>
+                  new AuthError(
+                    "Failed to connect and authenticate",
+                    err instanceof Error ? err : undefined,
+                  ),
               ),
-          ),
-        );
+            );
 
-      yield* this.client
-        .sendRpc("apps/register", { manifest: this.manifest })
-        .pipe(
-          Effect.mapError(
-            (err) =>
-              new ManifestRegistrationError(
-                `Failed to register manifest for "${this.manifest.appId}"`,
-                err instanceof Error ? err : undefined,
+          yield* this.client
+            .sendRpc("apps/register", { manifest: this.manifest })
+            .pipe(
+              Effect.mapError(
+                (err) =>
+                  new ManifestRegistrationError(
+                    `Failed to register manifest for "${this.manifest.appId}"`,
+                    err instanceof Error ? err : undefined,
+                  ),
               ),
-          ),
-        );
+            );
 
-      const sessionResult = (yield* this.client
-        .sendRpc("apps/create", {
-          appId: this.manifest.appId,
-          invitedAgentIds: this.invitedAgentIds,
-        })
-        .pipe(
-          Effect.mapError(
-            (err) =>
-              new SessionError(
-                "Failed to create app session",
-                err instanceof Error ? err : undefined,
+          const sessionResult = (yield* this.client
+            .sendRpc("apps/create", {
+              appId: this.manifest.appId,
+              invitedAgentIds: this.invitedAgentIds,
+            })
+            .pipe(
+              Effect.mapError(
+                (err) =>
+                  new SessionError(
+                    "Failed to create app session",
+                    err instanceof Error ? err : undefined,
+                  ),
               ),
-          ),
-        )) as { session: AppSession };
+            )) as { session: AppSession };
 
-      const handle = new AppSessionHandle(sessionResult.session);
-      this.sessions.set(handle.id, handle);
-      this.buildReverseConvMap(handle);
+          const handle = new AppSessionHandle(sessionResult.session);
+          this.sessions.set(handle.id, handle);
+          this.stampSessionStarted(handle.id);
+          this.buildReverseConvMap(handle);
 
-      this.heartbeat.start(
-        () => this.sendPing(),
-        this.heartbeatIntervalMs,
-        (err) => {
-          this.logger.warn("Heartbeat ping failed:", err.message);
-          this.trackFork(this.client.disconnect());
-        },
+          this.heartbeat.start(
+            () => this.sendPing(),
+            this.heartbeatIntervalMs,
+            (err) => {
+              this.logger.warn("Heartbeat ping failed:", err.message);
+              this.trackFork(this.client.disconnect());
+            },
+          );
+
+          this.started = true;
+
+          if (handle.isActive) {
+            this.fireSessionReady(handle);
+          }
+
+          return handle;
+        }),
       );
-
-      this.started = true;
-
-      if (handle.isActive) {
-        this.fireSessionReady(handle);
-      }
-
-      return handle;
     }).pipe(
       // If any step after subscribe() fails, clean up the subscription so
       // a retry does not accumulate orphaned subscriptions.
@@ -252,36 +321,66 @@ export class MoltZapApp {
   }
 
   stop(): Effect.Effect<void, never> {
-    return Effect.gen(this, function* () {
-      this.heartbeat.destroy();
+    return this.withAppSpan(
+      "app.stop",
+      { appId: this.manifest.appId },
+      Effect.gen(this, function* () {
+        this.heartbeat.destroy();
 
-      const pending = [...this.backgroundFibers];
-      this.backgroundFibers.clear();
-      this.recoveringSessions.clear();
-      if (pending.length > NO_BACKGROUND_FIBERS) {
-        yield* Fiber.interruptAll(pending);
-      }
-
-      for (const session of this.sessions.values()) {
-        if (session.isActive) {
-          yield* this.client
-            .sendRpc("apps/closeSession", { sessionId: session.id })
-            .pipe(Effect.ignore);
+        const pending = [...this.backgroundFibers];
+        this.backgroundFibers.clear();
+        this.recoveringSessions.clear();
+        if (pending.length > NO_BACKGROUND_FIBERS) {
+          yield* Fiber.interruptAll(pending);
         }
-      }
 
-      this.sessions.clear();
-      this.reverseConvMap.clear();
-      this.firedSessionReady.clear();
+        yield* Effect.forEach(
+          [...this.sessions.values()].filter((session) => session.isActive),
+          (session) => this.closeSession(session.id).pipe(Effect.ignore),
+          { concurrency: CLOSE_SESSIONS_CONCURRENCY },
+        );
 
-      if (this.activeSubscription !== null) {
-        yield* this.activeSubscription.unsubscribe;
-        this.activeSubscription = null;
-      }
+        this.sessions.clear();
+        this.sessionLifetimes.clear();
+        this.reverseConvMap.clear();
+        this.firedSessionReady.clear();
+        this.closingSessions.clear();
+        this.suppressedClosedSessions.clear();
 
-      yield* this.client.close();
-      this.started = false;
-    });
+        if (this.activeSubscription !== null) {
+          yield* this.activeSubscription.unsubscribe;
+          this.activeSubscription = null;
+        }
+
+        if (this.observabilityScope !== null) {
+          const shutdownTimeoutMs =
+            this.observability?.tracing?.shutdownTimeoutMs ??
+            DEFAULT_TRACER_SHUTDOWN_TIMEOUT_MS;
+          yield* Scope.close(this.observabilityScope, Exit.void).pipe(
+            Effect.timeout(Duration.millis(shutdownTimeoutMs)),
+            Effect.catchTag("TimeoutException", () =>
+              Effect.sync(() => {
+                this.logger.warn(
+                  `Tracer flush exceeded ${shutdownTimeoutMs.toString()}ms; some spans may be lost`,
+                );
+              }),
+            ),
+            Effect.ignore,
+          );
+          this.observabilityLayer = null;
+          this.observabilityScope = null;
+        }
+
+        yield* this.client.close();
+
+        if (this.replayRecorder !== null) {
+          yield* this.replayRecorder.clearAll;
+          this.replayRecorder = null;
+        }
+
+        this.started = false;
+      }),
+    );
   }
 
   /**
@@ -301,32 +400,141 @@ export class MoltZapApp {
     });
   }
 
+  private initializeObservability(): Effect.Effect<
+    void,
+    ObservabilityError | ConfigValidationError
+  > {
+    return Effect.gen(this, function* () {
+      const replayOptions = this.observability?.replay;
+      if (replayOptions?.enabled === true && this.replayRecorder === null) {
+        const recorder = yield* makeReplayRecorder({
+          bufferLimit: replayOptions.bufferLimit,
+          maxSessions: replayOptions.maxSessions,
+          softWarnThreshold: replayOptions.softWarnThreshold,
+          store: replayOptions.store,
+          logger: this.logger,
+          emitObservabilityError: (err) => this.emitError(err),
+        });
+        this.replayRecorder = recorder;
+        if (this.pendingSnapshotCallback !== null) {
+          yield* recorder
+            .setSnapshotCallback(this.pendingSnapshotCallback)
+            .pipe(
+              Effect.mapError(
+                () =>
+                  new ObservabilityError("Duplicate replay snapshot callback"),
+              ),
+            );
+        }
+      }
+
+      const tracingOptions = this.observability?.tracing;
+      const otlpEndpoint = hostEnv["OTEL_EXPORTER_OTLP_ENDPOINT"];
+      if (
+        tracingOptions?.enabled === true &&
+        otlpEndpoint !== undefined &&
+        otlpEndpoint.trim().length > 0 &&
+        this.observabilityScope === null
+      ) {
+        const scope = yield* Scope.make();
+        const tracerLayer = makeTracerLayer({
+          appId: this.manifest.appId,
+          serviceName:
+            tracingOptions.serviceName ?? `${this.manifest.appId}-app`,
+          otlpEndpoint,
+          shutdownTimeoutMs:
+            tracingOptions.shutdownTimeoutMs ??
+            DEFAULT_TRACER_SHUTDOWN_TIMEOUT_MS,
+        });
+        const memoizedLayer = yield* Scope.extend(
+          Layer.memoize(tracerLayer),
+          scope,
+        );
+        yield* Layer.buildWithScope(memoizedLayer, scope).pipe(
+          Effect.mapError(
+            (err) =>
+              new ObservabilityError(
+                "Failed to initialize app observability tracing",
+                err instanceof Error ? err : undefined,
+              ),
+          ),
+        );
+        this.observabilityLayer = memoizedLayer.pipe(
+          Layer.catchAll((err) =>
+            Layer.effectDiscard(
+              Effect.sync(() => {
+                this.emitError(
+                  new ObservabilityError(
+                    "Failed to provide app observability tracing",
+                    err instanceof Error ? err : undefined,
+                  ),
+                );
+              }),
+            ),
+          ),
+        );
+        this.observabilityScope = scope;
+      }
+    });
+  }
+
+  private withObservability<A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> {
+    return this.observabilityLayer === null
+      ? effect
+      : effect.pipe(Effect.provide(this.observabilityLayer));
+  }
+
+  private withAppSpan<A, E, R>(
+    name: string,
+    attributes: Record<string, unknown>,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> {
+    return this.withObservability(
+      effect.pipe(
+        Effect.withSpan(name, {
+          attributes,
+          captureStackTrace: false,
+        }),
+      ),
+    );
+  }
+
   // ── Session management ─────────────────────────────────────────────
 
   createSession(
     invitedAgentIds?: string[],
   ): Effect.Effect<AppSessionHandle, SessionError> {
-    return Effect.gen(this, function* () {
-      const result = (yield* this.client
-        .sendRpc("apps/create", {
-          appId: this.manifest.appId,
-          invitedAgentIds: invitedAgentIds ?? [],
-        })
-        .pipe(
-          Effect.mapError(
-            (err) =>
-              new SessionError(
-                "Failed to create app session",
-                err instanceof Error ? err : undefined,
-              ),
-          ),
-        )) as { session: AppSession };
+    return this.withAppSpan(
+      "app.createSession",
+      {
+        appId: this.manifest.appId,
+        invitedAgentCount: invitedAgentIds?.length ?? 0,
+      },
+      Effect.gen(this, function* () {
+        const result = (yield* this.client
+          .sendRpc("apps/create", {
+            appId: this.manifest.appId,
+            invitedAgentIds: invitedAgentIds ?? [],
+          })
+          .pipe(
+            Effect.mapError(
+              (err) =>
+                new SessionError(
+                  "Failed to create app session",
+                  err instanceof Error ? err : undefined,
+                ),
+            ),
+          )) as { session: AppSession };
 
-      const handle = new AppSessionHandle(result.session);
-      this.sessions.set(handle.id, handle);
-      this.buildReverseConvMap(handle);
-      return handle;
-    });
+        const handle = new AppSessionHandle(result.session);
+        this.sessions.set(handle.id, handle);
+        this.stampSessionStarted(handle.id);
+        this.buildReverseConvMap(handle);
+        return handle;
+      }),
+    );
   }
 
   getSession(sessionId: string): AppSessionHandle | undefined {
@@ -335,6 +543,51 @@ export class MoltZapApp {
 
   get activeSessions(): AppSessionHandle[] {
     return [...this.sessions.values()].filter((s) => s.isActive);
+  }
+
+  closeSession(sessionId: string): Effect.Effect<void, SessionError> {
+    return this.withAppSpan(
+      "app.closeSession",
+      { appId: this.manifest.appId, sessionId },
+      Effect.gen(this, function* () {
+        if (this.closingSessions.has(sessionId)) return;
+        if (!this.sessions.has(sessionId)) return;
+
+        this.closingSessions.add(sessionId);
+        this.suppressedClosedSessions.add(sessionId);
+
+        const cleanup = Effect.sleep(CLOSE_SESSION_EVENT_LOSS_CLEANUP_MS).pipe(
+          Effect.zipRight(
+            Effect.sync(() => {
+              this.closingSessions.delete(sessionId);
+              this.suppressedClosedSessions.delete(sessionId);
+            }),
+          ),
+        );
+
+        yield* this.client.sendRpc("apps/closeSession", { sessionId }).pipe(
+          Effect.mapError(
+            (err) =>
+              new SessionError(
+                `Failed to close session ${sessionId}`,
+                err instanceof Error ? err : undefined,
+              ),
+          ),
+          Effect.asVoid,
+          Effect.tap(() =>
+            Effect.sync(() => {
+              this.trackFork(cleanup);
+            }),
+          ),
+          Effect.tapError(() =>
+            Effect.sync(() => {
+              this.closingSessions.delete(sessionId);
+              this.suppressedClosedSessions.delete(sessionId);
+            }),
+          ),
+        );
+      }),
+    );
   }
 
   // ── Event registration ─────────────────────────────────────────────
@@ -363,6 +616,73 @@ export class MoltZapApp {
 
   onError(handler: (error: AppError) => void): void {
     this.errorHandler = handler;
+  }
+
+  onSessionSnapshot(callback: SnapshotCallback): void {
+    if (this.pendingSnapshotCallback !== null) {
+      throw new AppError(
+        "DUPLICATE_SNAPSHOT_CALLBACK",
+        "Replay snapshot callback already registered",
+      );
+    }
+
+    this.pendingSnapshotCallback = callback;
+    if (this.replayRecorder === null) return;
+
+    const exit = Effect.runSyncExit(
+      this.replayRecorder.setSnapshotCallback(callback),
+    );
+    if (Exit.isFailure(exit)) {
+      throw new AppError(
+        "DUPLICATE_SNAPSHOT_CALLBACK",
+        "Replay snapshot callback already registered",
+        causeToError(exit.cause),
+      );
+    }
+  }
+
+  exportSession(
+    sessionId: SessionId,
+  ): Effect.Effect<ReplayBundle | null, ReplayStoreIoError> {
+    return this.withAppSpan(
+      "app.exportSession",
+      { appId: this.manifest.appId, sessionId: sessionId as string },
+      Effect.gen(this, function* () {
+        if (this.replayRecorder === null) return null;
+        const bundle = yield* this.replayRecorder.exportSession(
+          sessionId,
+          this.manifest.appId,
+        );
+        return bundle === null ? null : this.applyReplayLifetime(bundle);
+      }),
+    );
+  }
+
+  writeTranscript(
+    sessionId: SessionId,
+    meta: TranscriptMeta,
+    outDir: string,
+  ): Effect.Effect<
+    string,
+    ReplayStoreIoError | SessionNotFoundError | TranscriptWriterError
+  > {
+    return this.withAppSpan(
+      "app.writeTranscript",
+      {
+        appId: this.manifest.appId,
+        sessionId: sessionId as string,
+        outDir,
+        metaKind: meta.kind,
+      },
+      Effect.gen(this, function* () {
+        const bundle = yield* this.exportSession(sessionId);
+        if (bundle === null) {
+          return yield* Effect.fail(new SessionNotFoundError(sessionId));
+        }
+        const writer = yield* makeTranscriptWriter();
+        return yield* writer.write(bundle, meta, outDir);
+      }),
+    );
   }
 
   // ── Admission + lifecycle handler surface (Phase 1.4 / B.5) ─────────────
@@ -403,7 +723,9 @@ export class MoltZapApp {
       "apps/onBeforeDispatch",
       handler,
       (decision) => ({ admission: decision }),
+      (decision) => decision.decision,
       () => ({ admission: { decision: "deny", reason: "app_handler_error" } }),
+      "deny",
     );
   }
 
@@ -426,7 +748,9 @@ export class MoltZapApp {
       "apps/onBeforeMessageDelivery",
       handler,
       (verdict) => verdict,
+      (verdict) => (verdict.block ? "block" : "allow"),
       () => ({ block: true, reason: "app_handler_error" }),
+      "block",
     );
   }
 
@@ -469,12 +793,16 @@ export class MoltZapApp {
     sessionId: string,
     conversationId: string,
   ): Effect.Effect<void, AttachError> {
-    return this.client
-      .sendRpc("apps/attachConversation", { sessionId, conversationId })
-      .pipe(
-        Effect.asVoid,
-        Effect.mapError((err) => mapAttachError(err)),
-      );
+    return this.withAppSpan(
+      "app.attachConversation",
+      { appId: this.manifest.appId, sessionId, conversationId },
+      this.client
+        .sendRpc("apps/attachConversation", { sessionId, conversationId })
+        .pipe(
+          Effect.asVoid,
+          Effect.mapError((err) => mapAttachError(err)),
+        ),
+    );
   }
 
   /**
@@ -488,53 +816,149 @@ export class MoltZapApp {
    * synchronously and only fails with `DuplicateServerRpcHandlerError`.
    */
   private registerAdmissionHandler<Ctx, Verdict>(
-    method: string,
+    method: HookMethod,
     handler: (ctx: Ctx) => Effect.Effect<Verdict, never>,
     wrapVerdict: (verdict: Verdict) => unknown,
+    verdictTag: (verdict: Verdict) => VerdictTag,
     failClosedVerdict: () => unknown,
+    failClosedVerdictTag: VerdictTag,
   ): void {
-    const wrapped = (params: unknown): Effect.Effect<unknown, RpcServerError> =>
+    const wrapped = (
+      params: unknown,
+      rpcCtx: ServerRpcContext,
+    ): Effect.Effect<unknown, RpcServerError> =>
       Effect.gen(this, function* () {
-        const ctx = params as Ctx;
-        const verdictExit = yield* Effect.exit(handler(ctx));
-        if (Exit.isSuccess(verdictExit)) {
-          return wrapVerdict(verdictExit.value);
-        }
-        // Fail-closed: log the underlying cause, synthesize the fail-closed
-        // verdict. Cause covers both typed failures (which are `never`-typed
-        // here so should not occur) and defects from `Effect.gen` throws.
-        const wrappedErr = new AppHandlerError(
-          method,
-          "handler failed; synthesizing fail-closed verdict",
-          causeToError(verdictExit.cause),
+        const parent = yield* this.parentSpanFromRpcContext(rpcCtx);
+        return yield* Effect.gen(this, function* () {
+          const sessionId = sessionIdFromParams(params);
+          const startedAtMs = Date.now();
+          const startedAt = new Date(startedAtMs).toISOString();
+          const ctx = params as Ctx;
+          const verdictExit = yield* Effect.exit(handler(ctx));
+          const durationMs = Date.now() - startedAtMs;
+          if (Exit.isSuccess(verdictExit)) {
+            const verdict = verdictExit.value;
+            const wireVerdict = wrapVerdict(verdict);
+            yield* this.recordReplayEvent({
+              sessionId,
+              method,
+              requestId: rpcCtx.requestId,
+              startedAt,
+              durationMs,
+              params,
+              outcome: {
+                kind: "ok",
+                verdictTag: verdictTag(verdict),
+                verdict,
+              },
+            });
+            return wireVerdict;
+          }
+          // Fail-closed: log the underlying cause, synthesize the fail-closed
+          // verdict. Cause covers both typed failures (which are `never`-typed
+          // here so should not occur) and defects from `Effect.gen` throws.
+          const cause = causeToError(verdictExit.cause);
+          const wrappedErr = new AppHandlerError(
+            method,
+            "handler failed; synthesizing fail-closed verdict",
+            cause,
+          );
+          this.emitError(wrappedErr);
+          const fallback = failClosedVerdict();
+          yield* this.recordReplayEvent({
+            sessionId: sessionIdFromParams(params),
+            method,
+            requestId: rpcCtx.requestId,
+            startedAt,
+            durationMs,
+            params,
+            outcome: {
+              kind: "fail-closed",
+              verdictTag: failClosedVerdictTag,
+              errorMessage: cause.message,
+              errorTag: wrappedErr._tag,
+            },
+          });
+          return fallback;
+        }).pipe(
+          Effect.withSpan(method, {
+            parent,
+            captureStackTrace: false,
+            attributes: hookSpanAttributes(this.manifest.appId, params, rpcCtx),
+          }),
         );
-        this.emitError(wrappedErr);
-        return failClosedVerdict();
       });
 
     this.installServerRpc(method, wrapped);
   }
 
   private registerLifecycleHandler<Ctx>(
-    method: string,
+    method: HookMethod,
     handler: (ctx: Ctx) => Effect.Effect<void, never>,
   ): void {
-    const wrapped = (params: unknown): Effect.Effect<unknown, RpcServerError> =>
+    const wrapped = (
+      params: unknown,
+      rpcCtx: ServerRpcContext,
+    ): Effect.Effect<unknown, RpcServerError> =>
       Effect.gen(this, function* () {
-        const ctx = params as Ctx;
-        const exit = yield* Effect.exit(handler(ctx));
-        if (Exit.isFailure(exit)) {
-          // Lifecycle hooks are awaitable-void: log and reply void so the
-          // server-side AppHost stops waiting. Never blocks session lifecycle.
-          this.emitError(
-            new AppHandlerError(
+        const parent = yield* this.parentSpanFromRpcContext(rpcCtx);
+        return yield* Effect.gen(this, function* () {
+          const sessionId = sessionIdFromParams(params);
+          if (method === "apps/onClose" && sessionId !== undefined) {
+            this.stampSessionFinished(sessionId);
+          }
+          const startedAtMs = Date.now();
+          const startedAt = new Date(startedAtMs).toISOString();
+          const ctx = params as Ctx;
+          const exit = yield* Effect.exit(handler(ctx));
+          const durationMs = Date.now() - startedAtMs;
+          if (Exit.isFailure(exit)) {
+            // Lifecycle hooks are awaitable-void: log and reply void so the
+            // server-side AppHost stops waiting. Never blocks session lifecycle.
+            const cause = causeToError(exit.cause);
+            this.emitError(
+              new AppHandlerError(
+                method,
+                "lifecycle handler failed; replying void",
+                cause,
+              ),
+            );
+            yield* this.recordReplayEvent({
+              sessionId,
               method,
-              "lifecycle handler failed; replying void",
-              causeToError(exit.cause),
-            ),
-          );
-        }
-        return {};
+              requestId: rpcCtx.requestId,
+              startedAt,
+              durationMs,
+              params,
+              outcome: {
+                kind: "fail-closed",
+                verdictTag: "void",
+                errorMessage: cause.message,
+              },
+            });
+          } else {
+            yield* this.recordReplayEvent({
+              sessionId: sessionIdFromParams(params),
+              method,
+              requestId: rpcCtx.requestId,
+              startedAt,
+              durationMs,
+              params,
+              outcome: {
+                kind: "ok",
+                verdictTag: "void",
+                verdict: {},
+              },
+            });
+          }
+          return {};
+        }).pipe(
+          Effect.withSpan(method, {
+            parent,
+            captureStackTrace: false,
+            attributes: hookSpanAttributes(this.manifest.appId, params, rpcCtx),
+          }),
+        );
       });
 
     this.installServerRpc(method, wrapped);
@@ -542,10 +966,15 @@ export class MoltZapApp {
 
   private installServerRpc(
     method: string,
-    wrapped: (params: unknown) => Effect.Effect<unknown, RpcServerError>,
+    wrapped: (
+      params: unknown,
+      ctx: ServerRpcContext,
+    ) => Effect.Effect<unknown, RpcServerError>,
   ): void {
     const exit = Effect.runSyncExit(
-      this.client.handleServerRpc(method, wrapped),
+      this.client.handleServerRpc(method, (params, ctx) =>
+        this.withObservability(wrapped(params, ctx)),
+      ),
     );
     if (Exit.isFailure(exit)) {
       // Only failure mode is `DuplicateServerRpcHandlerError`; surface as
@@ -559,6 +988,41 @@ export class MoltZapApp {
     }
   }
 
+  private parentSpanFromRpcContext(ctx: ServerRpcContext) {
+    return externalParentFromTraceparent(ctx.traceparent).pipe(
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          this.emitError(
+            new ObservabilityError(
+              "Invalid traceparent on inbound s2c frame",
+              err instanceof Error ? err : undefined,
+            ),
+          );
+          return undefined;
+        }),
+      ),
+    );
+  }
+
+  private recordReplayEvent(
+    event: Omit<ReplayEvent, "sessionId"> & {
+      readonly sessionId: SessionId | undefined;
+    },
+  ): Effect.Effect<void, never> {
+    if (event.sessionId === undefined || this.replayRecorder === null) {
+      return Effect.void;
+    }
+    return this.replayRecorder.record({
+      sessionId: event.sessionId,
+      method: event.method,
+      requestId: event.requestId,
+      startedAt: event.startedAt,
+      durationMs: event.durationMs,
+      params: event.params,
+      outcome: event.outcome,
+    });
+  }
+
   // ── Messaging ──────────────────────────────────────────────────────
 
   /** Send a message to a conversation by key (resolved via session conversation map) */
@@ -566,11 +1030,19 @@ export class MoltZapApp {
     conversationKey: string,
     parts: Part[],
   ): Effect.Effect<void, SendError | ConversationKeyError> {
-    return Effect.gen(this, function* () {
-      const conversationId =
-        yield* this.resolveConversationKey(conversationKey);
-      yield* this.sendTo(conversationId, parts);
-    });
+    return this.withAppSpan(
+      "app.send",
+      {
+        appId: this.manifest.appId,
+        conversationKey,
+        partsCount: parts.length,
+      },
+      Effect.gen(this, function* () {
+        const conversationId =
+          yield* this.resolveConversationKey(conversationKey);
+        yield* this.sendTo(conversationId, parts);
+      }),
+    );
   }
 
   /** Send a message to a conversation by raw conversation ID */
@@ -578,15 +1050,23 @@ export class MoltZapApp {
     conversationId: string,
     parts: Part[],
   ): Effect.Effect<void, SendError> {
-    return this.client.sendRpc("messages/send", { conversationId, parts }).pipe(
-      Effect.mapError(
-        (err) =>
-          new SendError(
-            `Failed to send message to conversation ${conversationId}`,
-            err instanceof Error ? err : undefined,
-          ),
+    return this.withAppSpan(
+      "app.sendTo",
+      {
+        appId: this.manifest.appId,
+        conversationId,
+        partsCount: parts.length,
+      },
+      this.client.sendRpc("messages/send", { conversationId, parts }).pipe(
+        Effect.mapError(
+          (err) =>
+            new SendError(
+              `Failed to send message to conversation ${conversationId}`,
+              err instanceof Error ? err : undefined,
+            ),
+        ),
+        Effect.asVoid,
       ),
-      Effect.asVoid,
     );
   }
 
@@ -595,18 +1075,26 @@ export class MoltZapApp {
    * conversation from `replyToId`.
    */
   reply(messageId: string, parts: Part[]): Effect.Effect<void, SendError> {
-    return this.client
-      .sendRpc("messages/send", { replyToId: messageId, parts })
-      .pipe(
-        Effect.mapError(
-          (err) =>
-            new SendError(
-              `Failed to reply to message ${messageId}`,
-              err instanceof Error ? err : undefined,
-            ),
+    return this.withAppSpan(
+      "app.reply",
+      {
+        appId: this.manifest.appId,
+        replyToId: messageId,
+        partsCount: parts.length,
+      },
+      this.client
+        .sendRpc("messages/send", { replyToId: messageId, parts })
+        .pipe(
+          Effect.mapError(
+            (err) =>
+              new SendError(
+                `Failed to reply to message ${messageId}`,
+                err instanceof Error ? err : undefined,
+              ),
+          ),
+          Effect.asVoid,
         ),
-        Effect.asVoid,
-      );
+    );
   }
 
   // ── Promise bridges for async/await consumers ──────────────────────
@@ -624,6 +1112,22 @@ export class MoltZapApp {
 
   createSessionAsync(invitedAgentIds?: string[]) {
     return Effect.runPromise(this.createSession(invitedAgentIds));
+  }
+
+  closeSessionAsync(sessionId: string) {
+    return Effect.runPromise(this.closeSession(sessionId));
+  }
+
+  exportSessionAsync(sessionId: SessionId) {
+    return Effect.runPromise(this.exportSession(sessionId));
+  }
+
+  writeTranscriptAsync(
+    sessionId: SessionId,
+    meta: TranscriptMeta,
+    outDir: string,
+  ) {
+    return Effect.runPromise(this.writeTranscript(sessionId, meta, outDir));
   }
 
   sendAsync(conversationKey: string, parts: Part[]) {
@@ -707,17 +1211,58 @@ export class MoltZapApp {
   }
 
   private handleSessionClosed(data: AppSessionClosedEvent): void {
+    this.stampSessionFinished(data.sessionId);
     const handle = this.sessions.get(data.sessionId);
-    if (handle) {
-      for (const convId of Object.values(handle.conversations)) {
-        this.reverseConvMap.delete(convId);
-      }
-      this.sessions.delete(data.sessionId);
-      this.firedSessionReady.delete(data.sessionId);
+    if (handle === undefined) {
+      return;
+    }
+
+    for (const convId of Object.values(handle.conversations)) {
+      this.reverseConvMap.delete(convId);
+    }
+    this.sessions.delete(data.sessionId);
+    this.firedSessionReady.delete(data.sessionId);
+    this.closingSessions.delete(data.sessionId);
+
+    const suppressed = this.suppressedClosedSessions.delete(data.sessionId);
+    if (!suppressed) {
       this.emitError(
         new SessionClosedError(`Session ${data.sessionId} was closed`),
       );
     }
+  }
+
+  private stampSessionStarted(sessionId: string): void {
+    if (this.sessionLifetimes.has(sessionId)) return;
+    this.sessionLifetimes.set(sessionId, {
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+    });
+  }
+
+  private stampSessionFinished(sessionId: string): void {
+    const lifetime = this.sessionLifetimes.get(sessionId);
+    const finishedAt = new Date().toISOString();
+    if (lifetime === undefined) {
+      this.sessionLifetimes.set(sessionId, {
+        startedAt: finishedAt,
+        finishedAt,
+      });
+      return;
+    }
+    if (lifetime.finishedAt === null) {
+      lifetime.finishedAt = finishedAt;
+    }
+  }
+
+  private applyReplayLifetime(bundle: ReplayBundle): ReplayBundle {
+    const lifetime = this.sessionLifetimes.get(bundle.sessionId as string);
+    if (lifetime === undefined) return bundle;
+    return {
+      ...bundle,
+      startedAt: lifetime.startedAt,
+      finishedAt: lifetime.finishedAt ?? bundle.finishedAt,
+    };
   }
 
   private handleSkillChallenge(data: AppSkillChallengeEvent): void {
@@ -1021,4 +1566,34 @@ function extractAttachCode(err: RpcServerError): AttachErrorCode {
   if (err.message.includes("already attached")) return "AlreadyAttached";
 
   return "AttachFailed";
+}
+
+function sessionIdFromParams(params: unknown): SessionId | undefined {
+  const sessionId = objectField(params, "sessionId");
+  return typeof sessionId === "string" && sessionId.length > 0
+    ? (sessionId as SessionId)
+    : undefined;
+}
+
+function hookSpanAttributes(
+  appId: string,
+  params: unknown,
+  ctx: ServerRpcContext,
+): Record<string, unknown> {
+  const sessionId = objectField(params, "sessionId");
+  const conversationId = objectField(params, "conversationId");
+  return {
+    "moltzap.app_id": appId,
+    "rpc.method": ctx.method,
+    "rpc.request_id": ctx.requestId,
+    ...(typeof sessionId === "string" ? { "session.id": sessionId } : {}),
+    ...(typeof conversationId === "string"
+      ? { "conversation.id": conversationId }
+      : {}),
+  };
+}
+
+function objectField(input: unknown, key: string): unknown {
+  if (typeof input !== "object" || input === null) return undefined;
+  return Object.getOwnPropertyDescriptor(input, key)?.value;
 }

--- a/packages/app-sdk/src/errors.ts
+++ b/packages/app-sdk/src/errors.ts
@@ -533,3 +533,39 @@ export class AttachError extends AppError {
     this.code = code;
   }
 }
+
+export class ObservabilityError extends AppError {
+  readonly _tag = "ObservabilityError" as const;
+
+  constructor(message: string, cause?: Error) {
+    super("OBSERVABILITY_ERROR", message, cause);
+    this.name = "ObservabilityError";
+  }
+}
+
+export class ConfigValidationError extends AppError {
+  readonly _tag = "ConfigValidationError" as const;
+  readonly field: string;
+  readonly value: unknown;
+
+  constructor(field: string, value: unknown, message: string, cause?: Error) {
+    super("CONFIG_VALIDATION_ERROR", message, cause);
+    this.name = "ConfigValidationError";
+    this.field = field;
+    this.value = value;
+  }
+}
+
+export class SessionNotFoundError extends AppError {
+  readonly _tag = "SessionNotFoundError" as const;
+  readonly sessionId: string;
+
+  constructor(sessionId: string) {
+    super(
+      "SESSION_NOT_FOUND",
+      `No replay bundle recorded for session ${sessionId}`,
+    );
+    this.name = "SessionNotFoundError";
+    this.sessionId = sessionId;
+  }
+}

--- a/packages/app-sdk/src/index.ts
+++ b/packages/app-sdk/src/index.ts
@@ -21,8 +21,48 @@ export {
   AdmissionTimeoutError,
   AppDisconnected,
   AttachError,
+  ConfigValidationError,
+  ObservabilityError,
+  SessionNotFoundError,
 } from "./errors.js";
 export type { AttachErrorCode } from "./errors.js";
+
+export {
+  MakeFileSystemStore,
+  MakeInMemoryStore,
+  ReplayStoreIoError,
+  ReplayStorePathError,
+  TraceparentInvalidError,
+  TracerInitError,
+  TranscriptWriterError,
+  externalParentFromTraceparent,
+  formatTraceparent,
+  makeReplayRecorder,
+  makeTracerLayer,
+  makeTranscriptWriter,
+  normalizeBufferLimit,
+  parseTraceparent,
+} from "./observability/index.js";
+export type {
+  BufferLimit,
+  BufferLimitInput,
+  HookMethod,
+  PositiveInt,
+  ReplayBundle,
+  ReplayEvent,
+  ReplayRecorder,
+  ReplayRecorderOptions,
+  ReplayStore,
+  ReplayStoreRead,
+  SessionId,
+  SessionSnapshot,
+  SnapshotCallback,
+  Traceparent,
+  TracerInitOptions,
+  TranscriptMeta,
+  TranscriptWriter,
+  VerdictTag,
+} from "./observability/index.js";
 
 // Re-export common protocol types for convenience
 export type {

--- a/packages/app-sdk/src/observability/index.ts
+++ b/packages/app-sdk/src/observability/index.ts
@@ -1,0 +1,40 @@
+export type {
+  BufferLimitInput,
+  HookMethod,
+  ReplayBundle,
+  ReplayEvent,
+  SessionId,
+  SessionSnapshot,
+  SnapshotCallback,
+  TracerInitOptions,
+  TranscriptMeta,
+  VerdictTag,
+} from "./types.js";
+export {
+  makeReplayRecorder,
+  normalizeBufferLimit,
+  type BufferLimit,
+  type PositiveInt,
+  type ReplayRecorder,
+  type ReplayRecorderOptions,
+  MakeFileSystemStore,
+  MakeInMemoryStore,
+  ReplayStoreIoError,
+  ReplayStorePathError,
+  type ReplayStore,
+  type ReplayStoreRead,
+} from "./replay/index.js";
+export {
+  externalParentFromTraceparent,
+  formatTraceparent,
+  makeTracerLayer,
+  parseTraceparent,
+  TraceparentInvalidError,
+  TracerInitError,
+  type Traceparent,
+} from "./tracer/index.js";
+export {
+  makeTranscriptWriter,
+  TranscriptWriterError,
+  type TranscriptWriter,
+} from "./writer.js";

--- a/packages/app-sdk/src/observability/replay/index.ts
+++ b/packages/app-sdk/src/observability/replay/index.ts
@@ -1,0 +1,16 @@
+export {
+  makeReplayRecorder,
+  normalizeBufferLimit,
+  type ReplayRecorder,
+  type ReplayRecorderOptions,
+} from "./recorder.js";
+export {
+  MakeFileSystemStore,
+  MakeInMemoryStore,
+  ReplayStoreIoError,
+  ReplayStorePathError,
+  type BufferLimit,
+  type PositiveInt,
+  type ReplayStore,
+  type ReplayStoreRead,
+} from "./stores.js";

--- a/packages/app-sdk/src/observability/replay/recorder.test.ts
+++ b/packages/app-sdk/src/observability/replay/recorder.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { Cause, Effect, Exit } from "effect";
+import { ConfigValidationError, ObservabilityError } from "../../errors.js";
+import type { ReplayEvent, SessionId } from "../types.js";
+import {
+  makeReplayRecorder,
+  normalizeBufferLimit,
+  ReplayStoreIoError,
+  type ReplayStore,
+} from "./index.js";
+
+const SESSION_ID = "session-1" as SessionId;
+
+const EVENT: ReplayEvent = {
+  sessionId: SESSION_ID,
+  method: "apps/onBeforeDispatch",
+  requestId: "req-1",
+  startedAt: "2026-05-03T00:00:00.000Z",
+  durationMs: 12,
+  params: { sessionId: SESSION_ID },
+  outcome: {
+    kind: "ok",
+    verdictTag: "grant",
+    verdict: { decision: "grant" },
+  },
+};
+
+describe("ReplayRecorder", () => {
+  it("normalizes positive buffer limits into branded values", () => {
+    expect(Effect.runSync(normalizeBufferLimit(undefined, "limit"))).toBe(
+      "unbounded",
+    );
+    expect(Effect.runSync(normalizeBufferLimit(3, "limit"))).toBe(3);
+
+    const exit = Effect.runSyncExit(normalizeBufferLimit(0, "limit"));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const err = Cause.failureOption(exit.cause);
+      expect(err._tag).toBe("Some");
+      if (err._tag === "Some") {
+        expect(err.value).toBeInstanceOf(ConfigValidationError);
+      }
+    }
+  });
+
+  it("records events and exports a replay bundle with snapshot data", () => {
+    const recorder = Effect.runSync(makeReplayRecorder({ bufferLimit: 10 }));
+
+    Effect.runSync(
+      recorder.setSnapshotCallback(() =>
+        Effect.succeed({ winner: "villagers", rounds: 2 }),
+      ),
+    );
+    Effect.runSync(recorder.record(EVENT));
+
+    const bundle = Effect.runSync(recorder.exportSession(SESSION_ID, "app-1"));
+
+    expect(bundle).toMatchObject({
+      schemaVersion: 1,
+      sessionId: SESSION_ID,
+      appId: "app-1",
+      startedAt: EVENT.startedAt,
+      truncated: false,
+      appData: { winner: "villagers", rounds: 2 },
+    });
+    expect(bundle?.traceEvents).toEqual([EVENT]);
+  });
+
+  it("surfaces store write failures through the observability callback", () => {
+    const emitted: ObservabilityError[] = [];
+    const storeError = new ReplayStoreIoError({
+      reason: "WriteFailed",
+      path: "/tmp/replay",
+      message: "write failed",
+    });
+    const store: ReplayStore = {
+      put: () => Effect.fail(storeError),
+      readAll: () => Effect.succeed(null),
+      clearSession: () => Effect.void,
+      clearAll: Effect.void,
+      evict: Effect.void,
+    };
+    const recorder = Effect.runSync(
+      makeReplayRecorder({
+        store,
+        emitObservabilityError: (err) => {
+          emitted.push(err);
+        },
+      }),
+    );
+
+    const exit = Effect.runSyncExit(recorder.record(EVENT));
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toBeInstanceOf(ObservabilityError);
+  });
+
+  it("rejects duplicate snapshot callbacks", () => {
+    const recorder = Effect.runSync(makeReplayRecorder({}));
+
+    Effect.runSync(recorder.setSnapshotCallback(() => Effect.succeed({})));
+    const exit = Effect.runSyncExit(
+      recorder.setSnapshotCallback(() => Effect.succeed({})),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});

--- a/packages/app-sdk/src/observability/replay/recorder.ts
+++ b/packages/app-sdk/src/observability/replay/recorder.ts
@@ -1,0 +1,197 @@
+import { Effect } from "effect";
+import { REPLAY_BUNDLE_SCHEMA_VERSION } from "../types.js";
+import type {
+  BufferLimitInput,
+  ReplayBundle,
+  ReplayEvent,
+  SessionId,
+  SessionSnapshot,
+  SnapshotCallback,
+} from "../types.js";
+import { ConfigValidationError, ObservabilityError } from "../../errors.js";
+import {
+  type BufferLimit,
+  MakeInMemoryStore,
+  type PositiveInt,
+  type ReplayStore,
+  type ReplayStoreIoError,
+} from "./stores.js";
+
+const DEFAULT_LIMIT: BufferLimit = "unbounded";
+const DEFAULT_SOFT_WARN_THRESHOLD = 100_000;
+const MIN_POSITIVE_INT = 1;
+
+export interface ReplayRecorderOptions {
+  readonly bufferLimit?: BufferLimitInput;
+  readonly maxSessions?: BufferLimitInput;
+  readonly softWarnThreshold?: number;
+  readonly store?: ReplayStore;
+  readonly logger?: { readonly warn: (msg: string, ctx?: unknown) => void };
+  readonly emitObservabilityError?: (err: ObservabilityError) => void;
+}
+
+export interface ReplayRecorder {
+  readonly record: (event: ReplayEvent) => Effect.Effect<void, never>;
+  readonly setSnapshotCallback: (
+    callback: SnapshotCallback,
+  ) => Effect.Effect<void, "DuplicateSnapshotCallback">;
+  readonly exportSession: (
+    sessionId: SessionId,
+    appId: string,
+  ) => Effect.Effect<ReplayBundle | null, ReplayStoreIoError>;
+  readonly clearSession: (sessionId: SessionId) => Effect.Effect<void, never>;
+  readonly clearAll: Effect.Effect<void, never>;
+}
+
+export function normalizeBufferLimit(
+  input: BufferLimitInput | undefined,
+  field: string,
+): Effect.Effect<BufferLimit, ConfigValidationError> {
+  if (input === undefined || input === "unbounded") {
+    return Effect.succeed(DEFAULT_LIMIT);
+  }
+  return Number.isInteger(input) && input >= MIN_POSITIVE_INT
+    ? Effect.succeed(input as PositiveInt)
+    : Effect.fail(
+        new ConfigValidationError(
+          field,
+          input,
+          `${field} must be a positive integer or "unbounded"`,
+        ),
+      );
+}
+
+export function makeReplayRecorder(
+  options: ReplayRecorderOptions,
+): Effect.Effect<ReplayRecorder, ConfigValidationError> {
+  return Effect.gen(function* () {
+    const bufferLimit = yield* normalizeBufferLimit(
+      options.bufferLimit,
+      "observability.replay.bufferLimit",
+    );
+    const maxSessions = yield* normalizeBufferLimit(
+      options.maxSessions,
+      "observability.replay.maxSessions",
+    );
+    const softWarnThreshold = yield* normalizeSoftWarnThreshold(
+      options.softWarnThreshold,
+    );
+    const logger = options.logger ?? { warn: () => {} };
+    const emitObservabilityError =
+      options.emitObservabilityError ??
+      ((err: ObservabilityError) => logger.warn(err.message, err));
+    const store =
+      options.store ??
+      (yield* MakeInMemoryStore({
+        bufferLimit,
+        maxSessions,
+        softWarnThreshold,
+        logger,
+      }));
+
+    let snapshotCallback: SnapshotCallback | null = null;
+
+    const emitStoreError = (message: string, err: ReplayStoreIoError): void => {
+      emitObservabilityError(new ObservabilityError(message, err));
+    };
+
+    return {
+      record: (event) =>
+        store.put(event.sessionId, event).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              emitStoreError("Replay event persistence failed", err);
+            }),
+          ),
+        ),
+      setSnapshotCallback: (callback) =>
+        Effect.sync(() => {
+          if (snapshotCallback !== null) {
+            return "DuplicateSnapshotCallback" as const;
+          }
+          snapshotCallback = callback;
+          return null;
+        }).pipe(
+          Effect.flatMap((result) =>
+            result === null ? Effect.void : Effect.fail(result),
+          ),
+        ),
+      exportSession: (sessionId, appId) =>
+        Effect.gen(function* () {
+          const read = yield* store.readAll(sessionId);
+          if (read === null || read.events.length === 0) {
+            return null;
+          }
+          const appData = yield* readSnapshot(
+            snapshotCallback,
+            sessionId,
+            emitObservabilityError,
+          );
+          const now = new Date().toISOString();
+          return {
+            schemaVersion: REPLAY_BUNDLE_SCHEMA_VERSION,
+            sessionId,
+            appId,
+            startedAt: read.events[0]?.startedAt ?? now,
+            finishedAt: now,
+            traceEvents: read.events,
+            truncated: read.truncated,
+            appData,
+          };
+        }),
+      clearSession: (sessionId) =>
+        store.clearSession(sessionId).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              emitStoreError("Replay session cleanup failed", err);
+            }),
+          ),
+        ),
+      clearAll: store.clearAll.pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            emitStoreError("Replay recorder cleanup failed", err);
+          }),
+        ),
+      ),
+    };
+  });
+}
+
+function normalizeSoftWarnThreshold(
+  value: number | undefined,
+): Effect.Effect<number, ConfigValidationError> {
+  if (value === undefined) return Effect.succeed(DEFAULT_SOFT_WARN_THRESHOLD);
+  return Number.isInteger(value) && value >= MIN_POSITIVE_INT
+    ? Effect.succeed(value)
+    : Effect.fail(
+        new ConfigValidationError(
+          "observability.replay.softWarnThreshold",
+          value,
+          "observability.replay.softWarnThreshold must be a positive integer",
+        ),
+      );
+}
+
+function readSnapshot(
+  callback: SnapshotCallback | null,
+  sessionId: SessionId,
+  emitObservabilityError: (err: ObservabilityError) => void,
+): Effect.Effect<SessionSnapshot, never> {
+  if (callback === null) return Effect.succeed({});
+  return Effect.exit(callback(sessionId)).pipe(
+    Effect.flatMap((exit) =>
+      exit._tag === "Success"
+        ? Effect.succeed(exit.value)
+        : Effect.sync(() => {
+            emitObservabilityError(
+              new ObservabilityError(
+                "Session snapshot callback failed",
+                new Error(String(exit.cause)),
+              ),
+            );
+            return {};
+          }),
+    ),
+  );
+}

--- a/packages/app-sdk/src/observability/replay/stores.test.ts
+++ b/packages/app-sdk/src/observability/replay/stores.test.ts
@@ -1,0 +1,113 @@
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { Cause, Effect, Exit } from "effect";
+import type { ReplayEvent, SessionId } from "../types.js";
+import {
+  MakeFileSystemStore,
+  MakeInMemoryStore,
+  ReplayStoreIoError,
+  ReplayStorePathError,
+  type ReplayStore,
+} from "./stores.js";
+
+const SESSION_ID = "session-store" as SessionId;
+
+const event = (requestId: string, durationMs = 1): ReplayEvent => ({
+  sessionId: SESSION_ID,
+  method: "apps/onBeforeMessageDelivery",
+  requestId,
+  startedAt: "2026-05-03T00:00:00.000Z",
+  durationMs,
+  params: { sessionId: SESSION_ID },
+  outcome: {
+    kind: "ok",
+    verdictTag: "allow",
+    verdict: { block: false },
+  },
+});
+
+const limits = {
+  bufferLimit: 2 as const,
+  maxSessions: "unbounded" as const,
+  softWarnThreshold: 100,
+  logger: { warn: () => {} },
+};
+
+const makeFileStore = async (): Promise<{
+  readonly rootDir: string;
+  readonly store: ReplayStore;
+}> => {
+  const rootDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "moltzap-replay-store-"),
+  );
+  const store = await Effect.runPromise(
+    MakeFileSystemStore({ ...limits, rootDir }),
+  );
+  return { rootDir, store };
+};
+
+describe("ReplayStore implementations", () => {
+  it("keeps a bounded replay window in memory", () => {
+    const store = Effect.runSync(MakeInMemoryStore(limits));
+
+    Effect.runSync(store.put(SESSION_ID, event("req-1")));
+    Effect.runSync(store.put(SESSION_ID, event("req-2")));
+    Effect.runSync(store.put(SESSION_ID, event("req-3")));
+
+    const read = Effect.runSync(store.readAll(SESSION_ID));
+    expect(read?.truncated).toBe(true);
+    expect(read?.events.map((e) => e.requestId)).toEqual(["req-2", "req-3"]);
+  });
+
+  it("keeps a bounded replay window on disk", async () => {
+    const { store } = await makeFileStore();
+
+    await Effect.runPromise(store.put(SESSION_ID, event("req-1")));
+    await Effect.runPromise(store.put(SESSION_ID, event("req-2")));
+    await Effect.runPromise(store.put(SESSION_ID, event("req-3")));
+
+    const read = await Effect.runPromise(store.readAll(SESSION_ID));
+    expect(read?.truncated).toBe(true);
+    expect(read?.events.map((e) => e.requestId)).toEqual(["req-2", "req-3"]);
+  });
+
+  it("rejects filesystem roots containing parent traversal", () => {
+    const exit = Effect.runSyncExit(
+      MakeFileSystemStore({ ...limits, rootDir: "../bad" }),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const err = Cause.failureOption(exit.cause);
+      expect(err._tag).toBe("Some");
+      if (err._tag === "Some") {
+        expect(err.value).toBeInstanceOf(ReplayStorePathError);
+        expect(err.value.reason).toBe("InvalidPath");
+      }
+    }
+  });
+
+  it("validates replay events read back from disk", async () => {
+    const { rootDir, store } = await makeFileStore();
+    await Effect.runPromise(store.put(SESSION_ID, event("req-1")));
+    await fsp.appendFile(
+      path.join(rootDir, `${encodeURIComponent(SESSION_ID)}.events.ndjson`),
+      JSON.stringify({ ...event("bad"), durationMs: -1 }) + "\n",
+      "utf8",
+    );
+
+    const exit = await Effect.runPromiseExit(store.readAll(SESSION_ID));
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const err = Cause.failureOption(exit.cause);
+      expect(err._tag).toBe("Some");
+      if (err._tag === "Some") {
+        expect(err.value).toBeInstanceOf(ReplayStoreIoError);
+        expect(err.value.reason).toBe("ReadFailed");
+      }
+    }
+  });
+});

--- a/packages/app-sdk/src/observability/replay/stores.ts
+++ b/packages/app-sdk/src/observability/replay/stores.ts
@@ -1,0 +1,500 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { Cause, Data, Effect, type Brand } from "effect";
+import type {
+  HookMethod,
+  ReplayEvent,
+  SessionId,
+  VerdictTag,
+} from "../types.js";
+
+export type PositiveInt = number & Brand.Brand<"PositiveInt">;
+export type BufferLimit = PositiveInt | "unbounded";
+
+export interface ReplayStoreRead {
+  readonly events: readonly ReplayEvent[];
+  readonly truncated: boolean;
+}
+
+export interface ReplayStore {
+  readonly put: (
+    sessionId: SessionId,
+    event: ReplayEvent,
+  ) => Effect.Effect<void, ReplayStoreIoError>;
+  readonly readAll: (
+    sessionId: SessionId,
+  ) => Effect.Effect<ReplayStoreRead | null, ReplayStoreIoError>;
+  readonly clearSession: (
+    sessionId: SessionId,
+  ) => Effect.Effect<void, ReplayStoreIoError>;
+  readonly clearAll: Effect.Effect<void, ReplayStoreIoError>;
+  readonly evict: Effect.Effect<void, ReplayStoreIoError>;
+}
+
+export class ReplayStorePathError extends Data.TaggedError(
+  "ReplayStorePathError",
+)<{
+  readonly reason: "InvalidPath" | "MkdirFailed" | "NotWritable";
+  readonly path: string;
+  readonly message: string;
+  readonly cause?: Cause.Cause<unknown>;
+}> {}
+
+export class ReplayStoreIoError extends Data.TaggedError("ReplayStoreIoError")<{
+  readonly reason: "WriteFailed" | "ReadFailed" | "RotateFailed";
+  readonly path: string;
+  readonly message: string;
+  readonly cause?: Cause.Cause<unknown>;
+}> {}
+
+interface StoreLimits {
+  readonly bufferLimit: BufferLimit;
+  readonly maxSessions: BufferLimit;
+  readonly softWarnThreshold: number;
+  readonly logger: { readonly warn: (msg: string, ctx?: unknown) => void };
+}
+
+interface MemorySession {
+  events: ReplayEvent[];
+  truncated: boolean;
+  warned: boolean;
+  lastWrite: number;
+}
+
+export function MakeInMemoryStore(options: StoreLimits) {
+  return Effect.sync((): ReplayStore => {
+    const sessions = new Map<string, MemorySession>();
+
+    const evict = Effect.sync(() => {
+      if (options.maxSessions === "unbounded") return;
+      while (sessions.size > options.maxSessions) {
+        let oldestKey: string | null = null;
+        let oldestWrite = Number.POSITIVE_INFINITY;
+        for (const [key, session] of sessions.entries()) {
+          if (session.lastWrite < oldestWrite) {
+            oldestKey = key;
+            oldestWrite = session.lastWrite;
+          }
+        }
+        if (oldestKey === null) return;
+        sessions.delete(oldestKey);
+      }
+    });
+
+    return {
+      put: (sessionId, event) =>
+        Effect.sync(() => {
+          const key = sessionId as string;
+          const session = sessions.get(key) ?? {
+            events: [],
+            truncated: false,
+            warned: false,
+            lastWrite: Date.now(),
+          };
+          session.events.push(event);
+          session.lastWrite = Date.now();
+          if (
+            !session.warned &&
+            session.events.length >= options.softWarnThreshold
+          ) {
+            session.warned = true;
+            options.logger.warn("Replay buffer crossed soft warn threshold", {
+              sessionId: key,
+              eventCount: session.events.length,
+              softWarnThreshold: options.softWarnThreshold,
+            });
+          }
+          if (
+            options.bufferLimit !== "unbounded" &&
+            session.events.length > options.bufferLimit
+          ) {
+            session.events = session.events.slice(-options.bufferLimit);
+            session.truncated = true;
+          }
+          sessions.set(key, session);
+        }).pipe(Effect.zipRight(evict)),
+      readAll: (sessionId) =>
+        Effect.sync(() => {
+          const session = sessions.get(sessionId as string);
+          return session === undefined
+            ? null
+            : {
+                events: [...session.events],
+                truncated: session.truncated,
+              };
+        }),
+      clearSession: (sessionId) =>
+        Effect.sync(() => {
+          sessions.delete(sessionId as string);
+        }),
+      clearAll: Effect.sync(() => {
+        sessions.clear();
+      }),
+      evict,
+    };
+  });
+}
+
+interface FileSessionMeta {
+  count: number;
+  truncated: boolean;
+  warned: boolean;
+  lastWrite: number;
+}
+
+export function MakeFileSystemStore(
+  options: StoreLimits & { readonly rootDir: string },
+): Effect.Effect<ReplayStore, ReplayStorePathError> {
+  const rootDir = path.resolve(options.rootDir);
+  if (hasParentTraversal(options.rootDir)) {
+    return Effect.fail(
+      new ReplayStorePathError({
+        reason: "InvalidPath",
+        path: options.rootDir,
+        message: `Replay store path must not contain '..': ${options.rootDir}`,
+      }),
+    );
+  }
+
+  return Effect.tryPromise({
+    try: () => fsp.mkdir(rootDir, { recursive: true }),
+    catch: (cause) =>
+      new ReplayStorePathError({
+        reason: "MkdirFailed",
+        path: rootDir,
+        message: `Failed to create replay store directory ${rootDir}`,
+        cause: Cause.die(cause),
+      }),
+  }).pipe(
+    Effect.asVoid,
+    Effect.map(() => makeFileStore(rootDir, options)),
+  );
+}
+
+function makeFileStore(rootDir: string, options: StoreLimits): ReplayStore {
+  const sessions = new Map<string, FileSessionMeta>();
+
+  const filePathFor = (sessionId: SessionId): string =>
+    path.join(
+      rootDir,
+      `${encodeURIComponent(sessionId as string)}.events.ndjson`,
+    );
+
+  const evict = Effect.gen(function* () {
+    if (options.maxSessions === "unbounded") return;
+    while (sessions.size > options.maxSessions) {
+      let oldestKey: string | null = null;
+      let oldestWrite = Number.POSITIVE_INFINITY;
+      for (const [key, session] of sessions.entries()) {
+        if (session.lastWrite < oldestWrite) {
+          oldestKey = key;
+          oldestWrite = session.lastWrite;
+        }
+      }
+      if (oldestKey === null) return;
+      sessions.delete(oldestKey);
+      const filePath = path.join(
+        rootDir,
+        `${encodeURIComponent(oldestKey)}.events.ndjson`,
+      );
+      yield* fsVoid("RotateFailed", filePath, () =>
+        fsp.rm(filePath, { force: true }),
+      );
+    }
+  });
+
+  return {
+    put: (sessionId, event) =>
+      Effect.gen(function* () {
+        const filePath = filePathFor(sessionId);
+        yield* fsVoid("WriteFailed", filePath, () =>
+          fsp.appendFile(filePath, `${JSON.stringify(event)}\n`, "utf8"),
+        );
+
+        const key = sessionId as string;
+        const meta = sessions.get(key) ?? {
+          count: 0,
+          truncated: false,
+          warned: false,
+          lastWrite: Date.now(),
+        };
+        meta.count += 1;
+        meta.lastWrite = Date.now();
+        if (!meta.warned && meta.count >= options.softWarnThreshold) {
+          meta.warned = true;
+          options.logger.warn("Replay file crossed soft warn threshold", {
+            sessionId: key,
+            eventCount: meta.count,
+            softWarnThreshold: options.softWarnThreshold,
+          });
+        }
+        if (
+          options.bufferLimit !== "unbounded" &&
+          meta.count > options.bufferLimit
+        ) {
+          const read = yield* readEvents(filePath);
+          const kept = read.events.slice(-options.bufferLimit);
+          yield* fsVoid("RotateFailed", filePath, () =>
+            fsp.writeFile(
+              filePath,
+              kept.map((e) => JSON.stringify(e)).join("\n") + "\n",
+              "utf8",
+            ),
+          );
+          meta.count = kept.length;
+          meta.truncated = true;
+        }
+        sessions.set(key, meta);
+        yield* evict;
+      }),
+    readAll: (sessionId) =>
+      Effect.gen(function* () {
+        const filePath = filePathFor(sessionId);
+        const meta = sessions.get(sessionId as string);
+        if (meta === undefined) return null;
+        const read = yield* readEvents(filePath);
+        return { events: read.events, truncated: meta.truncated };
+      }),
+    clearSession: (sessionId) =>
+      Effect.gen(function* () {
+        sessions.delete(sessionId as string);
+        yield* fsVoid("RotateFailed", filePathFor(sessionId), () =>
+          fsp.rm(filePathFor(sessionId), { force: true }),
+        );
+      }),
+    clearAll: Effect.gen(function* () {
+      sessions.clear();
+      yield* fsVoid("RotateFailed", rootDir, () =>
+        fsp.rm(rootDir, { recursive: true, force: true }),
+      );
+      yield* fsVoid("WriteFailed", rootDir, () =>
+        fsp.mkdir(rootDir, { recursive: true }),
+      );
+    }),
+    evict,
+  };
+}
+
+function hasParentTraversal(input: string): boolean {
+  return input.split(/[\\/]+/u).includes("..");
+}
+
+function fsVoid(
+  reason: ReplayStoreIoError["reason"],
+  filePath: string,
+  run: () => PromiseLike<unknown>,
+): Effect.Effect<void, ReplayStoreIoError> {
+  return Effect.tryPromise({
+    try: run,
+    catch: (cause) =>
+      new ReplayStoreIoError({
+        reason,
+        path: filePath,
+        message: `${reason} at ${filePath}`,
+        cause: Cause.die(cause),
+      }),
+  }).pipe(Effect.asVoid);
+}
+
+function readEvents(
+  filePath: string,
+): Effect.Effect<
+  { readonly events: readonly ReplayEvent[] },
+  ReplayStoreIoError
+> {
+  return Effect.tryPromise({
+    try: () => fsp.readFile(filePath, "utf8"),
+    catch: (cause) =>
+      new ReplayStoreIoError({
+        reason: "ReadFailed",
+        path: filePath,
+        message: `ReadFailed at ${filePath}`,
+        cause: Cause.die(cause),
+      }),
+  }).pipe(Effect.flatMap((raw) => decodeEventLines(filePath, raw)));
+}
+
+function decodeEventLines(
+  filePath: string,
+  raw: string,
+): Effect.Effect<
+  { readonly events: readonly ReplayEvent[] },
+  ReplayStoreIoError
+> {
+  return Effect.gen(function* () {
+    const events: ReplayEvent[] = [];
+    const lines = raw.split("\n");
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index]!.trim();
+      if (line.length === 0) continue;
+      const parsed = yield* Effect.try({
+        try: () => {
+          const value: unknown = JSON.parse(line);
+          return value;
+        },
+        catch: (cause) =>
+          new ReplayStoreIoError({
+            reason: "ReadFailed",
+            path: filePath,
+            message: `Replay event line ${index.toString()} is not valid JSON`,
+            cause: Cause.die(cause),
+          }),
+      });
+      events.push(yield* decodeReplayEvent(filePath, index, parsed));
+    }
+    return { events };
+  });
+}
+
+function decodeReplayEvent(
+  filePath: string,
+  lineIndex: number,
+  input: unknown,
+): Effect.Effect<ReplayEvent, ReplayStoreIoError> {
+  const sessionId = objectField(input, "sessionId");
+  const method = objectField(input, "method");
+  const requestId = objectField(input, "requestId");
+  const startedAt = objectField(input, "startedAt");
+  const durationMs = objectField(input, "durationMs");
+  const params = objectField(input, "params");
+  const outcome = objectField(input, "outcome");
+
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    return decodeFailed(
+      filePath,
+      lineIndex,
+      "sessionId must be a non-empty string",
+    );
+  }
+  if (!isHookMethod(method)) {
+    return decodeFailed(
+      filePath,
+      lineIndex,
+      "method must be a known hook method",
+    );
+  }
+  if (typeof requestId !== "string" || requestId.length === 0) {
+    return decodeFailed(
+      filePath,
+      lineIndex,
+      "requestId must be a non-empty string",
+    );
+  }
+  if (typeof startedAt !== "string" || startedAt.length === 0) {
+    return decodeFailed(
+      filePath,
+      lineIndex,
+      "startedAt must be a non-empty string",
+    );
+  }
+  if (
+    typeof durationMs !== "number" ||
+    !Number.isFinite(durationMs) ||
+    durationMs < 0
+  ) {
+    return decodeFailed(
+      filePath,
+      lineIndex,
+      "durationMs must be a finite non-negative number",
+    );
+  }
+  if (typeof outcome !== "object" || outcome === null) {
+    return decodeFailed(filePath, lineIndex, "outcome must be an object");
+  }
+
+  const outcomeKind = objectField(outcome, "kind");
+  const verdictTag = objectField(outcome, "verdictTag");
+  if (!isVerdictTag(verdictTag)) {
+    return decodeFailed(filePath, lineIndex, "outcome.verdictTag is invalid");
+  }
+  switch (outcomeKind) {
+    case "ok":
+      return Effect.succeed({
+        sessionId: sessionId as SessionId,
+        method,
+        requestId,
+        startedAt,
+        durationMs,
+        params,
+        outcome: {
+          kind: "ok",
+          verdictTag,
+          verdict: objectField(outcome, "verdict"),
+        },
+      });
+    case "fail-closed": {
+      const errorMessage = objectField(outcome, "errorMessage");
+      const errorTag = objectField(outcome, "errorTag");
+      if (typeof errorMessage !== "string" || errorMessage.length === 0) {
+        return decodeFailed(
+          filePath,
+          lineIndex,
+          "outcome.errorMessage must be a non-empty string",
+        );
+      }
+      if (errorTag !== undefined && typeof errorTag !== "string") {
+        return decodeFailed(
+          filePath,
+          lineIndex,
+          "outcome.errorTag must be a string when present",
+        );
+      }
+      return Effect.succeed({
+        sessionId: sessionId as SessionId,
+        method,
+        requestId,
+        startedAt,
+        durationMs,
+        params,
+        outcome: {
+          kind: "fail-closed",
+          verdictTag,
+          errorMessage,
+          ...(errorTag !== undefined ? { errorTag } : {}),
+        },
+      });
+    }
+    default:
+      return decodeFailed(filePath, lineIndex, "outcome.kind is invalid");
+  }
+}
+
+function decodeFailed(
+  filePath: string,
+  lineIndex: number,
+  message: string,
+): Effect.Effect<never, ReplayStoreIoError> {
+  return Effect.fail(
+    new ReplayStoreIoError({
+      reason: "ReadFailed",
+      path: filePath,
+      message: `Replay event line ${lineIndex.toString()} failed validation: ${message}`,
+    }),
+  );
+}
+
+function isHookMethod(input: unknown): input is HookMethod {
+  return (
+    input === "apps/onBeforeDispatch" ||
+    input === "apps/onBeforeMessageDelivery" ||
+    input === "apps/onSessionActive" ||
+    input === "apps/onJoin" ||
+    input === "apps/onClose"
+  );
+}
+
+function isVerdictTag(input: unknown): input is VerdictTag {
+  return (
+    input === "grant" ||
+    input === "deny" ||
+    input === "hold" ||
+    input === "allow" ||
+    input === "block" ||
+    input === "void"
+  );
+}
+
+function objectField(input: unknown, key: string): unknown {
+  if (typeof input !== "object" || input === null) return undefined;
+  return Object.getOwnPropertyDescriptor(input, key)?.value;
+}

--- a/packages/app-sdk/src/observability/tracer/index.ts
+++ b/packages/app-sdk/src/observability/tracer/index.ts
@@ -1,0 +1,8 @@
+export { makeTracerLayer, TracerInitError } from "./runtime.js";
+export {
+  externalParentFromTraceparent,
+  formatTraceparent,
+  parseTraceparent,
+  TraceparentInvalidError,
+  type Traceparent,
+} from "./traceparent.js";

--- a/packages/app-sdk/src/observability/tracer/runtime.test.ts
+++ b/packages/app-sdk/src/observability/tracer/runtime.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { Cause, Effect, Exit, Layer } from "effect";
+import { makeTracerLayer, TracerInitError } from "./runtime.js";
+
+const BASE_OPTIONS = {
+  appId: "test-app",
+  serviceName: "test-app-service",
+  shutdownTimeoutMs: 100,
+};
+
+describe("makeTracerLayer", () => {
+  it("builds as a no-op layer when the endpoint is empty", () => {
+    const exit = Effect.runSyncExit(
+      Effect.scoped(
+        Layer.build(
+          makeTracerLayer({
+            ...BASE_OPTIONS,
+            otlpEndpoint: "",
+          }),
+        ),
+      ),
+    );
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+  });
+
+  it("fails with TracerInitError for an invalid endpoint", () => {
+    const exit = Effect.runSyncExit(
+      Effect.scoped(
+        Layer.build(
+          makeTracerLayer({
+            ...BASE_OPTIONS,
+            otlpEndpoint: "not a url",
+          }),
+        ),
+      ),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const err = Cause.failureOption(exit.cause);
+      expect(err._tag).toBe("Some");
+      if (err._tag === "Some") {
+        expect(err.value).toBeInstanceOf(TracerInitError);
+        expect(err.value.reason).toBe("InvalidEndpoint");
+      }
+    }
+  });
+});

--- a/packages/app-sdk/src/observability/tracer/runtime.ts
+++ b/packages/app-sdk/src/observability/tracer/runtime.ts
@@ -1,0 +1,117 @@
+import { Cause, Data, Effect, Layer } from "effect";
+import type { TracerInitOptions } from "../types.js";
+
+type NodeSdkModule = typeof import("@effect/opentelemetry/NodeSdk");
+type OtlpExporterModule =
+  typeof import("@opentelemetry/exporter-trace-otlp-http");
+type SdkTraceBaseModule = typeof import("@opentelemetry/sdk-trace-base");
+
+const TRACER_DEP_LOAD_CONCURRENCY = 3;
+
+interface TracerDeps {
+  readonly NodeSdk: NodeSdkModule;
+  readonly OTLPTraceExporter: OtlpExporterModule["OTLPTraceExporter"];
+  readonly BatchSpanProcessor: SdkTraceBaseModule["BatchSpanProcessor"];
+}
+
+export class TracerInitError extends Data.TaggedError("TracerInitError")<{
+  readonly reason:
+    | "PeerDepMissing"
+    | "ExporterFactoryFailed"
+    | "InvalidEndpoint";
+  readonly message: string;
+  readonly cause?: Cause.Cause<unknown>;
+}> {}
+
+export function makeTracerLayer(
+  options: TracerInitOptions,
+): Layer.Layer<never, TracerInitError, never> {
+  if (
+    options.otlpEndpoint === undefined ||
+    options.otlpEndpoint.trim().length === 0
+  ) {
+    return Layer.empty;
+  }
+
+  return Layer.unwrapEffect(
+    Effect.gen(function* () {
+      const endpoint = yield* parseEndpoint(options.otlpEndpoint);
+      const deps = yield* loadTracerDeps();
+      return buildNodeSdkLayer(options, endpoint, deps);
+    }),
+  );
+}
+
+function buildNodeSdkLayer(
+  options: TracerInitOptions,
+  endpoint: URL,
+  deps: TracerDeps,
+): Layer.Layer<never, never, never> {
+  const exporter = new deps.OTLPTraceExporter({ url: endpoint.toString() });
+  const processor = new deps.BatchSpanProcessor(exporter);
+  return deps.NodeSdk.layer(() => ({
+    spanProcessor: processor,
+    shutdownTimeout: options.shutdownTimeoutMs,
+    resource: {
+      serviceName: options.serviceName,
+      attributes: {
+        "service.name": options.serviceName,
+        "moltzap.app_id": options.appId,
+      },
+    },
+  })).pipe(Layer.discard);
+}
+
+function parseEndpoint(
+  raw: string | undefined,
+): Effect.Effect<URL, TracerInitError> {
+  return Effect.try({
+    try: () => new URL(raw ?? ""),
+    catch: (cause) =>
+      new TracerInitError({
+        reason: "InvalidEndpoint",
+        message: `Invalid OTLP trace endpoint: ${raw ?? ""}`,
+        cause: Cause.die(cause),
+      }),
+  });
+}
+
+function loadTracerDeps(): Effect.Effect<TracerDeps, TracerInitError> {
+  const load = <A>(run: () => PromiseLike<A>) =>
+    Effect.tryPromise({
+      try: run,
+      catch: (cause) =>
+        new TracerInitError({
+          reason: isModuleResolutionError(cause)
+            ? "PeerDepMissing"
+            : "ExporterFactoryFailed",
+          message: isModuleResolutionError(cause)
+            ? "Optional OpenTelemetry peer dependency is missing"
+            : "Failed to load OpenTelemetry tracer dependency",
+          cause: Cause.die(cause),
+        }),
+    });
+
+  return Effect.all(
+    [
+      load(() => import("@effect/opentelemetry/NodeSdk")),
+      load(() => import("@opentelemetry/exporter-trace-otlp-http")),
+      load(() => import("@opentelemetry/sdk-trace-base")),
+    ],
+    { concurrency: TRACER_DEP_LOAD_CONCURRENCY },
+  ).pipe(
+    Effect.map(([NodeSdk, exporter, traceBase]) => {
+      return {
+        NodeSdk,
+        OTLPTraceExporter: exporter.OTLPTraceExporter,
+        BatchSpanProcessor: traceBase.BatchSpanProcessor,
+      };
+    }),
+  );
+}
+
+function isModuleResolutionError(cause: unknown): boolean {
+  if (typeof cause !== "object" || cause === null) return false;
+  const code = Object.getOwnPropertyDescriptor(cause, "code")?.value;
+  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+}

--- a/packages/app-sdk/src/observability/tracer/traceparent.test.ts
+++ b/packages/app-sdk/src/observability/tracer/traceparent.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { Cause, Effect, Exit } from "effect";
+import {
+  externalParentFromTraceparent,
+  formatTraceparent,
+  parseTraceparent,
+  TraceparentInvalidError,
+} from "./traceparent.js";
+
+const VALID_TRACEPARENT =
+  "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+describe("traceparent", () => {
+  it("parses and formats a valid W3C traceparent", () => {
+    const parsed = Effect.runSync(parseTraceparent(VALID_TRACEPARENT));
+
+    expect(parsed).toEqual({
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      spanId: "00f067aa0ba902b7",
+      traceFlags: 1,
+    });
+    expect(formatTraceparent(parsed)).toBe(VALID_TRACEPARENT);
+  });
+
+  it("rejects malformed traceparent strings with a typed error", () => {
+    const exit = Effect.runSyncExit(parseTraceparent("not-a-traceparent"));
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const err = Cause.failureOption(exit.cause);
+      expect(err._tag).toBe("Some");
+      if (err._tag === "Some") {
+        expect(err.value).toBeInstanceOf(TraceparentInvalidError);
+        expect(err.value.reason).toBe("MalformedString");
+      }
+    }
+  });
+
+  it("materializes an Effect external parent span from traceparent", () => {
+    const parent = Effect.runSync(
+      externalParentFromTraceparent(VALID_TRACEPARENT),
+    );
+
+    expect(parent?._tag).toBe("ExternalSpan");
+    if (parent?._tag === "ExternalSpan") {
+      expect(parent.traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+      expect(parent.spanId).toBe("00f067aa0ba902b7");
+      expect(parent.sampled).toBe(true);
+    }
+  });
+});

--- a/packages/app-sdk/src/observability/tracer/traceparent.ts
+++ b/packages/app-sdk/src/observability/tracer/traceparent.ts
@@ -1,0 +1,116 @@
+import { Data, Effect } from "effect";
+import * as Tracer from "effect/Tracer";
+
+const TRACEPARENT_PART_COUNT = 4;
+const VERSION_INDEX = 0;
+const TRACE_ID_INDEX = 1;
+const SPAN_ID_INDEX = 2;
+const FLAGS_INDEX = 3;
+const SUPPORTED_VERSION = "00";
+const TRACE_ID_LENGTH = 32;
+const SPAN_ID_LENGTH = 16;
+const FLAGS_LENGTH = 2;
+const HEX_RE = /^[0-9a-f]+$/u;
+const HEX_RADIX = 16;
+const SAMPLED_FLAG = 1;
+
+export interface Traceparent {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly traceFlags: number;
+}
+
+export class TraceparentInvalidError extends Data.TaggedError(
+  "TraceparentInvalidError",
+)<{
+  readonly reason:
+    | "MalformedString"
+    | "UnsupportedVersion"
+    | "InvalidTraceId"
+    | "InvalidSpanId"
+    | "InvalidFlags";
+  readonly raw: string;
+  readonly message: string;
+}> {}
+
+export function parseTraceparent(
+  raw: string,
+): Effect.Effect<Traceparent, TraceparentInvalidError> {
+  const parts = raw.split("-");
+  if (parts.length !== TRACEPARENT_PART_COUNT) {
+    return invalid("MalformedString", raw, "traceparent must have 4 parts");
+  }
+  const version = parts[VERSION_INDEX];
+  const traceId = parts[TRACE_ID_INDEX];
+  const spanId = parts[SPAN_ID_INDEX];
+  const flags = parts[FLAGS_INDEX];
+
+  if (version !== SUPPORTED_VERSION) {
+    return invalid(
+      "UnsupportedVersion",
+      raw,
+      `Unsupported traceparent version ${version}`,
+    );
+  }
+  if (
+    traceId === undefined ||
+    traceId.length !== TRACE_ID_LENGTH ||
+    !HEX_RE.test(traceId) ||
+    traceId === "0".repeat(TRACE_ID_LENGTH)
+  ) {
+    return invalid("InvalidTraceId", raw, "traceparent trace-id is invalid");
+  }
+  if (
+    spanId === undefined ||
+    spanId.length !== SPAN_ID_LENGTH ||
+    !HEX_RE.test(spanId) ||
+    spanId === "0".repeat(SPAN_ID_LENGTH)
+  ) {
+    return invalid("InvalidSpanId", raw, "traceparent span-id is invalid");
+  }
+  if (
+    flags === undefined ||
+    flags.length !== FLAGS_LENGTH ||
+    !HEX_RE.test(flags)
+  ) {
+    return invalid("InvalidFlags", raw, "traceparent flags are invalid");
+  }
+
+  return Effect.succeed({
+    traceId,
+    spanId,
+    traceFlags: Number.parseInt(flags, HEX_RADIX),
+  });
+}
+
+export function formatTraceparent(parent: Traceparent): string {
+  return [
+    SUPPORTED_VERSION,
+    parent.traceId,
+    parent.spanId,
+    parent.traceFlags.toString(HEX_RADIX).padStart(FLAGS_LENGTH, "0"),
+  ].join("-");
+}
+
+export function externalParentFromTraceparent(
+  raw: string | undefined,
+): Effect.Effect<Tracer.AnySpan | undefined, TraceparentInvalidError> {
+  if (raw === undefined) return Effect.succeed(undefined);
+  return parseTraceparent(raw).pipe(
+    Effect.map((traceparent) =>
+      Tracer.externalSpan({
+        traceId: traceparent.traceId,
+        spanId: traceparent.spanId,
+        sampled: (traceparent.traceFlags & SAMPLED_FLAG) === SAMPLED_FLAG,
+      }),
+    ),
+  );
+}
+
+function invalid(
+  reason: TraceparentInvalidError["reason"],
+  raw: string,
+  message: string,
+): Effect.Effect<never, TraceparentInvalidError> {
+  return Effect.fail(new TraceparentInvalidError({ reason, raw, message }));
+}

--- a/packages/app-sdk/src/observability/types.ts
+++ b/packages/app-sdk/src/observability/types.ts
@@ -1,0 +1,73 @@
+import type { Brand, Effect } from "effect";
+
+export type SessionId = string & Brand.Brand<"SessionId">;
+export type BufferLimitInput = number | "unbounded";
+
+export type HookMethod =
+  | "apps/onBeforeDispatch"
+  | "apps/onBeforeMessageDelivery"
+  | "apps/onSessionActive"
+  | "apps/onJoin"
+  | "apps/onClose";
+
+export type VerdictTag = "grant" | "deny" | "hold" | "allow" | "block" | "void";
+
+export interface ReplayEvent {
+  readonly sessionId: SessionId;
+  readonly method: HookMethod;
+  readonly requestId: string;
+  readonly startedAt: string;
+  readonly durationMs: number;
+  readonly params: unknown;
+  readonly outcome:
+    | {
+        readonly kind: "ok";
+        readonly verdictTag: VerdictTag;
+        readonly verdict: unknown;
+      }
+    | {
+        readonly kind: "fail-closed";
+        readonly verdictTag: VerdictTag;
+        readonly errorMessage: string;
+        readonly errorTag?: string;
+      };
+}
+
+export type SessionSnapshot = Readonly<Record<string, unknown>>;
+
+export type SnapshotCallback = (
+  sessionId: SessionId,
+) => Effect.Effect<SessionSnapshot, never>;
+
+export const REPLAY_BUNDLE_SCHEMA_VERSION = 1;
+
+export interface ReplayBundle {
+  readonly schemaVersion: typeof REPLAY_BUNDLE_SCHEMA_VERSION;
+  readonly sessionId: SessionId;
+  readonly appId: string;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly traceEvents: readonly ReplayEvent[];
+  readonly truncated: boolean;
+  readonly appData: SessionSnapshot;
+}
+
+export interface TracerInitOptions {
+  readonly serviceName: string;
+  readonly appId: string;
+  readonly otlpEndpoint: string | undefined;
+  readonly shutdownTimeoutMs: number;
+}
+
+export type TranscriptMeta =
+  | {
+      readonly kind: "arena-live";
+      readonly model: string;
+      readonly playerCount: number;
+      readonly gameNumber: number;
+      readonly status: string;
+    }
+  | {
+      readonly kind: "generic";
+      readonly attributes: Readonly<Record<string, unknown>>;
+    };

--- a/packages/app-sdk/src/observability/writer.test.ts
+++ b/packages/app-sdk/src/observability/writer.test.ts
@@ -1,0 +1,96 @@
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { Cause, Effect, Exit } from "effect";
+import type { ReplayBundle, ReplayEvent, SessionId } from "./types.js";
+import { makeTranscriptWriter, TranscriptWriterError } from "./writer.js";
+
+const SESSION_ID = "session-writer" as SessionId;
+
+const TRACE_EVENT: ReplayEvent = {
+  sessionId: SESSION_ID,
+  method: "apps/onClose",
+  requestId: "req-close",
+  startedAt: "2026-05-03T00:00:00.000Z",
+  durationMs: 5,
+  params: { sessionId: SESSION_ID },
+  outcome: {
+    kind: "ok",
+    verdictTag: "void",
+    verdict: {},
+  },
+};
+
+const BUNDLE: ReplayBundle = {
+  schemaVersion: 1,
+  sessionId: SESSION_ID,
+  appId: "arena-app",
+  startedAt: "2026-05-03T00:00:00.000Z",
+  finishedAt: "2026-05-03T00:01:00.000Z",
+  traceEvents: [TRACE_EVENT],
+  truncated: false,
+  appData: {
+    winner: "villagers",
+    rounds: 3,
+    phase: "complete",
+  },
+};
+
+describe("TranscriptWriter", () => {
+  it("writes the arena-live transcript shape used by arena captures", async () => {
+    const outDir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), "moltzap-transcript-"),
+    );
+    const writer = Effect.runSync(makeTranscriptWriter());
+
+    const outputPath = await Effect.runPromise(
+      writer.write(
+        BUNDLE,
+        {
+          kind: "arena-live",
+          model: "gpt 5.5",
+          playerCount: 7,
+          gameNumber: 42,
+          status: "complete",
+        },
+        outDir,
+      ),
+    );
+    const raw = await fsp.readFile(outputPath, "utf8");
+
+    expect(JSON.parse(raw)).toEqual({
+      meta: {
+        model: "gpt 5.5",
+        playerCount: 7,
+        gameNumber: 42,
+        startedAt: BUNDLE.startedAt,
+        finishedAt: BUNDLE.finishedAt,
+        winner: "villagers",
+        rounds: 3,
+        status: "complete",
+      },
+      gameplay: BUNDLE.appData,
+      traceEvents: BUNDLE.traceEvents,
+    });
+    expect(outputPath).toContain("arena-live-42-gpt-5.5-");
+  });
+
+  it("rejects output directories containing parent traversal", () => {
+    const writer = Effect.runSync(makeTranscriptWriter());
+
+    const exit = Effect.runSyncExit(
+      writer.write(BUNDLE, { kind: "generic", attributes: {} }, "../bad"),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const err = Cause.failureOption(exit.cause);
+      expect(err._tag).toBe("Some");
+      if (err._tag === "Some") {
+        expect(err.value).toBeInstanceOf(TranscriptWriterError);
+        expect(err.value.reason).toBe("InvalidOutDir");
+      }
+    }
+  });
+});

--- a/packages/app-sdk/src/observability/writer.ts
+++ b/packages/app-sdk/src/observability/writer.ts
@@ -1,0 +1,143 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { Cause, Data, Effect } from "effect";
+import type { ReplayBundle, TranscriptMeta } from "./types.js";
+
+const SAFE_SEGMENT_RE = /[^a-zA-Z0-9._-]+/gu;
+const EMPTY_SEGMENT_FALLBACK = "unknown";
+const TRANSCRIPT_JSON_INDENT_SPACES = 2;
+
+export class TranscriptWriterError extends Data.TaggedError(
+  "TranscriptWriterError",
+)<{
+  readonly reason: "MkdirFailed" | "WriteFailed" | "InvalidOutDir";
+  readonly path: string;
+  readonly message: string;
+  readonly cause?: Cause.Cause<unknown>;
+}> {}
+
+export interface TranscriptWriter {
+  readonly write: (
+    bundle: ReplayBundle,
+    meta: TranscriptMeta,
+    outDir: string,
+  ) => Effect.Effect<string, TranscriptWriterError>;
+}
+
+export function makeTranscriptWriter(): Effect.Effect<TranscriptWriter, never> {
+  return Effect.succeed({
+    write: (bundle, meta, outDir) =>
+      Effect.gen(function* () {
+        if (hasParentTraversal(outDir)) {
+          return yield* Effect.fail(
+            new TranscriptWriterError({
+              reason: "InvalidOutDir",
+              path: outDir,
+              message: `Transcript output directory must not contain '..': ${outDir}`,
+            }),
+          );
+        }
+
+        const dirName = transcriptDirName(bundle, meta);
+        const outputDir = path.join(outDir, dirName);
+        const outputPath = path.join(outputDir, "transcript.json");
+        yield* fsVoid("MkdirFailed", outputDir, () =>
+          fsp.mkdir(outputDir, { recursive: true }),
+        );
+        yield* fsVoid("WriteFailed", outputPath, () =>
+          fsp.writeFile(
+            outputPath,
+            JSON.stringify(
+              transcriptPayload(bundle, meta),
+              null,
+              TRANSCRIPT_JSON_INDENT_SPACES,
+            ) + "\n",
+            "utf8",
+          ),
+        );
+        return outputPath;
+      }),
+  });
+}
+
+function transcriptDirName(bundle: ReplayBundle, meta: TranscriptMeta): string {
+  const ts = sanitizeSegment(bundle.finishedAt);
+  switch (meta.kind) {
+    case "arena-live":
+      return [
+        "arena-live",
+        meta.gameNumber.toString(),
+        sanitizeSegment(meta.model),
+        ts,
+      ].join("-");
+    case "generic":
+      return [sanitizeSegment(bundle.sessionId as string), ts].join("-");
+    default:
+      return absurd(meta);
+  }
+}
+
+function transcriptPayload(bundle: ReplayBundle, meta: TranscriptMeta) {
+  switch (meta.kind) {
+    case "arena-live":
+      return {
+        meta: {
+          model: meta.model,
+          playerCount: meta.playerCount,
+          gameNumber: meta.gameNumber,
+          startedAt: bundle.startedAt,
+          finishedAt: bundle.finishedAt,
+          winner: snapshotField(bundle.appData, "winner"),
+          rounds: snapshotField(bundle.appData, "rounds"),
+          status: meta.status,
+        },
+        gameplay: bundle.appData,
+        traceEvents: bundle.traceEvents,
+      };
+    case "generic":
+      return {
+        meta: meta.attributes,
+        gameplay: bundle.appData,
+        traceEvents: bundle.traceEvents,
+      };
+    default:
+      return absurd(meta);
+  }
+}
+
+function snapshotField(
+  snapshot: Readonly<Record<string, unknown>>,
+  key: string,
+) {
+  return snapshot[key];
+}
+
+function sanitizeSegment(input: string): string {
+  const sanitized = input.replace(SAFE_SEGMENT_RE, "-");
+  return sanitized.length === 0 ? EMPTY_SEGMENT_FALLBACK : sanitized;
+}
+
+function hasParentTraversal(input: string): boolean {
+  return input.split(/[\\/]+/u).includes("..");
+}
+
+function fsVoid(
+  reason: TranscriptWriterError["reason"],
+  filePath: string,
+  run: () => PromiseLike<unknown>,
+): Effect.Effect<void, TranscriptWriterError> {
+  return Effect.tryPromise({
+    try: run,
+    catch: (cause) =>
+      new TranscriptWriterError({
+        reason,
+        path: filePath,
+        message: `${reason} at ${filePath}`,
+        cause: Cause.die(cause),
+      }),
+  }).pipe(Effect.asVoid);
+}
+
+function absurd(value: never): never {
+  return value;
+}

--- a/packages/client/src/runtime/frame.test.ts
+++ b/packages/client/src/runtime/frame.test.ts
@@ -33,4 +33,28 @@ describe("decodeFrames", () => {
       result: { ok: true },
     });
   });
+
+  it("decodes traceparent from inbound s2c request frames", async () => {
+    const raw = JSON.stringify({
+      jsonrpc: "2.0",
+      type: "request",
+      direction: "s2c",
+      id: "srv-trace-1",
+      method: "apps/onJoin",
+      params: { sessionId: "sess-trace" },
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    });
+
+    const decoded = await Effect.runPromise(decodeFrames(raw));
+
+    expect(decoded).toEqual([
+      {
+        _tag: "ServerRequest",
+        id: "srv-trace-1",
+        method: "apps/onJoin",
+        params: { sessionId: "sess-trace" },
+        traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      },
+    ]);
+  });
 });

--- a/packages/client/src/ws-client.test.ts
+++ b/packages/client/src/ws-client.test.ts
@@ -1054,18 +1054,28 @@ describe("Phase 1.0 (B.1) — handleServerRpc round-trip", () => {
                   id: "srv-test-1",
                   method: "apps/onJoin",
                   params: { sessionId: "sess-A" },
+                  traceparent:
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
                 }),
               );
             }
           }),
         );
         const client = makeClient(server.url);
+        let seenCtx: {
+          readonly requestId: string;
+          readonly method: string;
+          readonly traceparent?: string;
+        } | null = null;
         // Register a handler BEFORE connect so the dispatcher fiber sees
         // it on the very first inbound s2c request.
-        yield* client.handleServerRpc("apps/onJoin", (params) =>
-          Effect.succeed({
-            ack: true,
-            saw: (params as { sessionId: string }).sessionId,
+        yield* client.handleServerRpc("apps/onJoin", (params, ctx) =>
+          Effect.sync(() => {
+            seenCtx = ctx;
+            return {
+              ack: true,
+              saw: (params as { sessionId: string }).sessionId,
+            };
           }),
         );
         yield* Effect.promise(() => connectP(client));
@@ -1117,6 +1127,12 @@ describe("Phase 1.0 (B.1) — handleServerRpc round-trip", () => {
         expect(parsedResponse.id).toBe("srv-test-1");
         expect(parsedResponse.result.ack).toBe(true);
         expect(parsedResponse.result.saw).toBe("sess-A");
+        expect(seenCtx).toEqual({
+          requestId: "srv-test-1",
+          method: "apps/onJoin",
+          traceparent:
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        });
 
         yield* closeClient(client);
       }),

--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -5,16 +5,19 @@ import {
   Deferred,
   Duration,
   Effect,
+  Either,
   Exit,
   Fiber,
   HashMap,
   ManagedRuntime,
+  Match,
   Option,
   Ref,
   Schedule,
   Scope,
 } from "effect";
 import {
+  ErrorCodes,
   PROTOCOL_VERSION,
   responseFrame,
   type RequestFrame,
@@ -38,7 +41,11 @@ import {
   type SubscriberRegistry,
   type SubscriptionFilter,
 } from "./runtime/subscribers.js";
-import { extractCloseInfo, type CloseInfo } from "./runtime/close-info.js";
+import {
+  DEFAULT_GRACEFUL_CLOSE,
+  extractCloseInfo,
+  type CloseInfo,
+} from "./runtime/close-info.js";
 import {
   makePartitionedDispatcher,
   type PartitionedDispatcher,
@@ -65,6 +72,11 @@ export interface RpcCallOptions {
 /** Reconnect backoff: 1s base, doubling per attempt up to the cap. */
 const BASE_RECONNECT_DELAY_MS = 1000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
+const CLOSE_CLEANUP_CONCURRENCY = 3;
+const RECONNECT_BACKOFF_FACTOR = 2;
+const DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS = 5_000;
+const WEBSOCKET_OPEN_TIMEOUT_SECONDS = 10;
+const MALFORMED_FRAME_LOG_BYTES = 200;
 
 /**
  * Log 1-of-N malformed frames. A misbehaving server could flood us otherwise;
@@ -507,12 +519,17 @@ export class MoltZapWsClient {
           // the client is permanently torn down. Idempotent.
           this.subscribers.closeAll,
         ],
-        { concurrency: "unbounded" },
+        { concurrency: CLOSE_CLEANUP_CONCURRENCY },
       );
       const state = yield* Ref.getAndSet(this.stateRef, Option.none());
       if (Option.isSome(state)) {
         yield* state.value
-          .write(new Socket.CloseEvent(1000, "normal"))
+          .write(
+            new Socket.CloseEvent(
+              DEFAULT_GRACEFUL_CLOSE.code,
+              DEFAULT_GRACEFUL_CLOSE.reason,
+            ),
+          )
           .pipe(Effect.orDie);
         yield* Scope.close(state.value.scope, Exit.void);
         // The partitioned dispatcher's Scope is NOT bound to the
@@ -540,12 +557,14 @@ export class MoltZapWsClient {
    * with a per-call timeout. */
   waitForEvent(
     eventName: string,
-    timeoutMs = 5000,
+    timeoutMs = DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS,
   ): Effect.Effect<EventFrame, Error> {
     return Effect.gen(this, function* () {
       const buffered = yield* Ref.modify(this.eventsBufferRef, (events) => {
         const idx = events.findIndex((e) => e.event === eventName);
-        if (idx === -1) return [null as EventFrame | null, events];
+        if (idx === -1) {
+          return [null as EventFrame | null, events];
+        }
         const chosen = events[idx]!;
         const next = [...events.slice(0, idx), ...events.slice(idx + 1)];
         return [chosen, next];
@@ -626,7 +645,9 @@ export class MoltZapWsClient {
       // Map Socket open failures (SocketGenericError / SocketCloseError) to
       // NotConnectedError so callers see a single typed error.
       const socket = yield* Scope.extend(
-        Socket.makeWebSocket(url, { openTimeout: Duration.seconds(10) }),
+        Socket.makeWebSocket(url, {
+          openTimeout: Duration.seconds(WEBSOCKET_OPEN_TIMEOUT_SECONDS),
+        }),
         scope,
       ).pipe(
         Effect.catchAllCause((cause) =>
@@ -836,8 +857,15 @@ export class MoltZapWsClient {
         Effect.as(null),
       );
       const writeRace = yield* Effect.race(writeAttempt, earlyFailure);
-      if (writeRace !== null && writeRace._tag === "Left") {
-        this.options.logger?.warn("ws.send failed", writeRace.left);
+      const writeFailure =
+        writeRace === null
+          ? null
+          : Either.match(writeRace, {
+              onLeft: (err) => err,
+              onRight: () => null,
+            });
+      if (writeFailure !== null) {
+        this.options.logger?.warn("ws.send failed", writeFailure);
         yield* Ref.update(this.pendingRef, (m) => HashMap.remove(m, id));
         return yield* Effect.fail(
           new NotConnectedError({ message: MSG_NOT_CONNECTED }),
@@ -903,37 +931,31 @@ export class MoltZapWsClient {
     requestId: string,
     write: ConnState["write"],
   ): Effect.Effect<void, never> {
-    const reply: ResponseFrame = (() => {
-      switch (err._tag) {
-        case "MalformedPartitionKeyError":
-          return responseFrame("s2c", requestId, {
+    const reply: ResponseFrame = Match.value(err).pipe(
+      Match.tagsExhaustive({
+        MalformedPartitionKeyError: (malformed) =>
+          responseFrame("s2c", requestId, {
             error: {
               code: -32602,
-              message: `Invalid params: ${err.reason}`,
+              message: `Invalid params: ${malformed.reason}`,
             },
-          });
-        case "PartitionLimitError":
-          return responseFrame("s2c", requestId, {
+          }),
+        PartitionLimitError: (limit) =>
+          responseFrame("s2c", requestId, {
             error: {
               code: -32000,
-              message: `Server busy: partition limit reached (${err.activePartitions}/${err.maxPartitions})`,
+              message: `Server busy: partition limit reached (${limit.activePartitions}/${limit.maxPartitions})`,
             },
-          });
-        case "PartitionQueueFullError":
-          return responseFrame("s2c", requestId, {
+          }),
+        PartitionQueueFullError: (full) =>
+          responseFrame("s2c", requestId, {
             error: {
               code: -32000,
-              message: `Server busy: partition queue full (capacity=${err.capacity})`,
+              message: `Server busy: partition queue full (capacity=${full.capacity})`,
             },
-          });
-        default: {
-          const _exhaustive: never = err;
-          throw new Error(
-            `writeOfferRejection: unhandled OfferRejected tag: ${String(_exhaustive)}`,
-          );
-        }
-      }
-    })();
+          }),
+      }),
+    );
     return write(JSON.stringify(reply)).pipe(
       Effect.catchAll((werr) =>
         Effect.sync(() =>
@@ -970,7 +992,7 @@ export class MoltZapWsClient {
           ? Effect.succeed(
               responseFrame("s2c", request.id, {
                 error: {
-                  code: -32601,
+                  code: ErrorCodes.MethodNotFound,
                   message: `No handler registered for method: ${request.method}`,
                 },
               }) satisfies ResponseFrame,
@@ -1003,7 +1025,10 @@ export class MoltZapWsClient {
                       Cause.pretty(cause),
                     );
                     return responseFrame("s2c", request.id, {
-                      error: { code: -32603, message: "Internal error" },
+                      error: {
+                        code: ErrorCodes.InternalError,
+                        message: "Internal error",
+                      },
                     }) satisfies ResponseFrame;
                   }),
                 ),
@@ -1030,7 +1055,7 @@ export class MoltZapWsClient {
             if (n === 1 || n % MALFORMED_LOG_EVERY === 0) {
               this.options.logger?.warn(
                 `Malformed frame (#${n}):`,
-                err.raw.slice(0, 200),
+                err.raw.slice(0, MALFORMED_FRAME_LOG_BYTES),
               );
             }
             return null;
@@ -1054,7 +1079,10 @@ export class MoltZapWsClient {
             yield* Deferred.fail(
               pending,
               new RpcServerError({
-                code: typeof error.code === "number" ? error.code : -32603,
+                code:
+                  typeof error.code === "number"
+                    ? error.code
+                    : ErrorCodes.InternalError,
                 message: error.message ?? MSG_RPC_ERROR_FALLBACK,
                 data: error.data,
               }),
@@ -1094,15 +1122,16 @@ export class MoltZapWsClient {
               id: decoded.id,
               method: decoded.method,
               params: decoded.params,
+              ...(decoded.traceparent !== undefined
+                ? { traceparent: decoded.traceparent }
+                : {}),
             }),
           );
-          if (offered._tag === "Left") {
-            yield* this.writeOfferRejection(
-              offered.left,
-              decoded.id,
-              state.value.write,
-            );
-          }
+          yield* Either.match(offered, {
+            onLeft: (err) =>
+              this.writeOfferRejection(err, decoded.id, state.value.write),
+            onRight: () => Effect.void,
+          });
           continue;
         }
 
@@ -1190,13 +1219,11 @@ export class MoltZapWsClient {
           }
         }),
       ),
-      // Collapse typed errors so `Schedule.exponential` can retry.
-      Effect.mapError(() => new Error("reconnect attempt failed")),
     );
 
     const backoff = Schedule.exponential(
       Duration.millis(BASE_RECONNECT_DELAY_MS),
-      2,
+      RECONNECT_BACKOFF_FACTOR,
     ).pipe(
       Schedule.either(Schedule.spaced(Duration.millis(MAX_RECONNECT_DELAY_MS))),
       Schedule.jittered,

--- a/packages/protocol/src/schema/frames.test.ts
+++ b/packages/protocol/src/schema/frames.test.ts
@@ -38,6 +38,20 @@ describe("RequestFrameSchema", () => {
     ).toBe(true);
   });
 
+  it("accepts request frames with traceparent", () => {
+    expect(
+      validate({
+        jsonrpc: "2.0",
+        type: "request",
+        direction: "s2c",
+        id: "srv-trace-1",
+        method: "apps/onJoin",
+        params: { sessionId: "s-1" },
+        traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      }),
+    ).toBe(true);
+  });
+
   it("rejects missing direction", () => {
     expect(
       validate({

--- a/packages/server/src/ws/connection.s2c.test.ts
+++ b/packages/server/src/ws/connection.s2c.test.ts
@@ -103,11 +103,13 @@ describe("sendRpcToClient — happy-path round-trip", () => {
         id: string;
         method: string;
         params: { sessionId: string };
+        traceparent?: string;
       };
       expect(frame.type).toBe("request");
       expect(frame.direction).toBe("s2c");
       expect(frame.method).toBe("apps/onJoin");
       expect(frame.params.sessionId).toBe("sess-1");
+      expect(frame.traceparent).toBeUndefined();
       // `srv-<connId>-<seq>` namespace prefix — direction-namespacing keeps
       // c2s and s2c id pools disjoint per the architect plan.
       expect(frame.id.startsWith("srv-conn-happy-")).toBe(true);
@@ -135,6 +137,54 @@ describe("sendRpcToClient — happy-path round-trip", () => {
     if (Exit.isSuccess(exit)) {
       expect(exit.value).toEqual({ ok: true, surface: "decision" });
     }
+  });
+
+  it("injects the current Effect span as W3C traceparent when one is active", async () => {
+    const program = Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const { conn, outbound } = yield* Scope.extend(
+        makeFakeConnection("conn-trace"),
+        scope,
+      );
+
+      const fiber = yield* Effect.fork(
+        sendRpcToClient(conn, "apps/onJoin", { sessionId: "trace-sess" }).pipe(
+          Effect.withSpan("apphost.s2c.apps/onJoin"),
+        ),
+      );
+
+      const captured = yield* Ref.get(outbound).pipe(
+        Effect.flatMap((xs) =>
+          xs.length > 0
+            ? Effect.succeed(xs[0]!)
+            : Effect.fail(new Error("no frame yet")),
+        ),
+        Effect.retry({ times: 50, schedule: undefined }),
+      );
+
+      const frame = JSON.parse(captured) as {
+        id: string;
+        traceparent?: string;
+      };
+      expect(frame.traceparent).toMatch(
+        /^00-[0-9a-f]{32}-[0-9a-f]{16}-(00|01)$/u,
+      );
+
+      yield* completeS2cResponse(conn, {
+        jsonrpc: "2.0",
+        type: "response",
+        direction: "s2c",
+        id: frame.id,
+        result: { ok: true },
+      });
+
+      const exit = yield* Fiber.join(fiber).pipe(Effect.exit);
+      yield* Scope.close(scope, Exit.void);
+      return exit;
+    });
+
+    const exit = await Effect.runPromise(program);
+    expect(Exit.isSuccess(exit)).toBe(true);
   });
 
   it("propagates a typed error response as S2cRpcResponseError", async () => {

--- a/packages/server/src/ws/connection.ts
+++ b/packages/server/src/ws/connection.ts
@@ -9,6 +9,7 @@ import {
 } from "effect";
 import * as Socket from "@effect/platform/Socket";
 import type { ResponseFrame, RequestFrame } from "@moltzap/protocol";
+import type * as Tracer from "effect/Tracer";
 import type { AuthenticatedContext } from "../rpc/context.js";
 
 /**
@@ -52,6 +53,10 @@ export type S2cRpcError =
   | S2cRpcResponseError
   | S2cRpcDecodeError
   | S2cRpcSocketError;
+
+const TRACEPARENT_VERSION = "00";
+const TRACEPARENT_SAMPLED_FLAGS = "01";
+const TRACEPARENT_UNSAMPLED_FLAGS = "00";
 
 /**
  * Per-connection s2c pending map. Each entry correlates an outbound s2c
@@ -199,6 +204,7 @@ export function sendRpcToClient(
   return Effect.gen(function* () {
     const requestId = yield* nextS2cRequestId(connection);
     const deferred = yield* Deferred.make<unknown, S2cRpcError>();
+    const traceparent = yield* traceparentFromCurrentSpan;
     const frame: RequestFrame = {
       jsonrpc: "2.0",
       type: "request",
@@ -206,6 +212,7 @@ export function sendRpcToClient(
       id: requestId,
       method,
       params,
+      ...(traceparent !== undefined ? { traceparent } : {}),
     };
     const raw = JSON.stringify(frame);
 
@@ -232,20 +239,22 @@ export function sendRpcToClient(
       // Deferred. Caller observes whichever completion landed first;
       // both error tags are correct readings of the failure.
       () =>
-        Effect.gen(function* () {
-          const writeOutcome = yield* Effect.either(connection.write(raw));
-          if (writeOutcome._tag === "Left") {
-            const err = new S2cRpcSocketError({
-              connectionId: connection.id,
-              method,
-              requestId,
-              cause: writeOutcome.left,
-            });
-            yield* Deferred.fail(deferred, err).pipe(Effect.ignore);
-            return yield* Effect.fail<S2cRpcError>(err);
-          }
-          return yield* Deferred.await(deferred);
-        }),
+        connection.write(raw).pipe(
+          Effect.matchEffect({
+            onFailure: (socketError) =>
+              Effect.gen(function* () {
+                const err = new S2cRpcSocketError({
+                  connectionId: connection.id,
+                  method,
+                  requestId,
+                  cause: socketError,
+                });
+                yield* Deferred.fail(deferred, err).pipe(Effect.ignore);
+                return yield* Effect.fail<S2cRpcError>(err);
+              }),
+            onSuccess: () => Deferred.await(deferred),
+          }),
+        ),
       // release: remove the entry. Idempotent — `HashMap.remove` on an
       // already-removed key is a no-op, so this is safe whether
       // `completeS2cResponse` already removed it (success/error path)
@@ -254,6 +263,23 @@ export function sendRpcToClient(
         Ref.update(connection.s2cPending, (m) => HashMap.remove(m, requestId)),
     );
   });
+}
+
+const traceparentFromCurrentSpan: Effect.Effect<string | undefined> =
+  Effect.currentSpan.pipe(
+    Effect.match({
+      onFailure: () => undefined,
+      onSuccess: formatTraceparentFromSpan,
+    }),
+  );
+
+function formatTraceparentFromSpan(span: Tracer.Span): string {
+  return [
+    TRACEPARENT_VERSION,
+    span.traceId,
+    span.spanId,
+    span.sampled ? TRACEPARENT_SAMPLED_FLAGS : TRACEPARENT_UNSAMPLED_FLAGS,
+  ].join("-");
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,43 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+    optionalDependencies:
+      '@effect/opentelemetry':
+        specifier: 0.63.0
+        version: 0.63.0(@effect/platform@0.96.0(effect@3.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.216.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)(effect@3.21.0)
+      '@effect/platform':
+        specifier: 0.96.0
+        version: 0.96.0(effect@3.21.0)
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
+      '@opentelemetry/core':
+        specifier: 2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: 0.216.0
+        version: 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: 2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs':
+        specifier: 0.216.0
+        version: 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics':
+        specifier: 2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: 2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web':
+        specifier: 2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: 1.40.0
+        version: 1.40.0
 
   packages/claude-code-channel:
     dependencies:
@@ -814,6 +851,20 @@ packages:
         optional: true
       lmdb:
         optional: true
+
+  '@effect/opentelemetry@0.63.0':
+    resolution: {integrity: sha512-2yUG2QWNATi1uKP0kwhaP5eLp+c5NDzAL3EOpIcGLBAC0cbXZrx4n9Qw/QwUKxpuV+pbhrBUPCiByyWAFKfuCw==}
+    peerDependencies:
+      '@effect/platform': ^0.96.0
+      '@opentelemetry/api': ^1.9
+      '@opentelemetry/resources': ^2.0.0
+      '@opentelemetry/sdk-logs': '>=0.203.0 <0.300.0'
+      '@opentelemetry/sdk-metrics': ^2.0.0
+      '@opentelemetry/sdk-trace-base': ^2.0.0
+      '@opentelemetry/sdk-trace-node': ^2.0.0
+      '@opentelemetry/sdk-trace-web': ^2.0.0
+      '@opentelemetry/semantic-conventions': ^1.33.0
+      effect: ^3.21.0
 
   '@effect/platform-node-shared@0.59.0':
     resolution: {integrity: sha512-3bq2YKKfLY7UFauZSxqZUneCXoA3SMSls82V+0RKunvRlfPuPQW0hVn6t1RkvEdh0PDoygWG2mZXYQa6Iqgp9A==}
@@ -2064,6 +2115,84 @@ packages:
 
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     resolution: {integrity: sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==}
+
+  '@opentelemetry/api-logs@0.216.0':
+    resolution: {integrity: sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.7.1':
+    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.216.0':
+    resolution: {integrity: sha512-DhWjvj0PUPFwFnhOEivpum8sJzj6FTuyx88zff+oHVLUhfd6cLyw4AIai/F4j0PZqYZBFuMT/OTMUd9wdXnBEQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.216.0':
+    resolution: {integrity: sha512-sSnvb5f+FYa4mfYxj03rmmUh+aDwo3jok62dgIWUDw8ZCUPzEbgtv/YhZyKUSlKNNey7Uc5xmJgmtTLLIV6UDQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.216.0':
+    resolution: {integrity: sha512-g4Rb6sAsxQAo11eDjixfKxelruBsQFdJ8Wo23FCj7D6OXbidgXMu2xaRSYs4RdlomzAXSJuc86RcS3xmE8A6uA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.216.0':
+    resolution: {integrity: sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.7.1':
+    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-web@2.7.1':
+    resolution: {integrity: sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
 
   '@oxfmt/darwin-arm64@0.7.0':
     resolution: {integrity: sha512-By831Cju71Etl3VetSrL1DrYcUwYIaKlOt0Icss5zUBUMGy8g2/C6iImVTpccDkPDJEsr1N67adhGqUHisBxqA==}
@@ -5877,8 +6006,8 @@ packages:
     resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
     hasBin: true
 
-  msgpackr@1.11.9:
-    resolution: {integrity: sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==}
+  msgpackr@1.11.12:
+    resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
 
   multipasta@0.2.7:
     resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
@@ -6547,6 +6676,10 @@ packages:
 
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -8727,6 +8860,20 @@ snapshots:
       effect: 3.21.0
       uuid: 11.1.0
 
+  '@effect/opentelemetry@0.63.0(@effect/platform@0.96.0(effect@3.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.216.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)(effect@3.21.0)':
+    dependencies:
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      effect: 3.21.0
+    optional: true
+
   '@effect/platform-node-shared@0.59.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
       '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
@@ -8760,7 +8907,7 @@ snapshots:
     dependencies:
       effect: 3.21.0
       find-my-way-ts: 0.1.6
-      msgpackr: 1.11.9
+      msgpackr: 1.11.12
       multipasta: 0.2.7
 
   '@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.21.0))(effect@3.21.0)':
@@ -8778,7 +8925,7 @@ snapshots:
     dependencies:
       '@effect/platform': 0.96.0(effect@3.21.0)
       effect: 3.21.0
-      msgpackr: 1.11.9
+      msgpackr: 1.11.12
 
   '@effect/sql-kysely@0.47.0(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)(kysely@0.28.16)':
     dependencies:
@@ -10285,6 +10432,103 @@ snapshots:
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     dependencies:
       fast-deep-equal: 3.1.3
+
+  '@opentelemetry/api-logs@0.216.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+    optional: true
+
+  '@opentelemetry/api@1.9.1':
+    optional: true
+
+  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+    optional: true
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+    optional: true
+
+  '@opentelemetry/exporter-trace-otlp-http@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+    optional: true
+
+  '@opentelemetry/otlp-exporter-base@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+    optional: true
+
+  '@opentelemetry/otlp-transformer@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.1
+    optional: true
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    optional: true
+
+  '@opentelemetry/sdk-logs@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    optional: true
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+    optional: true
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    optional: true
+
+  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+    optional: true
+
+  '@opentelemetry/sdk-trace-web@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+    optional: true
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    optional: true
 
   '@oxfmt/darwin-arm64@0.7.0':
     optional: true
@@ -14900,7 +15144,7 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
     optional: true
 
-  msgpackr@1.11.9:
+  msgpackr@1.11.12:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
@@ -15615,6 +15859,22 @@ snapshots:
       '@protobufjs/utf8': 1.1.0
       '@types/node': 25.5.0
       long: 5.3.2
+
+  protobufjs@8.0.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 25.5.0
+      long: 5.3.2
+    optional: true
 
   proxy-addr@2.0.7:
     dependencies:


### PR DESCRIPTION
## Summary
- add app SDK observability primitives for tracing, replay bundles, snapshot export, and transcript writing
- propagate traceparent through protocol, client, and server RPC paths
- document OTLP/Jaeger setup and keep no-magic-numbers practical for -1/0/1/index idioms

## Verification
- pnpm --filter @moltzap/app-sdk exec tsc --noEmit
- pnpm --filter @moltzap/client exec tsc --noEmit
- pnpm --filter @moltzap/protocol exec tsc --noEmit
- pnpm --filter ./packages/server exec tsc --noEmit
- pnpm exec eslint <touched observability/client/server/protocol files>
- pnpm --filter @moltzap/app-sdk exec vitest run
- pnpm --filter @moltzap/client exec vitest run src/runtime/frame.test.ts src/ws-client.test.ts
- pnpm --filter @moltzap/protocol exec vitest run src/schema/frames.test.ts
- pnpm --filter ./packages/server exec vitest run src/ws/connection.s2c.test.ts
- pre-commit hook: oxfmt, pnpm check, pnpm build, pnpm typecheck, safer guardrails
