### PR TITLE
chore: clear safe lint backlog

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,7 +25,13 @@ export default [
     },
     rules: {
       ...guard.configs.recommended.rules,
-      "@typescript-eslint/no-magic-numbers": "warn",
+      "@typescript-eslint/no-magic-numbers": [
+        "warn",
+        {
+          ignore: [-1, 0, 1],
+          ignoreArrayIndexes: true,
+        },
+      ],
       "@typescript-eslint/no-unused-vars": "error",
       "sonarjs/no-duplicate-string": ["warn", { threshold: 4 }],
     },

--- a/packages/app-sdk/src/app.handlers.test.ts
+++ b/packages/app-sdk/src/app.handlers.test.ts
@@ -75,7 +75,7 @@ vi.mock("@moltzap/client", async () => {
           .fn()
           .mockImplementation(() => Effect.succeed({ agentId: "agent-1" })),
         sendRpc: vi.fn().mockImplementation((method: string) => {
-          if (method === "apps/attachConversation") {
+          if (method === AppsAttachConversation.name) {
             if (attachShouldFail !== null) {
               const err = attachShouldFail.error;
               attachShouldFail = null;
@@ -131,7 +131,23 @@ vi.mock("@moltzap/client", async () => {
 
 // Import the SDK AFTER vi.mock so the mock is active.
 import { MoltZapApp } from "./app.js";
-import { AppError, AppHandlerError, AttachError } from "./errors.js";
+import {
+  AppHandlerError,
+  AttachAlreadyAttachedError,
+  AttachConversationNotFoundError,
+  AttachFailedError,
+  AttachNotAuthorizedError,
+  AttachSessionNotFoundError,
+  DuplicateHookHandlerError,
+} from "./errors.js";
+import {
+  AppsAttachConversation,
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnClose,
+  AppsOnJoin,
+  AppsOnSessionActive,
+} from "@moltzap/protocol";
 
 interface MockedWsClient {
   _invokeHandler: (
@@ -205,13 +221,13 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
           leaseId: `lease-${ctx.sessionId.slice(0, 4)}`,
         }),
       );
-      expect(asMock(app.client)._hasHandler("apps/onBeforeDispatch")).toBe(
+      expect(asMock(app.client)._hasHandler(AppsOnBeforeDispatch.name)).toBe(
         true,
       );
 
       const reply = await Effect.runPromise(
         asMock(app.client)._invokeHandler(
-          "apps/onBeforeDispatch",
+          AppsOnBeforeDispatch.name,
           baseDispatchCtx,
         ),
       );
@@ -237,7 +253,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       const start = Date.now();
       const reply = await Effect.runPromise(
         asMock(app.client)._invokeHandler(
-          "apps/onBeforeDispatch",
+          AppsOnBeforeDispatch.name,
           baseDispatchCtx,
         ),
       );
@@ -261,7 +277,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       );
       const reply = await Effect.runPromise(
         asMock(app.client)._invokeHandler(
-          "apps/onBeforeDispatch",
+          AppsOnBeforeDispatch.name,
           baseDispatchCtx,
         ),
       );
@@ -271,11 +287,10 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       expect(onErr).toHaveBeenCalledTimes(1);
       const errArg = onErr.mock.calls[0]![0] as AppHandlerError;
       expect(errArg).toBeInstanceOf(AppHandlerError);
-      expect(errArg.code).toBe("APP_HANDLER_ERROR");
-      expect(errArg.method).toBe("apps/onBeforeDispatch");
+      expect(errArg.method).toBe(AppsOnBeforeDispatch.name);
     });
 
-    it("throws AppError DUPLICATE_HOOK_HANDLER on second registration", () => {
+    it("throws DuplicateHookHandlerError on second registration", () => {
       app.onBeforeDispatch(() =>
         Effect.succeed<DispatchAdmissionResult>({ decision: "grant" }),
       );
@@ -283,13 +298,13 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
         app.onBeforeDispatch(() =>
           Effect.succeed<DispatchAdmissionResult>({ decision: "grant" }),
         ),
-      ).toThrow(AppError);
+      ).toThrow(DuplicateHookHandlerError);
       try {
         app.onBeforeDispatch(() =>
           Effect.succeed<DispatchAdmissionResult>({ decision: "grant" }),
         );
       } catch (e) {
-        expect((e as AppError).code).toBe("DUPLICATE_HOOK_HANDLER");
+        expect(e).toBeInstanceOf(DuplicateHookHandlerError);
       }
     });
   });
@@ -303,7 +318,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       app.onBeforeMessageDelivery(() => Effect.succeed(verdict));
       const reply = await Effect.runPromise(
         asMock(app.client)._invokeHandler(
-          "apps/onBeforeMessageDelivery",
+          AppsOnBeforeMessageDelivery.name,
           baseDeliveryCtx,
         ),
       );
@@ -318,7 +333,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       );
       const reply = await Effect.runPromise(
         asMock(app.client)._invokeHandler(
-          "apps/onBeforeMessageDelivery",
+          AppsOnBeforeMessageDelivery.name,
           baseDeliveryCtx,
         ),
       );
@@ -329,9 +344,9 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
 
   describe("lifecycle hooks (onSessionActive / onJoin / onClose)", () => {
     it.each([
-      ["apps/onSessionActive", baseSessionActiveCtx, "onSessionActive"],
-      ["apps/onJoin", baseJoinCtx, "onJoin"],
-      ["apps/onClose", baseCloseCtx, "onClose"],
+      [AppsOnSessionActive.name, baseSessionActiveCtx, "onSessionActive"],
+      [AppsOnJoin.name, baseJoinCtx, "onJoin"],
+      [AppsOnClose.name, baseCloseCtx, "onClose"],
     ] as const)(
       "%s replies with empty result on success",
       async (method, ctx, methodName) => {
@@ -364,19 +379,21 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       );
       const reply = await Effect.runPromise(
         asMock(app.client)._invokeHandler(
-          "apps/onSessionActive",
+          AppsOnSessionActive.name,
           baseSessionActiveCtx,
         ),
       );
       expect(reply).toEqual({});
       expect(onErr).toHaveBeenCalledTimes(1);
       const errArg = onErr.mock.calls[0]![0] as AppHandlerError;
-      expect(errArg.method).toBe("apps/onSessionActive");
+      expect(errArg.method).toBe(AppsOnSessionActive.name);
     });
 
     it("each lifecycle hook rejects duplicate registration", () => {
       app.onJoin(() => Effect.void);
-      expect(() => app.onJoin(() => Effect.void)).toThrow(AppError);
+      expect(() => app.onJoin(() => Effect.void)).toThrow(
+        DuplicateHookHandlerError,
+      );
     });
   });
 
@@ -392,13 +409,13 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
     });
 
     it.each([
-      ["SessionNotFound", "SessionNotFound" as const],
-      ["ConversationNotFound", "ConversationNotFound" as const],
-      ["NotAuthorized", "NotAuthorized" as const],
-      ["AlreadyAttached", "AlreadyAttached" as const],
+      ["SessionNotFound", AttachSessionNotFoundError],
+      ["ConversationNotFound", AttachConversationNotFoundError],
+      ["NotAuthorized", AttachNotAuthorizedError],
+      ["AlreadyAttached", AttachAlreadyAttachedError],
     ])(
-      "maps RpcServerError data.code='%s' to AttachError code '%s'",
-      async (dataCode, expectedCode) => {
+      "maps RpcServerError data.code='%s' to %s",
+      async (dataCode, ExpectedError) => {
         asMock(app.client)._setAttachFailure(
           new MockRpcServerError({
             code: -32099,
@@ -415,8 +432,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
         expect(Exit.isFailure(exit)).toBe(true);
         if (Exit.isFailure(exit)) {
           const err = exit.cause._tag === "Fail" ? exit.cause.error : null;
-          expect(err).toBeInstanceOf(AttachError);
-          expect((err as AttachError).code).toBe(expectedCode);
+          expect(err).toBeInstanceOf(ExpectedError);
         }
       },
     );
@@ -425,8 +441,8 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
     // (no numeric -32003, no structured `data.code`), the SDK matches the
     // canonical server message — see
     // `packages/server/src/app/app-host.ts` ("Conversation X is already
-    // attached to session Y") — and routes to AttachError('AlreadyAttached').
-    it("maps 'already attached' message substring to AttachError code 'AlreadyAttached'", async () => {
+    // attached to session Y") — and routes to AttachAlreadyAttachedError.
+    it("maps 'already attached' message substring to AttachAlreadyAttachedError", async () => {
       asMock(app.client)._setAttachFailure(
         new MockRpcServerError({
           code: -32099,
@@ -443,8 +459,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       expect(Exit.isFailure(exit)).toBe(true);
       if (Exit.isFailure(exit)) {
         const err = exit.cause._tag === "Fail" ? exit.cause.error : null;
-        expect(err).toBeInstanceOf(AttachError);
-        expect((err as AttachError).code).toBe("AlreadyAttached");
+        expect(err).toBeInstanceOf(AttachAlreadyAttachedError);
       }
     });
 
@@ -461,8 +476,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       expect(Exit.isFailure(exit)).toBe(true);
       if (Exit.isFailure(exit)) {
         const err = exit.cause._tag === "Fail" ? exit.cause.error : null;
-        expect(err).toBeInstanceOf(AttachError);
-        expect((err as AttachError).code).toBe("AttachFailed");
+        expect(err).toBeInstanceOf(AttachFailedError);
       }
     });
 
@@ -470,16 +484,16 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
     // `err.code` first (NumericCodeToAttach), falling back to structured
     // `data.code` only on miss. Mirrors the integration test in
     // `30-app-hooks-rpc.integration.test.ts` ("Conflict (-32003) →
-    // AttachError('AlreadyAttached')"). Keeps the SDK-side numeric map
+    // AttachAlreadyAttachedError"). Keeps the SDK-side numeric map
     // honest without booting the real server.
     it.each([
-      [-32021, "SessionNotFound" as const],
-      [-32002, "ConversationNotFound" as const],
-      [-32001, "NotAuthorized" as const],
-      [-32003, "AlreadyAttached" as const],
+      [-32021, AttachSessionNotFoundError],
+      [-32002, AttachConversationNotFoundError],
+      [-32001, AttachNotAuthorizedError],
+      [-32003, AttachAlreadyAttachedError],
     ])(
-      "maps numeric err.code=%s to AttachError code '%s' via NumericCodeToAttach",
-      async (numericCode, expectedCode) => {
+      "maps numeric err.code=%s to %s via NumericCodeToAttach",
+      async (numericCode, ExpectedError) => {
         asMock(app.client)._setAttachFailure(
           new MockRpcServerError({ code: numericCode, message: "rejected" }),
         );
@@ -492,8 +506,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
         expect(Exit.isFailure(exit)).toBe(true);
         if (Exit.isFailure(exit)) {
           const err = exit.cause._tag === "Fail" ? exit.cause.error : null;
-          expect(err).toBeInstanceOf(AttachError);
-          expect((err as AttachError).code).toBe(expectedCode);
+          expect(err).toBeInstanceOf(ExpectedError);
         }
       },
     );
@@ -512,7 +525,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
           leaseId: ctx.message.id,
         });
       app.onBeforeDispatch(handler);
-      expect(asMock(app.client)._hasHandler("apps/onBeforeDispatch")).toBe(
+      expect(asMock(app.client)._hasHandler(AppsOnBeforeDispatch.name)).toBe(
         true,
       );
     });
@@ -523,7 +536,7 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
       ): Effect.Effect<HookResult, never> => Effect.succeed({ block: false });
       app.onBeforeMessageDelivery(handler);
       expect(
-        asMock(app.client)._hasHandler("apps/onBeforeMessageDelivery"),
+        asMock(app.client)._hasHandler(AppsOnBeforeMessageDelivery.name),
       ).toBe(true);
     });
 
@@ -532,7 +545,9 @@ describe("MoltZapApp — admission/lifecycle handler surface", () => {
         ctx: OnSessionActiveContext,
       ): Effect.Effect<void, never> => Effect.sync(() => ctx.sessionId);
       app.onSessionActive(handler);
-      expect(asMock(app.client)._hasHandler("apps/onSessionActive")).toBe(true);
+      expect(asMock(app.client)._hasHandler(AppsOnSessionActive.name)).toBe(
+        true,
+      );
     });
   });
 });

--- a/packages/app-sdk/src/app.test.ts
+++ b/packages/app-sdk/src/app.test.ts
@@ -2,11 +2,24 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Effect, Exit } from "effect";
 import { MoltZapApp } from "./app.js";
 import {
-  AppError,
   AuthError,
+  ConversationKeyError,
+  InvalidConfigError,
   ManifestRegistrationError,
   SessionError,
+  SessionClosedError,
+  UserHandlerError,
 } from "./errors.js";
+
+import {
+  AppsAttestSkill,
+  AppsCloseSession,
+  AppsCreate,
+  AppsGetSession,
+  AppsRegister,
+  MessagesSend,
+  SystemPing,
+} from "@moltzap/protocol";
 
 // Mock MoltZapWsClient. Client methods return Effects (primary API), so
 // mocks return `Effect.succeed` / `Effect.fail`. Captures constructor
@@ -48,10 +61,10 @@ vi.mock("@moltzap/client", () => {
               .fn()
               .mockImplementation(() => Effect.succeed({ agentId: "agent-1" })),
             sendRpc: vi.fn().mockImplementation((method: string) => {
-              if (method === "apps/register") {
+              if (method === AppsRegister.name) {
                 return Effect.succeed({ appId: "test-app" });
               }
-              if (method === "apps/create") {
+              if (method === AppsCreate.name) {
                 return Effect.succeed({
                   session: {
                     id: "session-1",
@@ -63,13 +76,13 @@ vi.mock("@moltzap/client", () => {
                   },
                 });
               }
-              if (method === "system/ping") {
+              if (method === SystemPing.name) {
                 return Effect.succeed({ ts: new Date().toISOString() });
               }
-              if (method === "apps/closeSession") {
+              if (method === AppsCloseSession.name) {
                 return Effect.succeed({ closed: true });
               }
-              if (method === "messages/send") {
+              if (method === MessagesSend.name) {
                 return Effect.succeed({
                   message: {
                     id: "msg-1",
@@ -131,7 +144,7 @@ describe("MoltZapApp", () => {
             serverUrl: "ws://localhost:3000",
             agentKey: "test-key",
           }),
-      ).toThrow(AppError);
+      ).toThrow(InvalidConfigError);
     });
 
     it("builds default manifest from appId", () => {
@@ -172,10 +185,10 @@ describe("MoltZapApp", () => {
       expect(session.isActive).toBe(true);
 
       expect(app.client.connect).toHaveBeenCalledTimes(1);
-      expect(app.client.sendRpc).toHaveBeenCalledWith("apps/register", {
+      expect(app.client.sendRpc).toHaveBeenCalledWith(AppsRegister.name, {
         manifest: expect.objectContaining({ appId: "test-app" }),
       });
-      expect(app.client.sendRpc).toHaveBeenCalledWith("apps/create", {
+      expect(app.client.sendRpc).toHaveBeenCalledWith(AppsCreate.name, {
         appId: "test-app",
         invitedAgentIds: [],
       });
@@ -203,7 +216,7 @@ describe("MoltZapApp", () => {
       await Effect.runPromise(app.start());
       await Effect.runPromise(app.stop());
 
-      expect(app.client.sendRpc).toHaveBeenCalledWith("apps/closeSession", {
+      expect(app.client.sendRpc).toHaveBeenCalledWith(AppsCloseSession.name, {
         sessionId: "session-1",
       });
       expect(app.client.close).toHaveBeenCalledTimes(1);
@@ -218,7 +231,7 @@ describe("MoltZapApp", () => {
       // path goes down the error branch.
       const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
       sendRpc.mockImplementationOnce((method: string) => {
-        if (method === "apps/closeSession") {
+        if (method === AppsCloseSession.name) {
           return Effect.fail(new Error("server rejected closeSession"));
         }
         return Effect.succeed({});
@@ -229,7 +242,7 @@ describe("MoltZapApp", () => {
       const exit = await Effect.runPromiseExit(app.stop());
       expect(Exit.isSuccess(exit)).toBe(true);
 
-      expect(app.client.sendRpc).toHaveBeenCalledWith("apps/closeSession", {
+      expect(app.client.sendRpc).toHaveBeenCalledWith(AppsCloseSession.name, {
         sessionId: "session-1",
       });
       expect(app.client.close).toHaveBeenCalledTimes(1);
@@ -279,7 +292,7 @@ describe("MoltZapApp", () => {
         app.send("default", [{ type: "text", text: "hello" }]),
       );
 
-      expect(app.client.sendRpc).toHaveBeenCalledWith("messages/send", {
+      expect(app.client.sendRpc).toHaveBeenCalledWith(MessagesSend.name, {
         conversationId: "conv-1",
         parts: [{ type: "text", text: "hello" }],
       });
@@ -292,7 +305,7 @@ describe("MoltZapApp", () => {
       );
       expect(Exit.isFailure(exit)).toBe(true);
       if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
-        expect(exit.cause.error.code).toBe("UNKNOWN_CONVERSATION_KEY");
+        expect(exit.cause.error).toBeInstanceOf(ConversationKeyError);
       } else {
         throw new Error("expected typed Fail");
       }
@@ -304,7 +317,7 @@ describe("MoltZapApp", () => {
         app.sendTo("conv-1", [{ type: "text", text: "hello" }]),
       );
 
-      expect(app.client.sendRpc).toHaveBeenCalledWith("messages/send", {
+      expect(app.client.sendRpc).toHaveBeenCalledWith(MessagesSend.name, {
         conversationId: "conv-1",
         parts: [{ type: "text", text: "hello" }],
       });
@@ -316,7 +329,7 @@ describe("MoltZapApp", () => {
         app.reply("msg-1", [{ type: "text", text: "reply" }]),
       );
 
-      expect(app.client.sendRpc).toHaveBeenCalledWith("messages/send", {
+      expect(app.client.sendRpc).toHaveBeenCalledWith(MessagesSend.name, {
         replyToId: "msg-1",
         parts: [{ type: "text", text: "reply" }],
       });
@@ -326,7 +339,7 @@ describe("MoltZapApp", () => {
       await Effect.runPromise(app.start());
       await app.sendAsync("default", [{ type: "text", text: "hello" }]);
 
-      expect(app.client.sendRpc).toHaveBeenCalledWith("messages/send", {
+      expect(app.client.sendRpc).toHaveBeenCalledWith(MessagesSend.name, {
         conversationId: "conv-1",
         parts: [{ type: "text", text: "hello" }],
       });
@@ -397,7 +410,7 @@ describe("MoltZapApp", () => {
       expect(handler).not.toHaveBeenCalled();
     });
 
-    it("emits HANDLER_ERROR via onError when a message handler throws", async () => {
+    it("emits UserHandlerError via onError when a message handler throws", async () => {
       const errorHandler = vi.fn();
       app.onError(errorHandler);
       app.onMessage("default", () => {
@@ -410,9 +423,8 @@ describe("MoltZapApp", () => {
       await new Promise((r) => setTimeout(r, 0));
 
       expect(errorHandler).toHaveBeenCalledTimes(1);
-      const err = errorHandler.mock.calls[0]![0] as AppError;
-      expect(err).toBeInstanceOf(AppError);
-      expect(err.code).toBe("HANDLER_ERROR");
+      const err = errorHandler.mock.calls[0]![0];
+      expect(err).toBeInstanceOf(UserHandlerError);
     });
 
     it("onParticipantAdmitted fires on app/participantAdmitted", async () => {
@@ -458,7 +470,7 @@ describe("MoltZapApp", () => {
 
       expect(app.getSession("session-1")).toBeUndefined();
       expect(errorHandler).toHaveBeenCalledTimes(1);
-      expect(errorHandler.mock.calls[0]![0].code).toBe("SESSION_CLOSED");
+      expect(errorHandler.mock.calls[0]![0]).toBeInstanceOf(SessionClosedError);
     });
 
     it("app/skillChallenge auto-responds with apps/attestSkill when manifest.skillUrl is set", async () => {
@@ -481,7 +493,7 @@ describe("MoltZapApp", () => {
       fireEvent(appWithSkill, "app/skillChallenge", { challengeId: "chal-1" });
 
       expect(appWithSkill.client.sendRpc).toHaveBeenCalledWith(
-        "apps/attestSkill",
+        AppsAttestSkill.name,
         {
           challengeId: "chal-1",
           skillUrl: "https://example.com/skill",
@@ -498,7 +510,7 @@ describe("MoltZapApp", () => {
       fireEvent(app, "app/skillChallenge", { challengeId: "chal-1" });
 
       expect(sendRpc).not.toHaveBeenCalledWith(
-        "apps/attestSkill",
+        AppsAttestSkill.name,
         expect.anything(),
       );
     });
@@ -513,7 +525,7 @@ describe("MoltZapApp", () => {
       expect(Exit.isFailure(exit)).toBe(true);
       if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
         expect(exit.cause.error).toBeInstanceOf(AuthError);
-        expect(exit.cause.error.code).toBe("AUTH_FAILED");
+        expect(exit.cause.error).toBeInstanceOf(AuthError);
       } else {
         throw new Error("expected typed Fail");
       }
@@ -522,7 +534,7 @@ describe("MoltZapApp", () => {
     it("fails with ManifestRegistrationError when apps/register fails", async () => {
       const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
       sendRpc.mockImplementationOnce((method: string) => {
-        if (method === "apps/register") {
+        if (method === AppsRegister.name) {
           return Effect.fail(new Error("manifest invalid"));
         }
         return Effect.succeed({});
@@ -532,7 +544,7 @@ describe("MoltZapApp", () => {
       expect(Exit.isFailure(exit)).toBe(true);
       if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
         expect(exit.cause.error).toBeInstanceOf(ManifestRegistrationError);
-        expect(exit.cause.error.code).toBe("MANIFEST_REJECTED");
+        expect(exit.cause.error).toBeInstanceOf(ManifestRegistrationError);
       } else {
         throw new Error("expected typed Fail");
       }
@@ -570,7 +582,7 @@ describe("MoltZapApp", () => {
       expect(Exit.isFailure(exit)).toBe(true);
       if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
         expect(exit.cause.error).toBeInstanceOf(SessionError);
-        expect(exit.cause.error.code).toBe("SESSION_ERROR");
+        expect(exit.cause.error).toBeInstanceOf(SessionError);
       } else {
         throw new Error("expected typed Fail");
       }
@@ -588,7 +600,7 @@ describe("MoltZapApp", () => {
       await Effect.runPromise(app.start());
       const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
       sendRpc.mockImplementationOnce((method: string) => {
-        if (method === "apps/getSession") {
+        if (method === AppsGetSession.name) {
           return Effect.succeed({
             session: {
               id: "session-1",
@@ -605,7 +617,7 @@ describe("MoltZapApp", () => {
 
       await triggerReconnect();
 
-      expect(sendRpc).toHaveBeenCalledWith("apps/getSession", {
+      expect(sendRpc).toHaveBeenCalledWith(AppsGetSession.name, {
         sessionId: "session-1",
       });
       expect(app.getSession("session-1")!.conversations.extra).toBe("conv-2");
@@ -618,7 +630,7 @@ describe("MoltZapApp", () => {
       await Effect.runPromise(app.start());
       const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
       sendRpc.mockImplementationOnce((method: string) => {
-        if (method === "apps/getSession") {
+        if (method === AppsGetSession.name) {
           return Effect.succeed({
             session: {
               id: "session-1",
@@ -637,7 +649,7 @@ describe("MoltZapApp", () => {
 
       expect(app.getSession("session-1")).toBeUndefined();
       expect(errorHandler).toHaveBeenCalledWith(
-        expect.objectContaining({ code: "SESSION_CLOSED" }),
+        expect.objectContaining({ _tag: "SessionClosedError" }),
       );
     });
 
@@ -648,7 +660,7 @@ describe("MoltZapApp", () => {
       await Effect.runPromise(app.start());
       const sendRpc = app.client.sendRpc as ReturnType<typeof vi.fn>;
       sendRpc.mockImplementationOnce((method: string) => {
-        if (method === "apps/getSession") {
+        if (method === AppsGetSession.name) {
           return Effect.fail(new Error("network gone"));
         }
         return Effect.succeed({});
@@ -657,7 +669,7 @@ describe("MoltZapApp", () => {
       await triggerReconnect();
 
       expect(errorHandler).toHaveBeenCalledWith(
-        expect.objectContaining({ code: "SESSION_ERROR" }),
+        expect.objectContaining({ _tag: "SessionError" }),
       );
       expect(app.getSession("session-1")).toBeDefined();
     });

--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -34,17 +34,40 @@ import { Cause, Effect, Exit, Fiber } from "effect";
 import { AppSessionHandle } from "./session.js";
 import { HeartbeatManager } from "./heartbeat.js";
 import {
-  AppError,
   AppHandlerError,
-  AttachError,
-  type AttachErrorCode,
+  AttachAlreadyAttachedError,
+  AttachConversationNotFoundError,
+  type AttachError,
+  AttachFailedError,
+  AttachNotAuthorizedError,
+  AttachSessionNotFoundError,
   AuthError,
+  ConversationKeyError,
+  DuplicateHookHandlerError,
+  type AppError,
+  InvalidConfigError,
   ManifestRegistrationError,
   SessionError,
   SessionClosedError,
-  ConversationKeyError,
   SendError,
+  UserHandlerError,
 } from "./errors.js";
+
+import {
+  AppsAttachConversation,
+  AppsAttestSkill,
+  AppsCloseSession,
+  AppsCreate,
+  AppsGetSession,
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnClose,
+  AppsOnJoin,
+  AppsOnSessionActive,
+  AppsRegister,
+  MessagesSend,
+  SystemPing,
+} from "@moltzap/protocol";
 
 type MessageHandler = (message: Message) => void | Promise<void>;
 type SessionReadyHandler = (session: AppSessionHandle) => void | Promise<void>;
@@ -67,6 +90,9 @@ export type StartError = AuthError | ManifestRegistrationError | SessionError;
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const NO_BACKGROUND_FIBERS = 0;
+
+const errorCause = (cause: unknown): { readonly cause?: Error } =>
+  cause instanceof Error ? { cause } : {};
 
 /**
  * MoltZapApp — main class for building MoltZap apps.
@@ -113,10 +139,9 @@ export class MoltZapApp {
 
   constructor(options: MoltZapAppOptions) {
     if (!options.appId && !options.manifest) {
-      throw new AppError(
-        "INVALID_CONFIG",
-        "Either appId or manifest must be provided",
-      );
+      throw new InvalidConfigError({
+        message: "Either appId or manifest must be provided",
+      });
     }
 
     this.manifest = options.manifest ?? {
@@ -167,10 +192,10 @@ export class MoltZapApp {
         .pipe(
           Effect.mapError(
             (err) =>
-              new AuthError(
-                "Failed to register event subscription",
-                err instanceof Error ? err : undefined,
-              ),
+              new AuthError({
+                message: "Failed to register event subscription",
+                ...errorCause(err),
+              }),
           ),
         );
 
@@ -178,42 +203,40 @@ export class MoltZapApp {
       // can clean up if a later step fails (preventing subscription leaks).
       this.activeSubscription = sub;
 
-      yield* this.client
-        .connect()
-        .pipe(
-          Effect.mapError(
-            (err) =>
-              new AuthError(
-                "Failed to connect and authenticate",
-                err instanceof Error ? err : undefined,
-              ),
-          ),
-        );
+      yield* this.client.connect().pipe(
+        Effect.mapError(
+          (err) =>
+            new AuthError({
+              message: "Failed to connect and authenticate",
+              ...errorCause(err),
+            }),
+        ),
+      );
 
       yield* this.client
-        .sendRpc("apps/register", { manifest: this.manifest })
+        .sendRpc(AppsRegister.name, { manifest: this.manifest })
         .pipe(
           Effect.mapError(
             (err) =>
-              new ManifestRegistrationError(
-                `Failed to register manifest for "${this.manifest.appId}"`,
-                err instanceof Error ? err : undefined,
-              ),
+              new ManifestRegistrationError({
+                message: `Failed to register manifest for "${this.manifest.appId}"`,
+                ...errorCause(err),
+              }),
           ),
         );
 
       const sessionResult = (yield* this.client
-        .sendRpc("apps/create", {
+        .sendRpc(AppsCreate.name, {
           appId: this.manifest.appId,
           invitedAgentIds: this.invitedAgentIds,
         })
         .pipe(
           Effect.mapError(
             (err) =>
-              new SessionError(
-                "Failed to create app session",
-                err instanceof Error ? err : undefined,
-              ),
+              new SessionError({
+                message: "Failed to create app session",
+                ...errorCause(err),
+              }),
           ),
         )) as { session: AppSession };
 
@@ -265,7 +288,7 @@ export class MoltZapApp {
       for (const session of this.sessions.values()) {
         if (session.isActive) {
           yield* this.client
-            .sendRpc("apps/closeSession", { sessionId: session.id })
+            .sendRpc(AppsCloseSession.name, { sessionId: session.id })
             .pipe(Effect.ignore);
         }
       }
@@ -308,17 +331,17 @@ export class MoltZapApp {
   ): Effect.Effect<AppSessionHandle, SessionError> {
     return Effect.gen(this, function* () {
       const result = (yield* this.client
-        .sendRpc("apps/create", {
+        .sendRpc(AppsCreate.name, {
           appId: this.manifest.appId,
           invitedAgentIds: invitedAgentIds ?? [],
         })
         .pipe(
           Effect.mapError(
             (err) =>
-              new SessionError(
-                "Failed to create app session",
-                err instanceof Error ? err : undefined,
-              ),
+              new SessionError({
+                message: "Failed to create app session",
+                ...errorCause(err),
+              }),
           ),
         )) as { session: AppSession };
 
@@ -400,7 +423,7 @@ export class MoltZapApp {
       BeforeDispatchContext,
       DispatchAdmissionResult
     >(
-      "apps/onBeforeDispatch",
+      AppsOnBeforeDispatch.name,
       handler,
       (decision) => ({ admission: decision }),
       () => ({ admission: { decision: "deny", reason: "app_handler_error" } }),
@@ -423,7 +446,7 @@ export class MoltZapApp {
     ) => Effect.Effect<HookResult, never>,
   ): void {
     this.registerAdmissionHandler<BeforeMessageDeliveryContext, HookResult>(
-      "apps/onBeforeMessageDelivery",
+      AppsOnBeforeMessageDelivery.name,
       handler,
       (verdict) => verdict,
       () => ({ block: true, reason: "app_handler_error" }),
@@ -442,19 +465,19 @@ export class MoltZapApp {
     handler: (ctx: OnSessionActiveContext) => Effect.Effect<void, never>,
   ): void {
     this.registerLifecycleHandler<OnSessionActiveContext>(
-      "apps/onSessionActive",
+      AppsOnSessionActive.name,
       handler,
     );
   }
 
   /** Register an awaitable `on_join` lifecycle handler. */
   onJoin(handler: (ctx: OnJoinContext) => Effect.Effect<void, never>): void {
-    this.registerLifecycleHandler<OnJoinContext>("apps/onJoin", handler);
+    this.registerLifecycleHandler<OnJoinContext>(AppsOnJoin.name, handler);
   }
 
   /** Register an awaitable `on_close` lifecycle handler. */
   onClose(handler: (ctx: OnCloseContext) => Effect.Effect<void, never>): void {
-    this.registerLifecycleHandler<OnCloseContext>("apps/onClose", handler);
+    this.registerLifecycleHandler<OnCloseContext>(AppsOnClose.name, handler);
   }
 
   /**
@@ -470,7 +493,7 @@ export class MoltZapApp {
     conversationId: string,
   ): Effect.Effect<void, AttachError> {
     return this.client
-      .sendRpc("apps/attachConversation", { sessionId, conversationId })
+      .sendRpc(AppsAttachConversation.name, { sessionId, conversationId })
       .pipe(
         Effect.asVoid,
         Effect.mapError((err) => mapAttachError(err)),
@@ -503,11 +526,11 @@ export class MoltZapApp {
         // Fail-closed: log the underlying cause, synthesize the fail-closed
         // verdict. Cause covers both typed failures (which are `never`-typed
         // here so should not occur) and defects from `Effect.gen` throws.
-        const wrappedErr = new AppHandlerError(
+        const wrappedErr = new AppHandlerError({
           method,
-          "handler failed; synthesizing fail-closed verdict",
-          causeToError(verdictExit.cause),
-        );
+          message: "handler failed; synthesizing fail-closed verdict",
+          cause: causeToError(verdictExit.cause),
+        });
         this.emitError(wrappedErr);
         return failClosedVerdict();
       });
@@ -527,11 +550,11 @@ export class MoltZapApp {
           // Lifecycle hooks are awaitable-void: log and reply void so the
           // server-side AppHost stops waiting. Never blocks session lifecycle.
           this.emitError(
-            new AppHandlerError(
+            new AppHandlerError({
               method,
-              "lifecycle handler failed; replying void",
-              causeToError(exit.cause),
-            ),
+              message: "lifecycle handler failed; replying void",
+              cause: causeToError(exit.cause),
+            }),
           );
         }
         return {};
@@ -551,11 +574,11 @@ export class MoltZapApp {
       // Only failure mode is `DuplicateServerRpcHandlerError`; surface as
       // sync throw per architect plan §3.5 ("Multiple registrations for the
       // same hook throw at registration time").
-      throw new AppError(
-        "DUPLICATE_HOOK_HANDLER",
-        `Handler already registered for ${method}`,
-        causeToError(exit.cause),
-      );
+      throw new DuplicateHookHandlerError({
+        method,
+        message: `Handler already registered for ${method}`,
+        cause: causeToError(exit.cause),
+      });
     }
   }
 
@@ -578,16 +601,18 @@ export class MoltZapApp {
     conversationId: string,
     parts: Part[],
   ): Effect.Effect<void, SendError> {
-    return this.client.sendRpc("messages/send", { conversationId, parts }).pipe(
-      Effect.mapError(
-        (err) =>
-          new SendError(
-            `Failed to send message to conversation ${conversationId}`,
-            err instanceof Error ? err : undefined,
-          ),
-      ),
-      Effect.asVoid,
-    );
+    return this.client
+      .sendRpc(MessagesSend.name, { conversationId, parts })
+      .pipe(
+        Effect.mapError(
+          (err) =>
+            new SendError({
+              message: `Failed to send message to conversation ${conversationId}`,
+              ...errorCause(err),
+            }),
+        ),
+        Effect.asVoid,
+      );
   }
 
   /**
@@ -596,14 +621,14 @@ export class MoltZapApp {
    */
   reply(messageId: string, parts: Part[]): Effect.Effect<void, SendError> {
     return this.client
-      .sendRpc("messages/send", { replyToId: messageId, parts })
+      .sendRpc(MessagesSend.name, { replyToId: messageId, parts })
       .pipe(
         Effect.mapError(
           (err) =>
-            new SendError(
-              `Failed to reply to message ${messageId}`,
-              err instanceof Error ? err : undefined,
-            ),
+            new SendError({
+              message: `Failed to reply to message ${messageId}`,
+              ...errorCause(err),
+            }),
         ),
         Effect.asVoid,
       );
@@ -647,7 +672,12 @@ export class MoltZapApp {
       const id = session.conversations[key];
       if (id) return Effect.succeed(id);
     }
-    return Effect.fail(new ConversationKeyError(key));
+    return Effect.fail(
+      new ConversationKeyError({
+        key,
+        message: `Unknown conversation key: "${key}"`,
+      }),
+    );
   }
 
   private buildReverseConvMap(session: AppSessionHandle): void {
@@ -715,7 +745,9 @@ export class MoltZapApp {
       this.sessions.delete(data.sessionId);
       this.firedSessionReady.delete(data.sessionId);
       this.emitError(
-        new SessionClosedError(`Session ${data.sessionId} was closed`),
+        new SessionClosedError({
+          message: `Session ${data.sessionId} was closed`,
+        }),
       );
     }
   }
@@ -726,7 +758,7 @@ export class MoltZapApp {
     if (skillUrl) {
       this.trackFork(
         this.client
-          .sendRpc("apps/attestSkill", {
+          .sendRpc(AppsAttestSkill.name, {
             challengeId: data.challengeId,
             skillUrl,
             version: this.manifest.skillMinVersion ?? "0.0.0",
@@ -736,10 +768,10 @@ export class MoltZapApp {
             Effect.catchAll((err) =>
               Effect.sync(() => {
                 this.emitError(
-                  new SessionError(
-                    "Failed to respond to skill challenge",
-                    err instanceof Error ? err : undefined,
-                  ),
+                  new SessionError({
+                    message: "Failed to respond to skill challenge",
+                    ...errorCause(err),
+                  }),
                 );
               }),
             ),
@@ -756,7 +788,6 @@ export class MoltZapApp {
       const handler = this.messageHandlers.get(key)!;
       this.trackFork(
         this.runUserHandler(() => handler(message), {
-          code: "HANDLER_ERROR",
           message: `Message handler for "${key}" threw`,
         }),
       );
@@ -766,7 +797,6 @@ export class MoltZapApp {
       const handler = this.messageHandlers.get("*")!;
       this.trackFork(
         this.runUserHandler(() => handler(message), {
-          code: "HANDLER_ERROR",
           message: "Catch-all message handler threw",
         }),
       );
@@ -780,7 +810,7 @@ export class MoltZapApp {
    */
   private runUserHandler(
     invoke: () => void | Promise<void>,
-    ctx: { code: string; message: string },
+    ctx: { message: string },
   ): Effect.Effect<void, never> {
     return Effect.try({
       try: invoke,
@@ -797,7 +827,9 @@ export class MoltZapApp {
       ),
       Effect.catchAll((err) =>
         Effect.sync(() => {
-          this.emitError(new AppError(ctx.code, ctx.message, err));
+          this.emitError(
+            new UserHandlerError({ message: ctx.message, cause: err }),
+          );
         }),
       ),
     );
@@ -824,7 +856,6 @@ export class MoltZapApp {
     for (const handler of this.sessionReadyHandlers) {
       this.trackFork(
         this.runUserHandler(() => handler(handle), {
-          code: "HANDLER_ERROR",
           message: "Session ready handler threw",
         }),
       );
@@ -859,7 +890,7 @@ export class MoltZapApp {
     session: AppSessionHandle,
   ): Effect.Effect<void, never> {
     return this.client
-      .sendRpc("apps/getSession", { sessionId: session.id })
+      .sendRpc(AppsGetSession.name, { sessionId: session.id })
       .pipe(
         Effect.flatMap((result: unknown) =>
           Effect.sync(() => {
@@ -876,9 +907,9 @@ export class MoltZapApp {
                 this.reverseConvMap.delete(convId);
               }
               this.emitError(
-                new SessionClosedError(
-                  `Session ${session.id} closed during disconnect`,
-                ),
+                new SessionClosedError({
+                  message: `Session ${session.id} closed during disconnect`,
+                }),
               );
             } else {
               const updated = new AppSessionHandle(freshSession);
@@ -890,10 +921,10 @@ export class MoltZapApp {
         Effect.catchAll((err) =>
           Effect.sync(() => {
             this.emitError(
-              new SessionError(
-                `Failed to recover session ${session.id} after reconnect`,
-                err instanceof Error ? err : undefined,
-              ),
+              new SessionError({
+                message: `Failed to recover session ${session.id} after reconnect`,
+                ...errorCause(err),
+              }),
             );
           }),
         ),
@@ -906,7 +937,7 @@ export class MoltZapApp {
   }
 
   private sendPing(): Effect.Effect<void, Error> {
-    return this.client.sendRpc("system/ping", {}).pipe(
+    return this.client.sendRpc(SystemPing.name, {}).pipe(
       Effect.asVoid,
       Effect.mapError(
         (e): Error => (e instanceof Error ? e : new Error(String(e))),
@@ -918,7 +949,7 @@ export class MoltZapApp {
     if (this.errorHandler) {
       this.errorHandler(error);
     } else {
-      this.logger.error(`[${error.code}] ${error.message}`);
+      this.logger.error(`[${error._tag}] ${error.message}`);
     }
   }
 }
@@ -947,28 +978,51 @@ function causeToError(cause: Cause.Cause<unknown>): Error {
 
 /**
  * Map a `client.sendRpc` failure for `apps/attachConversation` onto the
- * SDK's typed `AttachError`. RPC server errors carry the server's reason
- * code in `data.code` (or `message`); transport / timeout errors collapse
- * to `AttachFailed`.
+ * SDK's typed `AttachError`. RPC server errors carry the server's reason in
+ * `data.code` (or `message`); transport / timeout errors collapse to
+ * `AttachFailedError`.
  */
 type SendRpcError = NotConnectedError | RpcTimeoutError | RpcServerError;
 
 function mapAttachError(err: SendRpcError): AttachError {
   if (err instanceof RpcServerError) {
-    const code = extractAttachCode(err);
-    return new AttachError(code, err.message, err);
+    return makeAttachError(extractAttachKind(err), err.message, err);
   }
   // NotConnectedError or RpcTimeoutError — both extend Error via Data.TaggedError.
-  const cause = err instanceof Error ? err : undefined;
-  return new AttachError(
-    "AttachFailed",
-    `attachConversation failed: ${err.message}`,
-    cause,
-  );
+  return new AttachFailedError({
+    message: `attachConversation failed: ${err.message}`,
+    ...errorCause(err),
+  });
+}
+
+type AttachFailureKind =
+  | "SessionNotFound"
+  | "ConversationNotFound"
+  | "NotAuthorized"
+  | "AlreadyAttached"
+  | "AttachFailed";
+
+function makeAttachError(
+  kind: AttachFailureKind,
+  message: string,
+  cause: Error,
+): AttachError {
+  switch (kind) {
+    case "SessionNotFound":
+      return new AttachSessionNotFoundError({ message, cause });
+    case "ConversationNotFound":
+      return new AttachConversationNotFoundError({ message, cause });
+    case "NotAuthorized":
+      return new AttachNotAuthorizedError({ message, cause });
+    case "AlreadyAttached":
+      return new AttachAlreadyAttachedError({ message, cause });
+    case "AttachFailed":
+      return new AttachFailedError({ message, cause });
+  }
 }
 
 /**
- * Numeric JSON-RPC error code → `AttachErrorCode` mapping. Matches the
+ * Numeric JSON-RPC error code → SDK attach error tag mapping. Matches the
  * server's `ErrorCodes` table (see `packages/protocol/src/schema/errors.ts`)
  * — kept inline (no protocol import) because the SDK already pins
  * `@moltzap/protocol` for context types and re-importing the constants
@@ -977,14 +1031,14 @@ function mapAttachError(err: SendRpcError): AttachError {
  * boundary that stays in sync via the integration test for
  * `apps/attachConversation` happy + error paths.
  */
-const NumericCodeToAttach: Record<number, AttachErrorCode> = {
+const NumericCodeToAttach: Record<number, AttachFailureKind> = {
   [-32021]: "SessionNotFound", // ErrorCodes.SessionNotFound
   [-32002]: "ConversationNotFound", // ErrorCodes.NotFound (used for missing convId)
   [-32001]: "NotAuthorized", // ErrorCodes.Forbidden
   [-32003]: "AlreadyAttached", // ErrorCodes.Conflict (1:1 cross-session collision)
 };
 
-function extractAttachCode(err: RpcServerError): AttachErrorCode {
+function extractAttachKind(err: RpcServerError): AttachFailureKind {
   // 1. Prefer the wire-level numeric `err.code`. The real server emits
   //    JSON-RPC numeric codes from `ErrorCodes` (e.g. `SessionNotFound =
   //    -32021`), NOT the AttachError tag string. Numeric mapping is the

--- a/packages/app-sdk/src/errors.test.ts
+++ b/packages/app-sdk/src/errors.test.ts
@@ -1,208 +1,117 @@
 import { describe, it, expect } from "vitest";
 import { Effect } from "effect";
 import {
-  AppError,
-  AuthError,
-  SessionError,
-  SessionClosedError,
-  ManifestRegistrationError,
-  ConversationKeyError,
-  SendError,
+  AppDisconnected,
   AppHandlerError,
   AdmissionTimeoutError,
-  AppDisconnected,
-  AttachError,
+  AttachAlreadyAttachedError,
+  AttachConversationNotFoundError,
+  AttachFailedError,
+  AttachNotAuthorizedError,
+  AttachSessionNotFoundError,
+  AuthError,
+  ConversationKeyError,
+  DuplicateHookHandlerError,
+  InvalidConfigError,
+  ManifestRegistrationError,
+  SendError,
+  SessionClosedError,
+  SessionError,
+  UserHandlerError,
 } from "./errors.js";
 
-describe("AppError hierarchy", () => {
-  it("AppError has code and message", () => {
-    const err = new AppError("TEST_CODE", "test message");
-    expect(err.code).toBe("TEST_CODE");
-    expect(err.message).toBe("test message");
-    expect(err.name).toBe("AppError");
+import {
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnJoin,
+} from "@moltzap/protocol";
+
+describe("app SDK tagged errors", () => {
+  it("stores message and cause on plain SDK errors", () => {
+    const cause = new Error("original");
+    const err = new InvalidConfigError({ message: "bad config", cause });
+    expect(err._tag).toBe("InvalidConfigError");
+    expect(err.message).toBe("bad config");
+    expect(err.cause).toBe(cause);
     expect(err).toBeInstanceOf(Error);
   });
 
-  it("AppError preserves cause", () => {
-    const cause = new Error("original");
-    const err = new AppError("TEST", "wrapped", cause);
-    expect(err.cause).toBe(cause);
-  });
-
-  it("AuthError has AUTH_FAILED code", () => {
-    const err = new AuthError("bad creds");
-    expect(err.code).toBe("AUTH_FAILED");
-    expect(err.name).toBe("AuthError");
-    expect(err).toBeInstanceOf(AppError);
-  });
-
-  it("SessionError has SESSION_ERROR code", () => {
-    const err = new SessionError("session gone");
-    expect(err.code).toBe("SESSION_ERROR");
-    expect(err.name).toBe("SessionError");
-    expect(err).toBeInstanceOf(AppError);
-  });
-
-  it("SessionClosedError has SESSION_CLOSED code", () => {
-    const err = new SessionClosedError("closed");
-    expect(err.code).toBe("SESSION_CLOSED");
-    expect(err.name).toBe("SessionClosedError");
-    expect(err).toBeInstanceOf(AppError);
-  });
-
-  it("ManifestRegistrationError has MANIFEST_REJECTED code", () => {
-    const err = new ManifestRegistrationError("bad manifest");
-    expect(err.code).toBe("MANIFEST_REJECTED");
-    expect(err.name).toBe("ManifestRegistrationError");
-    expect(err).toBeInstanceOf(AppError);
-  });
-
-  it("ConversationKeyError has UNKNOWN_CONVERSATION_KEY code", () => {
-    const err = new ConversationKeyError("bad-key");
-    expect(err.code).toBe("UNKNOWN_CONVERSATION_KEY");
-    expect(err.message).toContain("bad-key");
-    expect(err.name).toBe("ConversationKeyError");
-    expect(err).toBeInstanceOf(AppError);
-  });
-
-  it("SendError has SEND_FAILED code", () => {
-    const err = new SendError("send failed");
-    expect(err.code).toBe("SEND_FAILED");
-    expect(err.name).toBe("SendError");
-    expect(err).toBeInstanceOf(AppError);
-  });
-});
-
-// `Effect.catchTag` discriminates on `_tag`. The 10 error subclasses each
-// carry a `readonly _tag = "<ClassName>" as const`, so the @example blocks
-// in `errors.ts` that pipe failures through `Effect.catchTag` actually
-// catch at runtime. This block is the runtime proof: each test fails the
-// effect with one error class, catches the matching tag, and asserts the
-// recovery handler ran exactly once. If a subclass loses its `_tag`, the
-// catchTag silently misses → the recovery never runs → the test fails.
-describe("error _tag discrimination via Effect.catchTag", () => {
-  it("AuthError is caught by catchTag('AuthError')", async () => {
+  it("discriminates domain errors with Effect.catchTag", async () => {
     const recovered = await Effect.runPromise(
-      Effect.fail(new AuthError("bad creds")).pipe(
-        Effect.catchTag("AuthError", (err) => Effect.succeed(err.code)),
+      Effect.fail(new AuthError({ message: "bad creds" })).pipe(
+        Effect.catchTag("AuthError", (err) => Effect.succeed(err.message)),
       ),
     );
-    expect(recovered).toBe("AUTH_FAILED");
+    expect(recovered).toBe("bad creds");
   });
 
-  it("SessionError is caught by catchTag('SessionError')", async () => {
-    const recovered = await Effect.runPromise(
-      Effect.fail(new SessionError("gone")).pipe(
-        Effect.catchTag("SessionError", (err) => Effect.succeed(err.code)),
-      ),
-    );
-    expect(recovered).toBe("SESSION_ERROR");
+  it("keeps contextual fields on structured errors", () => {
+    expect(
+      new ConversationKeyError({
+        key: "typo-key",
+        message: 'Unknown conversation key: "typo-key"',
+      }).key,
+    ).toBe("typo-key");
+    expect(
+      new AppHandlerError({
+        method: AppsOnBeforeDispatch.name,
+        message: "handler failed",
+      }).method,
+    ).toBe(AppsOnBeforeDispatch.name);
+    expect(
+      new AdmissionTimeoutError({
+        method: AppsOnJoin.name,
+        timeoutMs: 30_000,
+        message: "timeout",
+      }).timeoutMs,
+    ).toBe(30_000);
   });
 
-  it("SessionClosedError is caught by catchTag('SessionClosedError')", async () => {
-    const recovered = await Effect.runPromise(
-      Effect.fail(new SessionClosedError("closed")).pipe(
-        Effect.catchTag("SessionClosedError", (err) =>
-          Effect.succeed(err.code),
-        ),
-      ),
-    );
-    expect(recovered).toBe("SESSION_CLOSED");
+  it("exposes attach failure variants as tags", () => {
+    const errors = [
+      new AttachSessionNotFoundError({ message: "session missing" }),
+      new AttachConversationNotFoundError({ message: "conversation missing" }),
+      new AttachNotAuthorizedError({ message: "not authorized" }),
+      new AttachAlreadyAttachedError({ message: "already attached" }),
+      new AttachFailedError({ message: "transport failed" }),
+    ];
+    expect(errors.map((err) => err._tag)).toEqual([
+      "AttachSessionNotFoundError",
+      "AttachConversationNotFoundError",
+      "AttachNotAuthorizedError",
+      "AttachAlreadyAttachedError",
+      "AttachFailedError",
+    ]);
   });
 
-  it("ManifestRegistrationError is caught by catchTag('ManifestRegistrationError')", async () => {
-    const recovered = await Effect.runPromise(
-      Effect.fail(new ManifestRegistrationError("bad manifest")).pipe(
-        Effect.catchTag("ManifestRegistrationError", (err) =>
-          Effect.succeed(err.code),
-        ),
-      ),
+  it("has stable tags for all exported SDK errors", () => {
+    expect(
+      new DuplicateHookHandlerError({
+        method: AppsOnJoin.name,
+        message: "duplicate",
+      })._tag,
+    ).toBe("DuplicateHookHandlerError");
+    expect(
+      new UserHandlerError({
+        message: "handler threw",
+        cause: new Error("boom"),
+      })._tag,
+    ).toBe("UserHandlerError");
+    expect(new SessionError({ message: "session failed" })._tag).toBe(
+      "SessionError",
     );
-    expect(recovered).toBe("MANIFEST_REJECTED");
-  });
-
-  it("ConversationKeyError is caught by catchTag('ConversationKeyError')", async () => {
-    const recovered = await Effect.runPromise(
-      Effect.fail(new ConversationKeyError("typo-key")).pipe(
-        Effect.catchTag("ConversationKeyError", (err) =>
-          Effect.succeed(err.code),
-        ),
-      ),
+    expect(new SessionClosedError({ message: "closed" })._tag).toBe(
+      "SessionClosedError",
     );
-    expect(recovered).toBe("UNKNOWN_CONVERSATION_KEY");
-  });
-
-  it("SendError is caught by catchTag('SendError')", async () => {
-    const recovered = await Effect.runPromise(
-      Effect.fail(new SendError("send failed")).pipe(
-        Effect.catchTag("SendError", (err) => Effect.succeed(err.code)),
-      ),
-    );
-    expect(recovered).toBe("SEND_FAILED");
-  });
-
-  it("AppHandlerError is caught by catchTag('AppHandlerError')", async () => {
-    const recovered = await Effect.runPromise(
-      Effect.fail(
-        new AppHandlerError("apps/onBeforeDispatch", "user threw"),
-      ).pipe(
-        Effect.catchTag("AppHandlerError", (err) => Effect.succeed(err.method)),
-      ),
-    );
-    expect(recovered).toBe("apps/onBeforeDispatch");
-  });
-
-  it("AdmissionTimeoutError is caught by catchTag('AdmissionTimeoutError')", async () => {
-    const recovered = await Effect.runPromise(
-      Effect.fail(
-        new AdmissionTimeoutError("apps/onBeforeDispatch", 30_000),
-      ).pipe(
-        Effect.catchTag("AdmissionTimeoutError", (err) =>
-          Effect.succeed(err.timeoutMs),
-        ),
-      ),
-    );
-    expect(recovered).toBe(30_000);
-  });
-
-  it("AppDisconnected is caught by catchTag('AppDisconnected')", async () => {
-    const recovered = await Effect.runPromise(
-      Effect.fail(new AppDisconnected("apps/onBeforeMessageDelivery")).pipe(
-        Effect.catchTag("AppDisconnected", (err) => Effect.succeed(err.method)),
-      ),
-    );
-    expect(recovered).toBe("apps/onBeforeMessageDelivery");
-  });
-
-  it("AttachError is caught by catchTag('AttachError')", async () => {
-    const recovered = await Effect.runPromise(
-      Effect.fail(new AttachError("SessionNotFound", "session is gone")).pipe(
-        Effect.catchTag("AttachError", (err) => Effect.succeed(err.code)),
-      ),
-    );
-    expect(recovered).toBe("SessionNotFound");
-  });
-
-  // Belt-and-suspenders: the literal `_tag` field on each instance must
-  // equal the class name. catchTag is a thin wrapper over this property,
-  // but a direct assertion catches any future drift (e.g. a copy-paste
-  // bug where two classes share the same `_tag`).
-  it("each error class exposes a _tag matching its class name", () => {
-    expect(new AuthError("x")._tag).toBe("AuthError");
-    expect(new SessionError("x")._tag).toBe("SessionError");
-    expect(new SessionClosedError("x")._tag).toBe("SessionClosedError");
-    expect(new ManifestRegistrationError("x")._tag).toBe(
-      "ManifestRegistrationError",
-    );
-    expect(new ConversationKeyError("x")._tag).toBe("ConversationKeyError");
-    expect(new SendError("x")._tag).toBe("SendError");
-    expect(new AppHandlerError("apps/onJoin", "x")._tag).toBe(
-      "AppHandlerError",
-    );
-    expect(new AdmissionTimeoutError("apps/onJoin", 1)._tag).toBe(
-      "AdmissionTimeoutError",
-    );
-    expect(new AppDisconnected("apps/onJoin")._tag).toBe("AppDisconnected");
-    expect(new AttachError("SessionNotFound", "x")._tag).toBe("AttachError");
+    expect(
+      new ManifestRegistrationError({ message: "manifest rejected" })._tag,
+    ).toBe("ManifestRegistrationError");
+    expect(new SendError({ message: "send failed" })._tag).toBe("SendError");
+    expect(
+      new AppDisconnected({
+        method: AppsOnBeforeMessageDelivery.name,
+        message: "disconnected",
+      })._tag,
+    ).toBe("AppDisconnected");
   });
 });

--- a/packages/app-sdk/src/errors.ts
+++ b/packages/app-sdk/src/errors.ts
@@ -1,535 +1,129 @@
-/**
- * Base error class for all App SDK errors.
- *
- * Every error includes a machine-readable {@link code} so call sites can
- * branch on the failure mode without parsing strings, plus an optional
- * {@link cause} preserving the underlying error chain.
- *
- * Subclass for new error kinds; do not throw raw `AppError` instances
- * unless the code does not warrant a dedicated subclass.
- *
- * **Triggered by:** the SDK's option-parsing code when neither `appId`
- * nor `manifest` is supplied to {@link MoltZapApp}; subclasses cover
- * every other failure mode.
- *
- * **Common causes:** misuse of the SDK options object; programming
- * defects.
- *
- * **Recovery:** discriminate on `err.code` (or use the typed subclass)
- * and surface the misuse to the operator. There is no automatic
- * recovery — fix the call site.
- *
- * @example
- * ```ts
- * import { AppError } from "@moltzap/app-sdk";
- *
- * try {
- *   throw new AppError("INVALID_CONFIG", "appId or manifest is required");
- * } catch (err) {
- *   if (err instanceof AppError) {
- *     console.error(`[${err.code}] ${err.message}`);
- *   }
- * }
- * ```
- */
-export class AppError extends Error {
-  readonly code: string;
-  override readonly cause?: Error;
+import { Data } from "effect";
 
-  constructor(code: string, message: string, cause?: Error) {
-    super(message);
-    this.name = "AppError";
-    this.code = code;
-    this.cause = cause;
-  }
-}
+export class InvalidConfigError extends Data.TaggedError("InvalidConfigError")<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
 
-/**
- * Authentication or initial connect failed: the agent key was rejected,
- * the WebSocket could not open, or the protocol handshake failed.
- *
- * Surfaced from {@link MoltZapApp.start} when `auth/connect` fails.
- *
- * **Triggered by:** `auth/connect` returning an RPC error; WebSocket
- * connect failing before the handshake completes; protocol-version
- * negotiation failing.
- *
- * **Common causes:** wrong or revoked `agentKey`; server unreachable
- * (DNS, firewall); protocol-version skew between client and server;
- * server rejecting the connection at the upgrade.
- *
- * **Recovery:** authenticate fatal — re-issue the agent key, fix the
- * server URL, or upgrade the SDK to match the server's protocol
- * version. Retrying with the same credentials will not help.
- *
- * @example
- * ```ts
- * import { Effect } from "effect";
- * import { MoltZapApp, AuthError } from "@moltzap/app-sdk";
- *
- * const app = new MoltZapApp({ serverUrl, agentKey, appId: "my-app" });
- * await Effect.runPromise(
- *   app.start().pipe(
- *     Effect.catchTag("AuthError", (err: AuthError) =>
- *       Effect.sync(() => {
- *         console.error("auth failed:", err.message);
- *         process.exit(1); // re-issue the agent key, then retry
- *       }),
- *     ),
- *   ),
- * );
- * ```
- */
-export class AuthError extends AppError {
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "AuthError" as const;
-
-  constructor(message: string, cause?: Error) {
-    super("AUTH_FAILED", message, cause);
-    this.name = "AuthError";
-  }
-}
-
-/**
- * A session-scoped operation failed: create, recover, or operate on a
- * session that the server rejected for non-closed reasons (validation,
- * timeout, etc).
- *
- * Distinct from {@link SessionClosedError} — that fires only when a
- * session has reached terminal `closed` or `failed` state.
- *
- * **Triggered by:** `apps/create` returning an RPC error; session
- * recovery on reconnect failing; per-session admission timing out
- * before any agent is admitted.
- *
- * **Common causes:** invited agents not reachable (no `ownerUserId`,
- * ContactService rejection); admin permission timeouts; manifest
- * `limits.maxParticipants` exceeded; missing skill attestation.
- *
- * **Recovery:** retry creation with a different invitee set, or fix
- * the upstream issue (claim the agent's owner, grant the missing
- * permission, etc.). Retrying with the same inputs that just failed
- * will fail again.
- *
- * @example
- * ```ts
- * try {
- *   await app.createSessionAsync(["agent-a", "agent-b"]);
- * } catch (err) {
- *   if (err instanceof SessionError) {
- *     console.error(`[${err.code}] ${err.message}`);
- *     // Retry with only the reachable invitee:
- *     await app.createSessionAsync(["agent-a"]);
- *   }
- * }
- * ```
- */
-export class SessionError extends AppError {
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "SessionError" as const;
-
-  constructor(message: string, cause?: Error) {
-    super("SESSION_ERROR", message, cause);
-    this.name = "SessionError";
-  }
-}
-
-/**
- * The session has terminated and is no longer usable. Emitted via
- * `onError` when the server announces a session closure or when a
- * post-reconnect refresh finds the session in `closed` / `failed`.
- *
- * Handlers should drop session-scoped state and stop emitting messages
- * for the affected session.
- *
- * **Triggered by:** `app/sessionClosed` event delivery from the
- * server; post-reconnect `apps/getSession` reporting `state: "closed"`
- * or `"failed"`.
- *
- * **Common causes:** initiator agent called `apps/closeSession`;
- * session reached `limits.timeout_ms`; AppHost terminated the session
- * because all participants disconnected; an `on_close` lifecycle hook
- * failure cascaded.
- *
- * **Recovery:** drop session-scoped state, then optionally call
- * `app.createSession(...)` to start a fresh session. The closed
- * session id will not return — local references must go.
- *
- * @example
- * ```ts
- * app.onError((err) => {
- *   if (err instanceof SessionClosedError) {
- *     // session is gone; clean up local state
- *     myCache.delete(currentSessionId);
- *     // Optionally start a fresh session:
- *     //   void app.createSessionAsync(invitedAgentIds);
- *   }
- * });
- * ```
- */
-export class SessionClosedError extends AppError {
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "SessionClosedError" as const;
-
-  constructor(message: string, cause?: Error) {
-    super("SESSION_CLOSED", message, cause);
-    this.name = "SessionClosedError";
-  }
-}
-
-/**
- * The server rejected the manifest at `apps/register`.
- *
- * **Triggered by:** `apps/register` returning an RPC error during
- * {@link MoltZapApp.start}.
- *
- * **Common causes:** unknown permission resource; invalid or missing
- * conversation `key`; a manifest field that fails the schema check
- * (e.g., a removed field like `hooks.<name>.webhook` or `secret` —
- * Phase 1 deletion); duplicate `appId` registered against another key.
- *
- * **Recovery:** fix the manifest and restart. The schema rejects the
- * same input on retry, so blind retries do not help. Compare your
- * manifest against `docs/guides/building-apps.mdx` and
- * `docs/migration/webhook-to-rpc.mdx` (repo root) if you are porting
- * from the webhook era.
- *
- * @example
- * ```ts
- * import { Effect } from "effect";
- * import { ManifestRegistrationError } from "@moltzap/app-sdk";
- *
- * await Effect.runPromise(
- *   app.start().pipe(
- *     Effect.catchTag("ManifestRegistrationError", (err) => {
- *       console.error("manifest rejected:", err.message);
- *       // Likely a stale manifest field. Fix the manifest and re-deploy.
- *       return Effect.fail(err);
- *     }),
- *   ),
- * );
- * ```
- */
-export class ManifestRegistrationError extends AppError {
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "ManifestRegistrationError" as const;
-
-  constructor(message: string, cause?: Error) {
-    super("MANIFEST_REJECTED", message, cause);
-    this.name = "ManifestRegistrationError";
-  }
-}
-
-/**
- * `send(conversationKey, parts)` was called with a key that no active
- * session declares. Either the manifest does not declare the key, or no
- * session is currently active.
- *
- * Use {@link MoltZapApp.sendTo} (raw conversation id) when the key
- * indirection is unwanted.
- *
- * **Triggered by:** {@link MoltZapApp.send} resolving the conversation
- * id from the key and finding no entry in any active session's
- * `conversations` map.
- *
- * **Common causes:** typo in the key; the session has not finished
- * admission yet (no `app/sessionReady` received); the manifest's
- * `conversations[]` does not declare a conversation with that key.
- *
- * **Recovery:** route to a known-good key (the manifest's `default`
- * is always present), or wait for `onSessionReady` before sending.
- *
- * @example
- * ```ts
- * import { Effect } from "effect";
- *
- * await Effect.runPromise(
- *   app.send("typo-key", [{ type: "text", text: "hi" }]).pipe(
- *     Effect.catchTag("UNKNOWN_CONVERSATION_KEY" as never, () =>
- *       app.send("default", [{ type: "text", text: "hi" }]),
- *     ),
- *   ),
- * );
- * ```
- */
-export class ConversationKeyError extends AppError {
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "ConversationKeyError" as const;
-
-  constructor(key: string) {
-    super("UNKNOWN_CONVERSATION_KEY", `Unknown conversation key: "${key}"`);
-    this.name = "ConversationKeyError";
-  }
-}
-
-/**
- * `messages/send` failed at the transport or server-validation layer.
- * The {@link cause} retains the underlying RPC error tag.
- *
- * **Triggered by:** {@link MoltZapApp.send}, {@link MoltZapApp.sendTo},
- * or {@link MoltZapApp.reply} when the underlying `messages/send` RPC
- * returns an error or the transport drops mid-call.
- *
- * **Common causes:** the conversation no longer exists or you are not
- * a participant; rate-limited by the server; transport-level error
- * (WS closed, RPC timeout); a `before_dispatch` hook denied the
- * dispatch (the deny `reason` surfaces in `err.message`).
- *
- * **Recovery:** if `cause` is a transient RPC timeout, retry with
- * backoff; if it is a `deny` verdict from a hook, fix the message or
- * route differently — retrying the same payload will deny again.
- *
- * @example
- * ```ts
- * import { Effect } from "effect";
- *
- * await Effect.runPromise(
- *   app.sendTo(convId, [{ type: "text", text: "ping" }]).pipe(
- *     Effect.catchTag("SendError", (err) =>
- *       Effect.sync(() => console.warn("send failed:", err.message)),
- *     ),
- *   ),
- * );
- * ```
- */
-export class SendError extends AppError {
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "SendError" as const;
-
-  constructor(message: string, cause?: Error) {
-    super("SEND_FAILED", message, cause);
-    this.name = "SendError";
-  }
-}
-
-/**
- * A user admission/lifecycle handler failed (defect or typed error). The
- * SDK catches the failure to keep the AppHost RPC contract typed and
- * synthesizes a fail-closed verdict for admission hooks (`deny` /
- * `block: true`) or a no-op for void lifecycle hooks. The wrapped error
- * is logged via the SDK logger and exposed here for observability.
- *
- * Code: `APP_HANDLER_ERROR`.
- *
- * **Triggered by:** the SDK's hook-handler wrapper when a user
- * `onBeforeDispatch` / `onBeforeMessageDelivery` / `onSessionActive` /
- * `onJoin` / `onClose` callback returns a failed Effect or throws.
- *
- * **Common causes:** uncaught defect inside the handler; an external
- * dependency the handler called (DB, HTTP, RPC) failed; the handler
- * returned `Effect.fail(...)` without catching.
- *
- * **Recovery:** none at the SDK level — the AppHost has already
- * synthesized a fail-closed verdict. Tooling consumes this class via
- * the SDK logger or test fixtures to assert fail-closed behavior. To
- * choose a custom `reason` instead of `"app_handler_error"`, catch
- * inside your handler and return a typed verdict.
- *
- * @example
- * ```ts
- * // Tooling / test fixture observing fail-closed semantics:
- * import { AppHandlerError } from "@moltzap/app-sdk";
- *
- * const wrapped = new AppHandlerError(
- *   "apps/onBeforeDispatch",
- *   "user handler threw",
- *   new Error("rate-limit lookup timed out"),
- * );
- * console.error(wrapped.code, wrapped.method, wrapped.message);
- * // → APP_HANDLER_ERROR apps/onBeforeDispatch [apps/onBeforeDispatch] user handler threw
- * ```
- */
-export class AppHandlerError extends AppError {
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "AppHandlerError" as const;
-  /** RPC method whose handler failed (e.g. `apps/onBeforeDispatch`). */
+export class DuplicateHookHandlerError extends Data.TaggedError(
+  "DuplicateHookHandlerError",
+)<{
   readonly method: string;
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
 
-  constructor(method: string, message: string, cause?: Error) {
-    super("APP_HANDLER_ERROR", `[${method}] ${message}`, cause);
-    this.name = "AppHandlerError";
-    this.method = method;
-  }
-}
+export class UserHandlerError extends Data.TaggedError("UserHandlerError")<{
+  readonly message: string;
+  readonly cause: Error;
+}> {}
 
-/**
- * The server-side AppHost timed out waiting for the app's admission reply
- * and synthesized a fail-closed verdict. The SDK exposes this class so
- * test fixtures and instrumentation can model the timeout case
- * symmetrically with the SDK's own typed errors.
- *
- * Code: `ADMISSION_TIMEOUT`.
- *
- * **Triggered by:** the AppHost's `Effect.timeout(manifestMs)`
- * elapsing before the handler returns a verdict for an admission
- * hook (`apps/onBeforeDispatch`, `apps/onBeforeMessageDelivery`).
- *
- * **Common causes:** handler did slow I/O (DB, HTTP, LLM call) and
- * exceeded `manifest.hooks.<name>.timeout_ms`; handler is awaiting
- * external input that never arrived; misconfigured (too tight)
- * timeout for a legitimately slow workload.
- *
- * **Recovery:** raise `manifest.hooks.<name>.timeout_ms` (the schema is
- * `Type.Integer({ default: 5000, minimum: 1 })` — no upper bound since
- * B.4 follow-up #324); cache the slow lookup; or short-circuit fast
- * inside the handler when the answer is already known. The AppHost has
- * already issued the fail-closed verdict; this class is for observability.
- *
- * @example
- * ```ts
- * // Test fixture asserting fail-closed semantics on timeout:
- * import { AdmissionTimeoutError } from "@moltzap/app-sdk";
- *
- * const err = new AdmissionTimeoutError("apps/onBeforeDispatch", 30_000);
- * expect(err.code).toBe("ADMISSION_TIMEOUT");
- * expect(err.method).toBe("apps/onBeforeDispatch");
- * expect(err.timeoutMs).toBe(30_000);
- * ```
- */
-export class AdmissionTimeoutError extends AppError {
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "AdmissionTimeoutError" as const;
-  /** RPC method whose admission timed out. */
+export class AuthError extends Data.TaggedError("AuthError")<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
+
+export class SessionError extends Data.TaggedError("SessionError")<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
+
+export class SessionClosedError extends Data.TaggedError("SessionClosedError")<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
+
+export class ManifestRegistrationError extends Data.TaggedError(
+  "ManifestRegistrationError",
+)<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
+
+export class ConversationKeyError extends Data.TaggedError(
+  "ConversationKeyError",
+)<{
+  readonly key: string;
+  readonly message: string;
+}> {}
+
+export class SendError extends Data.TaggedError("SendError")<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
+
+export class AppHandlerError extends Data.TaggedError("AppHandlerError")<{
   readonly method: string;
-  /** Manifest-declared timeout in ms. */
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
+
+export class AdmissionTimeoutError extends Data.TaggedError(
+  "AdmissionTimeoutError",
+)<{
+  readonly method: string;
   readonly timeoutMs: number;
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
 
-  constructor(method: string, timeoutMs: number, cause?: Error) {
-    super(
-      "ADMISSION_TIMEOUT",
-      `[${method}] admission timed out after ${timeoutMs}ms`,
-      cause,
-    );
-    this.name = "AdmissionTimeoutError";
-    this.method = method;
-    this.timeoutMs = timeoutMs;
-  }
-}
-
-/**
- * SDK-side wrapper for the server's `AppDisconnected` failure. The
- * inbound s2c admission RPC failed because the app's WebSocket dropped
- * before the handler completed. Mirrors the runtime `AppDisconnected`
- * error in `@moltzap/server`'s WS edge.
- *
- * Code: `APP_DISCONNECTED`.
- *
- * **Triggered by:** the server-side connection scope finalizer
- * failing every pending s2c `Deferred` with `AppDisconnected` when
- * the app's WebSocket closes mid-admission.
- *
- * **Common causes:** app crashed; app deployed/restarted while a hook
- * was in flight; network partition; load-balancer health-check killed
- * the WS; client called `app.stop()` while a hook was in flight.
- *
- * **Recovery:** the AppHost has already applied fail-closed verdicts
- * for any pending admissions on the dropped connection; nothing to
- * recover. The reconnect loop in `MoltZapWsClient` re-establishes the
- * connection and re-registers the manifest; new hooks fire normally
- * after that. To make admission less brittle to restart, deploy
- * with rolling restart and a graceful drain.
- *
- * @example
- * ```ts
- * // Tooling instrumentation asserting fail-closed semantics on
- * // mid-admission disconnect:
- * import { AppDisconnected } from "@moltzap/app-sdk";
- *
- * const err = new AppDisconnected("apps/onBeforeMessageDelivery");
- * expect(err.code).toBe("APP_DISCONNECTED");
- * expect(err.method).toBe("apps/onBeforeMessageDelivery");
- * ```
- */
-export class AppDisconnected extends AppError {
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "AppDisconnected" as const;
-  /** RPC method whose pending request was dropped. */
+export class AppDisconnected extends Data.TaggedError("AppDisconnected")<{
   readonly method: string;
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
 
-  constructor(method: string, cause?: Error) {
-    super(
-      "APP_DISCONNECTED",
-      `[${method}] app disconnected before reply`,
-      cause,
-    );
-    this.name = "AppDisconnected";
-    this.method = method;
-  }
-}
+export class AttachSessionNotFoundError extends Data.TaggedError(
+  "AttachSessionNotFoundError",
+)<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
 
-/**
- * `attachConversation` failed. The {@link code} is one of:
- *
- * - `SessionNotFound` — session id does not refer to a session this app owns
- * - `ConversationNotFound` — conversation id does not exist
- * - `NotAuthorized` — the caller is not the session owner
- * - `AlreadyAttached` — the conversation is already attached to a different
- *   session (the 1:1 cross-session invariant on `AppHost.conversationToSession`)
- * - `AttachFailed` — generic transport / server failure (timeout, network)
- *
- * **Triggered by:** {@link MoltZapApp.attachConversation} resolving
- * the c2s `apps/attachConversation` RPC into a typed failure.
- *
- * **Common causes (per code):**
- *
- * - `SessionNotFound`: caller passed a stale session id, or the
- *   session has already closed.
- *
- * - `ConversationNotFound`: caller passed a stale conversation id, or
- *   the conversation was archived.
- *
- * - `NotAuthorized`: the apiKey on the WS connection does not own the
- *   session — wrong app or tenant.
- *
- * - `AttachFailed`: transport-level error (RPC timeout, server 5xx).
- *
- * **Recovery:** use `Effect.catchTag("AttachError", ...)` (this class
- * sets `_tag = "AttachError"`) and branch on `err.code`. For
- * `SessionNotFound` / `ConversationNotFound`, drop local references.
- * For `NotAuthorized`, fix the apiKey or session id wiring. For
- * `AttachFailed`, retry with backoff.
- *
- * @example
- * ```ts
- * import { Effect } from "effect";
- * import type { AttachError } from "@moltzap/app-sdk";
- *
- * await Effect.runPromise(
- *   app.attachConversation(sessionId, conversationId).pipe(
- *     Effect.catchTag("AttachError", (err: AttachError) => {
- *       switch (err.code) {
- *         case "SessionNotFound":
- *         case "ConversationNotFound":
- *           return Effect.sync(() => console.warn(`gone: ${err.code}`));
- *         case "AlreadyAttached":
- *           return Effect.sync(() =>
- *             console.warn("convId already bound to another session"),
- *           );
- *         case "NotAuthorized":
- *           return Effect.fail(err); // programming error; surface it
- *         case "AttachFailed":
- *           return Effect.sync(() => console.warn("retry later"));
- *       }
- *     }),
- *   ),
- * );
- * ```
- */
-export type AttachErrorCode =
-  | "SessionNotFound"
-  | "ConversationNotFound"
-  | "NotAuthorized"
-  | "AlreadyAttached"
-  | "AttachFailed";
+export class AttachConversationNotFoundError extends Data.TaggedError(
+  "AttachConversationNotFoundError",
+)<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
 
-export class AttachError extends AppError {
-  override readonly code: AttachErrorCode;
-  /** Tag used for `Effect.catchTag` discrimination. */
-  readonly _tag = "AttachError" as const;
+export class AttachNotAuthorizedError extends Data.TaggedError(
+  "AttachNotAuthorizedError",
+)<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
 
-  constructor(code: AttachErrorCode, message: string, cause?: Error) {
-    super(code, message, cause);
-    this.name = "AttachError";
-    this.code = code;
-  }
-}
+export class AttachAlreadyAttachedError extends Data.TaggedError(
+  "AttachAlreadyAttachedError",
+)<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
+
+export class AttachFailedError extends Data.TaggedError("AttachFailedError")<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
+
+export type AttachError =
+  | AttachSessionNotFoundError
+  | AttachConversationNotFoundError
+  | AttachNotAuthorizedError
+  | AttachAlreadyAttachedError
+  | AttachFailedError;
+
+export type AppError =
+  | InvalidConfigError
+  | DuplicateHookHandlerError
+  | UserHandlerError
+  | AuthError
+  | SessionError
+  | SessionClosedError
+  | ManifestRegistrationError
+  | ConversationKeyError
+  | SendError
+  | AppHandlerError
+  | AdmissionTimeoutError
+  | AppDisconnected
+  | AttachError;

--- a/packages/app-sdk/src/index.ts
+++ b/packages/app-sdk/src/index.ts
@@ -10,7 +10,9 @@ export { HeartbeatManager } from "./heartbeat.js";
 
 // Errors
 export {
-  AppError,
+  InvalidConfigError,
+  DuplicateHookHandlerError,
+  UserHandlerError,
   AuthError,
   SessionError,
   SessionClosedError,
@@ -20,9 +22,13 @@ export {
   AppHandlerError,
   AdmissionTimeoutError,
   AppDisconnected,
-  AttachError,
+  AttachSessionNotFoundError,
+  AttachConversationNotFoundError,
+  AttachNotAuthorizedError,
+  AttachAlreadyAttachedError,
+  AttachFailedError,
 } from "./errors.js";
-export type { AttachErrorCode } from "./errors.js";
+export type { AppError, AttachError } from "./errors.js";
 
 // Re-export common protocol types for convenience
 export type {

--- a/packages/app-sdk/src/session.ts
+++ b/packages/app-sdk/src/session.ts
@@ -26,7 +26,10 @@ export class AppSessionHandle {
   conversationId(key: string): string {
     const id = this.conversations[key];
     if (!id) {
-      throw new ConversationKeyError(key);
+      throw new ConversationKeyError({
+        key,
+        message: `Unknown conversation key: "${key}"`,
+      });
     }
     return id;
   }

--- a/packages/claude-code-channel/src/__tests__/echo.integration.test.ts
+++ b/packages/claude-code-channel/src/__tests__/echo.integration.test.ts
@@ -31,6 +31,8 @@ import type { Notification } from "@modelcontextprotocol/sdk/types.js";
 import { bootClaudeCodeChannel } from "../entry.js";
 import type { Handle } from "../types.js";
 
+import { ConversationsCreate } from "@moltzap/protocol";
+
 const silentLogger = {
   info: () => {},
   warn: () => {},
@@ -101,7 +103,7 @@ async function bootHarness(): Promise<Harness> {
 
   // Peer creates a DM with channel-agent-A.
   const convResponse = (await Effect.runPromise(
-    peerService.sendRpc("conversations/create", {
+    peerService.sendRpc(ConversationsCreate.name, {
       type: "dm",
       participants: [{ type: "agent", id: channelAgentId }],
     }),

--- a/packages/claude-code-channel/src/__tests__/server.test.ts
+++ b/packages/claude-code-channel/src/__tests__/server.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../server.js";
 import { createRoutingState } from "../routing.js";
 import type { ChatId, ClaudeChannelNotification, MessageId } from "../types.js";
-import type { ReplyError } from "../errors.js";
+import { SendFailed, type ReplyError } from "../errors.js";
 
 const silentLogger = {
   info: () => {},
@@ -380,10 +380,7 @@ describe("reply tool routing (spec OQ5)", () => {
   it("surfaces ReplyError.SendFailed as tool error (isError: true)", async () => {
     const { client, routing, cleanup } = await setup({
       onSendReply: () =>
-        Effect.fail<ReplyError>({
-          _tag: "SendFailed",
-          cause: "ws dropped",
-        }),
+        Effect.fail<ReplyError>(new SendFailed({ cause: "ws dropped" })),
     });
     try {
       routing.recordInbound("M-x" as MessageId, "C-x" as ChatId);

--- a/packages/claude-code-channel/src/bin.ts
+++ b/packages/claude-code-channel/src/bin.ts
@@ -17,28 +17,30 @@
  * Failure modes exit with code 1 and a diagnostic line on stderr.
  */
 import { bootClaudeCodeChannel } from "./entry.js";
-import { Data, Effect } from "effect";
+import { Config, ConfigError, Data, Effect, Option } from "effect";
 
 class ChannelMainError extends Data.TaggedError("ChannelMainError")<{
   readonly cause: unknown;
 }> {}
 
-function main(): Effect.Effect<void, ChannelMainError, never> {
+function main(): Effect.Effect<
+  void,
+  ChannelMainError | ConfigError.ConfigError,
+  never
+> {
   return Effect.gen(function* () {
-    const apiKey = process.env.MOLTZAP_API_KEY;
-    const serverUrl = process.env.MOLTZAP_SERVER_URL;
-    if (apiKey === undefined || apiKey.length === 0) {
-      process.stderr.write(
-        "moltzap-claude-code-channel: MOLTZAP_API_KEY env var is required\n",
-      );
-      process.exit(1);
-    }
-    if (serverUrl === undefined || serverUrl.length === 0) {
-      process.stderr.write(
-        "moltzap-claude-code-channel: MOLTZAP_SERVER_URL env var is required\n",
-      );
-      process.exit(1);
-    }
+    const apiKey = yield* Config.string("MOLTZAP_API_KEY").pipe(
+      Config.validate({
+        message: "MOLTZAP_API_KEY env var is required",
+        validation: (value) => value.length > 0,
+      }),
+    );
+    const serverUrl = yield* Config.string("MOLTZAP_SERVER_URL").pipe(
+      Config.validate({
+        message: "MOLTZAP_SERVER_URL env var is required",
+        validation: (value) => value.length > 0,
+      }),
+    );
 
     // Logger writes to stderr — stdout is reserved for MCP JSON-RPC framing.
     // Variadic `unknown[]` matches @moltzap/client's `WsClientLogger` shape
@@ -55,7 +57,9 @@ function main(): Effect.Effect<void, ChannelMainError, never> {
       },
     };
 
-    const serverName = process.env.MOLTZAP_SERVER_NAME;
+    const serverName = Option.getOrUndefined(
+      yield* Config.option(Config.string("MOLTZAP_SERVER_NAME")),
+    );
     const result = yield* Effect.tryPromise({
       try: () =>
         bootClaudeCodeChannel({

--- a/packages/claude-code-channel/src/entry.ts
+++ b/packages/claude-code-channel/src/entry.ts
@@ -13,12 +13,19 @@ import {
   MoltZapService,
   type EnrichedInboundMessage,
 } from "@moltzap/client";
-import { Effect } from "effect";
+import { Effect, Either } from "effect";
 import { toClaudeChannelNotification } from "./event.js";
 import { createRoutingState } from "./routing.js";
 import { bootChannelMcpServer, type ServerHandle } from "./server.js";
 import type { BootOptions, Handle } from "./types.js";
-import type { BootError, ReplyError } from "./errors.js";
+import {
+  AgentKeyInvalid,
+  McpTransportFailed,
+  SendFailed,
+  ServiceConnectFailed,
+  type BootError,
+  type ReplyError,
+} from "./errors.js";
 import { stringifyCause } from "./utils.js";
 
 export type BootResult =
@@ -50,10 +57,9 @@ function bootClaudeCodeChannelEffect(
     ) {
       return {
         _tag: "Err",
-        error: {
-          _tag: "AgentKeyInvalid",
+        error: new AgentKeyInvalid({
           cause: "agentKey must be a non-empty string",
-        },
+        }),
       };
     }
     if (
@@ -62,10 +68,9 @@ function bootClaudeCodeChannelEffect(
     ) {
       return {
         _tag: "Err",
-        error: {
-          _tag: "AgentKeyInvalid",
+        error: new AgentKeyInvalid({
           cause: "serverUrl must be a non-empty string",
-        },
+        }),
       };
     }
 
@@ -82,10 +87,10 @@ function bootClaudeCodeChannelEffect(
     const sendReply = (chatId: string, text: string) =>
       core.sendReply(chatId, text).pipe(
         Effect.mapError(
-          (cause): ReplyError => ({
-            _tag: "SendFailed",
-            cause: stringifyCause(cause),
-          }),
+          (cause): ReplyError =>
+            new SendFailed({
+              cause: stringifyCause(cause),
+            }),
         ),
       );
 
@@ -105,10 +110,10 @@ function bootClaudeCodeChannelEffect(
               : {}),
           },
         ),
-      catch: (cause): BootError => ({
-        _tag: "McpTransportFailed",
-        cause: stringifyCause(cause),
-      }),
+      catch: (cause): BootError =>
+        new McpTransportFailed({
+          cause: stringifyCause(cause),
+        }),
     }).pipe(
       Effect.catchAll((error) =>
         Effect.succeed({ _tag: "Err" as const, error }),
@@ -117,10 +122,9 @@ function bootClaudeCodeChannelEffect(
     if (serverBoot._tag === "Err") {
       return {
         _tag: "Err",
-        error: {
-          _tag: "McpTransportFailed",
+        error: new McpTransportFailed({
           cause: `${serverBoot.error._tag}: ${serverBoot.error.cause}`,
-        },
+        }),
       };
     }
     const serverHandle: ServerHandle = serverBoot.value;
@@ -167,16 +171,19 @@ function bootClaudeCodeChannelEffect(
     );
 
     const connectResult = yield* Effect.either(core.connect());
-    if (connectResult._tag === "Left") {
-      // Best-effort: tear down MCP transport before reporting to the caller.
+    const connectFailure = Either.match(connectResult, {
+      onLeft: (error) =>
+        ({
+          _tag: "Err",
+          error: new ServiceConnectFailed({
+            cause: stringifyCause(error),
+          }),
+        }) as const,
+      onRight: () => null,
+    });
+    if (connectFailure !== null) {
       yield* serverHandle.stop();
-      return {
-        _tag: "Err",
-        error: {
-          _tag: "ServiceConnectFailed",
-          cause: stringifyCause(connectResult.left),
-        },
-      };
+      return connectFailure;
     }
 
     const handle: Handle = {

--- a/packages/claude-code-channel/src/errors.ts
+++ b/packages/claude-code-channel/src/errors.ts
@@ -1,110 +1,81 @@
-/**
- * errors — tagged error unions.
- *
- * Principle 3 (typed errors) + Principle 4 (exhaustiveness over optionality).
- *
- * OQ3 resolution: `BootError` minimum tag set is
- *   { ServiceConnectFailed, McpTransportFailed, AgentKeyInvalid }
- * — architect-extensible (spec OQ3 default B). Additional tags added here
- * must be handled exhaustively at every call site; there is no open-ended
- * `Other` tag.
- */
+import { Data } from "effect";
 
-/**
- * Returned by `bootClaudeCodeChannel` when boot cannot proceed.
- */
+export class ServiceConnectFailed extends Data.TaggedError(
+  "ServiceConnectFailed",
+)<{
+  readonly cause: string;
+}> {}
+
+export class McpTransportFailed extends Data.TaggedError("McpTransportFailed")<{
+  readonly cause: string;
+}> {}
+
+export class AgentKeyInvalid extends Data.TaggedError("AgentKeyInvalid")<{
+  readonly cause: string;
+}> {}
+
+export class SchemaDecodeFailed extends Data.TaggedError("SchemaDecodeFailed")<{
+  readonly cause: string;
+  readonly at: "ws" | "mcp";
+}> {}
+
 export type BootError =
-  | {
-      readonly _tag: "ServiceConnectFailed";
-      /** MoltZap WS `connect()` failed. */
-      readonly cause: string;
-    }
-  | {
-      readonly _tag: "McpTransportFailed";
-      /** Stdio transport attach or MCP `server.connect` failed. */
-      readonly cause: string;
-    }
-  | {
-      readonly _tag: "AgentKeyInvalid";
-      /** `agentKey` was missing, malformed, or rejected by the server. */
-      readonly cause: string;
-    }
-  | {
-      readonly _tag: "SchemaDecodeFailed";
-      /** A WS or MCP boundary payload failed schema decode at boot. */
-      readonly cause: string;
-      /** The boundary that produced the decode failure. */
-      readonly at: "ws" | "mcp";
-    };
+  | ServiceConnectFailed
+  | McpTransportFailed
+  | AgentKeyInvalid
+  | SchemaDecodeFailed;
 
-/**
- * Returned by `Handle.push` when the MCP notification cannot be emitted.
- */
-export type PushError =
-  | {
-      readonly _tag: "EmitFailed";
-      readonly cause: string;
-    }
-  | {
-      readonly _tag: "NotConnected";
-      /** Transport dropped between boot and this push. */
-      readonly cause: string;
-    };
+export class EmitFailed extends Data.TaggedError("EmitFailed")<{
+  readonly cause: string;
+}> {}
 
-/**
- * Returned by `gateInbound` when the inbound event fails consumer policy.
- *
- * The upstream package ships no allowlist set; zapbot (and any other
- * consumer) supplies the predicate. Tag set is intentionally minimal so the
- * consumer can map its own policy outcomes here without shape negotiation.
- */
-export type AllowlistError =
-  | {
-      readonly _tag: "SenderNotAllowed";
-      readonly senderId: string;
-      readonly reason: string;
-    }
-  | {
-      readonly _tag: "ConversationNotAllowed";
-      readonly conversationId: string;
-      readonly reason: string;
-    };
+export class NotConnected extends Data.TaggedError("NotConnected")<{
+  readonly cause: string;
+}> {}
 
-/**
- * Returned by the `reply` tool handler when a call cannot be routed or sent.
- * Surfaces as an MCP tool error (isError: true) to Claude Code.
- *
- * `FilesUnsupported` is returned for `reply` calls that include a non-empty
- * `files` array. v1 ships contract-shaped decode for `files` (so Claude Code
- * can preview the argument surface) but does NOT ship attachment upload; a
- * v1.1 follow-up will wire `files` through the client attachments path. This
- * tagged error replaces the silent drop behavior reviewer-187 called out.
- */
+export type PushError = EmitFailed | NotConnected;
+
+export class SenderNotAllowed extends Data.TaggedError("SenderNotAllowed")<{
+  readonly senderId: string;
+  readonly reason: string;
+}> {}
+
+export class ConversationNotAllowed extends Data.TaggedError(
+  "ConversationNotAllowed",
+)<{
+  readonly conversationId: string;
+  readonly reason: string;
+}> {}
+
+export type AllowlistError = SenderNotAllowed | ConversationNotAllowed;
+
+export class NoActiveChat extends Data.TaggedError("NoActiveChat")<{
+  readonly cause: string;
+}> {}
+
+export class ReplyToUnknown extends Data.TaggedError("ReplyToUnknown")<{
+  readonly replyTo: string;
+}> {}
+
+export class SendFailed extends Data.TaggedError("SendFailed")<{
+  readonly cause: string;
+}> {}
+
+export class FilesUnsupported extends Data.TaggedError("FilesUnsupported")<{
+  readonly fileCount: number;
+}> {}
+
 export type ReplyError =
-  | {
-      readonly _tag: "NoActiveChat";
-      /** `reply_to` was absent and no inbound has been observed yet. */
-      readonly cause: string;
-    }
-  | {
-      readonly _tag: "ReplyToUnknown";
-      /** `reply_to` did not resolve to a known message_id. */
-      readonly replyTo: string;
-    }
-  | {
-      readonly _tag: "SendFailed";
-      readonly cause: string;
-    }
-  | {
-      readonly _tag: "FilesUnsupported";
-      /** Count of files the caller tried to attach; for operator diagnostics. */
-      readonly fileCount: number;
-    };
+  | NoActiveChat
+  | ReplyToUnknown
+  | SendFailed
+  | FilesUnsupported;
 
-/**
- * Returned by the `event.ts` translator when an inbound message cannot be
- * shaped into a contract-conformant notification.
- */
-export type EventShapeError =
-  | { readonly _tag: "ContentEmpty" }
-  | { readonly _tag: "MetaInvalid"; readonly reason: string };
+export class ContentEmpty extends Data.TaggedError("ContentEmpty") {}
+
+export class MetaInvalid extends Data.TaggedError("MetaInvalid")<{
+  readonly reason: string;
+  readonly message?: string;
+}> {}
+
+export type EventShapeError = ContentEmpty | MetaInvalid;

--- a/packages/claude-code-channel/src/event.ts
+++ b/packages/claude-code-channel/src/event.ts
@@ -26,7 +26,7 @@ import type {
   MessageId,
   UserId,
 } from "./types.js";
-import type { EventShapeError } from "./errors.js";
+import { ContentEmpty, MetaInvalid, type EventShapeError } from "./errors.js";
 
 /** Discriminated result — deliberately narrow, no generic `Result` dep. */
 export type EventShapeResult =
@@ -36,6 +36,9 @@ export type EventShapeResult =
 type BrandResult<T> =
   | { readonly _tag: "Ok"; readonly value: T }
   | { readonly _tag: "Err"; readonly reason: string };
+
+const metaInvalid = (reason: string): MetaInvalid =>
+  new MetaInvalid({ reason, message: reason });
 
 function brandChatIdSafe(raw: string): BrandResult<ChatId> {
   if (typeof raw !== "string" || raw.trim().length === 0) {
@@ -84,7 +87,7 @@ function brandIsoTimestampSafe(raw: string): BrandResult<IsoTimestamp> {
 export function brandChatId(raw: string): ChatId {
   const r = brandChatIdSafe(raw);
   if (r._tag === "Err") {
-    throw new Error(`brandChatId: ${r.reason}`);
+    throw metaInvalid(`brandChatId: ${r.reason}`);
   }
   return r.value;
 }
@@ -92,7 +95,7 @@ export function brandChatId(raw: string): ChatId {
 export function brandMessageId(raw: string): MessageId {
   const r = brandMessageIdSafe(raw);
   if (r._tag === "Err") {
-    throw new Error(`brandMessageId: ${r.reason}`);
+    throw metaInvalid(`brandMessageId: ${r.reason}`);
   }
   return r.value;
 }
@@ -100,7 +103,7 @@ export function brandMessageId(raw: string): MessageId {
 export function brandUserId(raw: string): UserId {
   const r = brandUserIdSafe(raw);
   if (r._tag === "Err") {
-    throw new Error(`brandUserId: ${r.reason}`);
+    throw metaInvalid(`brandUserId: ${r.reason}`);
   }
   return r.value;
 }
@@ -108,7 +111,7 @@ export function brandUserId(raw: string): UserId {
 export function brandIsoTimestamp(raw: string): IsoTimestamp {
   const r = brandIsoTimestampSafe(raw);
   if (r._tag === "Err") {
-    throw new Error(`brandIsoTimestamp: ${r.reason}`);
+    throw metaInvalid(`brandIsoTimestamp: ${r.reason}`);
   }
   return r.value;
 }
@@ -122,21 +125,21 @@ export function toClaudeChannelNotification(
 ): EventShapeResult {
   const content = typeof event.text === "string" ? event.text : "";
   if (content.trim().length === 0) {
-    return { _tag: "Err", error: { _tag: "ContentEmpty" } };
+    return { _tag: "Err", error: new ContentEmpty() };
   }
 
   const chatIdR = brandChatIdSafe(event.conversationId);
   if (chatIdR._tag === "Err") {
     return {
       _tag: "Err",
-      error: { _tag: "MetaInvalid", reason: chatIdR.reason },
+      error: metaInvalid(chatIdR.reason),
     };
   }
   const messageIdR = brandMessageIdSafe(event.id);
   if (messageIdR._tag === "Err") {
     return {
       _tag: "Err",
-      error: { _tag: "MetaInvalid", reason: messageIdR.reason },
+      error: metaInvalid(messageIdR.reason),
     };
   }
   const senderId =
@@ -145,14 +148,14 @@ export function toClaudeChannelNotification(
   if (userR._tag === "Err") {
     return {
       _tag: "Err",
-      error: { _tag: "MetaInvalid", reason: userR.reason },
+      error: metaInvalid(userR.reason),
     };
   }
   const tsR = brandIsoTimestampSafe(event.createdAt);
   if (tsR._tag === "Err") {
     return {
       _tag: "Err",
-      error: { _tag: "MetaInvalid", reason: tsR.reason },
+      error: metaInvalid(tsR.reason),
     };
   }
 

--- a/packages/claude-code-channel/src/routing.ts
+++ b/packages/claude-code-channel/src/routing.ts
@@ -23,7 +23,15 @@
  * the caller references a message beyond the window.
  */
 
+import { Data } from "effect";
 import type { ChatId, MessageId } from "./types.js";
+
+class RoutingCapacityInvalid extends Data.TaggedError(
+  "RoutingCapacityInvalid",
+)<{
+  readonly capacity: number;
+  readonly message: string;
+}> {}
 
 export interface RoutingState {
   /**
@@ -60,9 +68,10 @@ export function createRoutingState(
   capacity: number = DEFAULT_CAPACITY,
 ): RoutingState {
   if (!Number.isFinite(capacity) || capacity <= 0) {
-    throw new Error(
-      `createRoutingState: capacity must be a positive finite number, got ${capacity}`,
-    );
+    throw new RoutingCapacityInvalid({
+      capacity,
+      message: `createRoutingState: capacity must be a positive finite number, got ${capacity}`,
+    });
   }
   const cap = Math.floor(capacity);
   const map = new Map<MessageId, ChatId>();

--- a/packages/claude-code-channel/src/server.ts
+++ b/packages/claude-code-channel/src/server.ts
@@ -20,7 +20,7 @@
  * 135-148 (notification shape).
  */
 
-import { Effect } from "effect";
+import { Data, Effect, Either } from "effect";
 import type { WsClientLogger } from "@moltzap/client";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -32,7 +32,12 @@ import {
   type ListToolsResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { ClaudeChannelNotification, MessageId } from "./types.js";
-import type { PushError, ReplyError } from "./errors.js";
+import {
+  EmitFailed,
+  SendFailed,
+  type PushError,
+  type ReplyError,
+} from "./errors.js";
 import type { RoutingState } from "./routing.js";
 import { stringifyCause } from "./utils.js";
 
@@ -83,9 +88,17 @@ export interface ServerHandle {
   readonly stop: () => Effect.Effect<void>;
 }
 
-export type ServerBootError =
-  | { readonly _tag: "StdioConnectFailed"; readonly cause: string }
-  | { readonly _tag: "ToolRegistrationFailed"; readonly cause: string };
+export class StdioConnectFailed extends Data.TaggedError("StdioConnectFailed")<{
+  readonly cause: string;
+}> {}
+
+export class ToolRegistrationFailed extends Data.TaggedError(
+  "ToolRegistrationFailed",
+)<{
+  readonly cause: string;
+}> {}
+
+export type ServerBootError = StdioConnectFailed | ToolRegistrationFailed;
 
 export type ServerBootResult =
   | { readonly _tag: "Ok"; readonly value: ServerHandle }
@@ -338,14 +351,16 @@ function bootChannelMcpServerEffect(
                 const sendResult = yield* Effect.either(
                   deps.sendReply(resolution.chatId, decoded.value.text),
                 );
-                if (sendResult._tag === "Left") {
-                  const e = sendResult.left;
-                  return toolErrorResult(
-                    e._tag === "SendFailed"
-                      ? `send failed: ${e.cause}`
-                      : `reply error: ${e._tag}`,
-                  );
-                }
+                const sendFailure = Either.match(sendResult, {
+                  onLeft: (error) =>
+                    toolErrorResult(
+                      error instanceof SendFailed
+                        ? `send failed: ${error.cause}`
+                        : `reply error: ${error.name}`,
+                    ),
+                  onRight: () => null,
+                });
+                if (sendFailure !== null) return sendFailure;
                 return toolOkResult(
                   `Reply sent to ${resolution.chatId as string}.`,
                 );
@@ -372,10 +387,9 @@ function bootChannelMcpServerEffect(
     } catch (cause) {
       return {
         _tag: "Err",
-        error: {
-          _tag: "ToolRegistrationFailed",
+        error: new ToolRegistrationFailed({
           cause: stringifyCause(cause),
-        },
+        }),
       };
     }
 
@@ -389,10 +403,9 @@ function bootChannelMcpServerEffect(
       Effect.match({
         onFailure: (cause): ServerBootResult => ({
           _tag: "Err",
-          error: {
-            _tag: "StdioConnectFailed",
+          error: new StdioConnectFailed({
             cause: stringifyCause(cause),
-          },
+          }),
         }),
         onSuccess: () => null,
       }),
@@ -412,10 +425,10 @@ function bootChannelMcpServerEffect(
                 method: notification.method,
                 params: toMcpNotificationParams(notification.params),
               }),
-            catch: (cause): PushError => ({
-              _tag: "EmitFailed",
-              cause: stringifyCause(cause),
-            }),
+            catch: (cause): PushError =>
+              new EmitFailed({
+                cause: stringifyCause(cause),
+              }),
           });
         }),
       stop: () =>

--- a/packages/claude-code-channel/src/types.ts
+++ b/packages/claude-code-channel/src/types.ts
@@ -8,35 +8,39 @@
  * Interfaces only. No function bodies beyond `throw new Error("not implemented")`.
  */
 
-import type { Effect } from "effect";
+import { Brand, type Effect } from "effect";
 import type { EnrichedInboundMessage, WsClientLogger } from "@moltzap/client";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { AllowlistError, BootError, PushError } from "./errors.js";
+import type { AllowlistError, PushError } from "./errors.js";
 
 /**
  * Branded chat id — corresponds to MoltZap's `conversationId` on the wire,
  * rendered to Claude Code as the contract-meta key `chat_id`.
  * Principle 1: preventing accidental confusion with `MessageId` at call sites.
  */
-export type ChatId = string & { readonly __brand: "ChatId" };
+export type ChatId = string & Brand.Brand<"ChatId">;
+export const ChatId = Brand.nominal<ChatId>();
 
 /**
  * Branded message id — corresponds to MoltZap's `id`, rendered as
  * contract-meta `message_id`.
  */
-export type MessageId = string & { readonly __brand: "MessageId" };
+export type MessageId = string & Brand.Brand<"MessageId">;
+export const MessageId = Brand.nominal<MessageId>();
 
 /**
  * Branded user id — corresponds to MoltZap's `sender.id`, rendered as
  * contract-meta `user`.
  */
-export type UserId = string & { readonly __brand: "UserId" };
+export type UserId = string & Brand.Brand<"UserId">;
+export const UserId = Brand.nominal<UserId>();
 
 /**
  * ISO-8601 timestamp — corresponds to MoltZap's `createdAt` (already ISO),
  * rendered as contract-meta `ts`.
  */
-export type IsoTimestamp = string & { readonly __brand: "IsoTimestamp" };
+export type IsoTimestamp = string & Brand.Brand<"IsoTimestamp">;
+export const IsoTimestamp = Brand.nominal<IsoTimestamp>();
 
 /**
  * Claude Code channel notification shape.

--- a/packages/client/src/__tests__/service.integration.test.ts
+++ b/packages/client/src/__tests__/service.integration.test.ts
@@ -25,6 +25,8 @@ import {
 } from "@moltzap/client/test";
 import { MoltZapService } from "../service.js";
 
+import { MessagesList, MessagesSend } from "@moltzap/protocol";
+
 /** Shorthand: run a service Effect to a Promise. The CLI + OpenClaw edges
  * do the same thing — tests sit at the same boundary. */
 const run = <A, E>(e: Effect.Effect<A, E>): Promise<A> => Effect.runPromise(e);
@@ -80,7 +82,7 @@ function sendAndSettle(
   text: string,
 ) {
   return Effect.gen(function* () {
-    yield* client.sendRpc("messages/send", {
+    yield* client.sendRpc(MessagesSend.name, {
       conversationId,
       parts: [{ type: "text", text }],
     });
@@ -114,7 +116,7 @@ describe("Connection & Core API", () => {
 
         // Connect agent-a and create a conversation before agent-b connects as service
         yield* regA.client.connect();
-        const conv = (yield* regA.client.sendRpc("conversations/create", {
+        const conv = (yield* regA.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regB.agentId }],
         })) as { conversation: { id: string } };
@@ -139,7 +141,7 @@ describe("Connection & Core API", () => {
       yield* regSender.client.connect();
       const service = yield* connectService(regReceiver.apiKey);
 
-      const conv = (yield* regSender.client.sendRpc("conversations/create", {
+      const conv = (yield* regSender.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regReceiver.agentId }],
       })) as { conversation: { id: string } };
@@ -171,7 +173,7 @@ describe("Connection & Core API", () => {
       yield* regB.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const conv = (yield* service.sendRpc("conversations/create", {
+      const conv = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
@@ -199,7 +201,7 @@ describe("Connection & Core API", () => {
       yield* regSender.client.connect();
       const service = yield* connectService(regReceiver.apiKey);
 
-      const conv = (yield* regSender.client.sendRpc("conversations/create", {
+      const conv = (yield* regSender.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regReceiver.agentId }],
       })) as { conversation: { id: string } };
@@ -243,7 +245,7 @@ describe("Connection & Core API", () => {
       yield* regB.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const conv = (yield* service.sendRpc("conversations/create", {
+      const conv = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
@@ -323,7 +325,7 @@ describe("Cross-Conversation Context", () => {
       yield* regB.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const conv = (yield* service.sendRpc("conversations/create", {
+      const conv = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
@@ -350,13 +352,13 @@ describe("Cross-Conversation Context", () => {
       yield* regC.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const convB = (yield* service.sendRpc("conversations/create", {
+      const convB = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
 
       // Create conv with C but don't send any messages in it
-      yield* service.sendRpc("conversations/create", {
+      yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regC.agentId }],
       });
@@ -386,12 +388,12 @@ describe("Cross-Conversation Context", () => {
         yield* regC.client.connect();
         const service = yield* connectService(regA.apiKey);
 
-        const convB = (yield* service.sendRpc("conversations/create", {
+        const convB = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regB.agentId }],
         })) as { conversation: { id: string } };
 
-        const convC = (yield* service.sendRpc("conversations/create", {
+        const convC = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regC.agentId }],
         })) as { conversation: { id: string } };
@@ -430,11 +432,11 @@ describe("Cross-Conversation Context", () => {
       // Resolve C's name so it appears in context
       yield* service.resolveAgentName(regC.agentId);
 
-      const convB = (yield* service.sendRpc("conversations/create", {
+      const convB = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
-      const convC = (yield* service.sendRpc("conversations/create", {
+      const convC = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regC.agentId }],
       })) as { conversation: { id: string } };
@@ -461,11 +463,11 @@ describe("Cross-Conversation Context", () => {
       yield* regC.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const convB = (yield* service.sendRpc("conversations/create", {
+      const convB = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
-      const convC = (yield* service.sendRpc("conversations/create", {
+      const convC = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regC.agentId }],
       })) as { conversation: { id: string } };
@@ -495,11 +497,11 @@ describe("Cross-Conversation Context", () => {
       yield* regC.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const convB = (yield* service.sendRpc("conversations/create", {
+      const convB = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
-      const convC = (yield* service.sendRpc("conversations/create", {
+      const convC = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regC.agentId }],
       })) as { conversation: { id: string } };
@@ -530,11 +532,11 @@ describe("Cross-Conversation Context", () => {
       yield* regC.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const convB = (yield* service.sendRpc("conversations/create", {
+      const convB = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
-      const convC = (yield* service.sendRpc("conversations/create", {
+      const convC = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regC.agentId }],
       })) as { conversation: { id: string } };
@@ -578,15 +580,15 @@ describe("Cross-Conversation Context", () => {
       yield* regD.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const convB = (yield* service.sendRpc("conversations/create", {
+      const convB = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
-      const convC = (yield* service.sendRpc("conversations/create", {
+      const convC = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regC.agentId }],
       })) as { conversation: { id: string } };
-      const convD = (yield* service.sendRpc("conversations/create", {
+      const convD = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regD.agentId }],
       })) as { conversation: { id: string } };
@@ -619,7 +621,7 @@ describe("Cross-Conversation Context", () => {
 
       const convs = [];
       for (const a of agents) {
-        const conv = (yield* service.sendRpc("conversations/create", {
+        const conv = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: a.agentId }],
         })) as { conversation: { id: string } };
@@ -653,7 +655,7 @@ describe("Cross-Conversation Context", () => {
       yield* regB.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const conv = (yield* service.sendRpc("conversations/create", {
+      const conv = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
@@ -682,11 +684,11 @@ describe("Cross-Conversation Context", () => {
 
       yield* service.resolveAgentName(regC.agentId);
 
-      const convB = (yield* service.sendRpc("conversations/create", {
+      const convB = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
-      const convC = (yield* service.sendRpc("conversations/create", {
+      const convC = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regC.agentId }],
       })) as { conversation: { id: string } };
@@ -714,11 +716,11 @@ describe("Cross-Conversation Context", () => {
       yield* regC.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      const convB = (yield* service.sendRpc("conversations/create", {
+      const convB = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
-      const convC = (yield* service.sendRpc("conversations/create", {
+      const convC = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regC.agentId }],
       })) as { conversation: { id: string } };
@@ -753,17 +755,17 @@ describe("Cross-Conversation Context", () => {
       yield* regC.client.connect();
       const service = yield* connectService(regA.apiKey);
 
-      yield* service.sendRpc("conversations/create", {
+      yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       });
-      const convC = (yield* service.sendRpc("conversations/create", {
+      const convC = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regC.agentId }],
       })) as { conversation: { id: string } };
 
       for (let i = 0; i < 25; i++) {
-        yield* regC.client.sendRpc("messages/send", {
+        yield* regC.client.sendRpc(MessagesSend.name, {
           conversationId: convC.conversation.id,
           parts: [{ type: "text", text: `msg-${i}` }],
         });
@@ -805,12 +807,12 @@ describe("peekFullMessages", () => {
         yield* regC.client.connect();
         const service = yield* connectService(regA.apiKey);
 
-        const convB = (yield* service.sendRpc("conversations/create", {
+        const convB = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regB.agentId }],
         })) as { conversation: { id: string } };
 
-        const convC = (yield* service.sendRpc("conversations/create", {
+        const convC = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regC.agentId }],
         })) as { conversation: { id: string } };
@@ -848,7 +850,7 @@ describe("peekFullMessages", () => {
 
       const convIds: string[] = [];
       for (const agent of agents) {
-        const conv = (yield* service.sendRpc("conversations/create", {
+        const conv = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: agent.agentId }],
         })) as { conversation: { id: string } };
@@ -882,12 +884,12 @@ describe("peekFullMessages", () => {
         yield* regC.client.connect();
         const service = yield* connectService(regA.apiKey);
 
-        const convB = (yield* service.sendRpc("conversations/create", {
+        const convB = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regB.agentId }],
         })) as { conversation: { id: string } };
 
-        const convC = (yield* service.sendRpc("conversations/create", {
+        const convC = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regC.agentId }],
         })) as { conversation: { id: string } };
@@ -928,7 +930,7 @@ describe("History with session key", () => {
       const service = yield* connectService(regA.apiKey);
 
       // Create DM between A and B
-      const conv = (yield* service.sendRpc("conversations/create", {
+      const conv = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: regB.agentId }],
       })) as { conversation: { id: string } };
@@ -945,7 +947,7 @@ describe("History with session key", () => {
       yield* Effect.promise(() => new Promise((r) => setTimeout(r, 500)));
 
       // Fetch history via RPC (same as CLI moltzap history would do)
-      const result = (yield* service.sendRpc("messages/list", {
+      const result = (yield* service.sendRpc(MessagesList.name, {
         conversationId: conv.conversation.id,
         limit: 10,
       })) as {
@@ -990,7 +992,7 @@ describe("History with session key", () => {
       const service = yield* connectService(regA.apiKey);
 
       // Create group
-      const conv = (yield* service.sendRpc("conversations/create", {
+      const conv = (yield* service.sendRpc(ConversationsCreate.name, {
         type: "group",
         name: "Test Group",
         participants: [
@@ -1006,7 +1008,7 @@ describe("History with session key", () => {
       yield* sendAndSettle(regC.client, conv.conversation.id, "Agent C here");
 
       // Fetch history
-      const result = (yield* service.sendRpc("messages/list", {
+      const result = (yield* service.sendRpc(MessagesList.name, {
         conversationId: conv.conversation.id,
         limit: 10,
       })) as {
@@ -1097,7 +1099,7 @@ describe("Socket Server", () => {
       service.startSocketServer();
       try {
         const conv = (yield* Effect.promise(() =>
-          socketRequest("conversations/create", {
+          socketRequest(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: regB.agentId }],
           }),
@@ -1105,7 +1107,7 @@ describe("Socket Server", () => {
         expect(conv.conversation.id).toBeDefined();
 
         const msg = (yield* Effect.promise(() =>
-          socketRequest("messages/send", {
+          socketRequest(MessagesSend.name, {
             conversationId: conv.conversation.id,
             parts: [{ type: "text", text: "via socket" }],
           }),
@@ -1128,14 +1130,14 @@ describe("Socket Server", () => {
       service.startSocketServer();
       try {
         const conv = (yield* Effect.promise(() =>
-          socketRequest("conversations/create", {
+          socketRequest(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: regB.agentId }],
           }),
         )) as { conversation: { id: string } };
 
         yield* Effect.promise(() =>
-          socketRequest("messages/send", {
+          socketRequest(MessagesSend.name, {
             conversationId: conv.conversation.id,
             parts: [{ type: "text", text: "Hello from A" }],
           }),
@@ -1179,11 +1181,11 @@ describe("Socket Server", () => {
         const service = yield* connectService(regA.apiKey);
         service.startSocketServer();
         try {
-          const convB = (yield* service.sendRpc("conversations/create", {
+          const convB = (yield* service.sendRpc(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: regB.agentId }],
           })) as { conversation: { id: string } };
-          const convC = (yield* service.sendRpc("conversations/create", {
+          const convC = (yield* service.sendRpc(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: regC.agentId }],
           })) as { conversation: { id: string } };
@@ -1250,11 +1252,11 @@ describe("Socket Server", () => {
       const service = yield* connectService(regA.apiKey);
       service.startSocketServer();
       try {
-        const convB = (yield* service.sendRpc("conversations/create", {
+        const convB = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regB.agentId }],
         })) as { conversation: { id: string } };
-        const convC = (yield* service.sendRpc("conversations/create", {
+        const convC = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regC.agentId }],
         })) as { conversation: { id: string } };
@@ -1323,15 +1325,15 @@ describe("Socket Server", () => {
       const service = yield* connectService(regA.apiKey);
       service.startSocketServer();
       try {
-        const convB = (yield* service.sendRpc("conversations/create", {
+        const convB = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regB.agentId }],
         })) as { conversation: { id: string } };
-        const convC = (yield* service.sendRpc("conversations/create", {
+        const convC = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regC.agentId }],
         })) as { conversation: { id: string } };
-        const convD = (yield* service.sendRpc("conversations/create", {
+        const convD = (yield* service.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: regD.agentId }],
         })) as { conversation: { id: string } };
@@ -1439,7 +1441,7 @@ describe("Socket Server", () => {
       service.startSocketServer();
       try {
         const conv = (yield* Effect.promise(() =>
-          socketRequest("conversations/create", {
+          socketRequest(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: regB.agentId }],
           }),
@@ -1505,13 +1507,13 @@ describe("Socket Server", () => {
       service.startSocketServer();
       try {
         const conv = (yield* Effect.promise(() =>
-          socketRequest("conversations/create", {
+          socketRequest(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: regB.agentId }],
           }),
         )) as { conversation: { id: string } };
 
-        yield* regB.client.sendRpc("messages/send", {
+        yield* regB.client.sendRpc(MessagesSend.name, {
           conversationId: conv.conversation.id,
           parts: [
             { type: "text", text: "Check this out" },

--- a/packages/client/src/auth.ts
+++ b/packages/client/src/auth.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 
 /** HTTP response from the agent registration endpoints
  * (`/api/v1/auth/register` and `/api/v1/admin/register-agent`). */
@@ -21,6 +21,16 @@ export interface RegisterAgentOptions {
 const PUBLIC_PATH = "/api/v1/auth/register";
 const ADMIN_PATH = "/api/v1/admin/register-agent";
 
+export class RegisterAgentError extends Data.TaggedError("RegisterAgentError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+const registerAgentError = (
+  message: string,
+  cause?: unknown,
+): RegisterAgentError => new RegisterAgentError({ message, cause });
+
 /** Register a new agent via HTTP. Thin wrapper around the agent-registration
  * endpoints — the WebSocket dance is `MoltZapWsClient`'s job; this just
  * returns the credentials the caller feeds it as `agentKey` at construction.
@@ -32,7 +42,7 @@ export const registerAgent = (
   baseUrl: string,
   name: string,
   opts?: RegisterAgentOptions,
-): Effect.Effect<RegisterResponse, Error> =>
+): Effect.Effect<RegisterResponse, RegisterAgentError> =>
   Effect.tryPromise({
     try: () => {
       const body: Record<string, string> = { name };
@@ -46,22 +56,24 @@ export const registerAgent = (
         body: JSON.stringify(body),
       });
     },
-    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    catch: (err) => registerAgentError("Register request failed", err),
   }).pipe(
     Effect.flatMap((res) =>
       res.ok
         ? Effect.tryPromise({
             try: () => res.json() as Promise<RegisterResponse>,
             catch: (err) =>
-              err instanceof Error ? err : new Error(String(err)),
+              registerAgentError("Register response decode failed", err),
           })
         : Effect.tryPromise({
             try: () => res.text(),
             catch: (err) =>
-              err instanceof Error ? err : new Error(String(err)),
+              registerAgentError("Register error response read failed", err),
           }).pipe(
             Effect.flatMap((text) =>
-              Effect.fail(new Error(`Register failed: ${res.status} ${text}`)),
+              Effect.fail(
+                registerAgentError(`Register failed: ${res.status} ${text}`),
+              ),
             ),
           ),
     ),

--- a/packages/client/src/cli/commands/agents.ts
+++ b/packages/client/src/cli/commands/agents.ts
@@ -3,6 +3,8 @@ import { Effect } from "effect";
 import type { AgentCard } from "@moltzap/protocol";
 import { request } from "../socket-client.js";
 
+import { AgentsList, AgentsLookupByName } from "@moltzap/protocol";
+
 interface AgentsListResult {
   agents: Record<string, AgentCard>;
 }
@@ -14,15 +16,16 @@ interface LookupResult {
 const jsonOption = Options.boolean("json").pipe(
   Options.withDescription("Output as JSON"),
 );
+const JSON_INDENT_SPACES = 2;
 
 const listAgents = Command.make("list", { json: jsonOption }, ({ json }) =>
-  request("agents/list", {}).pipe(
+  request(AgentsList.name, {}).pipe(
     Effect.tap((result) =>
       Effect.sync(() => {
         const r = result as AgentsListResult;
         const entries = Object.values(r.agents);
         if (json) {
-          console.log(JSON.stringify(r.agents, null, 2));
+          console.log(JSON.stringify(r.agents, null, JSON_INDENT_SPACES));
           return;
         }
         if (entries.length === 0) {
@@ -55,7 +58,7 @@ const namesArg = Args.text({ name: "name" }).pipe(
 );
 
 const lookupAgents = Command.make("lookup", { names: namesArg }, ({ names }) =>
-  request("agents/lookupByName", { names }).pipe(
+  request(AgentsLookupByName.name, { names }).pipe(
     Effect.tap((result) =>
       Effect.sync(() => {
         const r = result as LookupResult;

--- a/packages/client/src/cli/commands/apps.test.ts
+++ b/packages/client/src/cli/commands/apps.test.ts
@@ -34,6 +34,15 @@ import {
   type TransportError,
 } from "../transport.js";
 
+import {
+  AppsAttestSkill,
+  AppsCloseSession,
+  AppsCreate,
+  AppsGetSession,
+  AppsListSessions,
+  AppsRegister,
+} from "@moltzap/protocol";
+
 type Call = { method: string; params: Record<string, unknown> };
 
 const makeFakeTransport = (
@@ -91,7 +100,7 @@ describe("apps register", () => {
       ),
     );
     expect(calls).toEqual([
-      { method: "apps/register", params: { manifest: { name: "demo-app" } } },
+      { method: AppsRegister.name, params: { manifest: { name: "demo-app" } } },
     ]);
     expect(stdout).toHaveBeenCalledWith("app-xyz");
   });
@@ -145,7 +154,7 @@ describe("apps create", () => {
     );
     expect(calls).toEqual([
       {
-        method: "apps/create",
+        method: AppsCreate.name,
         params: { appId: "app-1", invitedAgentIds: ["agent-a", "agent-b"] },
       },
     ]);
@@ -184,7 +193,7 @@ describe("apps list", () => {
     );
     expect(calls).toEqual([
       {
-        method: "apps/listSessions",
+        method: AppsListSessions.name,
         params: { appId: "app-1", status: "active", limit: 10 },
       },
     ]);
@@ -226,7 +235,7 @@ describe("apps get", () => {
       ),
     );
     expect(calls[0]).toEqual({
-      method: "apps/getSession",
+      method: AppsGetSession.name,
       params: { sessionId: "s1" },
     });
     expect(stdout).toHaveBeenCalledWith(JSON.stringify(sessionObj, null, 2));
@@ -258,7 +267,7 @@ describe("apps close", () => {
       ),
     );
     expect(calls[0]).toEqual({
-      method: "apps/closeSession",
+      method: AppsCloseSession.name,
       params: { sessionId: "s-42" },
     });
     expect(stdout).toHaveBeenCalledWith("s-42");
@@ -293,7 +302,7 @@ describe("apps attest-skill", () => {
     );
     expect(calls).toEqual([
       {
-        method: "apps/attestSkill",
+        method: AppsAttestSkill.name,
         params: {
           challengeId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
           skillUrl: "https://example.com/skills/my-skill",

--- a/packages/client/src/cli/commands/apps.ts
+++ b/packages/client/src/cli/commands/apps.ts
@@ -21,13 +21,22 @@
  */
 import * as fs from "node:fs";
 import { Args, Command, Options } from "@effect/cli";
-import { Effect, Option } from "effect";
+import { Data, Effect, Option } from "effect";
 import {
   rpc,
   runHandler,
   type Transport,
   type TransportError,
 } from "../transport.js";
+
+import {
+  AppsAttestSkill,
+  AppsCloseSession,
+  AppsCreate,
+  AppsGetSession,
+  AppsListSessions,
+  AppsRegister,
+} from "@moltzap/protocol";
 
 // ─── Errors ────────────────────────────────────────────────────────────────
 
@@ -38,12 +47,12 @@ import {
 export type AppsCommandError = TransportError | AppsInputError;
 
 /** CLI argument parsing rejected a value (e.g. `--manifest` points to a missing file). */
-export class AppsInputError extends Error {
-  readonly _tag = "AppsInputError" as const;
-  constructor(readonly reason: string) {
-    super(reason);
-  }
-}
+export class AppsInputError extends Data.TaggedError("AppsInputError")<{
+  readonly message: string;
+  readonly reason: string;
+}> {}
+
+const JSON_INDENT_SPACES = 2;
 
 // ─── Input shapes ──────────────────────────────────────────────────────────
 
@@ -108,27 +117,31 @@ export const appsRegisterHandler = (
     try {
       manifestText = fs.readFileSync(args.manifestPath, "utf-8");
     } catch (err) {
+      const reason = `manifest not readable at ${args.manifestPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
       return yield* Effect.fail(
-        new AppsInputError(
-          `manifest not readable at ${args.manifestPath}: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        ),
+        new AppsInputError({
+          message: reason,
+          reason,
+        }),
       );
     }
     let manifest: unknown;
     try {
       manifest = JSON.parse(manifestText);
     } catch (err) {
+      const reason = `manifest at ${args.manifestPath} is not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
       return yield* Effect.fail(
-        new AppsInputError(
-          `manifest at ${args.manifestPath} is not valid JSON: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        ),
+        new AppsInputError({
+          message: reason,
+          reason,
+        }),
       );
     }
-    const result = yield* rpc<{ appId: string }>("apps/register", {
+    const result = yield* rpc<{ appId: string }>(AppsRegister.name, {
       manifest,
     });
     yield* Effect.sync(() => {
@@ -141,7 +154,7 @@ export const appsCreateHandler = (
   args: AppsCreateArgs,
 ): Effect.Effect<void, AppsCommandError, Transport> =>
   Effect.gen(function* () {
-    const result = yield* rpc<{ session: { id: string } }>("apps/create", {
+    const result = yield* rpc<{ session: { id: string } }>(AppsCreate.name, {
       appId: args.appId,
       invitedAgentIds: [...args.invitedAgentIds],
     });
@@ -165,7 +178,7 @@ export const appsListHandler = (
         appId: string;
         status: AppSessionStatus;
       }>;
-    }>("apps/listSessions", params);
+    }>(AppsListSessions.name, params);
     yield* Effect.sync(() => {
       for (const s of result.sessions) {
         console.log(`${s.id}\t${s.appId}\t${s.status}`);
@@ -178,11 +191,11 @@ export const appsGetHandler = (
   args: AppsGetArgs,
 ): Effect.Effect<void, AppsCommandError, Transport> =>
   Effect.gen(function* () {
-    const result = yield* rpc<{ session: unknown }>("apps/getSession", {
+    const result = yield* rpc<{ session: unknown }>(AppsGetSession.name, {
       sessionId: args.sessionId,
     });
     yield* Effect.sync(() => {
-      console.log(JSON.stringify(result.session, null, 2));
+      console.log(JSON.stringify(result.session, null, JSON_INDENT_SPACES));
     });
   });
 
@@ -191,7 +204,7 @@ export const appsCloseHandler = (
   args: AppsCloseArgs,
 ): Effect.Effect<void, AppsCommandError, Transport> =>
   Effect.gen(function* () {
-    yield* rpc<{ closed: boolean }>("apps/closeSession", {
+    yield* rpc<{ closed: boolean }>(AppsCloseSession.name, {
       sessionId: args.sessionId,
     });
     yield* Effect.sync(() => {
@@ -208,7 +221,7 @@ export const appsCloseHandler = (
 export const appsAttestSkillHandler = (
   args: AppsAttestSkillArgs,
 ): Effect.Effect<void, AppsCommandError, Transport> =>
-  rpc<Record<string, never>>("apps/attestSkill", {
+  rpc<Record<string, never>>(AppsAttestSkill.name, {
     challengeId: args.challengeId,
     skillUrl: args.skillUrl,
     version: args.version,

--- a/packages/client/src/cli/commands/contacts.ts
+++ b/packages/client/src/cli/commands/contacts.ts
@@ -3,9 +3,12 @@ import { Effect } from "effect";
 import type { Contact } from "@moltzap/protocol";
 import { request } from "../socket-client.js";
 
+import { ContactsAccept, ContactsAdd, ContactsList } from "@moltzap/protocol";
+
 const jsonOption = Options.boolean("json").pipe(
   Options.withDescription("Output as JSON"),
 );
+const JSON_INDENT_SPACES = 2;
 
 const wrap = <A>(
   effect: Effect.Effect<A, Error>,
@@ -24,13 +27,13 @@ const wrap = <A>(
 
 const listContacts = Command.make("list", { json: jsonOption }, ({ json }) =>
   wrap(
-    request("contacts/list", {}) as Effect.Effect<
+    request(ContactsList.name, {}) as Effect.Effect<
       { contacts: Contact[] },
       Error
     >,
     (r) => {
       if (json) {
-        console.log(JSON.stringify(r.contacts, null, 2));
+        console.log(JSON.stringify(r.contacts, null, JSON_INDENT_SPACES));
         return;
       }
       if (r.contacts.length === 0) {
@@ -62,7 +65,7 @@ const addContact = Command.make(
       params.source = "manual";
     }
     return wrap(
-      request("contacts/add", params) as Effect.Effect<
+      request(ContactsAdd.name, params) as Effect.Effect<
         { contact: Contact },
         Error
       >,
@@ -82,7 +85,7 @@ const acceptContact = Command.make(
   { contactId: contactIdArg },
   ({ contactId }) =>
     wrap(
-      request("contacts/accept", { contactId }) as Effect.Effect<
+      request(ContactsAccept.name, { contactId }) as Effect.Effect<
         { contact: Contact },
         Error
       >,

--- a/packages/client/src/cli/commands/conversations-v2.test.ts
+++ b/packages/client/src/cli/commands/conversations-v2.test.ts
@@ -27,6 +27,12 @@ import {
   type TransportError,
 } from "../transport.js";
 
+import {
+  ConversationsArchive,
+  ConversationsGet,
+  ConversationsUnarchive,
+} from "@moltzap/protocol";
+
 type Call = { method: string; params: Record<string, unknown> };
 
 const makeFakeTransport = (
@@ -71,7 +77,7 @@ describe("conversations get (v2)", () => {
       ),
     );
     expect(calls[0]).toEqual({
-      method: "conversations/get",
+      method: ConversationsGet.name,
       params: { conversationId: "c1" },
     });
     expect(stdout).toHaveBeenCalledWith(JSON.stringify(body, null, 2));
@@ -103,7 +109,7 @@ describe("conversations archive (v2)", () => {
       ),
     );
     expect(calls[0]).toEqual({
-      method: "conversations/archive",
+      method: ConversationsArchive.name,
       params: { conversationId: "c1" },
     });
   });
@@ -134,7 +140,7 @@ describe("conversations unarchive (v2)", () => {
       ),
     );
     expect(calls[0]).toEqual({
-      method: "conversations/unarchive",
+      method: ConversationsUnarchive.name,
       params: { conversationId: "c1" },
     });
   });

--- a/packages/client/src/cli/commands/conversations.ts
+++ b/packages/client/src/cli/commands/conversations.ts
@@ -1,11 +1,16 @@
 import { Args, Command, Options } from "@effect/cli";
-import { Effect, Option } from "effect";
+import { Data, Effect, Option } from "effect";
 import type { ConversationSummary } from "@moltzap/protocol";
 import { request, resolveParticipant } from "../socket-client.js";
 
 const jsonOption = Options.boolean("json").pipe(
   Options.withDescription("Output as JSON"),
 );
+
+const DEFAULT_LIST_LIMIT = 20;
+const DEFAULT_HISTORY_LIMIT = 50;
+const JSON_INDENT_SPACES = 2;
+const MILLISECONDS_PER_MINUTE = 60_000;
 
 const wrap = <A>(
   effect: Effect.Effect<A, Error>,
@@ -23,7 +28,7 @@ const wrap = <A>(
   );
 
 const limitOption = Options.integer("limit").pipe(
-  Options.withDefault(20),
+  Options.withDefault(DEFAULT_LIST_LIMIT),
   Options.withDescription("Max conversations to list"),
 );
 
@@ -32,13 +37,15 @@ const listConversations = Command.make(
   { limit: limitOption, json: jsonOption },
   ({ limit, json }) =>
     wrap(
-      request("conversations/list", { limit }) as Effect.Effect<
+      request(ConversationsList.name, { limit }) as Effect.Effect<
         { conversations: ConversationSummary[] },
         Error
       >,
       (r) => {
         if (json) {
-          console.log(JSON.stringify(r.conversations, null, 2));
+          console.log(
+            JSON.stringify(r.conversations, null, JSON_INDENT_SPACES),
+          );
           return;
         }
         if (r.conversations.length === 0) {
@@ -88,7 +95,7 @@ const createConversation = Command.make(
         : parsed.length === 1
           ? "dm"
           : "group";
-      const result = (yield* request("conversations/create", {
+      const result = (yield* request(ConversationsCreate.name, {
         type: convType,
         name,
         participants: parsed,
@@ -114,7 +121,7 @@ const leaveConversation = Command.make(
   "leave",
   { conversationId: conversationIdArg },
   ({ conversationId }) =>
-    wrap(request("conversations/leave", { conversationId }), () => {
+    wrap(request(ConversationsLeave.name, { conversationId }), () => {
       console.log(`Left conversation ${conversationId}.`);
     }),
 ).pipe(Command.withDescription("Leave a conversation"));
@@ -130,7 +137,7 @@ const muteConversation = Command.make(
   ({ conversationId, until }) => {
     const params: Record<string, string> = { conversationId };
     if (Option.isSome(until)) params.until = until.value;
-    return wrap(request("conversations/mute", params), () => {
+    return wrap(request(ConversationsMute.name, params), () => {
       console.log(
         Option.isSome(until)
           ? `Conversation ${conversationId} muted until ${until.value}.`
@@ -144,7 +151,7 @@ const unmuteConversation = Command.make(
   "unmute",
   { conversationId: conversationIdArg },
   ({ conversationId }) =>
-    wrap(request("conversations/unmute", { conversationId }), () => {
+    wrap(request(ConversationsUnmute.name, { conversationId }), () => {
       console.log(`Conversation ${conversationId} unmuted.`);
     }),
 ).pipe(Command.withDescription("Unmute a conversation"));
@@ -158,7 +165,7 @@ const updateConversation = Command.make(
   { conversationId: conversationIdArg, name: nameOption },
   ({ conversationId, name }) =>
     wrap(
-      request("conversations/update", {
+      request(ConversationsUpdate.name, {
         conversationId,
         name,
       }) as Effect.Effect<
@@ -179,7 +186,7 @@ const addParticipantCommand = Command.make(
   ({ conversationId, participant }) =>
     Effect.gen(function* () {
       const ref = yield* resolveParticipant(participant);
-      yield* request("conversations/addParticipant", {
+      yield* request(ConversationsAddParticipant.name, {
         conversationId,
         participant: ref,
       });
@@ -200,7 +207,7 @@ const removeParticipantCommand = Command.make(
   ({ conversationId, participant }) =>
     Effect.gen(function* () {
       const ref = yield* resolveParticipant(participant);
-      yield* request("conversations/removeParticipant", {
+      yield* request(ConversationsRemoveParticipant.name, {
         conversationId,
         participant: ref,
       });
@@ -233,7 +240,7 @@ interface HistoryResult {
 }
 
 const historyLimitOption = Options.integer("limit").pipe(
-  Options.withDefault(50),
+  Options.withDefault(DEFAULT_HISTORY_LIMIT),
   Options.withDescription("Max messages to show"),
 );
 
@@ -249,7 +256,7 @@ const renderHistory = (
   json: boolean,
 ): void => {
   if (json) {
-    console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify(result, null, JSON_INDENT_SPACES));
     return;
   }
   if (result.messages.length === 0) {
@@ -266,7 +273,10 @@ const renderHistory = (
   for (const m of result.messages) {
     const ago = Math.max(
       0,
-      Math.round((Date.now() - new Date(m.createdAt).getTime()) / 60_000),
+      Math.round(
+        (Date.now() - new Date(m.createdAt).getTime()) /
+          MILLISECONDS_PER_MINUTE,
+      ),
     );
     const newMarker = m.isNew ? " *" : "";
     console.log(`  [${ago}m ago] ${m.senderName}: ${m.text}${newMarker}`);
@@ -320,6 +330,19 @@ import {
   type Transport,
   type TransportError,
 } from "../transport.js";
+import {
+  ConversationsAddParticipant,
+  ConversationsArchive,
+  ConversationsCreate,
+  ConversationsGet,
+  ConversationsLeave,
+  ConversationsList,
+  ConversationsMute,
+  ConversationsRemoveParticipant,
+  ConversationsUnarchive,
+  ConversationsUnmute,
+  ConversationsUpdate,
+} from "@moltzap/protocol";
 
 /** Discriminated error union for the three v2 conversation subcommands. */
 export type ConversationsCommandError =
@@ -327,12 +350,12 @@ export type ConversationsCommandError =
   | ConversationsInputError;
 
 /** CLI-level input was rejected (architect stage: signature only). */
-export class ConversationsInputError extends Error {
-  readonly _tag = "ConversationsInputError" as const;
-  constructor(readonly reason: string) {
-    super(reason);
-  }
-}
+export class ConversationsInputError extends Data.TaggedError(
+  "ConversationsInputError",
+)<{
+  readonly message: string;
+  readonly reason: string;
+}> {}
 
 /** `moltzap conversations get <id>` → conversations/get; prints { conversation, participants }. */
 export const conversationsGetHandler = (args: {
@@ -342,9 +365,9 @@ export const conversationsGetHandler = (args: {
     const result = yield* transportRpc<{
       conversation: unknown;
       participants: unknown;
-    }>("conversations/get", { conversationId: args.conversationId });
+    }>(ConversationsGet.name, { conversationId: args.conversationId });
     yield* Effect.sync(() => {
-      console.log(JSON.stringify(result, null, 2));
+      console.log(JSON.stringify(result, null, JSON_INDENT_SPACES));
     });
   });
 
@@ -353,7 +376,7 @@ export const conversationsArchiveHandler = (args: {
   readonly conversationId: string;
 }): Effect.Effect<void, ConversationsCommandError, Transport> =>
   Effect.gen(function* () {
-    yield* transportRpc<Record<string, never>>("conversations/archive", {
+    yield* transportRpc<Record<string, never>>(ConversationsArchive.name, {
       conversationId: args.conversationId,
     });
     yield* Effect.sync(() => {
@@ -366,7 +389,7 @@ export const conversationsUnarchiveHandler = (args: {
   readonly conversationId: string;
 }): Effect.Effect<void, ConversationsCommandError, Transport> =>
   Effect.gen(function* () {
-    yield* transportRpc<Record<string, never>>("conversations/unarchive", {
+    yield* transportRpc<Record<string, never>>(ConversationsUnarchive.name, {
       conversationId: args.conversationId,
     });
     yield* Effect.sync(() => {
@@ -403,7 +426,7 @@ const unarchiveConversationCommand = Command.make(
  * wired by impl-staff against the handlers above (sbd#185).
  */
 export const conversationsCommand = Command.make("conversations", {}, () =>
-  listConversations.handler({ limit: 20, json: false }),
+  listConversations.handler({ limit: DEFAULT_LIST_LIMIT, json: false }),
 ).pipe(
   Command.withDescription("Manage conversations"),
   Command.withSubcommands([

--- a/packages/client/src/cli/commands/messages.test.ts
+++ b/packages/client/src/cli/commands/messages.test.ts
@@ -20,6 +20,8 @@ import {
   type TransportError,
 } from "../transport.js";
 
+import { MessagesList } from "@moltzap/protocol";
+
 type Call = { method: string; params: Record<string, unknown> };
 
 const makeFakeTransport = (
@@ -84,7 +86,7 @@ describe("messages list", () => {
       ),
     );
     expect(calls[0]).toEqual({
-      method: "messages/list",
+      method: MessagesList.name,
       params: { conversationId: "c1", limit: 50 },
     });
     expect(stdout).toHaveBeenCalledTimes(2);

--- a/packages/client/src/cli/commands/messages.ts
+++ b/packages/client/src/cli/commands/messages.ts
@@ -15,7 +15,7 @@
  * deliberately absent from this interface until resolved.
  */
 import { Command, Options } from "@effect/cli";
-import { Effect, Option } from "effect";
+import { Data, Effect, Option } from "effect";
 import {
   rpc,
   runHandler,
@@ -23,16 +23,16 @@ import {
   type TransportError,
 } from "../transport.js";
 
+import { MessagesList } from "@moltzap/protocol";
+
 // ─── Errors ────────────────────────────────────────────────────────────────
 
 export type MessagesCommandError = TransportError | MessagesInputError;
 
-export class MessagesInputError extends Error {
-  readonly _tag = "MessagesInputError" as const;
-  constructor(readonly reason: string) {
-    super(reason);
-  }
-}
+export class MessagesInputError extends Data.TaggedError("MessagesInputError")<{
+  readonly message: string;
+  readonly reason: string;
+}> {}
 
 // ─── Input shapes ──────────────────────────────────────────────────────────
 
@@ -76,7 +76,7 @@ export const messagesListHandler = (
     const result = yield* rpc<{
       messages: ReadonlyArray<WireMessage>;
       hasMore: boolean;
-    }>("messages/list", params);
+    }>(MessagesList.name, params);
     yield* Effect.sync(() => {
       for (const m of result.messages) {
         const text = m.parts.find((p) => p.type === "text")?.text ?? "";

--- a/packages/client/src/cli/commands/permissions.test.ts
+++ b/packages/client/src/cli/commands/permissions.test.ts
@@ -24,6 +24,12 @@ import {
   type TransportError,
 } from "../transport.js";
 
+import {
+  PermissionsGrant,
+  PermissionsList,
+  PermissionsRevoke,
+} from "@moltzap/protocol";
+
 type Call = { method: string; params: Record<string, unknown> };
 
 const makeFakeTransport = (
@@ -68,7 +74,7 @@ describe("permissions grant", () => {
     );
     expect(calls).toEqual([
       {
-        method: "permissions/grant",
+        method: PermissionsGrant.name,
         params: {
           sessionId: "sess-1",
           agentId: "agent-a",
@@ -130,7 +136,7 @@ describe("permissions list", () => {
       ),
     );
     expect(calls[0]).toEqual({
-      method: "permissions/list",
+      method: PermissionsList.name,
       params: { appId: "app-1" },
     });
     expect(stdout).toHaveBeenCalledTimes(1);
@@ -172,7 +178,7 @@ describe("permissions revoke", () => {
       ),
     );
     expect(calls[0]).toEqual({
-      method: "permissions/revoke",
+      method: PermissionsRevoke.name,
       params: { appId: "app-1", resource: "r1" },
     });
   });

--- a/packages/client/src/cli/commands/permissions.ts
+++ b/packages/client/src/cli/commands/permissions.ts
@@ -11,7 +11,7 @@
  * verified against the server handler during impl (Q-PG-1 RESOLVED HIGH).
  */
 import { Command, Options } from "@effect/cli";
-import { Effect, Option } from "effect";
+import { Data, Effect, Option } from "effect";
 import {
   rpc,
   runHandler,
@@ -19,17 +19,23 @@ import {
   type TransportError,
 } from "../transport.js";
 
+import {
+  PermissionsGrant,
+  PermissionsList,
+  PermissionsRevoke,
+} from "@moltzap/protocol";
+
 // ─── Errors ────────────────────────────────────────────────────────────────
 
 /** Exhaustive error union for the permissions surface. */
 export type PermissionsCommandError = TransportError | PermissionsInputError;
 
-export class PermissionsInputError extends Error {
-  readonly _tag = "PermissionsInputError" as const;
-  constructor(readonly reason: string) {
-    super(reason);
-  }
-}
+export class PermissionsInputError extends Data.TaggedError(
+  "PermissionsInputError",
+)<{
+  readonly message: string;
+  readonly reason: string;
+}> {}
 
 // ─── Input shapes ──────────────────────────────────────────────────────────
 
@@ -64,13 +70,16 @@ export const permissionsGrantHandler = (
 ): Effect.Effect<void, PermissionsCommandError, Transport> =>
   Effect.gen(function* () {
     if (args.access.length === 0) {
+      const reason =
+        "--access requires at least one value (e.g. --access read)";
       return yield* Effect.fail(
-        new PermissionsInputError(
-          "--access requires at least one value (e.g. --access read)",
-        ),
+        new PermissionsInputError({
+          message: reason,
+          reason,
+        }),
       );
     }
-    yield* rpc<Record<string, never>>("permissions/grant", {
+    yield* rpc<Record<string, never>>(PermissionsGrant.name, {
       sessionId: args.sessionId,
       agentId: args.agentId,
       resource: args.resource,
@@ -100,7 +109,7 @@ export const permissionsListHandler = (
         access: ReadonlyArray<string>;
         grantedAt: string;
       }>;
-    }>("permissions/list", params);
+    }>(PermissionsList.name, params);
     yield* Effect.sync(() => {
       for (const g of result.grants) {
         console.log(
@@ -115,7 +124,7 @@ export const permissionsRevokeHandler = (
   args: PermissionsRevokeArgs,
 ): Effect.Effect<void, PermissionsCommandError, Transport> =>
   Effect.gen(function* () {
-    yield* rpc<Record<string, never>>("permissions/revoke", {
+    yield* rpc<Record<string, never>>(PermissionsRevoke.name, {
       appId: args.appId,
       resource: args.resource,
     });

--- a/packages/client/src/cli/commands/ping.ts
+++ b/packages/client/src/cli/commands/ping.ts
@@ -1,26 +1,45 @@
 import { Command } from "@effect/cli";
 import { HttpClient, HttpClientRequest } from "@effect/platform";
 import { NodeHttpClient } from "@effect/platform-node";
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import { getHttpUrl } from "../config.js";
 
-const pingEffect: Effect.Effect<void, Error> = Effect.gen(function* () {
+export class PingError extends Data.TaggedError("PingError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+const HTTP_SUCCESS_MIN = 200;
+const HTTP_REDIRECT_MIN = 300;
+
+const toPingError = (cause: unknown): PingError =>
+  cause instanceof PingError
+    ? cause
+    : new PingError({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause,
+      });
+
+const pingEffect: Effect.Effect<void, PingError> = Effect.gen(function* () {
   const baseUrl = yield* getHttpUrl;
   const client = yield* HttpClient.HttpClient;
   const response = yield* client.execute(
     HttpClientRequest.get(`${baseUrl}/health`),
   );
-  if (response.status < 200 || response.status >= 300) {
+  if (
+    response.status < HTTP_SUCCESS_MIN ||
+    response.status >= HTTP_REDIRECT_MIN
+  ) {
     return yield* Effect.fail(
-      new Error(`Server unreachable: HTTP ${response.status}`),
+      new PingError({
+        message: `Server unreachable: HTTP ${response.status}`,
+      }),
     );
   }
 }).pipe(
   Effect.timeout("5 seconds"),
   Effect.provide(NodeHttpClient.layer),
-  Effect.catchAll((err) =>
-    Effect.fail(err instanceof Error ? err : new Error(String(err))),
-  ),
+  Effect.mapError(toPingError),
 );
 
 /**

--- a/packages/client/src/cli/commands/presence.ts
+++ b/packages/client/src/cli/commands/presence.ts
@@ -2,6 +2,8 @@ import { Args, Command } from "@effect/cli";
 import { Effect, Option } from "effect";
 import { request } from "../socket-client.js";
 
+import { PresenceUpdate } from "@moltzap/protocol";
+
 const statusArg = Args.text({ name: "status" }).pipe(
   Args.withDescription("Status to set: online, offline, or away"),
   Args.optional,
@@ -31,7 +33,7 @@ export const presenceCommand = Command.make(
         process.exit(1);
       });
     }
-    return request("presence/update", { status: value }).pipe(
+    return request(PresenceUpdate.name, { status: value }).pipe(
       Effect.tap(() =>
         Effect.sync(() => {
           console.log(`Presence set to ${value}.`);

--- a/packages/client/src/cli/commands/register.ts
+++ b/packages/client/src/cli/commands/register.ts
@@ -13,6 +13,7 @@ import {
 } from "../profile.js";
 
 const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/;
+const JSON_INDENT_SPACES = 2;
 
 interface OpenClawConfig {
   channels?: {
@@ -72,7 +73,10 @@ const writeOpenClawChannelConfig = (account: {
       config.channels = channels;
 
       fs.mkdirSync(configDir, { recursive: true });
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify(config, null, JSON_INDENT_SPACES) + "\n",
+      );
     },
     catch: (err) => (err instanceof Error ? err : new Error(String(err))),
   });

--- a/packages/client/src/cli/commands/send.test.ts
+++ b/packages/client/src/cli/commands/send.test.ts
@@ -2,6 +2,8 @@ import { Effect, Option } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sendCommand } from "./send.js";
 
+import { MessagesSend } from "@moltzap/protocol";
+
 const mockRequest = vi.fn(() => Effect.succeed({ message: { id: "msg-123" } }));
 
 vi.mock("../socket-client.js", async (importOriginal) => {
@@ -35,7 +37,7 @@ describe("send command handler", () => {
         replyTo: Option.none(),
       }),
     );
-    expect(mockRequest).toHaveBeenCalledWith("messages/send", {
+    expect(mockRequest).toHaveBeenCalledWith(MessagesSend.name, {
       conversationId: "abc-123",
       parts: [{ type: "text", text: "Hello world" }],
     });
@@ -49,7 +51,7 @@ describe("send command handler", () => {
         replyTo: Option.none(),
       }),
     );
-    expect(mockRequest).toHaveBeenCalledWith("messages/send", {
+    expect(mockRequest).toHaveBeenCalledWith(MessagesSend.name, {
       to: "agent:alice",
       parts: [{ type: "text", text: "Hi Alice" }],
     });
@@ -63,7 +65,7 @@ describe("send command handler", () => {
         replyTo: Option.some("msg-original"),
       }),
     );
-    expect(mockRequest).toHaveBeenCalledWith("messages/send", {
+    expect(mockRequest).toHaveBeenCalledWith(MessagesSend.name, {
       conversationId: "abc-123",
       parts: [{ type: "text", text: "Reply text" }],
       replyToId: "msg-original",

--- a/packages/client/src/cli/commands/send.ts
+++ b/packages/client/src/cli/commands/send.ts
@@ -2,6 +2,10 @@ import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
 import { request } from "../socket-client.js";
 
+import { MessagesSend } from "@moltzap/protocol";
+
+const CONVERSATION_TARGET_PREFIX = "conv:";
+
 const targetArg = Args.text({ name: "target" }).pipe(
   Args.withDescription("Target (agent:<name> or conv:<id>)"),
 );
@@ -58,14 +62,14 @@ export const sendCommand = Command.make(
     const params: Record<string, unknown> = {
       parts: [{ type: "text", text: message }],
     };
-    if (target.startsWith("conv:")) {
-      params.conversationId = target.slice(5);
+    if (target.startsWith(CONVERSATION_TARGET_PREFIX)) {
+      params.conversationId = target.slice(CONVERSATION_TARGET_PREFIX.length);
     } else {
       params.to = target;
     }
     if (Option.isSome(replyTo)) params.replyToId = replyTo.value;
 
-    return request("messages/send", params).pipe(
+    return request(MessagesSend.name, params).pipe(
       Effect.tap((result) =>
         Effect.sync(() => {
           const r = result as { message: { id: string } };

--- a/packages/client/src/cli/commands/whoami.ts
+++ b/packages/client/src/cli/commands/whoami.ts
@@ -2,6 +2,9 @@ import { Command } from "@effect/cli";
 import { Effect } from "effect";
 import { getConfigPath, loadConfig } from "../config.js";
 
+const API_KEY_VISIBLE_PREFIX_CHARS = 20;
+const API_KEY_VISIBLE_SUFFIX_CHARS = 4;
+
 /**
  * `moltzap whoami` — print config path + server URL, and if registered the
  * agent name + masked API key. Output is user-facing prose so it goes to
@@ -15,7 +18,9 @@ export const whoamiCommand = Command.make("whoami", {}, () =>
         console.log(`Server: ${config.serverUrl}`);
         if (config.agentName && config.apiKey) {
           const masked =
-            config.apiKey.slice(0, 20) + "..." + config.apiKey.slice(-4);
+            config.apiKey.slice(0, API_KEY_VISIBLE_PREFIX_CHARS) +
+            "..." +
+            config.apiKey.slice(-API_KEY_VISIBLE_SUFFIX_CHARS);
           console.log(`\nAgent: ${config.agentName}`);
           console.log(`  API Key: ${masked}`);
         } else {

--- a/packages/client/src/cli/config.ts
+++ b/packages/client/src/cli/config.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { Config, ConfigProvider, Effect } from "effect";
+import { Config, ConfigProvider, Data, Effect, Option } from "effect";
 
 /**
  * CLI config shape. Loaded via `Effect.Config` from the on-disk JSON file
@@ -18,6 +18,38 @@ const CONFIG_DIR = path.join(os.homedir(), ".moltzap");
 const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
 
 const DEFAULT_SERVER_URL = "wss://api.moltzap.xyz";
+const CONFIG_FILE_MODE = 0o600;
+const JSON_INDENT_SPACES = 2;
+
+export type CliConfigError =
+  | ConfigReadError
+  | ConfigWriteError
+  | ConfigInvalidError
+  | AuthNotConfiguredError;
+
+export class ConfigReadError extends Data.TaggedError("ConfigReadError")<{
+  readonly cause: unknown;
+  readonly message: string;
+  readonly path: string;
+}> {}
+
+export class ConfigWriteError extends Data.TaggedError("ConfigWriteError")<{
+  readonly cause: unknown;
+  readonly message: string;
+  readonly path: string;
+}> {}
+
+export class ConfigInvalidError extends Data.TaggedError("ConfigInvalidError")<{
+  readonly cause: unknown;
+  readonly message: string;
+  readonly path: string;
+}> {}
+
+export class AuthNotConfiguredError extends Data.TaggedError(
+  "AuthNotConfiguredError",
+)<{
+  readonly message: string;
+}> {}
 
 /** Effect.Config schema. Matches the on-disk JSON shape. */
 const ConfigSchema = Config.all({
@@ -27,32 +59,65 @@ const ConfigSchema = Config.all({
   apiKey: Config.option(Config.string("apiKey")),
   agentName: Config.option(Config.string("agentName")),
 });
+const EnvOverrideSchema = Config.all({
+  apiKey: Config.option(Config.string("MOLTZAP_API_KEY")),
+  serverUrl: Config.option(Config.string("MOLTZAP_SERVER_URL")),
+});
 
 export function getConfigPath(): string {
   return CONFIG_PATH;
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 /** Read the on-disk JSON (best-effort: ENOENT → empty object). */
-const readJsonFile = (): Effect.Effect<Record<string, unknown>, Error> =>
-  Effect.try({
-    try: () => {
-      try {
-        return JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")) as Record<
-          string,
-          unknown
-        >;
-      } catch (err) {
+const readJsonFile = (): Effect.Effect<
+  Record<string, unknown>,
+  ConfigReadError
+> =>
+  Effect.gen(function* () {
+    const text = yield* Effect.try({
+      try: () => fs.readFileSync(CONFIG_PATH, "utf-8"),
+      catch: (err) => err,
+    }).pipe(
+      Effect.catchAll((err) => {
         const code = (err as NodeJS.ErrnoException).code;
-        if (code === "ENOENT") return {};
-        throw err;
-      }
-    },
-    catch: (err) =>
-      new Error(
-        `Failed to read ${CONFIG_PATH}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      ),
+        return code === "ENOENT"
+          ? Effect.succeed(null)
+          : Effect.fail(
+              new ConfigReadError({
+                cause: err,
+                message: `Failed to read ${CONFIG_PATH}: ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+                path: CONFIG_PATH,
+              }),
+            );
+      }),
+    );
+    if (text === null) return {};
+    const parsed = yield* Effect.try({
+      try: (): unknown => JSON.parse(text),
+      catch: (err) =>
+        new ConfigReadError({
+          cause: err,
+          message: `Failed to parse ${CONFIG_PATH}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          path: CONFIG_PATH,
+        }),
+    });
+    if (!isRecord(parsed)) {
+      return yield* Effect.fail(
+        new ConfigReadError({
+          cause: "config root is not a JSON object",
+          message: `Failed to parse ${CONFIG_PATH}: config root is not a JSON object`,
+          path: CONFIG_PATH,
+        }),
+      );
+    }
+    return parsed;
   });
 
 /**
@@ -61,74 +126,122 @@ const readJsonFile = (): Effect.Effect<Record<string, unknown>, Error> =>
  * Missing file resolves with defaults; parse errors surface as typed
  * failures so callers see them instead of getting silent defaults.
  */
-export const loadConfig: Effect.Effect<MoltZapConfig, Error> = Effect.gen(
-  function* () {
-    const json = yield* readJsonFile();
+export const loadConfig: Effect.Effect<
+  MoltZapConfig,
+  ConfigReadError | ConfigInvalidError
+> = Effect.gen(function* () {
+  const json = yield* readJsonFile();
 
-    const env: Record<string, string> = {};
-    if (process.env.MOLTZAP_SERVER_URL)
-      env.serverUrl = process.env.MOLTZAP_SERVER_URL;
-    if (process.env.MOLTZAP_API_KEY) env.apiKey = process.env.MOLTZAP_API_KEY;
+  const env: Record<string, string> = {};
+  const envOverrides = yield* EnvOverrideSchema.pipe(
+    Effect.withConfigProvider(ConfigProvider.fromEnv()),
+    Effect.orElseSucceed(() => ({
+      apiKey: Option.none<string>(),
+      serverUrl: Option.none<string>(),
+    })),
+  );
+  Option.match(envOverrides.serverUrl, {
+    onNone: () => undefined,
+    onSome: (value) => {
+      env.serverUrl = value;
+    },
+  });
+  Option.match(envOverrides.apiKey, {
+    onNone: () => undefined,
+    onSome: (value) => {
+      env.apiKey = value;
+    },
+  });
 
-    const provider = ConfigProvider.fromJson({ ...json, ...env });
-    const value = yield* ConfigSchema.pipe(
-      Effect.withConfigProvider(provider),
-      Effect.mapError(
-        (cause) => new Error(`Invalid config in ${CONFIG_PATH}: ${cause}`),
-      ),
-    );
+  const provider = ConfigProvider.fromJson({ ...json, ...env });
+  const value = yield* ConfigSchema.pipe(
+    Effect.withConfigProvider(provider),
+    Effect.mapError(
+      (cause) =>
+        new ConfigInvalidError({
+          cause,
+          message: `Invalid config in ${CONFIG_PATH}: ${cause}`,
+          path: CONFIG_PATH,
+        }),
+    ),
+  );
 
-    const result: MoltZapConfig = { serverUrl: value.serverUrl };
-    if (value.apiKey._tag === "Some") result.apiKey = value.apiKey.value;
-    if (value.agentName._tag === "Some")
-      result.agentName = value.agentName.value;
-    return result;
-  },
-);
+  const result: MoltZapConfig = { serverUrl: value.serverUrl };
+  Option.match(value.apiKey, {
+    onNone: () => undefined,
+    onSome: (value) => {
+      result.apiKey = value;
+    },
+  });
+  Option.match(value.agentName, {
+    onNone: () => undefined,
+    onSome: (value) => {
+      result.agentName = value;
+    },
+  });
+  return result;
+});
 
 /** Write a new config blob to disk. Used by `moltzap register` post-registration. */
 export const writeConfig = (
   config: MoltZapConfig,
-): Effect.Effect<void, Error> =>
+): Effect.Effect<void, ConfigWriteError> =>
   Effect.try({
     try: () => {
       fs.mkdirSync(CONFIG_DIR, { recursive: true });
-      fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", {
-        mode: 0o600,
-      });
+      fs.writeFileSync(
+        CONFIG_PATH,
+        JSON.stringify(config, null, JSON_INDENT_SPACES) + "\n",
+        {
+          mode: CONFIG_FILE_MODE,
+        },
+      );
     },
     catch: (err) =>
-      new Error(
-        `Failed to write ${CONFIG_PATH}: ${
+      new ConfigWriteError({
+        cause: err,
+        message: `Failed to write ${CONFIG_PATH}: ${
           err instanceof Error ? err.message : String(err)
         }`,
-      ),
+        path: CONFIG_PATH,
+      }),
   });
 
 /** Load-modify-write helper. */
 export const updateConfig = (
   updater: (config: MoltZapConfig) => MoltZapConfig,
-): Effect.Effect<void, Error> =>
+): Effect.Effect<
+  void,
+  ConfigInvalidError | ConfigReadError | ConfigWriteError
+> =>
   loadConfig.pipe(Effect.flatMap((current) => writeConfig(updater(current))));
 
 /** WebSocket server URL (env-overridable). */
-export const getServerUrl: Effect.Effect<string, Error> = loadConfig.pipe(
-  Effect.map((c) => c.serverUrl),
-);
+export const getServerUrl: Effect.Effect<
+  string,
+  ConfigInvalidError | ConfigReadError
+> = loadConfig.pipe(Effect.map((c) => c.serverUrl));
 
 /** HTTP base URL — ws/wss → http/https. */
-export const getHttpUrl: Effect.Effect<string, Error> = getServerUrl.pipe(
+export const getHttpUrl: Effect.Effect<
+  string,
+  ConfigInvalidError | ConfigReadError
+> = getServerUrl.pipe(
   Effect.map((url) => url.replace(/^wss:/, "https:").replace(/^ws:/, "http:")),
 );
 
 /** Resolve agent API key. Fails if neither env nor config has one set. */
-export const resolveAuth: Effect.Effect<{ agentKey: string }, Error> =
-  loadConfig.pipe(
-    Effect.flatMap((config) =>
-      config.apiKey
-        ? Effect.succeed({ agentKey: config.apiKey })
-        : Effect.fail(
-            new Error("No agent registered. Run `moltzap register` first."),
-          ),
-    ),
-  );
+export const resolveAuth: Effect.Effect<
+  { agentKey: string },
+  AuthNotConfiguredError | ConfigInvalidError | ConfigReadError
+> = loadConfig.pipe(
+  Effect.flatMap((config) =>
+    config.apiKey
+      ? Effect.succeed({ agentKey: config.apiKey })
+      : Effect.fail(
+          new AuthNotConfiguredError({
+            message: "No agent registered. Run `moltzap register` first.",
+          }),
+        ),
+  ),
+);

--- a/packages/client/src/cli/http-client.ts
+++ b/packages/client/src/cli/http-client.ts
@@ -1,22 +1,33 @@
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import { HttpClient, HttpClientRequest } from "@effect/platform";
 import type { HttpClientError } from "@effect/platform";
 import { NodeHttpClient } from "@effect/platform-node";
-import { getHttpUrl, resolveAuth } from "./config.js";
+import { getHttpUrl, resolveAuth, type CliConfigError } from "./config.js";
 import type { Register, Static } from "@moltzap/protocol";
 
 type RegisterResult = Static<typeof Register.resultSchema>;
+const HTTP_SUCCESS_MIN = 200;
+const HTTP_REDIRECT_MIN = 300;
+
+export class CliHttpStatusError extends Data.TaggedError("CliHttpStatusError")<{
+  readonly status: number;
+  readonly responseText: string;
+  readonly message: string;
+}> {}
 
 /**
  * POST JSON to a MoltZap REST endpoint. Transport failures surface as the
  * typed `HttpClientError` union (`RequestError | ResponseError`); non-2xx
- * responses surface as `Error(HTTP <status>: <body>)`.
+ * responses surface as `CliHttpStatusError`.
  */
 function postJson<T>(
   path: string,
   body: unknown,
   opts?: { noAuth?: boolean },
-): Effect.Effect<T, Error | HttpClientError.HttpClientError> {
+): Effect.Effect<
+  T,
+  CliConfigError | CliHttpStatusError | HttpClientError.HttpClientError
+> {
   return Effect.gen(function* () {
     const baseUrl = yield* getHttpUrl;
     const headers: Record<string, string> = opts?.noAuth
@@ -28,9 +39,18 @@ function postJson<T>(
       HttpClientRequest.bodyUnsafeJson(body),
     );
     const response = yield* client.execute(request);
-    if (response.status < 200 || response.status >= 300) {
+    if (
+      response.status < HTTP_SUCCESS_MIN ||
+      response.status >= HTTP_REDIRECT_MIN
+    ) {
       const text = yield* response.text;
-      return yield* Effect.fail(new Error(`HTTP ${response.status}: ${text}`));
+      return yield* Effect.fail(
+        new CliHttpStatusError({
+          status: response.status,
+          responseText: text,
+          message: `HTTP ${response.status}: ${text}`,
+        }),
+      );
     }
     return (yield* response.json) as T;
   }).pipe(Effect.provide(NodeHttpClient.layer));
@@ -40,7 +60,10 @@ export function registerAgent(
   name: string,
   inviteCode: string,
   description?: string,
-): Effect.Effect<RegisterResult, Error | HttpClientError.HttpClientError> {
+): Effect.Effect<
+  RegisterResult,
+  CliConfigError | CliHttpStatusError | HttpClientError.HttpClientError
+> {
   return postJson<RegisterResult>(
     "/api/v1/auth/register",
     { name, inviteCode, description },

--- a/packages/client/src/cli/index.ts
+++ b/packages/client/src/cli/index.ts
@@ -156,9 +156,10 @@ const moltzap = Command.make("moltzap").pipe(
 );
 
 const cli = Command.run(moltzap, { name: "moltzap", version });
+const NODE_ARGV_USER_ARGS_OFFSET = 2;
 
 const { impersonateKey, profileName, rest } = extractGlobalFlags(
-  process.argv.slice(2),
+  process.argv.slice(NODE_ARGV_USER_ARGS_OFFSET),
 );
 
 const resolverInput: { impersonateKey?: string; profileName?: string } = {};

--- a/packages/client/src/cli/profile.ts
+++ b/packages/client/src/cli/profile.ts
@@ -19,7 +19,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Data, Effect } from "effect";
+import { Brand, Config, ConfigProvider, Data, Effect, Option } from "effect";
 
 // ─── Branded names ─────────────────────────────────────────────────────────
 
@@ -27,7 +27,8 @@ import { Data, Effect } from "effect";
  * Branded profile name. Enforces the same NAME_PATTERN already gated by
  * `commands/register.ts`: `/^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/`.
  */
-export type ProfileName = string & { readonly __brand: "ProfileName" };
+export type ProfileName = string & Brand.Brand<"ProfileName">;
+export const ProfileName = Brand.nominal<ProfileName>();
 
 /** Sentinel used when the caller addresses the legacy top-level record. */
 export type DefaultProfileId = "default";
@@ -35,9 +36,19 @@ export type DefaultProfileId = "default";
 const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/;
 
 const DEFAULT_SERVER_URL = "wss://api.moltzap.xyz";
+const CONFIG_FILE_MODE = 0o600;
+const JSON_INDENT_SPACES = 2;
+const ConfigHome = Config.option(Config.string("MOLTZAP_CONFIG_HOME"));
+
+const getConfigHomeSync = (): string | undefined =>
+  Option.getOrUndefined(
+    Effect.runSync(
+      ConfigHome.pipe(Effect.withConfigProvider(ConfigProvider.fromEnv())),
+    ),
+  );
 
 const getConfigDir = (): string =>
-  process.env.MOLTZAP_CONFIG_HOME ?? path.join(os.homedir(), ".moltzap");
+  getConfigHomeSync() ?? path.join(os.homedir(), ".moltzap");
 
 const getConfigFilePathSync = (): string =>
   path.join(getConfigDir(), "config.json");
@@ -136,7 +147,7 @@ export const parseProfileName = (
       }),
     );
   }
-  return Effect.succeed(raw as ProfileName);
+  return Effect.succeed(ProfileName(raw));
 };
 
 interface RawConfig {
@@ -172,29 +183,45 @@ const readRawConfig = (): Effect.Effect<
   { raw: RawConfig; existed: boolean },
   ProfileConfigReadError
 > =>
-  Effect.try({
-    try: () => {
-      const p = getConfigFilePathSync();
-      try {
-        const text = fs.readFileSync(p, "utf-8");
-        const parsed: unknown = JSON.parse(text);
-        if (!isRecord(parsed)) {
-          throw new Error("config root is not a JSON object");
-        }
-        return { raw: parsed as RawConfig, existed: true };
-      } catch (err) {
+  Effect.gen(function* () {
+    const configPath = getConfigFilePathSync();
+    const text = yield* Effect.try({
+      try: () => fs.readFileSync(configPath, "utf-8"),
+      catch: (err) => err,
+    }).pipe(
+      Effect.catchAll((err) => {
         const code = (err as NodeJS.ErrnoException).code;
-        if (code === "ENOENT") {
-          return { raw: {} as RawConfig, existed: false };
-        }
-        throw err;
-      }
-    },
-    catch: (err) =>
-      new ProfileConfigReadError({
-        path: getConfigFilePathSync(),
-        cause: err,
+        return code === "ENOENT"
+          ? Effect.succeed(null)
+          : Effect.fail(
+              new ProfileConfigReadError({
+                path: configPath,
+                cause: err,
+              }),
+            );
       }),
+    );
+    if (text === null) {
+      return { raw: {}, existed: false };
+    }
+
+    const parsed = yield* Effect.try({
+      try: (): unknown => JSON.parse(text),
+      catch: (err) =>
+        new ProfileConfigReadError({
+          path: configPath,
+          cause: err,
+        }),
+    });
+    if (!isRecord(parsed)) {
+      return yield* Effect.fail(
+        new ProfileConfigReadError({
+          path: configPath,
+          cause: "config root is not a JSON object",
+        }),
+      );
+    }
+    return { raw: parsed as RawConfig, existed: true };
   });
 
 /**
@@ -229,7 +256,7 @@ export const loadLayeredConfig: Effect.Effect<
       if (!NAME_PATTERN.test(name)) continue; // tolerate malformed entries
       const record = decodeProfileRecord(value, serverUrl);
       if (record !== undefined) {
-        profiles.set(name as ProfileName, record);
+        profiles.set(ProfileName(name), record);
       }
     }
   }
@@ -311,9 +338,13 @@ export const writeProfile = (
     yield* Effect.try({
       try: () => {
         fs.mkdirSync(configDir, { recursive: true });
-        fs.writeFileSync(configPath, JSON.stringify(next, null, 2) + "\n", {
-          mode: 0o600,
-        });
+        fs.writeFileSync(
+          configPath,
+          JSON.stringify(next, null, JSON_INDENT_SPACES) + "\n",
+          {
+            mode: CONFIG_FILE_MODE,
+          },
+        );
       },
       catch: (err) =>
         new ProfileConfigWriteError({ path: configPath, cause: err }),

--- a/packages/client/src/cli/runtime.ts
+++ b/packages/client/src/cli/runtime.ts
@@ -9,13 +9,28 @@
  * as an Effect `Logger` so `Effect.logInfo(...).pipe(Effect.annotateLogs(...))`
  * inside commands routes through the same output format.
  */
-import { Logger as EffectLogger, LogLevel } from "effect";
+import {
+  Config,
+  ConfigProvider,
+  Effect,
+  Logger as EffectLogger,
+  LogLevel,
+} from "effect";
 import pino from "pino";
 
+const CliRuntimeEnv = Config.all({
+  logLevel: Config.string("MOLTZAP_LOG_LEVEL").pipe(Config.withDefault("info")),
+  nodeEnv: Config.string("NODE_ENV").pipe(Config.withDefault("development")),
+});
+
+const runtimeEnv = Effect.runSync(
+  CliRuntimeEnv.pipe(Effect.withConfigProvider(ConfigProvider.fromEnv())),
+);
+
 const PINO = pino({
-  level: process.env["MOLTZAP_LOG_LEVEL"] ?? "info",
+  level: runtimeEnv.logLevel,
   transport:
-    process.env["NODE_ENV"] !== "production"
+    runtimeEnv.nodeEnv !== "production"
       ? { target: "pino-pretty", options: { colorize: true } }
       : undefined,
 });
@@ -86,7 +101,7 @@ export const LoggerLive = EffectLogger.replace(
  * Used when composing layers at the CLI entrypoint.
  */
 export const minLogLevel: LogLevel.LogLevel = (() => {
-  const env = (process.env["MOLTZAP_LOG_LEVEL"] ?? "info").toLowerCase();
+  const env = runtimeEnv.logLevel.toLowerCase();
   switch (env) {
     case "trace":
       return LogLevel.Trace;

--- a/packages/client/src/cli/socket-client.ts
+++ b/packages/client/src/cli/socket-client.ts
@@ -1,12 +1,38 @@
 import * as net from "node:net";
 import * as fs from "node:fs";
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import { MoltZapService } from "../service.js";
+
+import { AgentsLookupByName } from "@moltzap/protocol";
+
+const SOCKET_REQUEST_TIMEOUT_MS = 10_000;
 
 interface RawResponse {
   result?: unknown;
   error?: string;
 }
+
+export class SocketRequestError extends Data.TaggedError("SocketRequestError")<{
+  readonly method: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export class ParticipantResolveError extends Data.TaggedError(
+  "ParticipantResolveError",
+)<{
+  readonly input: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export type SocketClientError = SocketRequestError | ParticipantResolveError;
+
+const socketRequestError = (
+  method: string,
+  message: string,
+  cause?: unknown,
+): SocketRequestError => new SocketRequestError({ method, message, cause });
 
 /**
  * Send a request to the MoltZapService via Unix socket, returning the `result`
@@ -23,14 +49,14 @@ export const request = (
   method: string,
   params?: Record<string, unknown>,
   socketPath?: string,
-): Effect.Effect<unknown, Error> =>
-  Effect.async<unknown, Error>((resume, signal) => {
+): Effect.Effect<unknown, SocketRequestError> =>
+  Effect.async<unknown, SocketRequestError>((resume, signal) => {
     const sockPath = socketPath ?? MoltZapService.SOCKET_PATH;
     const conn = net.createConnection(sockPath);
     let buffer = "";
     let settled = false;
 
-    const done = (outcome: Effect.Effect<unknown, Error>) => {
+    const done = (outcome: Effect.Effect<unknown, SocketRequestError>) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -40,11 +66,11 @@ export const request = (
     };
 
     const timer = setTimeout(() => {
-      done(Effect.fail(new Error("Socket request timed out")));
-    }, 10_000);
+      done(Effect.fail(socketRequestError(method, "Socket request timed out")));
+    }, SOCKET_REQUEST_TIMEOUT_MS);
 
     signal.addEventListener("abort", () => {
-      done(Effect.fail(new Error("Socket request aborted")));
+      done(Effect.fail(socketRequestError(method, "Socket request aborted")));
     });
 
     conn.on("connect", () => {
@@ -63,17 +89,19 @@ export const request = (
         } catch (err) {
           done(
             Effect.fail(
-              new Error(
+              socketRequestError(
+                method,
                 `Malformed response from service: ${
                   err instanceof Error ? err.message : String(err)
                 }`,
+                err,
               ),
             ),
           );
           return;
         }
         if (parsed.error) {
-          done(Effect.fail(new Error(parsed.error)));
+          done(Effect.fail(socketRequestError(method, parsed.error)));
         } else {
           done(Effect.succeed(parsed.result));
         }
@@ -85,13 +113,15 @@ export const request = (
       if (code === "ENOENT" || code === "ECONNREFUSED") {
         done(
           Effect.fail(
-            new Error(
+            socketRequestError(
+              method,
               "MoltZap service is not running. Start the OpenClaw channel plugin first.",
+              err,
             ),
           ),
         );
       } else {
-        done(Effect.fail(err));
+        done(Effect.fail(socketRequestError(method, err.message, err)));
       }
     });
   });
@@ -106,23 +136,38 @@ interface LookupResult {
 /** Resolve "agent:name" or "agent:<uuid>" to { type, id }. */
 export const resolveParticipant = (
   raw: string,
-): Effect.Effect<{ type: string; id: string }, Error> =>
+): Effect.Effect<{ type: string; id: string }, SocketClientError> =>
   Effect.gen(function* () {
     const colon = raw.indexOf(":");
     if (colon === -1) {
-      return yield* Effect.fail(new Error(`Invalid: "${raw}". Use agent:name`));
+      return yield* Effect.fail(
+        new ParticipantResolveError({
+          input: raw,
+          message: `Invalid: "${raw}". Use agent:name`,
+        }),
+      );
     }
     const type = raw.slice(0, colon);
     const value = raw.slice(colon + 1);
     if (UUID_RE.test(value)) return { type, id: value };
     if (type !== "agent") {
-      return yield* Effect.fail(new Error(`Cannot resolve "${raw}"`));
+      return yield* Effect.fail(
+        new ParticipantResolveError({
+          input: raw,
+          message: `Cannot resolve "${raw}"`,
+        }),
+      );
     }
-    const result = (yield* request("agents/lookupByName", {
+    const result = (yield* request(AgentsLookupByName.name, {
       names: [value],
     })) as LookupResult;
     if (result.agents.length === 0) {
-      return yield* Effect.fail(new Error(`Agent "${value}" not found`));
+      return yield* Effect.fail(
+        new ParticipantResolveError({
+          input: raw,
+          message: `Agent "${value}" not found`,
+        }),
+      );
     }
     return { type: "agent", id: result.agents[0]!.id };
   });

--- a/packages/client/src/cli/transport.test.ts
+++ b/packages/client/src/cli/transport.test.ts
@@ -6,6 +6,11 @@
 import { Cause, Effect, Exit, Option } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  NotConnectedError,
+  RpcServerError,
+  RpcTimeoutError,
+} from "../runtime/errors.js";
+import {
   decideTransport,
   makeTransportLayer,
   resolveTransportInputs,
@@ -17,6 +22,8 @@ import {
   TransportTimeoutError,
   type TransportOptions,
 } from "./transport.js";
+
+import { AppsListSessions } from "@moltzap/protocol";
 
 /**
  * Module-level mock so transport.ts's `new MoltZapWsClient(...)` call is
@@ -82,19 +89,23 @@ describe("decideTransport", () => {
     expect(decision).toEqual({ _tag: "UseDirect", reason: "profile" });
   });
 
-  it("returns UseDirect{env-fallback} when MOLTZAP_API_KEY env + daemonReachable=false", async () => {
-    process.env.MOLTZAP_API_KEY = "env-key";
+  it("returns UseDirect{env-fallback} when envFallbackKey + daemonReachable=false", async () => {
     const decision = await Effect.runPromise(
-      decideTransport(makeOpts({ probeDaemon: () => Effect.succeed(false) })),
+      decideTransport(
+        makeOpts({
+          envFallbackKey: "env-key",
+          probeDaemon: () => Effect.succeed(false),
+        }),
+      ),
     );
     expect(decision).toEqual({ _tag: "UseDirect", reason: "env-fallback" });
   });
 
-  it("returns UseDaemon when MOLTZAP_API_KEY env + daemonReachable=true", async () => {
-    process.env.MOLTZAP_API_KEY = "env-key";
+  it("returns UseDaemon when envFallbackKey + daemonReachable=true", async () => {
     const decision = await Effect.runPromise(
       decideTransport(
         makeOpts({
+          envFallbackKey: "env-key",
           socketPath: "/tmp/sock",
           probeDaemon: () => Effect.succeed(true),
         }),
@@ -141,11 +152,13 @@ describe("decideTransport", () => {
  */
 describe("tagWsError — maps ws-client error tags to TransportError variants", () => {
   it("RpcServerError maps to TransportRpcError (not TransportDecodeError)", () => {
-    const err = tagWsError("apps/listSessions", {
-      _tag: "RpcServerError",
-      code: -32001,
-      message: "session not found",
-    });
+    const err = tagWsError(
+      AppsListSessions.name,
+      new RpcServerError({
+        code: -32001,
+        message: "session not found",
+      }),
+    );
     expect(err).toBeInstanceOf(TransportRpcError);
     expect(err._tag).toBe("TransportRpcError");
     if (err instanceof TransportRpcError) {
@@ -155,16 +168,22 @@ describe("tagWsError — maps ws-client error tags to TransportError variants", 
   });
 
   it("NotConnectedError maps to ServiceUnreachableError", () => {
-    const err = tagWsError("apps/listSessions", { _tag: "NotConnectedError" });
+    const err = tagWsError(
+      AppsListSessions.name,
+      new NotConnectedError({ message: "not connected" }),
+    );
     expect(err).toBeInstanceOf(ServiceUnreachableError);
     expect(err._tag).toBe("ServiceUnreachableError");
   });
 
   it("RpcTimeoutError maps to TransportTimeoutError with timeoutMs forwarded", () => {
-    const err = tagWsError("apps/listSessions", {
-      _tag: "RpcTimeoutError",
-      timeoutMs: 15_000,
-    });
+    const err = tagWsError(
+      AppsListSessions.name,
+      new RpcTimeoutError({
+        method: AppsListSessions.name,
+        timeoutMs: 15_000,
+      }),
+    );
     expect(err).toBeInstanceOf(TransportTimeoutError);
     if (err instanceof TransportTimeoutError) {
       expect(err.timeoutMs).toBe(15_000);
@@ -175,7 +194,7 @@ describe("tagWsError — maps ws-client error tags to TransportError variants", 
     // Guards the regression: a future runPromise bridge would produce an object
     // with no _tag (FiberFailureImpl shape). This pins the default branch to
     // TransportDecodeError so the error is observable, not silently swallowed.
-    const err = tagWsError("apps/listSessions", {
+    const err = tagWsError(AppsListSessions.name, {
       message: "some unknown error",
     });
     expect(err).toBeInstanceOf(TransportDecodeError);
@@ -239,7 +258,7 @@ describe("makeDirectTransport — composed rpc() failure path", () => {
     };
     const exit = await Effect.runPromise(
       Transport.pipe(
-        Effect.flatMap((t) => t.rpc("apps/listSessions", {})),
+        Effect.flatMap((t) => t.rpc(AppsListSessions.name, {})),
         Effect.exit,
         Effect.provide(makeTransportLayer(opts)),
       ),

--- a/packages/client/src/cli/transport.ts
+++ b/packages/client/src/cli/transport.ts
@@ -14,8 +14,13 @@
  * directly via `Effect.provideService`.
  */
 import * as net from "node:net";
-import { Context, Data, Effect, Layer, Scope } from "effect";
+import { Config, Context, Data, Effect, Layer, Option, Scope } from "effect";
 import { MoltZapService } from "../service.js";
+import {
+  NotConnectedError,
+  RpcServerError,
+  RpcTimeoutError,
+} from "../runtime/errors.js";
 import { MoltZapWsClient } from "../ws-client.js";
 import { request as daemonRequest } from "./socket-client.js";
 import type { ProfileError } from "./profile.js";
@@ -117,6 +122,8 @@ export interface TransportOptions {
   readonly impersonateKey?: string;
   /** Resolved profile apiKey if `--profile <name>` supplied. */
   readonly profileKey?: string;
+  /** Resolved MOLTZAP_API_KEY for the legacy direct fallback branch. */
+  readonly envFallbackKey?: string;
   /** Server URL resolved from config + env (wss:// or http://). */
   readonly serverUrl: string;
   /** Daemon socket path (absent only in tests that don't set it). */
@@ -144,6 +151,26 @@ export type TransportDecision =
   | { readonly _tag: "UseTest" };
 
 const DEFAULT_SERVER_URL = "wss://api.moltzap.xyz";
+const DAEMON_TIMEOUT_MS = 10_000;
+const JSON_RPC_SERVER_ERROR_CODE = -32000;
+const PROBE_DAEMON_TIMEOUT_MS = 250;
+
+const EnvServerUrl = Config.option(Config.string("MOLTZAP_SERVER_URL"));
+const EnvApiKey = Config.option(Config.string("MOLTZAP_API_KEY"));
+
+const loadEnvServerUrl: Effect.Effect<string | undefined, never> =
+  EnvServerUrl.pipe(
+    Effect.map(Option.getOrUndefined),
+    Effect.orElseSucceed(() => undefined),
+  );
+const loadEnvServerUrlWithDefault: Effect.Effect<string, never> =
+  loadEnvServerUrl.pipe(
+    Effect.map((serverUrl) => serverUrl ?? DEFAULT_SERVER_URL),
+  );
+const loadEnvApiKey: Effect.Effect<string | undefined, never> = EnvApiKey.pipe(
+  Effect.map(Option.getOrUndefined),
+  Effect.orElseSucceed(() => undefined),
+);
 
 /**
  * Decision function — Effect-returning because the env-fallback branch
@@ -163,7 +190,7 @@ export const decideTransport = (
       return { _tag: "UseDirect", reason: "profile" } as const;
     }
     // Env-fallback branch: MOLTZAP_API_KEY is set AND daemon is unreachable.
-    const hasEnvKey = process.env.MOLTZAP_API_KEY !== undefined;
+    const hasEnvKey = options.envFallbackKey !== undefined;
     if (hasEnvKey && options.probeDaemon !== undefined) {
       const reachable = yield* options.probeDaemon();
       if (!reachable) {
@@ -191,7 +218,7 @@ const tagDaemonError = (method: string, err: Error): TransportError => {
     });
   }
   if (msg.includes("timed out") || msg.includes("aborted")) {
-    return new TransportTimeoutError({ method, timeoutMs: 10_000 });
+    return new TransportTimeoutError({ method, timeoutMs: DAEMON_TIMEOUT_MS });
   }
   if (msg.startsWith("Malformed")) {
     return new TransportDecodeError({ method, cause: err });
@@ -199,7 +226,7 @@ const tagDaemonError = (method: string, err: Error): TransportError => {
   // Remote error surfaces as a bare message from the service.
   return new TransportRpcError({
     method,
-    code: -32000,
+    code: JSON_RPC_SERVER_ERROR_CODE,
     message: msg,
   });
 };
@@ -214,40 +241,30 @@ const makeDaemonTransport = (socketPath: string): Transport => ({
 });
 
 // Map ws-client errors (NotConnectedError | RpcTimeoutError | RpcServerError)
-// to TransportError tags. Names are matched via _tag rather than instanceof
-// to avoid a circular import chain through runtime/errors.
+// to TransportError tags.
 /** @internal exported for decoder-fixture tests only (sbd#198). */
-export const tagWsError = (
-  method: string,
-  err: {
-    readonly _tag?: string;
-    readonly message?: string;
-    readonly code?: number;
-    readonly timeoutMs?: number;
-    readonly data?: unknown;
-  },
-): TransportError => {
-  switch (err._tag) {
-    case "NotConnectedError":
-      return new ServiceUnreachableError({
-        socketPath: "(direct-ws)",
-        cause: err,
-      });
-    case "RpcTimeoutError":
-      return new TransportTimeoutError({
-        method,
-        timeoutMs: err.timeoutMs ?? 30_000,
-      });
-    case "RpcServerError":
-      return new TransportRpcError({
-        method,
-        code: err.code ?? -32000,
-        message: err.message ?? "RPC error",
-        data: err.data,
-      });
-    default:
-      return new TransportDecodeError({ method, cause: err });
+export const tagWsError = (method: string, err: unknown): TransportError => {
+  if (err instanceof NotConnectedError) {
+    return new ServiceUnreachableError({
+      socketPath: "(direct-ws)",
+      cause: err,
+    });
   }
+  if (err instanceof RpcTimeoutError) {
+    return new TransportTimeoutError({
+      method,
+      timeoutMs: err.timeoutMs,
+    });
+  }
+  if (err instanceof RpcServerError) {
+    return new TransportRpcError({
+      method,
+      code: err.code,
+      message: err.message,
+      data: err.data,
+    });
+  }
+  return new TransportDecodeError({ method, cause: err });
 };
 
 /**
@@ -359,7 +376,7 @@ export const makeTransportLayer = (
               key = options.profileKey;
               break;
             case "env-fallback":
-              key = process.env.MOLTZAP_API_KEY;
+              key = options.envFallbackKey;
               break;
           }
           if (key === undefined) {
@@ -446,7 +463,7 @@ export const resolveTransportInputs = (parsed: {
     // ─── Branch A: impersonate (--as) ──────────────────────────────────────
     // Invariant §4.2: no loadConfig, no MOLTZAP_API_KEY read, no config.json open.
     if (parsed.impersonateKey !== undefined) {
-      const serverUrl = process.env.MOLTZAP_SERVER_URL ?? DEFAULT_SERVER_URL;
+      const serverUrl = yield* loadEnvServerUrlWithDefault;
       return {
         impersonateKey: parsed.impersonateKey,
         serverUrl,
@@ -457,18 +474,19 @@ export const resolveTransportInputs = (parsed: {
       const name = yield* parseProfileName(parsed.profileName);
       const layered = yield* loadLayeredConfig;
       const record = yield* resolveProfileAuth(name);
-      const serverUrl =
-        process.env.MOLTZAP_SERVER_URL ?? record.serverUrl ?? layered.serverUrl;
+      const serverUrl = yield* loadEnvServerUrl;
       return {
         profileKey: record.apiKey,
-        serverUrl,
+        serverUrl: serverUrl ?? record.serverUrl ?? layered.serverUrl,
         socketPath: MoltZapService.SOCKET_PATH,
         probeDaemon: probeDaemonDefault,
       };
     }
     // ─── Branch C: legacy daemon / env fallback ────────────────────────────
-    const serverUrl = process.env.MOLTZAP_SERVER_URL ?? DEFAULT_SERVER_URL;
+    const serverUrl = yield* loadEnvServerUrlWithDefault;
+    const envFallbackKey = yield* loadEnvApiKey;
     return {
+      ...(envFallbackKey !== undefined ? { envFallbackKey } : {}),
       serverUrl,
       socketPath: MoltZapService.SOCKET_PATH,
       probeDaemon: probeDaemonDefault,
@@ -495,7 +513,7 @@ const probeDaemonDefault = (): Effect.Effect<boolean, never> =>
       resume(Effect.succeed(reachable));
     };
     const conn = net.createConnection(MoltZapService.SOCKET_PATH);
-    const timer = setTimeout(() => done(false), 250);
+    const timer = setTimeout(() => done(false), PROBE_DAEMON_TIMEOUT_MS);
     conn.once("connect", () => done(true));
     conn.once("error", () => done(false));
   });

--- a/packages/client/src/internal/__tests__/s2c-partition-key.test.ts
+++ b/packages/client/src/internal/__tests__/s2c-partition-key.test.ts
@@ -21,6 +21,14 @@ import {
   type PartitionableRequest,
 } from "../s2c-partition-key.js";
 
+import {
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnClose,
+  AppsOnJoin,
+  AppsOnSessionActive,
+} from "@moltzap/protocol";
+
 const SESSION_A = "11111111-1111-4111-8111-111111111111";
 const SESSION_B = "22222222-2222-4222-8222-222222222222";
 const CONV_X = "conv-X";
@@ -31,7 +39,7 @@ function reqOnBeforeDispatch(
 ): PartitionableRequest {
   return {
     id: "rpc-1",
-    method: "apps/onBeforeDispatch",
+    method: AppsOnBeforeDispatch.name,
     params: {
       sessionId: SESSION_A,
       conversationId: CONV_X,
@@ -43,7 +51,7 @@ function reqOnBeforeDispatch(
 function reqOnBeforeMessageDelivery(): PartitionableRequest {
   return {
     id: "rpc-2",
-    method: "apps/onBeforeMessageDelivery",
+    method: AppsOnBeforeMessageDelivery.name,
     params: { sessionId: SESSION_A, conversationId: CONV_X },
   };
 }
@@ -74,32 +82,32 @@ describe("extractPartitionKey — happy paths", () => {
   });
 
   it("apps/onJoin yields key with LIFECYCLE_CONVERSATION_SENTINEL", () => {
-    const result = extractPartitionKey(reqLifecycle("apps/onJoin"));
+    const result = extractPartitionKey(reqLifecycle(AppsOnJoin.name));
     expect(Either.isRight(result)).toBe(true);
     if (Either.isRight(result)) {
       const parts = describePartitionKey(result.right);
       expect(parts.conversationId).toBe(LIFECYCLE_CONVERSATION_SENTINEL);
-      expect(parts.method).toBe("apps/onJoin");
+      expect(parts.method).toBe(AppsOnJoin.name);
     }
   });
 
   it("apps/onClose yields key with LIFECYCLE_CONVERSATION_SENTINEL", () => {
-    const result = extractPartitionKey(reqLifecycle("apps/onClose"));
+    const result = extractPartitionKey(reqLifecycle(AppsOnClose.name));
     expect(Either.isRight(result)).toBe(true);
     if (Either.isRight(result)) {
       const parts = describePartitionKey(result.right);
       expect(parts.conversationId).toBe(LIFECYCLE_CONVERSATION_SENTINEL);
-      expect(parts.method).toBe("apps/onClose");
+      expect(parts.method).toBe(AppsOnClose.name);
     }
   });
 
   it("apps/onSessionActive yields key with LIFECYCLE_CONVERSATION_SENTINEL", () => {
-    const result = extractPartitionKey(reqLifecycle("apps/onSessionActive"));
+    const result = extractPartitionKey(reqLifecycle(AppsOnSessionActive.name));
     expect(Either.isRight(result)).toBe(true);
     if (Either.isRight(result)) {
       const parts = describePartitionKey(result.right);
       expect(parts.conversationId).toBe(LIFECYCLE_CONVERSATION_SENTINEL);
-      expect(parts.method).toBe("apps/onSessionActive");
+      expect(parts.method).toBe(AppsOnSessionActive.name);
     }
   });
 
@@ -107,7 +115,7 @@ describe("extractPartitionKey — happy paths", () => {
     const a = extractPartitionKey(reqOnBeforeDispatch());
     const b = extractPartitionKey({
       id: "rpc-99",
-      method: "apps/onBeforeDispatch",
+      method: AppsOnBeforeDispatch.name,
       params: { sessionId: SESSION_B, conversationId: CONV_X },
     });
     expect(Either.isRight(a) && Either.isRight(b)).toBe(true);
@@ -120,7 +128,7 @@ describe("extractPartitionKey — happy paths", () => {
     const a = extractPartitionKey(reqOnBeforeDispatch());
     const b = extractPartitionKey({
       id: "rpc-99",
-      method: "apps/onBeforeDispatch",
+      method: AppsOnBeforeDispatch.name,
       params: { sessionId: SESSION_A, conversationId: CONV_Y },
     });
     expect(Either.isRight(a) && Either.isRight(b)).toBe(true);
@@ -167,7 +175,7 @@ describe("extractPartitionKey — failure modes (each `_tag`)", () => {
   it("non-object params → reason=params-shape", () => {
     const result = extractPartitionKey({
       id: "rpc-y",
-      method: "apps/onBeforeDispatch",
+      method: AppsOnBeforeDispatch.name,
       params: "not-an-object",
     });
     expect(Either.isLeft(result)).toBe(true);
@@ -179,7 +187,7 @@ describe("extractPartitionKey — failure modes (each `_tag`)", () => {
   it("array params → reason=params-shape", () => {
     const result = extractPartitionKey({
       id: "rpc-z",
-      method: "apps/onBeforeDispatch",
+      method: AppsOnBeforeDispatch.name,
       params: [SESSION_A, CONV_X],
     });
     expect(Either.isLeft(result)).toBe(true);
@@ -244,19 +252,19 @@ describe("describePartitionKey — round-trip", () => {
       const parts = describePartitionKey(key.right);
       expect(parts.sessionId).toBe(SESSION_A);
       expect(parts.conversationId).toBe(CONV_X);
-      expect(parts.method).toBe("apps/onBeforeDispatch");
+      expect(parts.method).toBe(AppsOnBeforeDispatch.name);
     }
   });
 
   it("preserves the lifecycle sentinel for lifecycle methods", () => {
-    const req = reqLifecycle("apps/onSessionActive");
+    const req = reqLifecycle(AppsOnSessionActive.name);
     const key = extractPartitionKey(req);
     expect(Either.isRight(key)).toBe(true);
     if (Either.isRight(key)) {
       const parts = describePartitionKey(key.right);
       expect(parts.sessionId).toBe(SESSION_A);
       expect(parts.conversationId).toBe(LIFECYCLE_CONVERSATION_SENTINEL);
-      expect(parts.method).toBe("apps/onSessionActive");
+      expect(parts.method).toBe(AppsOnSessionActive.name);
     }
   });
 });

--- a/packages/client/src/internal/__tests__/s2c-partition-worker.test.ts
+++ b/packages/client/src/internal/__tests__/s2c-partition-worker.test.ts
@@ -16,11 +16,13 @@ import type {
   PartitionableRequest,
 } from "../s2c-partition-key.js";
 
+import { AppsOnBeforeDispatch } from "@moltzap/protocol";
+
 const KEY = "test-key" as PartitionKey;
 
 const REQ = (id: string): PartitionableRequest => ({
   id,
-  method: "apps/onBeforeDispatch",
+  method: AppsOnBeforeDispatch.name,
   params: {},
 });
 

--- a/packages/client/src/internal/__tests__/s2c-partitioned-dispatcher-real-ws.test.ts
+++ b/packages/client/src/internal/__tests__/s2c-partitioned-dispatcher-real-ws.test.ts
@@ -23,6 +23,12 @@ import { describe, expect, it } from "vitest";
 import { PROTOCOL_VERSION } from "@moltzap/protocol";
 import { MoltZapWsClient } from "../../ws-client.js";
 
+import {
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  Connect,
+} from "@moltzap/protocol";
+
 const SESSION_A = "11111111-1111-4111-8111-111111111111";
 const SESSION_B = "22222222-2222-4222-8222-222222222222";
 const CONV_X = "conv-X";
@@ -110,7 +116,7 @@ describe("integration: AppHost + partitioned s2c dispatcher", () => {
                 id?: string;
                 method?: string;
               };
-              if (frame.method === "auth/connect" && frame.id) {
+              if (frame.method === Connect.name && frame.id) {
                 yield* conn.send(
                   JSON.stringify({
                     jsonrpc: "2.0",
@@ -132,7 +138,7 @@ describe("integration: AppHost + partitioned s2c dispatcher", () => {
                     type: "request",
                     direction: "s2c",
                     id: "rpc-bd-1",
-                    method: "apps/onBeforeDispatch",
+                    method: AppsOnBeforeDispatch.name,
                     params: { sessionId: SESSION_A, conversationId: CONV_X },
                   }),
                 );
@@ -142,7 +148,7 @@ describe("integration: AppHost + partitioned s2c dispatcher", () => {
                     type: "request",
                     direction: "s2c",
                     id: "rpc-bmd-1",
-                    method: "apps/onBeforeMessageDelivery",
+                    method: AppsOnBeforeMessageDelivery.name,
                     params: { sessionId: SESSION_A, conversationId: CONV_X },
                   }),
                 );
@@ -165,7 +171,7 @@ describe("integration: AppHost + partitioned s2c dispatcher", () => {
           // because both queue on a single dispatch fiber.
           const release = yield* Deferred.make<void>();
           yield* client.handleServerRpc(
-            "apps/onBeforeDispatch",
+            AppsOnBeforeDispatch.name,
             () =>
               Effect.gen(function* () {
                 yield* Deferred.await(release);
@@ -173,7 +179,7 @@ describe("integration: AppHost + partitioned s2c dispatcher", () => {
               }) as Effect.Effect<unknown, never>,
           );
           yield* client.handleServerRpc(
-            "apps/onBeforeMessageDelivery",
+            AppsOnBeforeMessageDelivery.name,
             () =>
               Effect.gen(function* () {
                 yield* Deferred.succeed(release, undefined);
@@ -228,7 +234,7 @@ describe("integration: AppHost + partitioned s2c dispatcher", () => {
                 id?: string;
                 method?: string;
               };
-              if (frame.method === "auth/connect" && frame.id) {
+              if (frame.method === Connect.name && frame.id) {
                 yield* conn.send(
                   JSON.stringify({
                     jsonrpc: "2.0",
@@ -248,7 +254,7 @@ describe("integration: AppHost + partitioned s2c dispatcher", () => {
                     type: "request",
                     direction: "s2c",
                     id: "rpc-A",
-                    method: "apps/onBeforeDispatch",
+                    method: AppsOnBeforeDispatch.name,
                     params: { sessionId: SESSION_A, conversationId: CONV_X },
                   }),
                 );
@@ -259,7 +265,7 @@ describe("integration: AppHost + partitioned s2c dispatcher", () => {
                     type: "request",
                     direction: "s2c",
                     id: "rpc-B",
-                    method: "apps/onBeforeDispatch",
+                    method: AppsOnBeforeDispatch.name,
                     params: { sessionId: SESSION_B, conversationId: CONV_X },
                   }),
                 );
@@ -278,7 +284,7 @@ describe("integration: AppHost + partitioned s2c dispatcher", () => {
             },
           });
           yield* client.handleServerRpc(
-            "apps/onBeforeDispatch",
+            AppsOnBeforeDispatch.name,
             (params) =>
               Effect.gen(function* () {
                 const sid = (params as { sessionId: string }).sessionId;

--- a/packages/client/src/internal/__tests__/s2c-partitioned-dispatcher.test.ts
+++ b/packages/client/src/internal/__tests__/s2c-partitioned-dispatcher.test.ts
@@ -15,6 +15,12 @@ import {
 } from "../s2c-partitioned-dispatcher.js";
 import type { PartitionableRequest } from "../s2c-partition-key.js";
 
+import {
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnJoin,
+} from "@moltzap/protocol";
+
 const SESSION_A = "11111111-1111-4111-8111-111111111111";
 const CONV_X = "conv-X";
 const CONV_Y = "conv-Y";
@@ -25,7 +31,7 @@ const reqBeforeDispatch = (
   conv = CONV_X,
 ): PartitionableRequest => ({
   id,
-  method: "apps/onBeforeDispatch",
+  method: AppsOnBeforeDispatch.name,
   params: { sessionId, conversationId: conv },
 });
 
@@ -35,13 +41,13 @@ const reqBeforeMessageDelivery = (
   conv = CONV_X,
 ): PartitionableRequest => ({
   id,
-  method: "apps/onBeforeMessageDelivery",
+  method: AppsOnBeforeMessageDelivery.name,
   params: { sessionId, conversationId: conv },
 });
 
 const reqLifecycle = (
   id: string,
-  method = "apps/onJoin",
+  method = AppsOnJoin.name,
   sessionId = SESSION_A,
 ): PartitionableRequest => ({
   id,
@@ -142,7 +148,7 @@ describe("makePartitionedDispatcher — routing", () => {
           return yield* Effect.either(
             dispatcher.offer({
               id: "rpc-x",
-              method: "apps/onBeforeDispatch",
+              method: AppsOnBeforeDispatch.name,
               params: { /* sessionId missing */ conversationId: CONV_X },
             }),
           );
@@ -227,7 +233,7 @@ describe("makePartitionedDispatcher — backpressure", () => {
           const dispatcher = yield* makePartitionedDispatcher({
             handle: (req) =>
               Effect.gen(function* () {
-                if (req.method === "apps/onBeforeDispatch") {
+                if (req.method === AppsOnBeforeDispatch.name) {
                   yield* Deferred.await(releaseA);
                 } else if (req.id === "rpc-B-go") {
                   yield* Deferred.succeed(bDone, undefined);
@@ -246,7 +252,7 @@ describe("makePartitionedDispatcher — backpressure", () => {
           for (let i = 0; i < 200; i++) {
             const stats = yield* dispatcher.stats;
             const partA = stats.partitions.find((p) =>
-              p.key.includes("apps/onBeforeDispatch"),
+              p.key.includes(AppsOnBeforeDispatch.name),
             );
             if (partA && partA.queueSize === 0) break;
             yield* Effect.yieldNow();
@@ -335,11 +341,11 @@ describe("makePartitionedDispatcher — deadlock fix (D10 reproducer at dispatch
           const dispatcher = yield* makePartitionedDispatcher({
             handle: (req) =>
               Effect.gen(function* () {
-                if (req.method === "apps/onBeforeDispatch") {
+                if (req.method === AppsOnBeforeDispatch.name) {
                   // Park.
                   yield* Deferred.await(releaseDispatch);
                   yield* Deferred.succeed(dispatchDone, undefined);
-                } else if (req.method === "apps/onBeforeMessageDelivery") {
+                } else if (req.method === AppsOnBeforeMessageDelivery.name) {
                   // The lease-release hook in arena's pattern. Run
                   // to completion and signal the dispatch path to
                   // resume.
@@ -466,7 +472,7 @@ describe("makePartitionedDispatcher — scope teardown", () => {
         });
         yield* dispatcher.offer(reqBeforeDispatch("rpc-1"));
         yield* dispatcher.offer(reqBeforeMessageDelivery("rpc-2"));
-        yield* dispatcher.offer(reqLifecycle("rpc-3", "apps/onJoin"));
+        yield* dispatcher.offer(reqLifecycle("rpc-3", AppsOnJoin.name));
         // Close while every handler is parked. Must not hang.
         yield* Scope.close(scope, Exit.void);
         // Release any awaiters (no-op if scope close already

--- a/packages/client/src/internal/s2c-partition-key.ts
+++ b/packages/client/src/internal/s2c-partition-key.ts
@@ -23,14 +23,30 @@
  * The result is a branded string `PartitionKey`. Branding prevents
  * accidental reuse of raw `string` keys in the worker map.
  */
-import { Either } from "effect";
+import { Brand, Data, Either } from "effect";
 import { MalformedPartitionKeyError } from "./s2c-dispatcher-errors.js";
+
+import {
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnClose,
+  AppsOnJoin,
+  AppsOnSessionActive,
+} from "@moltzap/protocol";
 
 /**
  * Branded partition-key string. Constructed only by `extractPartitionKey`.
  * Format is opaque to consumers; equality is value equality.
  */
-export type PartitionKey = string & { readonly __brand: "PartitionKey" };
+export type PartitionKey = string & Brand.Brand<"PartitionKey">;
+export const PartitionKey = Brand.nominal<PartitionKey>();
+
+export class PartitionKeyInvariantError extends Data.TaggedError(
+  "PartitionKeyInvariantError",
+)<{
+  readonly key: PartitionKey;
+  readonly message: string;
+}> {}
 
 /**
  * Sentinel placeholder for s2c methods that carry no `conversationId`
@@ -50,14 +66,14 @@ export const LIFECYCLE_CONVERSATION_SENTINEL = "*lifecycle*" as const;
  * the routing layer pure and import-cycle-free per architect §3.2.
  */
 const CONVERSATION_BEARING_METHODS = new Set<string>([
-  "apps/onBeforeDispatch",
-  "apps/onBeforeMessageDelivery",
+  AppsOnBeforeDispatch.name,
+  AppsOnBeforeMessageDelivery.name,
 ]);
 
 const LIFECYCLE_METHODS = new Set<string>([
-  "apps/onJoin",
-  "apps/onClose",
-  "apps/onSessionActive",
+  AppsOnJoin.name,
+  AppsOnClose.name,
+  AppsOnSessionActive.name,
 ]);
 
 /**
@@ -145,9 +161,11 @@ export function extractPartitionKey(
     conversationId = LIFECYCLE_CONVERSATION_SENTINEL;
   }
 
-  const encoded =
-    `${sessionIdRaw}${KEY_SEP}${conversationId}${KEY_SEP}${method}` as PartitionKey;
-  return Either.right(encoded);
+  return Either.right(
+    PartitionKey(
+      `${sessionIdRaw}${KEY_SEP}${conversationId}${KEY_SEP}${method}`,
+    ),
+  );
 }
 
 /**
@@ -172,7 +190,10 @@ export function describePartitionKey(key: PartitionKey): {
     // `extractPartitionKey` is the only constructor; an unparsable key
     // means a caller bypassed branding. This is a programmer error,
     // not a runtime user-input failure — fail loudly.
-    throw new Error(`describePartitionKey: malformed PartitionKey: ${key}`);
+    throw new PartitionKeyInvariantError({
+      key,
+      message: `describePartitionKey: malformed PartitionKey: ${key}`,
+    });
   }
   return {
     sessionId: key.slice(0, first),

--- a/packages/client/src/internal/s2c-partitioned-dispatcher.ts
+++ b/packages/client/src/internal/s2c-partitioned-dispatcher.ts
@@ -307,11 +307,13 @@ export function makePartitionedDispatcher(
         yield* Ref.update(counters.totalOffered, (n) => n + 1);
 
         const keyResult = extractPartitionKey(request);
-        if (Either.isLeft(keyResult)) {
-          yield* Ref.update(counters.malformed, (n) => n + 1);
-          return yield* Effect.fail(keyResult.left);
-        }
-        const key = keyResult.right;
+        const key = yield* Either.match(keyResult, {
+          onLeft: (err) =>
+            Ref.update(counters.malformed, (n) => n + 1).pipe(
+              Effect.zipRight(Effect.fail(err)),
+            ),
+          onRight: (value) => Effect.succeed(value),
+        });
 
         const worker = yield* getOrCreatePartitionWorker({
           key,
@@ -319,7 +321,7 @@ export function makePartitionedDispatcher(
           state: internal,
         }).pipe(
           Effect.tapError((err) =>
-            err._tag === "PartitionLimitError"
+            err instanceof PartitionLimitError
               ? Ref.update(counters.partitionLimit, (n) => n + 1)
               : Effect.void,
           ),

--- a/packages/client/src/runtime/close-info.ts
+++ b/packages/client/src/runtime/close-info.ts
@@ -16,7 +16,7 @@
  * a `CloseInfo`. The defaults below are the resolution of OQ-5 (A). No
  * typed error surface on this module.
  */
-import { Cause, Exit } from "effect";
+import { Cause, Data, Exit } from "effect";
 import * as Socket from "@effect/platform/Socket";
 
 /**
@@ -41,31 +41,27 @@ export interface CloseInfo {
  * any `SocketError` variant @effect/platform adds in the future. The
  * implementation's pattern-match ends in `default: return absurd(kind)`.
  */
-export type CloseKind =
-  | {
-      /** Graceful `SocketCloseError` — upstream code + reason round-tripped. */
-      readonly _tag: "Clean";
-      readonly code: number;
-      readonly reason: string;
-    }
-  | {
-      /** `Exit.Success` with no close frame observed — socket ended cleanly. */
-      readonly _tag: "EndOfStream";
-    }
-  | {
-      /** `SocketGenericError` with reason "Open" / "OpenTimeout". */
-      readonly _tag: "HandshakeFailure";
-      readonly underlying: "Open" | "OpenTimeout";
-    }
-  | {
-      /** `SocketGenericError` with reason "Read" / "Write" — transport broke. */
-      readonly _tag: "TransportFailure";
-      readonly underlying: "Read" | "Write";
-    }
-  | {
-      /** Cause did not match any known `SocketError` shape. */
-      readonly _tag: "Unknown";
-    };
+export type CloseKind = Data.TaggedEnum<{
+  /** Graceful `SocketCloseError` — upstream code + reason round-tripped. */
+  Clean: {
+    readonly code: number;
+    readonly reason: string;
+  };
+  /** `Exit.Success` with no close frame observed — socket ended cleanly. */
+  EndOfStream: {};
+  /** `SocketGenericError` with reason "Open" / "OpenTimeout". */
+  HandshakeFailure: {
+    readonly underlying: "Open" | "OpenTimeout";
+  };
+  /** `SocketGenericError` with reason "Read" / "Write" — transport broke. */
+  TransportFailure: {
+    readonly underlying: "Read" | "Write";
+  };
+  /** Cause did not match any known `SocketError` shape. */
+  Unknown: {};
+}>;
+
+const CloseKind = Data.taggedEnum<CloseKind>();
 
 /**
  * OQ-5 resolution defaults. Exported so the implementation, tests, and
@@ -107,11 +103,10 @@ export function classifyCloseCause(
   // match. `Chunk` is iterable, so a `for…of` walk is sufficient.
   for (const failure of Cause.failures(cause)) {
     if (Socket.SocketCloseError.is(failure)) {
-      return {
-        _tag: "Clean",
+      return CloseKind.Clean({
         code: failure.code,
         reason: failure.closeReason ?? "",
-      };
+      });
     }
     if (Socket.isSocketError(failure)) {
       // SocketGenericError — branch on the four documented reasons and
@@ -120,16 +115,20 @@ export function classifyCloseCause(
       switch (generic.reason) {
         case "Open":
         case "OpenTimeout":
-          return { _tag: "HandshakeFailure", underlying: generic.reason };
+          return CloseKind.HandshakeFailure({
+            underlying: generic.reason,
+          });
         case "Read":
         case "Write":
-          return { _tag: "TransportFailure", underlying: generic.reason };
+          return CloseKind.TransportFailure({
+            underlying: generic.reason,
+          });
         default:
-          return { _tag: "Unknown" };
+          return CloseKind.Unknown();
       }
     }
   }
-  return { _tag: "Unknown" };
+  return CloseKind.Unknown();
 }
 
 /**

--- a/packages/client/src/runtime/errors.test.ts
+++ b/packages/client/src/runtime/errors.test.ts
@@ -7,6 +7,8 @@ import {
   RpcTimeoutError,
 } from "./errors.js";
 
+import { MessagesSend } from "@moltzap/protocol";
+
 describe("AgentNotFoundError", () => {
   it("carries agentName and derives a `_tag` + `message`", () => {
     const err = new AgentNotFoundError({ agentName: "foo" });
@@ -38,11 +40,11 @@ describe("NotConnectedError", () => {
 describe("RpcTimeoutError", () => {
   it("carries method + timeoutMs and `_tag === 'RpcTimeoutError'`", () => {
     const err = new RpcTimeoutError({
-      method: "messages/send",
+      method: MessagesSend.name,
       timeoutMs: 30_000,
     });
     expect(err._tag).toBe("RpcTimeoutError");
-    expect(err.method).toBe("messages/send");
+    expect(err.method).toBe(MessagesSend.name);
     expect(err.timeoutMs).toBe(30_000);
   });
 });

--- a/packages/client/src/runtime/runtime.test.ts
+++ b/packages/client/src/runtime/runtime.test.ts
@@ -7,17 +7,19 @@ import {
   RpcTimeoutError,
 } from "./errors.js";
 
+import { MessagesSend } from "@moltzap/protocol";
+
 it.effect("tagged errors discriminate by _tag", () =>
   Effect.gen(function* () {
     const exit = yield* Effect.exit(
       Effect.fail(
-        new RpcTimeoutError({ method: "messages/send", timeoutMs: 30_000 }),
+        new RpcTimeoutError({ method: MessagesSend.name, timeoutMs: 30_000 }),
       ),
     );
     if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
       const err = exit.cause.error;
       expect(err._tag).toBe("RpcTimeoutError");
-      expect(err.method).toBe("messages/send");
+      expect(err.method).toBe(MessagesSend.name);
     } else {
       throw new Error("expected failure");
     }

--- a/packages/client/src/runtime/subscribers.ts
+++ b/packages/client/src/runtime/subscribers.ts
@@ -29,11 +29,12 @@
  * pre-deletion). The registry itself has no typed error surface —
  * `register`, `dispatch`, and `closeAll` are `Effect<T, never>`.
  */
-import { Effect, Ref } from "effect";
+import { Brand, Effect, Ref } from "effect";
 import type { EventFrame } from "@moltzap/protocol";
 
 /** Branded identifier for a subscription handle. Minted by `register`. */
-export type SubscriptionId = string & { readonly __brand: "SubscriptionId" };
+export type SubscriptionId = string & Brand.Brand<"SubscriptionId">;
+export const SubscriptionId = Brand.nominal<SubscriptionId>();
 
 /**
  * Filter grammar for `subscribe`. An event is delivered to a subscription
@@ -170,7 +171,7 @@ export function makeSubscriberRegistry(logger: {
     const register: SubscriberRegistry["register"] = (filter, handler) =>
       Effect.gen(function* () {
         const n = yield* Ref.updateAndGet(counterRef, (c) => c + 1);
-        const id = `sub-${n}` as SubscriptionId;
+        const id = SubscriptionId(`sub-${n}`);
         const live: LiveSubscription = { id, filter, handler };
         yield* Ref.update(subsRef, (xs) => [...xs, live]);
         const unsubscribe: Effect.Effect<void, never> = Ref.update(

--- a/packages/client/src/service.test.ts
+++ b/packages/client/src/service.test.ts
@@ -14,6 +14,12 @@ import {
 import { sanitizeForSystemReminder } from "./service.js";
 import { FakeMoltZapService } from "./test-utils/fake-service.js";
 
+import {
+  AgentsLookupByName,
+  ConversationsCreate,
+  PermissionsGrant,
+} from "@moltzap/protocol";
+
 /** Run a service Effect to a Promise for test assertions. */
 const run = <A, E>(e: Effect.Effect<A, E>): Promise<A> => Effect.runPromise(e);
 
@@ -25,7 +31,7 @@ describe("MoltZapService.sendToAgent", () => {
     // `setResponse` is typed: the wire name must be a `RpcMethodName` literal
     // and the value must match `RpcMap[M]["result"]`. Both guard against the
     // contract-drift bug (A7) that motivated this fake.
-    service.setResponse("agents/lookupByName", {
+    service.setResponse(AgentsLookupByName.name, {
       agents: [
         {
           id: "agent-alice-id",
@@ -34,7 +40,7 @@ describe("MoltZapService.sendToAgent", () => {
         },
       ],
     });
-    service.setResponse("conversations/create", {
+    service.setResponse(ConversationsCreate.name, {
       conversation: {
         id: "conv-alice",
         type: "dm",
@@ -43,7 +49,7 @@ describe("MoltZapService.sendToAgent", () => {
         updatedAt: "2026-04-16T00:00:00Z",
       },
     });
-    service.setResponse("messages/send", {
+    service.setResponse(MessagesSend.name, {
       message: {
         id: "msg-1",
         conversationId: "conv-alice",
@@ -58,16 +64,16 @@ describe("MoltZapService.sendToAgent", () => {
     await run(service.sendToAgent("alice", "hello"));
 
     expect(service.calls).toEqual([
-      { method: "agents/lookupByName", params: { names: ["alice"] } },
+      { method: AgentsLookupByName.name, params: { names: ["alice"] } },
       {
-        method: "conversations/create",
+        method: ConversationsCreate.name,
         params: {
           type: "dm",
           participants: [{ type: "agent", id: "agent-alice-id" }],
         },
       },
       {
-        method: "messages/send",
+        method: MessagesSend.name,
         params: {
           conversationId: "conv-alice",
           parts: [{ type: "text", text: "hello" }],
@@ -84,7 +90,7 @@ describe("MoltZapService.sendToAgent", () => {
 
     expect(service.calls).toEqual([
       {
-        method: "messages/send",
+        method: MessagesSend.name,
         params: {
           conversationId: "conv-alice",
           parts: [{ type: "text", text: "second" }],
@@ -98,7 +104,7 @@ describe("MoltZapService.sendToAgent", () => {
       service.sendToAgent("alice", "reply text", { replyTo: "msg-123" }),
     );
 
-    const sendCall = service.calls.find((c) => c.method === "messages/send");
+    const sendCall = service.calls.find((c) => c.method === MessagesSend.name);
     expect(sendCall?.params).toEqual({
       conversationId: "conv-alice",
       parts: [{ type: "text", text: "reply text" }],
@@ -107,15 +113,15 @@ describe("MoltZapService.sendToAgent", () => {
   });
 
   it("maintains separate cache entries per agent name", async () => {
-    service.setResponse("agents/lookupByName", {
+    service.setResponse(AgentsLookupByName.name, {
       agents: [{ id: "agent-alice-id", name: "alice", status: "active" }],
     });
     await run(service.sendToAgent("alice", "hello alice"));
 
-    service.setResponse("agents/lookupByName", {
+    service.setResponse(AgentsLookupByName.name, {
       agents: [{ id: "agent-bob-id", name: "bob", status: "active" }],
     });
-    service.setResponse("conversations/create", {
+    service.setResponse(ConversationsCreate.name, {
       conversation: {
         id: "conv-bob",
         type: "dm",
@@ -130,7 +136,9 @@ describe("MoltZapService.sendToAgent", () => {
     await run(service.sendToAgent("alice", "alice again"));
     await run(service.sendToAgent("bob", "bob again"));
 
-    const sendCalls = service.calls.filter((c) => c.method === "messages/send");
+    const sendCalls = service.calls.filter(
+      (c) => c.method === MessagesSend.name,
+    );
     expect(sendCalls).toHaveLength(2);
     expect(
       (sendCalls[0]!.params as { conversationId: string }).conversationId,
@@ -141,7 +149,7 @@ describe("MoltZapService.sendToAgent", () => {
   });
 
   it("throws a clear error when no agent is found for the given name", async () => {
-    service.setResponse("agents/lookupByName", { agents: [] });
+    service.setResponse(AgentsLookupByName.name, { agents: [] });
 
     await expect(run(service.sendToAgent("nobody", "hi"))).rejects.toThrow(
       /Agent not found: nobody/,
@@ -149,7 +157,7 @@ describe("MoltZapService.sendToAgent", () => {
   });
 
   it("propagates errors from agents/lookupByName", async () => {
-    service.deleteResponse("agents/lookupByName");
+    service.deleteResponse(AgentsLookupByName.name);
 
     await expect(run(service.sendToAgent("alice", "hi"))).rejects.toThrow(
       /no canned response for agents\/lookupByName/,
@@ -157,7 +165,7 @@ describe("MoltZapService.sendToAgent", () => {
   });
 
   it("propagates errors from conversations/create", async () => {
-    service.deleteResponse("conversations/create");
+    service.deleteResponse(ConversationsCreate.name);
 
     await expect(run(service.sendToAgent("alice", "hi"))).rejects.toThrow(
       /no canned response for conversations\/create/,
@@ -165,7 +173,7 @@ describe("MoltZapService.sendToAgent", () => {
   });
 
   it("propagates errors from messages/send", async () => {
-    service.deleteResponse("messages/send");
+    service.deleteResponse(MessagesSend.name);
 
     await expect(run(service.sendToAgent("alice", "hi"))).rejects.toThrow(
       /no canned response for messages\/send/,
@@ -773,7 +781,7 @@ describe("MoltZapService conversation archive lifecycle", () => {
 describe("MoltZapService.grantPermission", () => {
   it("sends permissions/grant RPC", async () => {
     const service = new FakeMoltZapService();
-    service.setResponse("permissions/grant", {});
+    service.setResponse(PermissionsGrant.name, {});
 
     await run(
       service.grantPermission({
@@ -785,7 +793,7 @@ describe("MoltZapService.grantPermission", () => {
     );
 
     expect(service.calls).toContainEqual({
-      method: "permissions/grant",
+      method: PermissionsGrant.name,
       params: {
         sessionId: "sess-1",
         agentId: "agent-2",

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -23,7 +23,16 @@ import {
   MessagesSend,
   PermissionsGrant,
 } from "@moltzap/protocol";
-import { Effect, HashMap, Match, Option, Ref } from "effect";
+import {
+  Config,
+  ConfigProvider,
+  Data,
+  Effect,
+  HashMap,
+  Match,
+  Option,
+  Ref,
+} from "effect";
 import {
   MoltZapWsClient,
   type RpcCallOptions,
@@ -44,8 +53,33 @@ import type {
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const CROSS_CONTEXT_TEXT_LIMIT = 120;
+const DEFAULT_HISTORY_LIMIT = 10;
+const DEFAULT_MAX_CONTEXT_CONVERSATIONS = 5;
+const DEFAULT_MAX_MESSAGES_PER_CONVERSATION = 3;
+const HISTORY_LOOKUP_CONCURRENCY = 2;
+const MILLISECONDS_PER_MINUTE = 60_000;
+const SOCKET_FILE_MODE = 0o600;
+
+class ServiceInputError extends Data.TaggedError("ServiceInputError")<{
+  readonly message: string;
+}> {}
+
+const ClientEventLogDir = Config.option(
+  Config.string("MOLTZAP_CLIENT_EVENT_LOG_DIR"),
+);
+
+const getClientEventLogDir = (): string | undefined =>
+  Option.getOrUndefined(
+    Effect.runSync(
+      ClientEventLogDir.pipe(
+        Effect.withConfigProvider(ConfigProvider.fromEnv()),
+      ),
+    ),
+  );
+
 function appendClientEventTrace(record: Record<string, unknown>): void {
-  const dir = process.env["MOLTZAP_CLIENT_EVENT_LOG_DIR"];
+  const dir = getClientEventLogDir();
   if (!dir) return;
   try {
     fs.mkdirSync(dir, { recursive: true });
@@ -117,7 +151,9 @@ export function formatCrossConversationBlock(
   if (entries.length === 0) return null;
   const lines = entries.map((e) => {
     const safeSender = sanitizeForSystemReminder(e.senderName);
-    const safeText = sanitizeForSystemReminder(e.text.slice(0, 120));
+    const safeText = sanitizeForSystemReminder(
+      e.text.slice(0, CROSS_CONTEXT_TEXT_LIMIT),
+    );
     return `@${safeSender} (${e.minutesAgo}m ago): (${e.count} new) "${safeText}"`;
   });
   return [
@@ -265,6 +301,7 @@ export class MoltZapService {
         // close metadata today; signature kept explicit so a future
         // disconnect-handler chain can plumb code/reason through.
         onDisconnect: (_close) => {
+          void _close;
           this._connected = false;
           fanout(this.disconnectHandlers, undefined, this.opts.logger);
         },
@@ -385,7 +422,7 @@ export class MoltZapService {
       // impersonates this agent to the server, so other local users on the
       // host must not be able to connect.
       try {
-        fs.chmodSync(sockPath, 0o600);
+        fs.chmodSync(sockPath, SOCKET_FILE_MODE);
       } catch (err) {
         this.opts.logger?.warn("chmod 0600 on socket failed", err);
       }
@@ -488,7 +525,7 @@ export class MoltZapService {
   private handleSocketRequestEffect(
     method: string,
     params: Record<string, unknown>,
-  ): Effect.Effect<unknown, Error | ServiceRpcError> {
+  ): Effect.Effect<unknown, ServiceInputError | ServiceRpcError> {
     return Effect.suspend(() => {
       switch (method) {
         case "ping":
@@ -513,18 +550,22 @@ export class MoltZapService {
 
   private handleHistoryRequest(
     params: Record<string, unknown>,
-  ): Effect.Effect<unknown, Error | ServiceRpcError> {
+  ): Effect.Effect<unknown, ServiceInputError | ServiceRpcError> {
     return Effect.gen(this, function* () {
       if (typeof params.conversationId !== "string" || !params.conversationId) {
         return yield* Effect.fail(
-          new Error("conversationId is required and must be a string"),
+          new ServiceInputError({
+            message: "conversationId is required and must be a string",
+          }),
         );
       }
       if (params.limit !== undefined && typeof params.limit !== "number") {
-        return yield* Effect.fail(new Error("limit must be a number"));
+        return yield* Effect.fail(
+          new ServiceInputError({ message: "limit must be a number" }),
+        );
       }
       const convId = params.conversationId;
-      const limit = (params.limit as number) ?? 10;
+      const limit = (params.limit as number) ?? DEFAULT_HISTORY_LIMIT;
       const sessionKey = params.sessionKey as string | undefined;
       const result = (yield* this.sendRpc(MessagesList.name, {
         conversationId: convId,
@@ -573,7 +614,7 @@ export class MoltZapService {
       );
 
       const [, convMeta] = yield* Effect.all([lookupEff, metaEff], {
-        concurrency: "unbounded",
+        concurrency: HISTORY_LOOKUP_CONCURRENCY,
       });
 
       // Determine what's "new" using lastRead (not lastNotified).
@@ -849,8 +890,10 @@ export class MoltZapService {
     currentConvId: string,
     opts?: { maxConversations?: number; maxMessagesPerConv?: number },
   ): { entries: CrossConversationEntry[]; commit: () => void } {
-    const maxConvs = opts?.maxConversations ?? 5;
-    const maxMsgsPerConv = opts?.maxMessagesPerConv ?? 3;
+    const maxConvs =
+      opts?.maxConversations ?? DEFAULT_MAX_CONTEXT_CONVERSATIONS;
+    const maxMsgsPerConv =
+      opts?.maxMessagesPerConv ?? DEFAULT_MAX_MESSAGES_PER_CONVERSATION;
     const { messagesMap, conversationsMap, agentNamesMap, viewMarkers } =
       this.readCrossConvState(currentConvId);
 
@@ -891,7 +934,10 @@ export class MoltZapService {
       );
       const minutesAgo = Math.max(
         0,
-        Math.round((Date.now() - new Date(last.createdAt).getTime()) / 60_000),
+        Math.round(
+          (Date.now() - new Date(last.createdAt).getTime()) /
+            MILLISECONDS_PER_MINUTE,
+        ),
       );
 
       entries.push({

--- a/packages/client/src/test-utils/conformance-adapter.ts
+++ b/packages/client/src/test-utils/conformance-adapter.ts
@@ -26,7 +26,7 @@
  *   - `subscribe` registers a real per-filter handle on the client; the
  *     no-op stub is gone (C4 + subscribe-stub).
  */
-import { Effect, Ref, Scope } from "effect";
+import { Data, Effect, Either, Ref, Scope } from "effect";
 import type { EventFrame, ResponseFrame } from "@moltzap/protocol";
 import type {
   RealClientCloseEvent,
@@ -34,12 +34,20 @@ import type {
   RealClientHandle,
   RealClientEventSubscriber,
   RealClientLifecycleError,
+  RealClientRpcError,
   RealClientRpcCaller,
   RealClientSubscription,
   ObservedEvent,
 } from "@moltzap/protocol/testing";
 import { MoltZapWsClient, type CloseInfo } from "../ws-client.js";
 import type { SubscriptionFilter } from "../runtime/subscribers.js";
+import {
+  NotConnectedError,
+  RpcServerError,
+  RpcTimeoutError,
+} from "../runtime/errors.js";
+
+const CONNECT_READY_TIMEOUT_MS = 30_000;
 
 /**
  * Options for the adapter factory. `agentKey` and `agentId` are caller-
@@ -52,18 +60,62 @@ export interface RealClientFactoryOptions {
   readonly agentId: string;
 }
 
-type LifecycleError = {
-  readonly _tag: "RealClientLifecycleError";
+class RealClientLifecycleFailure extends Data.TaggedError(
+  "RealClientLifecycleError",
+)<{
   readonly cause: unknown;
-};
+}> {}
 
-function lifecycleError(cause: unknown): LifecycleError {
+class RealClientRpcFailure extends Data.TaggedError("RealClientRpcError")<{
+  readonly cause: unknown;
+  readonly documentedErrorTag: string | null;
+  readonly kind: RealClientRpcError["kind"];
+  readonly method: string;
+}> {}
+
+function lifecycleError(cause: unknown): RealClientLifecycleError {
   // Struct-shaped value rather than a `new RealClientLifecycleError` — the
   // protocol's `runner.ts` defines the class, but this adapter ships in
   // `@moltzap/client` which consumes the protocol package as a leaf (can't
   // cross-import the class without creating a cycle via typings alone). The
   // shape matches 1:1 so callers that discriminate on `_tag` work.
-  return { _tag: "RealClientLifecycleError", cause };
+  return new RealClientLifecycleFailure({ cause }) as RealClientLifecycleError;
+}
+
+function rpcError(
+  cause: NotConnectedError | RpcServerError | RpcTimeoutError,
+  method: string,
+): RealClientRpcError {
+  if (cause instanceof RpcTimeoutError) {
+    return new RealClientRpcFailure({
+      cause,
+      documentedErrorTag: "RpcTimeoutError",
+      kind: "timeout",
+      method,
+    }) as RealClientRpcError;
+  }
+  if (cause instanceof RpcServerError) {
+    return new RealClientRpcFailure({
+      cause,
+      documentedErrorTag: "RpcServerError",
+      kind: "server-error",
+      method,
+    }) as RealClientRpcError;
+  }
+  if (cause instanceof NotConnectedError) {
+    return new RealClientRpcFailure({
+      cause,
+      documentedErrorTag: "NotConnectedError",
+      kind: "disconnected",
+      method,
+    }) as RealClientRpcError;
+  }
+  return new RealClientRpcFailure({
+    cause,
+    documentedErrorTag: null,
+    kind: "malformed-response",
+    method,
+  }) as RealClientRpcError;
 }
 
 /**
@@ -153,11 +205,7 @@ export function createMoltZapRealClientFactory(
             }
           }),
         )
-        .pipe(
-          Effect.mapError(
-            (cause) => lifecycleError(cause) as RealClientLifecycleError,
-          ),
-        );
+        .pipe(Effect.mapError((cause) => lifecycleError(cause)));
 
       // Scope-release finalizer: drop the capture subscription and
       // close the WS client. `ws.close()` is Effect-native post-#234,
@@ -172,14 +220,15 @@ export function createMoltZapRealClientFactory(
         "pending" | "resolved" | { readonly cause: unknown }
       >("pending");
       yield* Effect.forkScoped(
-        Effect.gen(function* () {
-          const outcome = yield* Effect.either(ws.connect());
-          if (outcome._tag === "Right") {
-            yield* Ref.set(readyDeferred, "resolved");
-          } else {
-            yield* Ref.set(readyDeferred, { cause: outcome.left });
-          }
-        }),
+        ws.connect().pipe(
+          Effect.either,
+          Effect.flatMap(
+            Either.match({
+              onLeft: (cause) => Ref.set(readyDeferred, { cause }),
+              onRight: () => Ref.set(readyDeferred, "resolved"),
+            }),
+          ),
+        ),
       );
 
       const ready: Effect.Effect<void, RealClientLifecycleError> = Effect.gen(
@@ -187,22 +236,16 @@ export function createMoltZapRealClientFactory(
           // Internal handshake budget is generous — the outer
           // `_fixtures.acquireFixture` wraps the whole `ready` with a
           // suite-level timeout that defines the actual property budget.
-          const deadline = Date.now() + 30_000;
+          const deadline = Date.now() + CONNECT_READY_TIMEOUT_MS;
           while (Date.now() < deadline) {
             const state = yield* Ref.get(readyDeferred);
             if (state === "resolved") return;
             if (typeof state === "object") {
-              return yield* Effect.fail(
-                lifecycleError(state.cause) as RealClientLifecycleError,
-              );
+              return yield* Effect.fail(lifecycleError(state.cause));
             }
             yield* Effect.sleep("25 millis");
           }
-          return yield* Effect.fail(
-            lifecycleError(
-              new Error("connect timeout"),
-            ) as RealClientLifecycleError,
-          );
+          return yield* Effect.fail(lifecycleError("connect timeout"));
         },
       );
 
@@ -216,9 +259,7 @@ export function createMoltZapRealClientFactory(
               id: handle.id,
               unsubscribe: handle.unsubscribe,
             })),
-            Effect.mapError(
-              (cause) => lifecycleError(cause) as RealClientLifecycleError,
-            ),
+            Effect.mapError((cause) => lifecycleError(cause)),
           );
 
       const snapshot: RealClientEventSubscriber["snapshot"] =
@@ -234,28 +275,9 @@ export function createMoltZapRealClientFactory(
           // B4 + V5: `sendRpcTracked` returns the real outbound id and
           // the response envelope `type`. The adapter forwards both
           // straight through — no mirror id, no hardcoded `"response"`.
-          const outcome = yield* Effect.either(
-            ws.sendRpcTracked(method, params),
-          );
-          if (outcome._tag === "Left") {
-            const tag = outcome.left._tag;
-            const kind =
-              tag === "RpcTimeoutError"
-                ? ("timeout" as const)
-                : tag === "RpcServerError"
-                  ? ("server-error" as const)
-                  : tag === "NotConnectedError"
-                    ? ("disconnected" as const)
-                    : ("malformed-response" as const);
-            return yield* Effect.fail({
-              _tag: "RealClientRpcError" as const,
-              kind,
-              method,
-              documentedErrorTag: tag,
-              cause: outcome.left,
-            });
-          }
-          const tracked = outcome.right;
+          const tracked = yield* ws
+            .sendRpcTracked(method, params)
+            .pipe(Effect.mapError((cause) => rpcError(cause, method)));
           // Record the real id (Invariant 3 from spec #222: same id
           // minted at the `rpc-${++counter}` site, surfaced as-is).
           yield* Ref.update(outboundIdsRef, (xs) => [...xs, tracked.id]);

--- a/packages/client/src/test-utils/index.ts
+++ b/packages/client/src/test-utils/index.ts
@@ -18,6 +18,15 @@ export {
 } from "./conformance-adapter.js";
 
 import type { Message } from "@moltzap/protocol";
+import { Data, Effect } from "effect";
+
+const FLUSH_DISPATCH_TURNS = 20;
+
+class FlushDispatchChainError extends Data.TaggedError(
+  "FlushDispatchChainError",
+)<{
+  readonly cause: unknown;
+}> {}
 
 export function buildMessage(overrides: Partial<Message> = {}): Message {
   return {
@@ -30,8 +39,15 @@ export function buildMessage(overrides: Partial<Message> = {}): Message {
   } as Message;
 }
 
-export async function flushDispatchChain(): Promise<void> {
-  for (let i = 0; i < 20; i++) {
-    await Promise.resolve();
-  }
+export function flushDispatchChain() {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      for (let i = 0; i < FLUSH_DISPATCH_TURNS; i++) {
+        yield* Effect.tryPromise({
+          try: () => Promise.resolve(),
+          catch: (cause) => new FlushDispatchChainError({ cause }),
+        });
+      }
+    }),
+  );
 }

--- a/packages/client/src/test/index.ts
+++ b/packages/client/src/test/index.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import { MoltZapWsClient } from "../ws-client.js";
 import { registerAgent, type RegisterAgentOptions } from "../auth.js";
 
@@ -25,6 +25,13 @@ export interface ConnectedTestAgent {
   claimToken: string;
 }
 
+export class RegisterAndConnectError extends Data.TaggedError(
+  "RegisterAndConnectError",
+)<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
 /** Register a fresh agent, build a `MoltZapWsClient` with its apiKey, and
  * complete the `auth/connect` handshake. Returns the live client ready for
  * RPCs and event waits. Caller is responsible for `yield* client.close()`. */
@@ -33,18 +40,37 @@ export const registerAndConnect = (
   wsUrl: string,
   name: string,
   opts?: RegisterAgentOptions,
-): Effect.Effect<ConnectedTestAgent, Error> =>
+): Effect.Effect<ConnectedTestAgent, RegisterAndConnectError> =>
   Effect.gen(function* () {
-    const reg = yield* registerAgent(baseUrl, name, opts);
+    const reg = yield* registerAgent(baseUrl, name, opts).pipe(
+      Effect.mapError(
+        (cause) =>
+          new RegisterAndConnectError({
+            message: "Agent registration failed",
+            cause,
+          }),
+      ),
+    );
     const client = new MoltZapWsClient({
       serverUrl: stripWsPath(wsUrl),
       agentKey: reg.apiKey,
     });
     yield* client.connect().pipe(
       Effect.catchTag("RpcTimeoutError", (err) =>
-        Effect.fail(new Error(`RPC timeout: ${err.method}`)),
+        Effect.fail(
+          new RegisterAndConnectError({
+            message: `RPC timeout: ${err.method}`,
+            cause: err,
+          }),
+        ),
       ),
-      Effect.mapError((err) => new Error(err.message)),
+      Effect.mapError(
+        (cause) =>
+          new RegisterAndConnectError({
+            message: cause.message,
+            cause,
+          }),
+      ),
     );
     return { client, ...reg };
   });

--- a/packages/client/src/ws-client.test.ts
+++ b/packages/client/src/ws-client.test.ts
@@ -14,6 +14,7 @@
  * `TestClock` (see the `describe("reconnect backoff")` block for details).
  */
 import { execSync } from "node:child_process";
+import { createServer } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { it as itEffect } from "@effect/vitest";
 import {
@@ -38,7 +39,18 @@ import {
 import { RpcServerError, RpcTimeoutError } from "./runtime/errors.js";
 import type { EventFrame } from "@moltzap/protocol";
 
+import {
+  AgentsLookupByName,
+  AppsOnClose,
+  AppsOnJoin,
+  Connect,
+  ConversationsList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 // ── Test server helpers ────────────────────────────────────────────────
+
+const LOCALHOST_HOST = "127.0.0.1";
 
 /**
  * Per-connection context exposed to a handler so tests can inspect and
@@ -82,7 +94,7 @@ const startTestServer = (
   Effect.gen(function* () {
     const server = yield* NodeSocketServer.makeWebSocket({
       port: 0,
-      host: "127.0.0.1",
+      host: LOCALHOST_HOST,
     });
     const addr = server.address;
     if (addr._tag !== "TcpAddress") {
@@ -121,11 +133,32 @@ const startTestServer = (
     );
 
     return {
-      url: `http://${addr.hostname}:${addr.port}`,
+      url: `http://${LOCALHOST_HOST}:${addr.port}`,
       get connections() {
         return connections;
       },
     };
+  });
+
+const findClosedLocalPort = (): Promise<number> =>
+  new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, LOCALHOST_HOST, () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        server.close();
+        reject(new Error("expected TCP server address"));
+        return;
+      }
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(address.port);
+      });
+    });
   });
 
 // ── Logger helper ──────────────────────────────────────────────────────
@@ -205,7 +238,7 @@ const startHandshakingServer = (
         method: string;
         params?: unknown;
       };
-      if (frame.method === "auth/connect") {
+      if (frame.method === Connect.name) {
         yield* conn.send(
           JSON.stringify({
             jsonrpc: "2.0",
@@ -333,7 +366,8 @@ describe("§5.1 connect() does not hang on pre-open failure", () => {
     // Observed: ECONNREFUSED fires in single-digit ms locally; give
     // generous CI headroom via the 15s assertion but keep test timeout at
     // 20s to avoid flakes on slow runners.
-    const client = makeClient("http://127.0.0.1:1");
+    const refusedPort = await findClosedLocalPort();
+    const client = makeClient(`http://${LOCALHOST_HOST}:${refusedPort}`);
     const t0 = Date.now();
     try {
       await connectP(client);
@@ -376,7 +410,7 @@ describe("§5.2 pending RPCs fail on disconnect", () => {
         const client = makeClient(server.url);
         yield* Effect.promise(() => connectP(client));
 
-        const rpcP = sendRpcP(client, "messages/send", {
+        const rpcP = sendRpcP(client, MessagesSend.name, {
           conversationId: "c1",
           parts: [{ type: "text", text: "hi" }],
         });
@@ -430,7 +464,7 @@ describe("§5.3 sendRpc does NOT retry on timeout (TestClock)", () => {
         const beforeCount = serverConn.received.length;
 
         const rpcFiber = yield* Effect.fork(
-          client.sendRpc("messages/send", {
+          client.sendRpc(MessagesSend.name, {
             conversationId: "c1",
             parts: [{ type: "text", text: "payload" }],
           }),
@@ -471,7 +505,7 @@ describe("§5.3 sendRpc does NOT retry on timeout (TestClock)", () => {
             const err = failed.value;
             expect(err).toBeInstanceOf(RpcTimeoutError);
             if (err instanceof RpcTimeoutError) {
-              expect(err.method).toBe("messages/send");
+              expect(err.method).toBe(MessagesSend.name);
               expect(err.timeoutMs).toBe(RPC_TIMEOUT_MS);
             }
           }
@@ -509,7 +543,7 @@ describe("reconnect backoff", () => {
         const server = yield* startTestServer((conn, raw) =>
           Effect.gen(function* () {
             const frame = JSON.parse(raw) as { id: string; method: string };
-            if (frame.method === "auth/connect") {
+            if (frame.method === Connect.name) {
               authResponsesSent++;
               yield* conn.send(
                 JSON.stringify({
@@ -571,7 +605,7 @@ describe("§5.4 malformed frames are logged but do not affect pending RPCs", () 
         // malformed inbound frames, then the real response.
         const server = yield* startHandshakingServer((conn, _raw, frame) =>
           Effect.gen(function* () {
-            if (frame.method !== "conversations/list") return;
+            if (frame.method !== ConversationsList.name) return;
             // Inject: non-JSON, then missing-id response, then unknown type.
             yield* conn.send("not json at all");
             yield* conn.send(JSON.stringify({ type: "response" }));
@@ -592,7 +626,7 @@ describe("§5.4 malformed frames are logged but do not affect pending RPCs", () 
         yield* Effect.promise(() => connectP(client));
 
         const result = (yield* Effect.promise(() =>
-          sendRpcP(client, "conversations/list", {}),
+          sendRpcP(client, ConversationsList.name, {}),
         )) as { conversations: unknown[] };
         expect(result.conversations).toEqual([]);
         // Logger saw at least one malformed-frame warning.
@@ -610,7 +644,7 @@ describe("§5.4 malformed frames are logged but do not affect pending RPCs", () 
         const events: unknown[] = [];
         const server = yield* startHandshakingServer((conn, _raw, frame) =>
           Effect.gen(function* () {
-            if (frame.method !== "conversations/list") return;
+            if (frame.method !== ConversationsList.name) return;
             yield* conn.send(
               JSON.stringify({
                 jsonrpc: "2.0",
@@ -636,7 +670,7 @@ describe("§5.4 malformed frames are logged but do not affect pending RPCs", () 
         yield* Effect.promise(() => connectP(client));
 
         const result = (yield* Effect.promise(() =>
-          sendRpcP(client, "conversations/list", {}),
+          sendRpcP(client, ConversationsList.name, {}),
         )) as { conversations: unknown[] };
 
         expect(result.conversations).toEqual([]);
@@ -769,7 +803,7 @@ describe("close() interleaved with a pending RPC", () => {
         const client = makeClient(server.url);
         yield* Effect.promise(() => connectP(client));
 
-        const rpcP = sendRpcP(client, "conversations/list", {});
+        const rpcP = sendRpcP(client, ConversationsList.name, {});
         yield* Effect.promise(() =>
           waitFor(() => server.connections[0]!.received.length >= 2),
         );
@@ -801,7 +835,7 @@ describe("socket error after connect", () => {
         const client = makeClient(server.url, { logger });
         yield* Effect.promise(() => connectP(client));
 
-        const rpcP = sendRpcP(client, "conversations/list", {});
+        const rpcP = sendRpcP(client, ConversationsList.name, {});
         yield* Effect.promise(() =>
           expect(rpcP).rejects.toThrow(/WebSocket not connected/),
         );
@@ -854,7 +888,7 @@ describe("sendRpc(RpcDefinition, params) — typed manifest overload", () => {
           echoedParams: { names: string[] };
           agents: unknown[];
         };
-        expect(result.echoedMethod).toBe("agents/lookupByName");
+        expect(result.echoedMethod).toBe(AgentsLookupByName.name);
         expect(result.echoedParams).toEqual({ names: ["alice"] });
 
         yield* closeClient(client);
@@ -880,9 +914,9 @@ describe("sendRpc(RpcDefinition, params) — typed manifest overload", () => {
         yield* Effect.promise(() => connectP(client));
 
         const result = (yield* Effect.promise(() =>
-          sendRpcP(client, "agents/lookupByName", { names: ["bob"] }),
+          sendRpcP(client, AgentsLookupByName.name, { names: ["bob"] }),
         )) as { echoedMethod: string; agents: unknown[] };
-        expect(result.echoedMethod).toBe("agents/lookupByName");
+        expect(result.echoedMethod).toBe(AgentsLookupByName.name);
 
         yield* closeClient(client);
       }),
@@ -1032,7 +1066,7 @@ describe("Phase 1.0 (B.1) — handleServerRpc round-trip", () => {
         const server = yield* startTestServer((conn, raw) =>
           Effect.gen(function* () {
             const frame = JSON.parse(raw) as { id: string; method: string };
-            if (frame.method === "auth/connect") {
+            if (frame.method === Connect.name) {
               yield* conn.send(
                 JSON.stringify({
                   jsonrpc: "2.0",
@@ -1052,7 +1086,7 @@ describe("Phase 1.0 (B.1) — handleServerRpc round-trip", () => {
                   type: "request",
                   direction: "s2c",
                   id: "srv-test-1",
-                  method: "apps/onJoin",
+                  method: AppsOnJoin.name,
                   params: { sessionId: "sess-A" },
                 }),
               );
@@ -1062,7 +1096,7 @@ describe("Phase 1.0 (B.1) — handleServerRpc round-trip", () => {
         const client = makeClient(server.url);
         // Register a handler BEFORE connect so the dispatcher fiber sees
         // it on the very first inbound s2c request.
-        yield* client.handleServerRpc("apps/onJoin", (params) =>
+        yield* client.handleServerRpc(AppsOnJoin.name, (params) =>
           Effect.succeed({
             ack: true,
             saw: (params as { sessionId: string }).sessionId,
@@ -1129,7 +1163,7 @@ describe("Phase 1.0 (B.1) — handleServerRpc round-trip", () => {
         const server = yield* startTestServer((conn, raw) =>
           Effect.gen(function* () {
             const frame = JSON.parse(raw) as { id: string; method: string };
-            if (frame.method === "auth/connect") {
+            if (frame.method === Connect.name) {
               yield* conn.send(
                 JSON.stringify({
                   jsonrpc: "2.0",
@@ -1145,7 +1179,7 @@ describe("Phase 1.0 (B.1) — handleServerRpc round-trip", () => {
                   type: "request",
                   direction: "s2c",
                   id: "srv-err-1",
-                  method: "apps/onClose",
+                  method: AppsOnClose.name,
                   // Spec #356: the partitioned dispatcher
                   // narrow-validates routing fields; sessionId is
                   // required for every s2c hook. Synthetic test
@@ -1159,7 +1193,7 @@ describe("Phase 1.0 (B.1) — handleServerRpc round-trip", () => {
           }),
         );
         const client = makeClient(server.url);
-        yield* client.handleServerRpc("apps/onClose", () =>
+        yield* client.handleServerRpc(AppsOnClose.name, () =>
           Effect.fail(
             new RpcServerError({
               code: -32099,
@@ -1217,11 +1251,11 @@ describe("Phase 1.0 (B.1) — handleServerRpc round-trip", () => {
       agentKey: "test",
     });
     const first = await Effect.runPromiseExit(
-      client.handleServerRpc("apps/onJoin", () => Effect.succeed({})),
+      client.handleServerRpc(AppsOnJoin.name, () => Effect.succeed({})),
     );
     expect(Exit.isSuccess(first)).toBe(true);
     const second = await Effect.runPromiseExit(
-      client.handleServerRpc("apps/onJoin", () => Effect.succeed({})),
+      client.handleServerRpc(AppsOnJoin.name, () => Effect.succeed({})),
     );
     expect(Exit.isFailure(second)).toBe(true);
     if (Exit.isFailure(second)) {

--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -2,8 +2,10 @@ import * as Socket from "@effect/platform/Socket";
 import * as NodeSocket from "@effect/platform-node/NodeSocket";
 import {
   Cause,
+  Data,
   Deferred,
   Duration,
+  Either,
   Effect,
   Exit,
   Fiber,
@@ -44,7 +46,14 @@ import {
   type PartitionedDispatcher,
   type PartitionedDispatcherConfig,
 } from "./internal/s2c-partitioned-dispatcher.js";
-import type { OfferRejected } from "./internal/s2c-dispatcher-errors.js";
+import {
+  MalformedPartitionKeyError,
+  PartitionLimitError,
+  PartitionQueueFullError,
+  type OfferRejected,
+} from "./internal/s2c-dispatcher-errors.js";
+
+import { Connect } from "@moltzap/protocol";
 
 // Re-export `CloseInfo` so consumers can import it from
 // `@moltzap/client` alongside `MoltZapWsClient` itself; the type lives
@@ -65,6 +74,12 @@ export interface RpcCallOptions {
 /** Reconnect backoff: 1s base, doubling per attempt up to the cap. */
 const BASE_RECONNECT_DELAY_MS = 1000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
+const RECONNECT_BACKOFF_FACTOR = 2;
+const NORMAL_CLOSE_CODE = 1000;
+const EVENT_WAIT_TIMEOUT_MS = 5000;
+const WEB_SOCKET_OPEN_TIMEOUT_SECONDS = 10;
+const MALFORMED_FRAME_PREVIEW_CHARS = 200;
+const JSON_RPC_INTERNAL_ERROR_CODE = -32603;
 
 /**
  * Log 1-of-N malformed frames. A misbehaving server could flood us otherwise;
@@ -84,8 +99,17 @@ const MSG_RPC_ERROR_FALLBACK = "RPC error";
 
 const UTF8_DECODER = new TextDecoder("utf-8");
 
+const makeNotConnectedError = (): NotConnectedError =>
+  new NotConnectedError({ message: MSG_NOT_CONNECTED });
+
 /** Tagged error type for any pending-RPC Deferred. */
 type PendingError = RpcServerError | NotConnectedError | RpcTimeoutError;
+
+class ReconnectAttemptFailedError extends Data.TaggedError(
+  "ReconnectAttemptFailedError",
+)<{
+  readonly reason: string;
+}> {}
 
 /**
  * Per-connection runtime state. `None` = not connected → `sendRpc` fails fast
@@ -371,9 +395,7 @@ export class MoltZapWsClient {
   > {
     return Effect.suspend(() => {
       if (this.closed) {
-        return Effect.fail(
-          new NotConnectedError({ message: MSG_NOT_CONNECTED }),
-        );
+        return Effect.fail(makeNotConnectedError());
       }
       return this.connectEffect().pipe(
         // `makeWebSocket` requires `Socket.WebSocketConstructor`; our
@@ -475,9 +497,7 @@ export class MoltZapWsClient {
   ): Effect.Effect<EventSubscription, NotConnectedError> {
     return Effect.suspend(() => {
       if (this.closed) {
-        return Effect.fail(
-          new NotConnectedError({ message: MSG_NOT_CONNECTED }),
-        );
+        return Effect.fail(makeNotConnectedError());
       }
       return this.subscribers.register(filter, handler);
     });
@@ -492,6 +512,7 @@ export class MoltZapWsClient {
   close(): Effect.Effect<void, never> {
     return Effect.gen(this, function* () {
       if (this.closed) return;
+      const hasCompletedHandshake = this._helloOk !== null;
       this.closed = true;
       this._helloOk = null;
       if (this.reconnectFiber !== null) {
@@ -499,22 +520,21 @@ export class MoltZapWsClient {
         this.reconnectFiber = null;
         yield* Effect.forkDaemon(Fiber.interrupt(f));
       }
-      yield* Effect.all(
-        [
-          this.failAllPending(MSG_NOT_CONNECTED),
-          this.failAllEventWaiters(MSG_NOT_CONNECTED),
-          // Drop every live subscription so handlers stop firing once
-          // the client is permanently torn down. Idempotent.
-          this.subscribers.closeAll,
-        ],
-        { concurrency: "unbounded" },
-      );
+      yield* this.failAllPending(MSG_NOT_CONNECTED);
+      yield* this.failAllEventWaiters(MSG_NOT_CONNECTED);
+      // Drop every live subscription so handlers stop firing once
+      // the client is permanently torn down. Idempotent.
+      yield* this.subscribers.closeAll;
       const state = yield* Ref.getAndSet(this.stateRef, Option.none());
       if (Option.isSome(state)) {
-        yield* state.value
-          .write(new Socket.CloseEvent(1000, "normal"))
-          .pipe(Effect.orDie);
-        yield* Scope.close(state.value.scope, Exit.void);
+        if (hasCompletedHandshake) {
+          yield* state.value
+            .write(new Socket.CloseEvent(NORMAL_CLOSE_CODE, "normal"))
+            .pipe(Effect.orDie);
+          yield* Scope.close(state.value.scope, Exit.void);
+        } else {
+          this.runtime.runFork(Scope.close(state.value.scope, Exit.void));
+        }
         // The partitioned dispatcher's Scope is NOT bound to the
         // socket Scope (see ConnState doc): tear it down via runFork
         // so this Effect remains sync-runnable for callers using
@@ -540,7 +560,7 @@ export class MoltZapWsClient {
    * with a per-call timeout. */
   waitForEvent(
     eventName: string,
-    timeoutMs = 5000,
+    timeoutMs = EVENT_WAIT_TIMEOUT_MS,
   ): Effect.Effect<EventFrame, Error> {
     return Effect.gen(this, function* () {
       const buffered = yield* Ref.modify(this.eventsBufferRef, (events) => {
@@ -625,22 +645,23 @@ export class MoltZapWsClient {
 
       // Map Socket open failures (SocketGenericError / SocketCloseError) to
       // NotConnectedError so callers see a single typed error.
+      const openTimeout = Duration.seconds(WEB_SOCKET_OPEN_TIMEOUT_SECONDS);
       const socket = yield* Scope.extend(
-        Socket.makeWebSocket(url, { openTimeout: Duration.seconds(10) }),
+        Socket.makeWebSocket(url, { openTimeout }),
         scope,
       ).pipe(
+        Effect.timeoutFail({
+          duration: openTimeout,
+          onTimeout: makeNotConnectedError,
+        }),
         Effect.catchAllCause((cause) =>
           Effect.zipRight(
             Effect.sync(() =>
               this.options.logger?.warn("WebSocket open failed", cause),
             ),
-            Scope.close(scope, Exit.void).pipe(
-              Effect.zipRight(
-                Effect.fail(
-                  new NotConnectedError({ message: MSG_NOT_CONNECTED }),
-                ),
-              ),
-            ),
+            Effect.sync(() => {
+              this.runtime.runFork(Scope.close(scope, Exit.void));
+            }).pipe(Effect.zipRight(Effect.fail(makeNotConnectedError()))),
           ),
         ),
       );
@@ -703,7 +724,7 @@ export class MoltZapWsClient {
               // Unblock any `connect()` still awaiting the handshake.
               yield* Deferred.fail(
                 handshakeSettled,
-                new NotConnectedError({ message: MSG_NOT_CONNECTED }),
+                makeNotConnectedError(),
               ).pipe(Effect.ignore);
               // Clear connection state BEFORE the s2c teardown so
               // `sendRpc` and observers see the closed state immediately.
@@ -756,7 +777,7 @@ export class MoltZapWsClient {
         }),
       );
 
-      const authEffect = this.sendRpcEffect("auth/connect", {
+      const authEffect = this.sendRpcEffect(Connect.name, {
         agentKey: this.options.agentKey,
         minProtocol: PROTOCOL_VERSION,
         maxProtocol: PROTOCOL_VERSION,
@@ -800,9 +821,7 @@ export class MoltZapWsClient {
     return Effect.gen(this, function* () {
       const state = yield* Ref.get(this.stateRef);
       if (Option.isNone(state)) {
-        return yield* Effect.fail(
-          new NotConnectedError({ message: MSG_NOT_CONNECTED }),
-        );
+        return yield* Effect.fail(makeNotConnectedError());
       }
 
       const id = `rpc-${++this.requestCounter}`;
@@ -836,12 +855,17 @@ export class MoltZapWsClient {
         Effect.as(null),
       );
       const writeRace = yield* Effect.race(writeAttempt, earlyFailure);
-      if (writeRace !== null && writeRace._tag === "Left") {
-        this.options.logger?.warn("ws.send failed", writeRace.left);
+      const writeFailure =
+        writeRace === null
+          ? null
+          : Either.match(writeRace, {
+              onLeft: (err) => err,
+              onRight: () => null,
+            });
+      if (writeFailure !== null) {
+        this.options.logger?.warn("ws.send failed", writeFailure);
         yield* Ref.update(this.pendingRef, (m) => HashMap.remove(m, id));
-        return yield* Effect.fail(
-          new NotConnectedError({ message: MSG_NOT_CONNECTED }),
-        );
+        return yield* Effect.fail(makeNotConnectedError());
       }
 
       const timeoutMs = opts?.timeoutMs ?? RPC_TIMEOUT_MS;
@@ -903,37 +927,7 @@ export class MoltZapWsClient {
     requestId: string,
     write: ConnState["write"],
   ): Effect.Effect<void, never> {
-    const reply: ResponseFrame = (() => {
-      switch (err._tag) {
-        case "MalformedPartitionKeyError":
-          return responseFrame("s2c", requestId, {
-            error: {
-              code: -32602,
-              message: `Invalid params: ${err.reason}`,
-            },
-          });
-        case "PartitionLimitError":
-          return responseFrame("s2c", requestId, {
-            error: {
-              code: -32000,
-              message: `Server busy: partition limit reached (${err.activePartitions}/${err.maxPartitions})`,
-            },
-          });
-        case "PartitionQueueFullError":
-          return responseFrame("s2c", requestId, {
-            error: {
-              code: -32000,
-              message: `Server busy: partition queue full (capacity=${err.capacity})`,
-            },
-          });
-        default: {
-          const _exhaustive: never = err;
-          throw new Error(
-            `writeOfferRejection: unhandled OfferRejected tag: ${String(_exhaustive)}`,
-          );
-        }
-      }
-    })();
+    const reply = this.offerRejectedResponse(err, requestId);
     return write(JSON.stringify(reply)).pipe(
       Effect.catchAll((werr) =>
         Effect.sync(() =>
@@ -941,6 +935,38 @@ export class MoltZapWsClient {
         ),
       ),
     );
+  }
+
+  private offerRejectedResponse(
+    err: OfferRejected,
+    requestId: string,
+  ): ResponseFrame {
+    if (err instanceof MalformedPartitionKeyError) {
+      return responseFrame("s2c", requestId, {
+        error: {
+          code: -32602,
+          message: `Invalid params: ${err.reason}`,
+        },
+      });
+    }
+    if (err instanceof PartitionLimitError) {
+      return responseFrame("s2c", requestId, {
+        error: {
+          code: -32000,
+          message: `Server busy: partition limit reached (${err.activePartitions}/${err.maxPartitions})`,
+        },
+      });
+    }
+    if (err instanceof PartitionQueueFullError) {
+      return responseFrame("s2c", requestId, {
+        error: {
+          code: -32000,
+          message: `Server busy: partition queue full (capacity=${err.capacity})`,
+        },
+      });
+    }
+    const _exhaustive: never = err;
+    return _exhaustive;
   }
 
   /**
@@ -1030,7 +1056,7 @@ export class MoltZapWsClient {
             if (n === 1 || n % MALFORMED_LOG_EVERY === 0) {
               this.options.logger?.warn(
                 `Malformed frame (#${n}):`,
-                err.raw.slice(0, 200),
+                err.raw.slice(0, MALFORMED_FRAME_PREVIEW_CHARS),
               );
             }
             return null;
@@ -1054,7 +1080,10 @@ export class MoltZapWsClient {
             yield* Deferred.fail(
               pending,
               new RpcServerError({
-                code: typeof error.code === "number" ? error.code : -32603,
+                code:
+                  typeof error.code === "number"
+                    ? error.code
+                    : JSON_RPC_INTERNAL_ERROR_CODE,
                 message: error.message ?? MSG_RPC_ERROR_FALLBACK,
                 data: error.data,
               }),
@@ -1096,9 +1125,13 @@ export class MoltZapWsClient {
               params: decoded.params,
             }),
           );
-          if (offered._tag === "Left") {
+          const offerFailure = Either.match(offered, {
+            onLeft: (err) => err,
+            onRight: () => null,
+          });
+          if (offerFailure !== null) {
             yield* this.writeOfferRejection(
-              offered.left,
+              offerFailure,
               decoded.id,
               state.value.write,
             );
@@ -1191,12 +1224,17 @@ export class MoltZapWsClient {
         }),
       ),
       // Collapse typed errors so `Schedule.exponential` can retry.
-      Effect.mapError(() => new Error("reconnect attempt failed")),
+      Effect.mapError(
+        () =>
+          new ReconnectAttemptFailedError({
+            reason: "reconnect attempt failed",
+          }),
+      ),
     );
 
     const backoff = Schedule.exponential(
       Duration.millis(BASE_RECONNECT_DELAY_MS),
-      2,
+      RECONNECT_BACKOFF_FACTOR,
     ).pipe(
       Schedule.either(Schedule.spaced(Duration.millis(MAX_RECONNECT_DELAY_MS))),
       Schedule.jittered,

--- a/packages/nanoclaw-channel/src/channels/moltzap.ts
+++ b/packages/nanoclaw-channel/src/channels/moltzap.ts
@@ -1,4 +1,4 @@
-import { Data, Effect } from "effect";
+import { Config, ConfigProvider, Data, Effect, Option } from "effect";
 import {
   MoltZapChannelCore,
   MoltZapService,
@@ -8,6 +8,8 @@ import {
   type EnrichedInboundMessage,
   type WsClientLogger,
 } from "@moltzap/client";
+
+const EVAL_GROUP_NAME_ID_CHARS = 8;
 
 import type { Channel } from "../types.js";
 import { logger } from "../logger.js";
@@ -39,6 +41,13 @@ function formatCrossConvNanoclaw(
 
 const MOLTZAP_JID_PREFIX = "mz:";
 const DEFAULT_SERVER_URL = "wss://api.moltzap.xyz";
+const MoltZapChannelEnv = Config.all({
+  apiKey: Config.option(Config.string("MOLTZAP_API_KEY")),
+  serverUrl: Config.string("MOLTZAP_SERVER_URL").pipe(
+    Config.withDefault(DEFAULT_SERVER_URL),
+  ),
+  evalMode: Config.string("MOLTZAP_EVAL_MODE").pipe(Config.withDefault("0")),
+});
 
 class MoltZapChannelError extends Data.TaggedError("MoltZapChannelError")<{
   readonly reason: string;
@@ -54,6 +63,21 @@ function jidFromConversationId(conversationId: string): string {
 
 function conversationIdFromJid(jid: string): string {
   return jid.slice(MOLTZAP_JID_PREFIX.length);
+}
+
+function loadMoltZapChannelEnv(): {
+  readonly apiKey: string | undefined;
+  readonly serverUrl: string;
+  readonly evalMode: boolean;
+} {
+  const env = Effect.runSync(
+    MoltZapChannelEnv.pipe(Effect.withConfigProvider(ConfigProvider.fromEnv())),
+  );
+  return {
+    apiKey: Option.getOrUndefined(env.apiKey),
+    serverUrl: env.serverUrl,
+    evalMode: env.evalMode === "1",
+  };
 }
 
 // Nanoclaw's router consumes NewMessage.content verbatim into prompt XML,
@@ -192,8 +216,8 @@ export class MoltZapChannel implements Channel {
     // Mutates the live map — registry exposes it via registeredGroups() in
     // nanoclaw 1.2.52 (no setter).
     registered[chatJid] = {
-      name: `eval-${conversationId.slice(0, 8)}`,
-      folder: `eval_${conversationId.slice(0, 8)}`,
+      name: `eval-${conversationId.slice(0, EVAL_GROUP_NAME_ID_CHARS)}`,
+      folder: `eval_${conversationId.slice(0, EVAL_GROUP_NAME_ID_CHARS)}`,
       trigger: ".*",
       added_at: new Date().toISOString(),
       requiresTrigger: false,
@@ -203,9 +227,7 @@ export class MoltZapChannel implements Channel {
 }
 
 registerChannel("moltzap", (opts: ChannelOpts): Channel | null => {
-  const apiKey = process.env.MOLTZAP_API_KEY;
-  const serverUrl = process.env.MOLTZAP_SERVER_URL ?? DEFAULT_SERVER_URL;
-  const evalMode = process.env.MOLTZAP_EVAL_MODE === "1";
+  const { apiKey, serverUrl, evalMode } = loadMoltZapChannelEnv();
 
   if (!apiKey) return null;
 

--- a/packages/nanoclaw-channel/src/logger.ts
+++ b/packages/nanoclaw-channel/src/logger.ts
@@ -4,7 +4,9 @@
 
 type LogInput = Record<string, unknown> | string;
 
-function noop(_dataOrMsg: LogInput, _msg?: string): void {
+function noop(dataOrMsg: LogInput, msg?: string): void {
+  void dataOrMsg;
+  void msg;
   // Unit tests don't assert on log output. In a real nanoclaw install, this
   // file is not used — imports resolve against nanoclaw's own logger.ts.
 }

--- a/packages/openclaw-channel/src/__tests__/echo-server.ts
+++ b/packages/openclaw-channel/src/__tests__/echo-server.ts
@@ -11,8 +11,99 @@ import type {
   ChatCompletionCreateParams,
   ChatCompletionContentPartText,
 } from "openai/resources/chat/completions";
+import { Config, ConfigProvider, Effect, Option } from "effect";
 
 export type EchoServer = { port: number; close: () => void };
+
+export interface EchoServerOptions {
+  readonly debug?: boolean;
+}
+
+const EchoDebug = Config.option(Config.string("ECHO_DEBUG"));
+const HTTP_OK = 200;
+const HTTP_BAD_REQUEST = 400;
+const HTTP_NOT_FOUND = 404;
+const MS_PER_SECOND = 1000;
+const DEBUG_MESSAGE_PREVIEW_CHARS = 80;
+const ECHO_MODEL_ID = "echo-1";
+const CHAT_COMPLETION_OBJECT = "chat.completion";
+const CHAT_COMPLETION_CHUNK_OBJECT = "chat.completion.chunk";
+const STOP_FINISH_REASON = "stop";
+const JSON_ERROR_NOT_FOUND = "Not found";
+const JSON_ERROR_MALFORMED_BODY = "Malformed JSON body";
+const JSON_ERROR_EMPTY_MESSAGES = "Missing or empty messages array";
+const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+} as const;
+
+class EchoServerError extends Error {
+  override readonly name = "EchoServerError";
+}
+
+function readEchoDebug(): boolean {
+  const raw = Option.getOrUndefined(
+    Effect.runSync(
+      EchoDebug.pipe(Effect.withConfigProvider(ConfigProvider.fromEnv())),
+    ),
+  );
+  return raw !== undefined && raw !== "" && raw !== "0" && raw !== "false";
+}
+
+function writeJson(
+  res: http.ServerResponse,
+  statusCode: number,
+  body: unknown,
+): void {
+  res.writeHead(statusCode, JSON_HEADERS);
+  res.end(JSON.stringify(body));
+}
+
+function writeJsonError(
+  res: http.ServerResponse,
+  statusCode: number,
+  error: string,
+): void {
+  writeJson(res, statusCode, { error });
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / MS_PER_SECOND);
+}
+
+function makeCompletionId(): string {
+  return `chatcmpl-echo-${Date.now()}`;
+}
+
+function makeCompletionMetadata(id: string) {
+  return {
+    id,
+    created: nowSeconds(),
+    model: ECHO_MODEL_ID,
+  };
+}
+
+function isModelListRequest(req: http.IncomingMessage): boolean {
+  return (
+    (req.url === "/v1/models" || req.url === "/models") && req.method === "GET"
+  );
+}
+
+function isChatCompletionRequest(req: http.IncomingMessage): boolean {
+  return (
+    req.method === "POST" &&
+    (req.url === "/v1/chat/completions" || req.url === "/chat/completions")
+  );
+}
+
+function writeModelList(res: http.ServerResponse): void {
+  writeJson(res, HTTP_OK, {
+    object: "list",
+    data: [{ id: ECHO_MODEL_ID, object: "model", owned_by: "echo" }],
+  });
+}
 
 function extractUserText(params: ChatCompletionCreateParams): string {
   const lastUserMsg = [...params.messages]
@@ -32,147 +123,168 @@ function extractUserText(params: ChatCompletionCreateParams): string {
     .join("");
 }
 
-export function startEchoServer(): Promise<EchoServer> {
-  return new Promise((resolve, reject) => {
-    const server = http.createServer(async (req, res) => {
+function formatDebugUserMessages(params: ChatCompletionCreateParams): string[] {
+  return params.messages
+    .filter((m) => m.role === "user")
+    .map((m) => {
+      const content =
+        typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+      return `${content.slice(0, DEBUG_MESSAGE_PREVIEW_CHARS)}(${content.length})`;
+    });
+}
+
+function makeContentChunk(params: {
+  readonly id: string;
+  readonly content: string;
+}): ChatCompletionChunk {
+  return {
+    ...makeCompletionMetadata(params.id),
+    object: CHAT_COMPLETION_CHUNK_OBJECT,
+    choices: [
+      {
+        index: 0,
+        delta: { role: "assistant", content: params.content },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  };
+}
+
+function makeStopChunk(id: string): ChatCompletionChunk {
+  return {
+    ...makeCompletionMetadata(id),
+    object: CHAT_COMPLETION_CHUNK_OBJECT,
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: STOP_FINISH_REASON,
+        logprobs: null,
+      },
+    ],
+  };
+}
+
+function makeCompletion(params: {
+  readonly id: string;
+  readonly content: string;
+}): ChatCompletion {
+  return {
+    ...makeCompletionMetadata(params.id),
+    object: CHAT_COMPLETION_OBJECT,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: params.content, refusal: null },
+        finish_reason: STOP_FINISH_REASON,
+        logprobs: null,
+      },
+    ],
+    usage: {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    },
+  };
+}
+
+function writeSseChunk(
+  res: http.ServerResponse,
+  chunk: ChatCompletionChunk,
+): void {
+  res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+}
+
+function writeStreamingCompletion(
+  res: http.ServerResponse,
+  params: { readonly id: string; readonly content: string },
+): void {
+  res.writeHead(HTTP_OK, SSE_HEADERS);
+  writeSseChunk(res, makeContentChunk(params));
+  writeSseChunk(res, makeStopChunk(params.id));
+  res.write("data: [DONE]\n\n");
+  res.end();
+}
+
+function writeChatCompletion(
+  res: http.ServerResponse,
+  body: ChatCompletionCreateParams,
+  debug: boolean,
+): void {
+  const userText = extractUserText(body);
+  const content = `ECHO: ${userText}`;
+  const completionId = makeCompletionId();
+
+  if (debug) {
+    const userMsgs = formatDebugUserMessages(body);
+    console.log(
+      `[echo-server] stream=${!!body.stream} userMsgs=[${userMsgs}] replyLen=${content.length}`,
+    );
+  }
+
+  if (body.stream) {
+    writeStreamingCompletion(res, { id: completionId, content });
+    return;
+  }
+
+  writeJson(res, HTTP_OK, makeCompletion({ id: completionId, content }));
+}
+
+function handleRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  rawBody: string,
+  debug: boolean,
+): void {
+  if (debug) {
+    console.log(`[echo-server] ${req.method} ${req.url}`);
+  }
+
+  if (isModelListRequest(req)) {
+    writeModelList(res);
+    return;
+  }
+
+  if (!isChatCompletionRequest(req)) {
+    writeJsonError(res, HTTP_NOT_FOUND, JSON_ERROR_NOT_FOUND);
+    return;
+  }
+
+  let body: ChatCompletionCreateParams;
+  try {
+    body = JSON.parse(rawBody);
+  } catch (cause) {
+    void cause;
+    writeJsonError(res, HTTP_BAD_REQUEST, JSON_ERROR_MALFORMED_BODY);
+    return;
+  }
+
+  if (!Array.isArray(body.messages) || body.messages.length === 0) {
+    writeJsonError(res, HTTP_BAD_REQUEST, JSON_ERROR_EMPTY_MESSAGES);
+    return;
+  }
+
+  writeChatCompletion(res, body, debug);
+}
+
+export function startEchoServer(options: EchoServerOptions = {}) {
+  const debug = options.debug ?? readEchoDebug();
+  return new Promise<EchoServer>((resolve, reject) => {
+    const server = http.createServer((req, res) => {
       const bodyChunks: Buffer[] = [];
-      for await (const chunk of req) bodyChunks.push(chunk as Buffer);
-      const rawBody = Buffer.concat(bodyChunks).toString();
-
-      if (process.env.ECHO_DEBUG) {
-        console.log(`[echo-server] ${req.method} ${req.url}`);
-      }
-
-      // Model listing (OpenClaw may probe this)
-      if (
-        (req.url === "/v1/models" || req.url === "/models") &&
-        req.method === "GET"
-      ) {
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(
-          JSON.stringify({
-            object: "list",
-            data: [{ id: "echo-1", object: "model", owned_by: "echo" }],
-          }),
-        );
-        return;
-      }
-
-      // Only handle chat completions
-      const isCompletions =
-        req.method === "POST" &&
-        (req.url === "/v1/chat/completions" || req.url === "/chat/completions");
-      if (!isCompletions) {
-        res.writeHead(404, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Not found" }));
-        return;
-      }
-
-      let body: ChatCompletionCreateParams;
-      try {
-        body = JSON.parse(rawBody);
-      } catch {
-        res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Malformed JSON body" }));
-        return;
-      }
-
-      if (!Array.isArray(body.messages) || body.messages.length === 0) {
-        res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Missing or empty messages array" }));
-        return;
-      }
-
-      const userText = extractUserText(body);
-      const content = `ECHO: ${userText}`;
-      const completionId = `chatcmpl-echo-${Date.now()}`;
-
-      if (process.env.ECHO_DEBUG) {
-        const userMsgs = body.messages
-          .filter((m) => m.role === "user")
-          .map((m) => {
-            const c =
-              typeof m.content === "string"
-                ? m.content
-                : JSON.stringify(m.content);
-            return `${c.slice(0, 80)}(${c.length})`;
-          });
-        console.log(
-          `[echo-server] stream=${!!body.stream} userMsgs=[${userMsgs}] replyLen=${content.length}`,
-        );
-      }
-
-      if (body.stream) {
-        // SSE streaming response
-        res.writeHead(200, {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        });
-
-        const contentChunk: ChatCompletionChunk = {
-          id: completionId,
-          object: "chat.completion.chunk",
-          created: Math.floor(Date.now() / 1000),
-          model: "echo-1",
-          choices: [
-            {
-              index: 0,
-              delta: { role: "assistant", content },
-              finish_reason: null,
-              logprobs: null,
-            },
-          ],
-        };
-        res.write(`data: ${JSON.stringify(contentChunk)}\n\n`);
-
-        const stopChunk: ChatCompletionChunk = {
-          id: completionId,
-          object: "chat.completion.chunk",
-          created: Math.floor(Date.now() / 1000),
-          model: "echo-1",
-          choices: [
-            {
-              index: 0,
-              delta: {},
-              finish_reason: "stop",
-              logprobs: null,
-            },
-          ],
-        };
-        res.write(`data: ${JSON.stringify(stopChunk)}\n\n`);
-        res.write("data: [DONE]\n\n");
-        res.end();
-      } else {
-        // Non-streaming response
-        const completion: ChatCompletion = {
-          id: completionId,
-          object: "chat.completion",
-          created: Math.floor(Date.now() / 1000),
-          model: "echo-1",
-          choices: [
-            {
-              index: 0,
-              message: { role: "assistant", content, refusal: null },
-              finish_reason: "stop",
-              logprobs: null,
-            },
-          ],
-          usage: {
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            total_tokens: 0,
-          },
-        };
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify(completion));
-      }
+      req.on("data", (chunk: Buffer) => bodyChunks.push(chunk));
+      req.on("error", reject);
+      req.on("end", () => {
+        const rawBody = Buffer.concat(bodyChunks).toString();
+        handleRequest(req, res, rawBody, debug);
+      });
     });
 
     server.listen(0, () => {
       const addr = server.address();
       if (!addr || typeof addr === "string") {
-        reject(new Error("Failed to get server address"));
+        reject(new EchoServerError("Failed to get server address"));
         return;
       }
       resolve({

--- a/packages/openclaw-channel/src/__tests__/openclaw-routing.integration.test.ts
+++ b/packages/openclaw-channel/src/__tests__/openclaw-routing.integration.test.ts
@@ -19,6 +19,12 @@ import {
   extractText,
 } from "./test-helpers.js";
 
+import {
+  AgentsLookupByName,
+  ConversationsCreate,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let wsUrl: string;
 
 beforeAll(() => {
@@ -67,13 +73,13 @@ describe.skipIf(inject("containerAId") === "")(
             yield* aliceClient.connect();
 
             const convId = extractConvId(
-              yield* aliceClient.sendRpc("conversations/create", {
+              yield* aliceClient.sendRpc(ConversationsCreate.name, {
                 type: "dm",
                 participants: [{ type: "agent", id: containerAAgentId }],
               }),
             );
 
-            yield* aliceClient.sendRpc("messages/send", {
+            yield* aliceClient.sendRpc(MessagesSend.name, {
               conversationId: convId,
               parts: [{ type: "text", text: "hello from alice" }],
             });
@@ -113,7 +119,7 @@ describe.skipIf(inject("containerAId") === "")(
             yield* aliceClient.connect();
 
             const convId = extractConvId(
-              yield* aliceClient.sendRpc("conversations/create", {
+              yield* aliceClient.sendRpc(ConversationsCreate.name, {
                 type: "group",
                 name: "Integration Group",
                 participants: [
@@ -126,7 +132,7 @@ describe.skipIf(inject("containerAId") === "")(
             // Wait for conversation event to propagate to the gateway
             yield* Effect.promise(() => new Promise((r) => setTimeout(r, 500)));
 
-            yield* aliceClient.sendRpc("messages/send", {
+            yield* aliceClient.sendRpc(MessagesSend.name, {
               conversationId: convId,
               parts: [{ type: "text", text: "hello group" }],
             });
@@ -160,14 +166,14 @@ describe.skipIf(inject("containerAId") === "")(
             yield* aliceClient.connect();
 
             const convId = extractConvId(
-              yield* aliceClient.sendRpc("conversations/create", {
+              yield* aliceClient.sendRpc(ConversationsCreate.name, {
                 type: "dm",
                 participants: [{ type: "agent", id: containerAAgentId }],
               }),
             );
 
             for (let i = 0; i < 3; i++) {
-              yield* aliceClient.sendRpc("messages/send", {
+              yield* aliceClient.sendRpc(MessagesSend.name, {
                 conversationId: convId,
                 parts: [{ type: "text", text: `Message ${i}` }],
               });
@@ -214,24 +220,24 @@ describe.skipIf(inject("containerAId") === "")(
           yield* aliceClient.connect();
 
           const convAId = extractConvId(
-            yield* aliceClient.sendRpc("conversations/create", {
+            yield* aliceClient.sendRpc(ConversationsCreate.name, {
               type: "dm",
               participants: [{ type: "agent", id: containerAAgentId }],
             }),
           );
 
           const convBId = extractConvId(
-            yield* aliceClient.sendRpc("conversations/create", {
+            yield* aliceClient.sendRpc(ConversationsCreate.name, {
               type: "dm",
               participants: [{ type: "agent", id: containerBAgentId }],
             }),
           );
 
-          yield* aliceClient.sendRpc("messages/send", {
+          yield* aliceClient.sendRpc(MessagesSend.name, {
             conversationId: convAId,
             parts: [{ type: "text", text: "hello container-a" }],
           });
-          yield* aliceClient.sendRpc("messages/send", {
+          yield* aliceClient.sendRpc(MessagesSend.name, {
             conversationId: convBId,
             parts: [{ type: "text", text: "hello container-b" }],
           });
@@ -286,14 +292,14 @@ describe.skipIf(inject("containerAId") === "")(
             yield* senderClient.connect();
 
             const lookupResult = (yield* senderClient.sendRpc(
-              "agents/lookupByName",
+              AgentsLookupByName.name,
               {
                 names: ["out-receiver-pro"],
               },
             )) as { agents: { id: string }[] };
 
             const convId = extractConvId(
-              yield* senderClient.sendRpc("conversations/create", {
+              yield* senderClient.sendRpc(ConversationsCreate.name, {
                 type: "dm",
                 participants: [
                   { type: "agent", id: lookupResult.agents[0]!.id },
@@ -301,7 +307,7 @@ describe.skipIf(inject("containerAId") === "")(
               }),
             );
 
-            yield* senderClient.sendRpc("messages/send", {
+            yield* senderClient.sendRpc(MessagesSend.name, {
               conversationId: convId,
               parts: [{ type: "text", text: "proactive hello" }],
             });
@@ -342,14 +348,14 @@ describe.skipIf(inject("containerAId") === "")(
             yield* senderClient.connect();
 
             const lookupResult = (yield* senderClient.sendRpc(
-              "agents/lookupByName",
+              AgentsLookupByName.name,
               {
                 names: ["out-receiver-dup"],
               },
             )) as { agents: { id: string }[] };
 
             const convId1 = extractConvId(
-              yield* senderClient.sendRpc("conversations/create", {
+              yield* senderClient.sendRpc(ConversationsCreate.name, {
                 type: "dm",
                 participants: [
                   { type: "agent", id: lookupResult.agents[0]!.id },
@@ -357,7 +363,7 @@ describe.skipIf(inject("containerAId") === "")(
               }),
             );
 
-            yield* senderClient.sendRpc("messages/send", {
+            yield* senderClient.sendRpc(MessagesSend.name, {
               conversationId: convId1,
               parts: [{ type: "text", text: "first" }],
             });
@@ -365,7 +371,7 @@ describe.skipIf(inject("containerAId") === "")(
               yield* receiverClient.waitForEvent("messages/received", 60_000),
             );
 
-            yield* senderClient.sendRpc("messages/send", {
+            yield* senderClient.sendRpc(MessagesSend.name, {
               conversationId: convId1,
               parts: [{ type: "text", text: "second" }],
             });
@@ -400,7 +406,7 @@ describe.skipIf(inject("containerAId") === "")(
             yield* agentClient.connect();
 
             const result = yield* Effect.exit(
-              agentClient.sendRpc("agents/lookupByName", {
+              agentClient.sendRpc(AgentsLookupByName.name, {
                 name: "nonexistent-agent-xyz",
               }),
             );
@@ -428,7 +434,7 @@ describe.skipIf(inject("containerAId") === "")(
             yield* aliceClient.connect();
 
             const convId = extractConvId(
-              yield* aliceClient.sendRpc("conversations/create", {
+              yield* aliceClient.sendRpc(ConversationsCreate.name, {
                 type: "dm",
                 participants: [{ type: "agent", id: containerAAgentId }],
               }),
@@ -436,7 +442,7 @@ describe.skipIf(inject("containerAId") === "")(
 
             const largeText = "A".repeat(5000);
 
-            yield* aliceClient.sendRpc("messages/send", {
+            yield* aliceClient.sendRpc(MessagesSend.name, {
               conversationId: convId,
               parts: [{ type: "text", text: largeText }],
             });
@@ -472,14 +478,14 @@ describe.skipIf(inject("containerAId") === "")(
             yield* aliceClient.connect();
 
             const convId = extractConvId(
-              yield* aliceClient.sendRpc("conversations/create", {
+              yield* aliceClient.sendRpc(ConversationsCreate.name, {
                 type: "dm",
                 participants: [{ type: "agent", id: containerAAgentId }],
               }),
             );
 
             // Send first message to verify baseline works
-            yield* aliceClient.sendRpc("messages/send", {
+            yield* aliceClient.sendRpc(MessagesSend.name, {
               conversationId: convId,
               parts: [{ type: "text", text: "before drop" }],
             });
@@ -502,7 +508,7 @@ describe.skipIf(inject("containerAId") === "")(
             yield* aliceClient2.connect();
 
             // Send message after reconnection
-            yield* aliceClient2.sendRpc("messages/send", {
+            yield* aliceClient2.sendRpc(MessagesSend.name, {
               conversationId: convId,
               parts: [{ type: "text", text: "after reconnect" }],
             });

--- a/packages/openclaw-channel/src/__tests__/reconnection.integration.test.ts
+++ b/packages/openclaw-channel/src/__tests__/reconnection.integration.test.ts
@@ -7,6 +7,12 @@ import type { EventFrame, Message } from "@moltzap/protocol";
 import { EventNames } from "@moltzap/protocol";
 import { registerAndClaim, waitFor } from "./test-helpers.js";
 
+import {
+  AgentsLookup,
+  ConversationsCreate,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 /** The MoltZapWsClient API is Effect-native. These helpers run the Effects
  * at the test boundary so the integration flow reads like Promise code. */
 const connectWs = (c: MoltZapWsClient) => Effect.runPromise(c.connect());
@@ -84,7 +90,7 @@ describe("Flow 8: Reconnection + missed message catch-up", () => {
       });
       yield* aliceClient.connect();
 
-      const conv = (yield* aliceClient.sendRpc("conversations/create", {
+      const conv = (yield* aliceClient.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       })) as { conversation: { id: string } };
@@ -115,7 +121,7 @@ describe("Flow 8: Reconnection + missed message catch-up", () => {
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       });
 
-      yield* aliceClient.sendRpc("messages/send", {
+      yield* aliceClient.sendRpc(MessagesSend.name, {
         conversationId,
         parts: [{ type: "text", text: "Missed while offline" }],
       });
@@ -178,12 +184,12 @@ describe("Flow 8: Reconnection + missed message catch-up", () => {
       });
       yield* aliceClient.connect();
 
-      const conv = (yield* aliceClient.sendRpc("conversations/create", {
+      const conv = (yield* aliceClient.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       })) as { conversation: { id: string } };
 
-      yield* aliceClient.sendRpc("messages/send", {
+      yield* aliceClient.sendRpc(MessagesSend.name, {
         conversationId: conv.conversation.id,
         parts: [{ type: "text", text: "Before disconnect" }],
       });
@@ -210,7 +216,7 @@ describe("Flow 8: Reconnection + missed message catch-up", () => {
 
       receivedMessages.length = 0;
 
-      yield* aliceClient.sendRpc("messages/send", {
+      yield* aliceClient.sendRpc(MessagesSend.name, {
         conversationId: conv.conversation.id,
         parts: [{ type: "text", text: "After reconnect" }],
       });
@@ -297,7 +303,7 @@ describe("Flow 8: Reconnection + missed message catch-up", () => {
       });
 
       const result = (yield* Effect.promise(() =>
-        rpcWs(client, "agents/lookup", {
+        rpcWs(client, AgentsLookup.name, {
           agentIds: [bob.agentId],
         }),
       )) as { agents: Array<{ id: string; name: string }> };

--- a/packages/openclaw-channel/src/__tests__/spawn-server.ts
+++ b/packages/openclaw-channel/src/__tests__/spawn-server.ts
@@ -10,6 +10,7 @@ import { existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import pg from "pg";
+import { Config, ConfigProvider, Effect, Option } from "effect";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Auto-start entry. `dist/index.js` is the library export surface and exits
@@ -24,6 +25,23 @@ const SERVER_ENTRY = join(
   "dist",
   "standalone.js",
 );
+const SpawnPath = Config.option(Config.string("PATH"));
+const DEFAULT_HEALTH_TIMEOUT_MS = 30_000;
+const HEALTH_POLL_INTERVAL_MS = 100;
+const ADMIN_POOL_MAX_CONNECTIONS = 2;
+const MASTER_SECRET_BYTES = 32;
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+class SpawnedServerError extends Error {
+  override readonly name = "SpawnedServerError";
+
+  constructor(
+    message: string,
+    override readonly cause?: unknown,
+  ) {
+    super(message);
+  }
+}
 
 export interface SpawnedServer {
   baseUrl: string;
@@ -51,14 +69,30 @@ function generateTestFirebaseKey(): string {
   });
 }
 
-async function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
+function readSpawnPath(): string | undefined {
+  return Option.getOrUndefined(
+    Effect.runSync(
+      SpawnPath.pipe(Effect.withConfigProvider(ConfigProvider.fromEnv())),
+    ),
+  );
+}
+
+function asSpawnedServerError(cause: unknown, fallbackMessage: string) {
+  return cause instanceof SpawnedServerError
+    ? cause
+    : new SpawnedServerError(fallbackMessage, cause);
+}
+
+function findFreePort() {
+  return new Promise<number>((resolve, reject) => {
     const server = createServer();
     server.listen(0, () => {
       const addr = server.address();
       if (!addr || typeof addr === "string") {
         server.close();
-        reject(new Error("Failed to get port from server address"));
+        reject(
+          new SpawnedServerError("Failed to get port from server address"),
+        );
         return;
       }
       const port = addr.port;
@@ -68,140 +102,243 @@ async function findFreePort(): Promise<number> {
   });
 }
 
-async function pollHealth(port: number, timeoutMs = 30_000): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const res = await fetch(`http://localhost:${port}/health`);
-      if (res.ok) return;
-    } catch {
-      // Server not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 100));
-  }
-  throw new Error(
-    `Server health check timed out after ${timeoutMs}ms on port ${port}`,
+function pollHealth(port: number, timeoutMs = DEFAULT_HEALTH_TIMEOUT_MS) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        const healthy = yield* Effect.tryPromise({
+          try: (signal) => fetch(`http://localhost:${port}/health`, { signal }),
+          catch: (cause) =>
+            new SpawnedServerError("Server health check request failed", cause),
+        }).pipe(
+          Effect.map((res) => res.ok),
+          Effect.catchAll(() => Effect.succeed(false)),
+        );
+        if (healthy) return;
+        yield* Effect.sleep(`${HEALTH_POLL_INTERVAL_MS} millis`);
+      }
+      return yield* Effect.fail(
+        new SpawnedServerError(
+          `Server health check timed out after ${timeoutMs}ms on port ${port}`,
+        ),
+      );
+    }),
   );
 }
 
-export async function spawnTestServer(
-  pgHost: string,
-  pgPort: number,
-): Promise<SpawnedServer> {
-  // 1. Check server binary exists
-  if (!existsSync(SERVER_ENTRY)) {
-    throw new Error(
-      `Server not built. Run: pnpm --filter @moltzap/server build\n` +
-        `Expected: ${SERVER_ENTRY}`,
-    );
-  }
+function adminQuery(pool: pg.Pool, sql: string) {
+  return pool.query(sql);
+}
 
-  // 2. Create temp database from template
-  const dbName = `test_${crypto.randomUUID().replace(/-/g, "")}`;
-  const adminPool = new pg.Pool({
-    host: pgHost,
-    port: pgPort,
-    user: "test",
-    password: "test",
-    database: "postgres",
-    max: 2,
+function quoteDatabaseName(dbName: string): string {
+  return `"${dbName}"`;
+}
+
+function runAdminQuery(pool: pg.Pool, sql: string) {
+  return Effect.tryPromise({
+    try: () => adminQuery(pool, sql),
+    catch: (cause) =>
+      new SpawnedServerError("Admin database query failed", cause),
   });
-  await adminPool.query(
-    `CREATE DATABASE "${dbName}" TEMPLATE moltzap_template`,
+}
+
+function createDatabaseFromTemplate(pool: pg.Pool, dbName: string) {
+  return runAdminQuery(
+    pool,
+    `CREATE DATABASE ${quoteDatabaseName(dbName)} TEMPLATE moltzap_template`,
   );
+}
 
-  // 3. Pre-allocate a free port
-  const port = await findFreePort();
+function dropDatabase(pool: pg.Pool, dbName: string) {
+  return runAdminQuery(
+    pool,
+    `DROP DATABASE IF EXISTS ${quoteDatabaseName(dbName)}`,
+  );
+}
 
-  // 4. Spawn server subprocess
-  const masterSecret = randomBytes(32).toString("base64");
-  const child = spawn("node", [SERVER_ENTRY], {
-    env: {
-      PATH: process.env.PATH,
-      NODE_ENV: "production",
-      DATABASE_URL: `postgresql://test:test@${pgHost}:${pgPort}/${dbName}`,
-      ENCRYPTION_MASTER_SECRET: masterSecret,
-      MOLTZAP_DEV_MODE: "true",
-      PORT: String(port),
-      FIREBASE_SERVICE_ACCOUNT_KEY: generateTestFirebaseKey(),
-      VAPID_PUBLIC_KEY:
-        "BHKL-uNCIASscCmYZERbVn--qT9RVp6mt90rIrLwrXSAxuCTSbamzi7JlQulOQ5TTmAzMgYLcsqzEM-zFLSFbdE",
-      VAPID_PRIVATE_KEY: "Z9kV3uuqbO7rr_39L2dFA-FKgVpeLv6gS6W_5_cylMk",
-      VAPID_SUBJECT: "mailto:test@example.com",
-      CLAIM_BASE_URL: `http://localhost:${port}`,
-    },
-    stdio: ["pipe", "pipe", "pipe"],
+function closeAdminPool(pool: pg.Pool) {
+  return Effect.tryPromise({
+    try: () => pool.end(),
+    catch: (cause) =>
+      new SpawnedServerError("Admin database pool close failed", cause),
   });
+}
 
-  // Capture stdout + stderr for diagnostics on failure. The server uses
-  // pino, which writes to stdout — surface both streams so failure messages
-  // aren't swallowed.
-  let stdout = "";
-  let stderr = "";
-  child.stdout?.on("data", (chunk: Buffer) => {
-    stdout += chunk.toString();
+function waitForProcessExitOrKill(process: ChildProcess, timeoutMs: number) {
+  return new Promise<void>((resolve) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      process.off("exit", onExit);
+    };
+    const onExit = () => {
+      cleanup();
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      if (process.exitCode === null) {
+        process.kill("SIGKILL");
+      }
+      cleanup();
+      resolve();
+    }, timeoutMs);
+    process.once("exit", onExit);
   });
-  child.stderr?.on("data", (chunk: Buffer) => {
-    stderr += chunk.toString();
-  });
+}
 
-  // Handle unexpected exit
-  const exitPromise = new Promise<never>((_, reject) => {
+function unexpectedExitPromise(
+  child: ChildProcess,
+  readLogs: () => { readonly stdout: string; readonly stderr: string },
+) {
+  return new Promise<never>((_, reject) => {
     child.on("exit", (code) => {
+      const logs = readLogs();
       reject(
-        new Error(
-          `Server exited unexpectedly with code ${code}.\nstdout: ${stdout}\nstderr: ${stderr}`,
+        new SpawnedServerError(
+          `Server exited unexpectedly with code ${code}.\nstdout: ${logs.stdout}\nstderr: ${logs.stderr}`,
         ),
       );
     });
   });
-
-  // 5. Wait for server to be ready
-  try {
-    await Promise.race([pollHealth(port), exitPromise]);
-  } catch (err) {
-    child.kill("SIGKILL");
-    await adminPool.query(`DROP DATABASE IF EXISTS "${dbName}"`);
-    await adminPool.end();
-    throw err;
-  }
-
-  return {
-    baseUrl: `http://localhost:${port}`,
-    wsUrl: `ws://localhost:${port}/ws`,
-    dbName,
-    port,
-    process: child,
-    adminPool,
-  };
 }
 
-export async function stopSpawnedServer(server: SpawnedServer): Promise<void> {
-  // Kill the server process
-  if (server.process.exitCode === null) {
-    server.process.kill("SIGTERM");
+function waitForServerReady(
+  child: ChildProcess,
+  port: number,
+  readLogs: () => {
+    readonly stdout: string;
+    readonly stderr: string;
+  },
+) {
+  return Effect.tryPromise({
+    try: () =>
+      Promise.race([pollHealth(port), unexpectedExitPromise(child, readLogs)]),
+    catch: (cause) =>
+      asSpawnedServerError(cause, "Server failed before becoming healthy"),
+  });
+}
 
-    // Wait up to 5s for graceful shutdown, then force kill
-    await Promise.race([
-      new Promise<void>((resolve) =>
-        server.process.on("exit", () => resolve()),
-      ),
-      new Promise<void>((resolve) =>
-        setTimeout(() => {
-          if (server.process.exitCode === null) {
-            server.process.kill("SIGKILL");
-          }
-          resolve();
-        }, 5000),
-      ),
-    ]);
-  }
+function cleanupSpawnFailure(
+  child: ChildProcess,
+  adminPool: pg.Pool,
+  dbName: string,
+) {
+  return Effect.gen(function* () {
+    child.kill("SIGKILL");
+    yield* dropDatabase(adminPool, dbName).pipe(
+      Effect.catchAll(() => Effect.void),
+    );
+    yield* closeAdminPool(adminPool).pipe(Effect.catchAll(() => Effect.void));
+  });
+}
 
-  // Drop temp database
-  try {
-    await server.adminPool.query(`DROP DATABASE IF EXISTS "${server.dbName}"`);
-  } catch {
-    // Best effort — container may already be stopping
-  }
-  await server.adminPool.end();
+export function spawnTestServer(pgHost: string, pgPort: number) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      // 1. Check server binary exists
+      if (!existsSync(SERVER_ENTRY)) {
+        return yield* Effect.fail(
+          new SpawnedServerError(
+            `Server not built. Run: pnpm --filter @moltzap/server build\n` +
+              `Expected: ${SERVER_ENTRY}`,
+          ),
+        );
+      }
+
+      // 2. Create temp database from template
+      const dbName = `test_${crypto.randomUUID().replace(/-/g, "")}`;
+      const adminPool = new pg.Pool({
+        host: pgHost,
+        port: pgPort,
+        user: "test",
+        password: "test",
+        database: "postgres",
+        max: ADMIN_POOL_MAX_CONNECTIONS,
+      });
+      yield* createDatabaseFromTemplate(adminPool, dbName);
+
+      // 3. Pre-allocate a free port
+      const port = yield* Effect.tryPromise({
+        try: () => findFreePort(),
+        catch: (cause) =>
+          asSpawnedServerError(cause, "Failed to find a free server port"),
+      });
+
+      // 4. Spawn server subprocess
+      const masterSecret = randomBytes(MASTER_SECRET_BYTES).toString("base64");
+      const child = spawn("node", [SERVER_ENTRY], {
+        env: {
+          PATH: readSpawnPath(),
+          NODE_ENV: "production",
+          DATABASE_URL: `postgresql://test:test@${pgHost}:${pgPort}/${dbName}`,
+          ENCRYPTION_MASTER_SECRET: masterSecret,
+          MOLTZAP_DEV_MODE: "true",
+          PORT: String(port),
+          FIREBASE_SERVICE_ACCOUNT_KEY: generateTestFirebaseKey(),
+          VAPID_PUBLIC_KEY:
+            "BHKL-uNCIASscCmYZERbVn--qT9RVp6mt90rIrLwrXSAxuCTSbamzi7JlQulOQ5TTmAzMgYLcsqzEM-zFLSFbdE",
+          VAPID_PRIVATE_KEY: "Z9kV3uuqbO7rr_39L2dFA-FKgVpeLv6gS6W_5_cylMk",
+          VAPID_SUBJECT: "mailto:test@example.com",
+          CLAIM_BASE_URL: `http://localhost:${port}`,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      // Capture stdout + stderr for diagnostics on failure. The server uses
+      // pino, which writes to stdout — surface both streams so failure messages
+      // aren't swallowed.
+      let stdout = "";
+      let stderr = "";
+      child.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      // 5. Wait for server to be ready
+      yield* waitForServerReady(child, port, () => ({ stdout, stderr })).pipe(
+        Effect.catchAll((err) =>
+          cleanupSpawnFailure(child, adminPool, dbName).pipe(
+            Effect.zipRight(Effect.fail(err)),
+          ),
+        ),
+      );
+
+      return {
+        baseUrl: `http://localhost:${port}`,
+        wsUrl: `ws://localhost:${port}/ws`,
+        dbName,
+        port,
+        process: child,
+        adminPool,
+      };
+    }),
+  );
+}
+
+export function stopSpawnedServer(server: SpawnedServer) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      // Kill the server process
+      if (server.process.exitCode === null) {
+        server.process.kill("SIGTERM");
+        yield* Effect.tryPromise({
+          try: () =>
+            waitForProcessExitOrKill(
+              server.process,
+              GRACEFUL_SHUTDOWN_TIMEOUT_MS,
+            ),
+          catch: (cause) =>
+            new SpawnedServerError("Server process shutdown failed", cause),
+        });
+      }
+
+      // Drop temp database
+      yield* dropDatabase(server.adminPool, server.dbName).pipe(
+        Effect.catchAll(() => Effect.void),
+      );
+      yield* closeAdminPool(server.adminPool);
+    }),
+  );
 }

--- a/packages/openclaw-channel/src/__tests__/stress.integration.test.ts
+++ b/packages/openclaw-channel/src/__tests__/stress.integration.test.ts
@@ -16,6 +16,12 @@ import {
 } from "./test-helpers.js";
 import type { Message } from "@moltzap/protocol";
 
+import {
+  ConversationsCreate,
+  MessagesList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let wsUrl: string;
 
 async function waitForRepliesByList(params: {
@@ -29,7 +35,7 @@ async function waitForRepliesByList(params: {
 
   while (Date.now() < deadline) {
     const result = (await Effect.runPromise(
-      params.client.sendRpc("messages/list", {
+      params.client.sendRpc(MessagesList.name, {
         conversationId: params.conversationId,
         limit: 50,
       }),
@@ -107,19 +113,19 @@ describe.skipIf(inject("containerAId") === "")(
             const [convA, convB, convC] = yield* Effect.all(
               [
                 clientA
-                  .sendRpc("conversations/create", {
+                  .sendRpc(ConversationsCreate.name, {
                     type: "dm",
                     participants: [{ type: "agent", id: receiverAgentId }],
                   })
                   .pipe(Effect.map(extractConvId)),
                 clientB
-                  .sendRpc("conversations/create", {
+                  .sendRpc(ConversationsCreate.name, {
                     type: "dm",
                     participants: [{ type: "agent", id: receiverAgentId }],
                   })
                   .pipe(Effect.map(extractConvId)),
                 clientC
-                  .sendRpc("conversations/create", {
+                  .sendRpc(ConversationsCreate.name, {
                     type: "dm",
                     participants: [{ type: "agent", id: receiverAgentId }],
                   })
@@ -130,19 +136,19 @@ describe.skipIf(inject("containerAId") === "")(
 
             const sendEffects = [
               ...Array.from({ length: 4 }, (_, i) =>
-                clientA.sendRpc("messages/send", {
+                clientA.sendRpc(MessagesSend.name, {
                   conversationId: convA,
                   parts: [{ type: "text", text: `A-msg-${i}` }],
                 }),
               ),
               ...Array.from({ length: 3 }, (_, i) =>
-                clientB.sendRpc("messages/send", {
+                clientB.sendRpc(MessagesSend.name, {
                   conversationId: convB,
                   parts: [{ type: "text", text: `B-msg-${i}` }],
                 }),
               ),
               ...Array.from({ length: 3 }, (_, i) =>
-                clientC.sendRpc("messages/send", {
+                clientC.sendRpc(MessagesSend.name, {
                   conversationId: convC,
                   parts: [{ type: "text", text: `C-msg-${i}` }],
                 }),

--- a/packages/openclaw-channel/src/__tests__/test-helpers.ts
+++ b/packages/openclaw-channel/src/__tests__/test-helpers.ts
@@ -8,29 +8,69 @@
 
 import { inject } from "vitest";
 import type { Message } from "@moltzap/protocol";
+import { Data, Effect } from "effect";
 
-export async function registerAndClaim(name: string): Promise<{
+const WAIT_FOR_POLL_INTERVAL_MS = 50;
+
+type RegisteredAgentClaim = {
   apiKey: string;
   agentId: string;
   claimToken: string;
-}> {
+};
+
+class RegisterAndClaimError extends Data.TaggedError("RegisterAndClaimError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+class WaitForTimeoutError extends Error {
+  override readonly name = "WaitForTimeoutError";
+}
+
+export function registerAndClaim(name: string) {
   const baseUrl = inject("baseUrl");
 
-  const res = await fetch(`${baseUrl}/api/v1/auth/register`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name }),
-  });
-  if (!res.ok) {
-    throw new Error(
-      `Register ${name} failed: ${res.status} ${await res.text()}`,
-    );
-  }
-  return (await res.json()) as {
-    agentId: string;
-    apiKey: string;
-    claimToken: string;
-  };
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const res = yield* Effect.tryPromise({
+        try: (signal) =>
+          fetch(`${baseUrl}/api/v1/auth/register`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name }),
+            signal,
+          }),
+        catch: (cause) =>
+          new RegisterAndClaimError({
+            message: `Register ${name} request failed`,
+            cause,
+          }),
+      });
+      if (!res.ok) {
+        const text = yield* Effect.tryPromise({
+          try: () => res.text(),
+          catch: (cause) =>
+            new RegisterAndClaimError({
+              message: `Register ${name} error body read failed`,
+              cause,
+            }),
+        });
+        return yield* Effect.fail(
+          new RegisterAndClaimError({
+            message: `Register ${name} failed: ${res.status} ${text}`,
+          }),
+        );
+      }
+      return yield* Effect.tryPromise({
+        try: () => res.json() as PromiseLike<RegisteredAgentClaim>,
+        catch: (cause) =>
+          new RegisterAndClaimError({
+            message: `Register ${name} response decode failed`,
+            cause,
+          }),
+      });
+    }),
+  );
 }
 
 export function extractMessage(event: { data: unknown }): Message {
@@ -46,19 +86,16 @@ export function extractText(message: Message): string {
   return part && "text" in part ? part.text : "";
 }
 
-export function waitFor(
-  predicate: () => boolean,
-  timeoutMs: number,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
+export function waitFor(predicate: () => boolean, timeoutMs: number) {
+  return new Promise<void>((resolve, reject) => {
     const start = Date.now();
     const check = () => {
       if (predicate()) {
         resolve();
       } else if (Date.now() - start > timeoutMs) {
-        reject(new Error("waitFor timeout"));
+        reject(new WaitForTimeoutError("waitFor timeout"));
       } else {
-        setTimeout(check, 50);
+        setTimeout(check, WAIT_FOR_POLL_INTERVAL_MS);
       }
     };
     check();

--- a/packages/openclaw-channel/src/context-log.ts
+++ b/packages/openclaw-channel/src/context-log.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { Config, ConfigProvider, Effect, Option } from "effect";
 import type { CrossConvMessage } from "@moltzap/client";
 
 export interface OpenClawContextLogEntry {
@@ -43,11 +44,22 @@ function sanitizePathPart(value: string): string {
   return sanitized.length > 0 ? sanitized : "unknown";
 }
 
+const OpenClawStateDir = Config.option(Config.string("OPENCLAW_STATE_DIR"));
+
+const getOpenClawStateDir = (): string | undefined =>
+  Option.getOrUndefined(
+    Effect.runSync(
+      OpenClawStateDir.pipe(
+        Effect.withConfigProvider(ConfigProvider.fromEnv()),
+      ),
+    ),
+  );
+
 export function contextLogPath(
   logDir: string,
   accountAgentName: string | undefined,
 ): string {
-  const stateDir = process.env["OPENCLAW_STATE_DIR"];
+  const stateDir = getOpenClawStateDir();
   const stateName = stateDir ? path.basename(stateDir) : `pid-${process.pid}`;
   const agentName = accountAgentName ?? "agent";
   return path.join(
@@ -58,15 +70,14 @@ export function contextLogPath(
 
 export function writeOpenClawContextLog(input: OpenClawContextLogInput): void {
   if (!input.logDir) return;
+  const stateDir = getOpenClawStateDir();
 
   const entry: OpenClawContextLogEntry = {
     schemaVersion: 1,
     recordedAt: new Date().toISOString(),
     pid: process.pid,
     cwd: process.cwd(),
-    ...(process.env["OPENCLAW_STATE_DIR"] !== undefined
-      ? { stateDir: process.env["OPENCLAW_STATE_DIR"] }
-      : {}),
+    ...(stateDir !== undefined ? { stateDir } : {}),
     accountId: input.accountId,
     ...(input.accountAgentName !== undefined
       ? { accountAgentName: input.accountAgentName }

--- a/packages/openclaw-channel/src/format-cross-conv.ts
+++ b/packages/openclaw-channel/src/format-cross-conv.ts
@@ -10,6 +10,7 @@ import type { CrossConvMessage } from "@moltzap/client";
 export type { CrossConvMessage };
 
 export const CROSS_CONV_HEADER = "Messages (untrusted metadata):";
+const JSON_INDENT_SPACES = 2;
 
 export function formatCrossConvOpenClaw(
   messages: CrossConvMessage[],
@@ -24,5 +25,5 @@ export function formatCrossConvOpenClaw(
     timestamp: m.timestamp,
   }));
 
-  return `${CROSS_CONV_HEADER}\n\`\`\`json\n${JSON.stringify(items, null, 2)}\n\`\`\``;
+  return `${CROSS_CONV_HEADER}\n\`\`\`json\n${JSON.stringify(items, null, JSON_INDENT_SPACES)}\n\`\`\``;
 }

--- a/packages/openclaw-channel/src/openclaw-entry.delivery.test.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.delivery.test.ts
@@ -54,6 +54,12 @@ vi.mock("@moltzap/client", async () => {
 
 import { moltzapChannelPlugin } from "./openclaw-entry.js";
 
+import {
+  AgentsLookup,
+  ConversationsGet,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 function makeMessage(overrides: Partial<Message> = {}): Message {
   return {
     id: "msg-300",
@@ -102,12 +108,12 @@ describe("Flow 6: Outbound delivery — deliver callback + sendText", () => {
     mockSendToAgent.mockReturnValue(Effect.void);
 
     mockSendRpc.mockImplementation((method: string) => {
-      if (method === "agents/lookup") {
+      if (method === AgentsLookup.name) {
         return Effect.succeed({
           agents: [{ id: "agent-sender-1", name: "Atlas" }],
         });
       }
-      if (method === "conversations/get") {
+      if (method === ConversationsGet.name) {
         return Effect.succeed({
           conversation: { type: "dm" },
           participants: [
@@ -116,7 +122,7 @@ describe("Flow 6: Outbound delivery — deliver callback + sendText", () => {
           ],
         });
       }
-      if (method === "messages/send") {
+      if (method === MessagesSend.name) {
         return Effect.succeed({ message: { id: "sent-1" } });
       }
       return Effect.succeed({});

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -18,7 +18,7 @@ import {
   MoltZapService,
   type WsClientLogger,
 } from "@moltzap/client";
-import { Effect } from "effect";
+import { Config, ConfigProvider, Data, Effect, Option } from "effect";
 import { formatCrossConvOpenClaw } from "./format-cross-conv.js";
 import { writeOpenClawContextLog } from "./context-log.js";
 import {
@@ -31,15 +31,48 @@ import {
 } from "./mapping.js";
 import { EventNames } from "@moltzap/protocol";
 
+import {
+  AgentsLookup,
+  ContactsList,
+  ConversationsList,
+} from "@moltzap/protocol";
+
 const DEFAULT_ACCOUNT_ID = "default";
 const CHANNEL_ID = "moltzap" as const;
 const TARGET_PREFIX_AGENT = "agent:";
 const TARGET_PREFIX_CONV = "conv:";
+const OPENCLAW_STRUCTURED_LOG_MIN_ARGS = 2;
+const INBOUND_LOG_PREVIEW_CHARS = 80;
+const BODY_FOR_AGENT_LOG_PREVIEW_CHARS = 500;
+const OUTBOUND_LOG_PREVIEW_CHARS = 80;
 
 const MOLTZAP_TARGET_RE = /^(agent|conv):.+$/;
+const OpenClawContextLogDir = Config.option(
+  Config.string("MOLTZAP_OPENCLAW_CONTEXT_LOG_DIR"),
+);
 
 function isMoltZapTarget(raw: string): boolean {
   return MOLTZAP_TARGET_RE.test(raw);
+}
+
+function readOpenClawContextLogDir(): string | undefined {
+  return Option.getOrUndefined(
+    Effect.runSync(
+      OpenClawContextLogDir.pipe(
+        Effect.withConfigProvider(ConfigProvider.fromEnv()),
+      ),
+    ),
+  );
+}
+
+class MoltZapClientNotConnectedError extends Data.TaggedError(
+  "MoltZapClientNotConnectedError",
+)<{
+  readonly accountId: string;
+}> {
+  override get message(): string {
+    return `MoltZap client not connected for account ${this.accountId}`;
+  }
 }
 
 function adaptOpenClawLogger(
@@ -48,7 +81,7 @@ function adaptOpenClawLogger(
   return (...args: unknown[]) => {
     if (!logMethod) return;
     if (
-      args.length >= 2 &&
+      args.length >= OPENCLAW_STRUCTURED_LOG_MIN_ARGS &&
       typeof args[0] === "object" &&
       args[0] !== null &&
       typeof args[1] === "string"
@@ -74,6 +107,43 @@ type OpenClawConfig = Record<string, unknown> & {
       accounts?: MoltZapAccount[];
     };
   };
+};
+
+type OpenClawLogger = {
+  info?: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  error?: (...args: unknown[]) => void;
+  debug?: (...args: unknown[]) => void;
+};
+
+type OpenClawDeliver = (
+  payload: { text?: string; body?: string },
+  info?: { kind?: string },
+) => PromiseLike<boolean>;
+
+type OpenClawReplyDispatcher = (params: {
+  ctx: Record<string, string | undefined>;
+  cfg: OpenClawConfig;
+  dispatcherOptions: { deliver: OpenClawDeliver };
+}) => PromiseLike<{ queuedFinal: boolean }>;
+
+type OpenClawStartAccountContext = {
+  cfg: OpenClawConfig;
+  accountId: string;
+  account: MoltZapAccount;
+  abortSignal: AbortSignal;
+  log?: OpenClawLogger;
+  setStatus: (next: Record<string, unknown>) => void;
+  channelRuntime?: {
+    reply?: {
+      dispatchReplyWithBufferedBlockDispatcher?: OpenClawReplyDispatcher;
+    };
+  };
+};
+
+type OpenClawStopAccountContext = {
+  accountId: string;
+  log?: Pick<OpenClawLogger, "info">;
 };
 
 function resolveAccountList(cfg: OpenClawConfig): MoltZapAccount[] {
@@ -114,6 +184,7 @@ const waitForAbort = (signal: AbortSignal): Effect.Effect<void> =>
  * this closure. `register(api)` calls this so each registration gets its own
  * per-plugin state, eliminating module-level mutable globals.
  */
+// eslint-disable-next-line agent-code-guard/manual-result -- OpenClaw plugin factory returns the channel object shape, not a reusable Result/Either algebra.
 export function createMoltzapChannelPlugin() {
   const activeClients = new Map<string, MoltZapService>();
 
@@ -180,7 +251,7 @@ export function createMoltzapChannelPlugin() {
           );
           if (!service) return [];
           const { contacts } = (yield* service.sendRpc(
-            "contacts/list",
+            ContactsList.name,
             {},
           )) as {
             contacts: Array<{
@@ -192,7 +263,7 @@ export function createMoltzapChannelPlugin() {
             (c.agents ?? []).map((a) => a.id),
           );
           if (agentIds.length === 0) return [];
-          const { agents } = (yield* service.sendRpc("agents/lookup", {
+          const { agents } = (yield* service.sendRpc(AgentsLookup.name, {
             agentIds,
           })) as {
             agents: Array<{ id: string; name: string; displayName?: string }>;
@@ -217,7 +288,7 @@ export function createMoltzapChannelPlugin() {
           );
           if (!service) return [];
           const { conversations } = (yield* service.sendRpc(
-            "conversations/list",
+            ConversationsList.name,
             {},
           )) as {
             conversations: Array<{ id: string; type: string; name?: string }>;
@@ -263,34 +334,9 @@ export function createMoltzapChannelPlugin() {
     },
 
     gateway: {
-      startAccount(ctx: {
-        cfg: OpenClawConfig;
-        accountId: string;
-        account: MoltZapAccount;
-        abortSignal: AbortSignal;
-        log?: {
-          info?: (...args: unknown[]) => void;
-          warn?: (...args: unknown[]) => void;
-          error?: (...args: unknown[]) => void;
-          debug?: (...args: unknown[]) => void;
-        };
-        setStatus: (next: Record<string, unknown>) => void;
-        channelRuntime?: {
-          reply?: {
-            dispatchReplyWithBufferedBlockDispatcher?: (params: {
-              ctx: Record<string, string | undefined>;
-              cfg: OpenClawConfig;
-              dispatcherOptions: {
-                deliver: (
-                  payload: { text?: string; body?: string },
-                  info?: { kind?: string },
-                ) => Promise<boolean>;
-              };
-            }) => Promise<{ queuedFinal: boolean }>;
-          };
-        };
-      }) {
+      startAccount(ctx: OpenClawStartAccountContext) {
         const { accountId, account, abortSignal, log, setStatus } = ctx;
+        const contextLogDir = readOpenClawContextLogDir();
 
         if (!account.apiKey || !account.serverUrl) {
           log?.error?.("MoltZap: missing apiKey or serverUrl");
@@ -324,7 +370,7 @@ export function createMoltzapChannelPlugin() {
             const fromId = `agent:${enriched.sender.id}`;
 
             log?.info?.(
-              `MoltZap: inbound from ${fromId}: ${enriched.text.slice(0, 80)}`,
+              `MoltZap: inbound from ${fromId}: ${enriched.text.slice(0, INBOUND_LOG_PREVIEW_CHARS)}`,
             );
 
             setStatus({
@@ -345,7 +391,7 @@ export function createMoltzapChannelPlugin() {
 
             try {
               writeOpenClawContextLog({
-                logDir: process.env["MOLTZAP_OPENCLAW_CONTEXT_LOG_DIR"],
+                logDir: contextLogDir,
                 accountId,
                 accountAgentName: account.agentName,
                 ownAgentId: service.ownAgentId,
@@ -366,7 +412,7 @@ export function createMoltzapChannelPlugin() {
 
             if (crossConvBlock) {
               log?.info?.(
-                `MoltZap: BodyForAgent has cross-conv context (${crossConversationMessages.length} msgs) for ${enriched.conversationId}: ${bodyForAgent.slice(0, 500)}`,
+                `MoltZap: BodyForAgent has cross-conv context (${crossConversationMessages.length} msgs) for ${enriched.conversationId}: ${bodyForAgent.slice(0, BODY_FOR_AGENT_LOG_PREVIEW_CHARS)}`,
               );
             }
 
@@ -431,7 +477,7 @@ export function createMoltzapChannelPlugin() {
                           Effect.tap(() =>
                             Effect.sync(() =>
                               log?.info?.(
-                                `MoltZap: outbound reply to ${enriched.conversationId}: ${text.slice(0, 80)}`,
+                                `MoltZap: outbound reply to ${enriched.conversationId}: ${text.slice(0, OUTBOUND_LOG_PREVIEW_CHARS)}`,
                               ),
                             ),
                           ),
@@ -600,10 +646,7 @@ export function createMoltzapChannelPlugin() {
         );
       },
 
-      stopAccount(ctx: {
-        accountId: string;
-        log?: { info?: (...args: unknown[]) => void };
-      }) {
+      stopAccount(ctx: OpenClawStopAccountContext) {
         const service = activeClients.get(ctx.accountId);
         if (service) {
           ctx.log?.info?.("MoltZap: stopping");
@@ -653,7 +696,7 @@ export function createMoltzapChannelPlugin() {
           const service = activeClients.get(accountId);
           if (!service) {
             return yield* Effect.fail(
-              new Error("MoltZap client not connected"),
+              new MoltZapClientNotConnectedError({ accountId }),
             );
           }
           if (ctx.to.startsWith(TARGET_PREFIX_AGENT)) {

--- a/packages/openclaw-channel/src/test-utils/container-core.ts
+++ b/packages/openclaw-channel/src/test-utils/container-core.ts
@@ -9,8 +9,23 @@ import path from "node:path";
 import os from "node:os";
 
 const CONTROL_UI_PORT = 18789;
+const OPENCLAW_TOKEN_RADIX = 36;
+const DEFAULT_PORT_RANGE_START = 19000;
+const DEFAULT_PORT_RANGE_END = 19999;
+const JSON_INDENT_SPACES = 2;
+const MS_PER_SECOND = 1000;
+const DEFAULT_GATEWAY_TIMEOUT_MS = 30_000;
+const DEFAULT_CHANNEL_TIMEOUT_MS = 180_000;
+const DEFAULT_READY_TIMEOUT_MS = 180_000;
+const GATEWAY_READY_PATTERN = "[gateway]";
+const CHANNEL_READY_PATTERNS = ["[moltzap]", "connected as"] as const;
+
 export const IMAGE_NAME = "moltzap-eval-agent:local";
 export const OPENCLAW_STATE_DIR = "/home/node/.openclaw";
+
+class OpenClawContainerError extends Error {
+  override readonly name = "OpenClawContainerError";
+}
 
 export type ContainerModelConfig = {
   modelString: string;
@@ -33,7 +48,8 @@ export function isImageAvailable(): boolean {
   try {
     execSync(`docker image inspect ${IMAGE_NAME}`, { stdio: "pipe" });
     return true;
-  } catch {
+  } catch (cause) {
+    void cause;
     return false;
   }
 }
@@ -87,7 +103,10 @@ export function buildOpenClawConfig(opts: {
         dangerouslyAllowHostHeaderOriginFallback: true,
         dangerouslyDisableDeviceAuth: true,
       },
-      auth: { mode: "token", token: `e2e-${Date.now().toString(36)}` },
+      auth: {
+        mode: "token",
+        token: `e2e-${Date.now().toString(OPENCLAW_TOKEN_RADIX)}`,
+      },
     },
     meta: {
       lastTouchedVersion: "2026.3.14",
@@ -123,12 +142,15 @@ export function startRawContainer(
   },
 ): OpenClawContainer {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-e2e-"));
-  const [lo, hi] = opts.portRange ?? [19000, 19999];
+  const [lo, hi] = opts.portRange ?? [
+    DEFAULT_PORT_RANGE_START,
+    DEFAULT_PORT_RANGE_END,
+  ];
   const controlPort = lo + Math.floor(Math.random() * (hi - lo));
 
   fs.writeFileSync(
     path.join(tmpDir, "openclaw.json"),
-    JSON.stringify(config, null, 2),
+    JSON.stringify(config, null, JSON_INDENT_SPACES),
   );
   for (const sub of ["workspace", "logs"]) {
     fs.mkdirSync(path.join(tmpDir, sub), { recursive: true });
@@ -140,7 +162,7 @@ export function startRawContainer(
   );
 
   const containerName = `moltzap-e2e-${opts.name}-${Date.now()}`;
-  const startedEpoch = Math.floor(Date.now() / 1000);
+  const startedEpoch = Math.floor(Date.now() / MS_PER_SECOND);
   const envParts = [`-e OPENCLAW_STATE_DIR=${OPENCLAW_STATE_DIR}`];
   if (opts.envVars) {
     for (const [k, v] of Object.entries(opts.envVars)) {
@@ -180,7 +202,8 @@ export function getLogs(containerId: string): string {
     return execSync(`docker logs ${containerId} 2>&1`, {
       encoding: "utf-8",
     });
-  } catch {
+  } catch (cause) {
+    void cause;
     return "";
   }
 }
@@ -190,7 +213,7 @@ export function waitForLogMatch(
   containerId: string,
   patterns: string | string[],
   timeoutMs: number,
-): Promise<void> {
+) {
   const required = Array.isArray(patterns) ? patterns : [patterns];
 
   return new Promise<void>((resolve, reject) => {
@@ -202,7 +225,7 @@ export function waitForLogMatch(
       ).trim();
       if (status !== "running") {
         reject(
-          new Error(
+          new OpenClawContainerError(
             `Container not running (status: ${status}) before log stream.\nLogs:\n${getLogs(containerId)}`,
           ),
         );
@@ -210,7 +233,7 @@ export function waitForLogMatch(
       }
     } catch (err) {
       reject(
-        new Error(
+        new OpenClawContainerError(
           `Failed to inspect container ${containerId}: ${err instanceof Error ? err.message : err}`,
         ),
       );
@@ -235,7 +258,7 @@ export function waitForLogMatch(
     const timer = setTimeout(() => {
       const missing = required.filter((p) => !matched.has(p));
       finish(
-        new Error(
+        new OpenClawContainerError(
           `waitForLogMatch timed out after ${timeoutMs}ms.\n` +
             `Matched: [${[...matched].join(", ")}]\n` +
             `Missing: [${missing.join(", ")}]\n` +
@@ -267,7 +290,7 @@ export function waitForLogMatch(
 
     proc.on("error", (err) => {
       finish(
-        new Error(
+        new OpenClawContainerError(
           `docker logs process error: ${err.message}\nLogs:\n${getLogs(containerId)}`,
         ),
       );
@@ -287,7 +310,7 @@ export function waitForLogMatch(
         }
         const missing = required.filter((p) => !matched.has(p));
         finish(
-          new Error(
+          new OpenClawContainerError(
             `docker logs exited (code ${code}) before all patterns matched.\n` +
               `Matched: [${[...matched].join(", ")}]\n` +
               `Missing: [${missing.join(", ")}]\n` +
@@ -300,27 +323,27 @@ export function waitForLogMatch(
 }
 
 /** Wait for the OpenClaw gateway process to start. */
-export async function waitForGateway(
+export function waitForGateway(
   containerId: string,
-  timeoutMs = 30_000,
-): Promise<void> {
-  await waitForLogMatch(containerId, "[gateway]", timeoutMs);
+  timeoutMs = DEFAULT_GATEWAY_TIMEOUT_MS,
+) {
+  return waitForLogMatch(containerId, GATEWAY_READY_PATTERN, timeoutMs);
 }
 
 /** Wait for the MoltZap channel to connect within the container. */
-export async function waitForChannel(
+export function waitForChannel(
   containerId: string,
-  timeoutMs = 180_000,
-): Promise<void> {
-  await waitForLogMatch(containerId, ["[moltzap]", "connected as"], timeoutMs);
+  timeoutMs = DEFAULT_CHANNEL_TIMEOUT_MS,
+) {
+  return waitForLogMatch(containerId, [...CHANNEL_READY_PATTERNS], timeoutMs);
 }
 
 /** Wait for both gateway and channel to be ready (single log stream). */
-export async function waitForReady(containerId: string): Promise<void> {
-  await waitForLogMatch(
+export function waitForReady(containerId: string) {
+  return waitForLogMatch(
     containerId,
-    ["[gateway]", "[moltzap]", "connected as"],
-    180_000,
+    [GATEWAY_READY_PATTERN, ...CHANNEL_READY_PATTERNS],
+    DEFAULT_READY_TIMEOUT_MS,
   );
 }
 
@@ -328,12 +351,14 @@ export async function waitForReady(containerId: string): Promise<void> {
 export function stopContainer(container: OpenClawContainer): void {
   try {
     execSync(`docker rm -f ${container.containerId}`, { stdio: "pipe" });
-  } catch {
+  } catch (cause) {
+    void cause;
     // best effort
   }
   try {
     fs.rmSync(container.tmpDir, { recursive: true, force: true });
-  } catch {
+  } catch (cause) {
+    void cause;
     // best effort
   }
 }

--- a/packages/protocol/src/schema/frames.test.ts
+++ b/packages/protocol/src/schema/frames.test.ts
@@ -7,6 +7,9 @@ import {
   EventFrameSchema,
 } from "./frames.js";
 
+import { AppsOnJoin } from "./methods/apps.js";
+import { MessagesSend } from "./methods/messages.js";
+
 const ajv = addFormats(new Ajv({ strict: true }));
 
 describe("RequestFrameSchema", () => {
@@ -19,7 +22,7 @@ describe("RequestFrameSchema", () => {
         type: "request",
         direction: "c2s",
         id: "req-1",
-        method: "messages/send",
+        method: MessagesSend.name,
         params: { text: "hello" },
       }),
     ).toBe(true);
@@ -32,7 +35,7 @@ describe("RequestFrameSchema", () => {
         type: "request",
         direction: "s2c",
         id: "srv-1",
-        method: "apps/onJoin",
+        method: AppsOnJoin.name,
         params: { sessionId: "s-1" },
       }),
     ).toBe(true);
@@ -44,7 +47,7 @@ describe("RequestFrameSchema", () => {
         jsonrpc: "2.0",
         type: "request",
         id: "req-1",
-        method: "messages/send",
+        method: MessagesSend.name,
         params: { text: "hello" },
       }),
     ).toBe(false);
@@ -57,7 +60,7 @@ describe("RequestFrameSchema", () => {
         type: "request",
         direction: "broadcast",
         id: "req-1",
-        method: "messages/send",
+        method: MessagesSend.name,
       }),
     ).toBe(false);
   });

--- a/packages/protocol/src/test-fixtures/seed-data.ts
+++ b/packages/protocol/src/test-fixtures/seed-data.ts
@@ -53,6 +53,23 @@ export const SEED_USERS = [
   },
 ] as const;
 
+const SEED_AGENT_INDEX = {
+  YOU: 0,
+  LISA: 1,
+  MIKE: 2,
+  SARAH: 3,
+  RAJ: 4,
+  MAYA: 5,
+  JAMES: 6,
+  PRIYA: 8,
+} as const;
+
+const SKI_TRIP_OVERVIEW_PANEL_ID = "overview-panel";
+const SKI_TRIP_ITINERARY_PANEL_ID = "itinerary-panel";
+const SKI_TRIP_COSTS_PANEL_ID = "costs-panel";
+const SKI_TRIP_PACKING_PANEL_ID = "packing-panel";
+const SKI_TRIP_ACTIVE_TAB_STATE = "/activeTab";
+
 export const SEED_AGENTS = [
   {
     id: "00000000-0000-0000-0001-000000000001",
@@ -115,7 +132,11 @@ export const SEED_CONVERSATIONS = [
     id: "00000000-0000-0000-0002-000000000001",
     type: "group" as const,
     name: "Weekend Ski Trip",
-    agentIndices: [0, 1, 2],
+    agentIndices: [
+      SEED_AGENT_INDEX.YOU,
+      SEED_AGENT_INDEX.LISA,
+      SEED_AGENT_INDEX.MIKE,
+    ],
     lastPreview:
       "Lisa's agent: I found a great cabin near Palisades for $340/pp",
   },
@@ -123,49 +144,61 @@ export const SEED_CONVERSATIONS = [
     id: "00000000-0000-0000-0002-000000000002",
     type: "group" as const,
     name: "Dinner Club - March",
-    agentIndices: [0, 3, 5],
+    agentIndices: [
+      SEED_AGENT_INDEX.YOU,
+      SEED_AGENT_INDEX.SARAH,
+      SEED_AGENT_INDEX.MAYA,
+    ],
     lastPreview: "Maya's agent: Thai cuisine is leading the vote 4-2",
   },
   {
     id: "00000000-0000-0000-0002-000000000003",
     type: "dm" as const,
     name: undefined,
-    agentIndices: [0, 1],
+    agentIndices: [SEED_AGENT_INDEX.YOU, SEED_AGENT_INDEX.LISA],
     lastPreview: "Your agent handled the scheduling conflict",
   },
   {
     id: "00000000-0000-0000-0002-000000000004",
     type: "group" as const,
     name: "Sprint 47 Standup",
-    agentIndices: [0, 5],
+    agentIndices: [SEED_AGENT_INDEX.YOU, SEED_AGENT_INDEX.MAYA],
     lastPreview: "Maya's agent: 3 tickets done, 1 blocker on API migration",
   },
   {
     id: "00000000-0000-0000-0002-000000000005",
     type: "dm" as const,
     name: undefined,
-    agentIndices: [0, 2],
+    agentIndices: [SEED_AGENT_INDEX.YOU, SEED_AGENT_INDEX.MIKE],
     lastPreview: "Apartment alert: 3 new listings in Hayes Valley",
   },
   {
     id: "00000000-0000-0000-0002-000000000006",
     type: "group" as const,
     name: "Saturday Soccer",
-    agentIndices: [0, 3, 4],
+    agentIndices: [
+      SEED_AGENT_INDEX.YOU,
+      SEED_AGENT_INDEX.SARAH,
+      SEED_AGENT_INDEX.RAJ,
+    ],
     lastPreview: "Raj's agent: 8/11 confirmed, need your RSVP",
   },
   {
     id: "00000000-0000-0000-0002-000000000007",
     type: "group" as const,
     name: "Book Club",
-    agentIndices: [0, 3, 5],
+    agentIndices: [
+      SEED_AGENT_INDEX.YOU,
+      SEED_AGENT_INDEX.SARAH,
+      SEED_AGENT_INDEX.MAYA,
+    ],
     lastPreview: "Klara is leading the discussion on March 4th",
   },
   {
     id: "00000000-0000-0000-0002-000000000008",
     type: "dm" as const,
     name: undefined,
-    agentIndices: [0, 1],
+    agentIndices: [SEED_AGENT_INDEX.YOU, SEED_AGENT_INDEX.LISA],
     lastPreview: "Insurance quote ready for review - save $340/yr",
   },
 ] as const;
@@ -371,16 +404,16 @@ export const SEED_SURFACES = [
           type: "Tabs",
           props: {
             items: ["Overview", "Itinerary", "Costs", "Packing"],
-            value: { $state: "/activeTab" },
+            value: { $state: SKI_TRIP_ACTIVE_TAB_STATE },
           },
           children: [
-            "overview-panel",
-            "itinerary-panel",
-            "costs-panel",
-            "packing-panel",
+            SKI_TRIP_OVERVIEW_PANEL_ID,
+            SKI_TRIP_ITINERARY_PANEL_ID,
+            SKI_TRIP_COSTS_PANEL_ID,
+            SKI_TRIP_PACKING_PANEL_ID,
           ],
         },
-        "overview-panel": {
+        [SKI_TRIP_OVERVIEW_PANEL_ID]: {
           type: "Stack",
           props: { direction: "vertical", gap: 16 },
           children: [
@@ -389,13 +422,13 @@ export const SEED_SURFACES = [
             "people-section",
             "progress-card",
           ],
-          visible: { $state: "/activeTab", eq: "overview" },
+          visible: { $state: SKI_TRIP_ACTIVE_TAB_STATE, eq: "overview" },
         },
-        "itinerary-panel": {
+        [SKI_TRIP_ITINERARY_PANEL_ID]: {
           type: "Stack",
           props: { direction: "vertical", gap: 12 },
           children: ["itinerary-content"],
-          visible: { $state: "/activeTab", eq: "itinerary" },
+          visible: { $state: SKI_TRIP_ACTIVE_TAB_STATE, eq: "itinerary" },
         },
         "itinerary-content": {
           type: "Card",
@@ -410,11 +443,11 @@ export const SEED_SURFACES = [
           },
           children: [],
         },
-        "costs-panel": {
+        [SKI_TRIP_COSTS_PANEL_ID]: {
           type: "Stack",
           props: { direction: "vertical", gap: 12 },
           children: ["costs-content"],
-          visible: { $state: "/activeTab", eq: "costs" },
+          visible: { $state: SKI_TRIP_ACTIVE_TAB_STATE, eq: "costs" },
         },
         "costs-content": {
           type: "StatCard",
@@ -426,11 +459,11 @@ export const SEED_SURFACES = [
           },
           children: [],
         },
-        "packing-panel": {
+        [SKI_TRIP_PACKING_PANEL_ID]: {
           type: "Stack",
           props: { direction: "vertical", gap: 12 },
           children: ["packing-content"],
-          visible: { $state: "/activeTab", eq: "packing" },
+          visible: { $state: SKI_TRIP_ACTIVE_TAB_STATE, eq: "packing" },
         },
         "packing-content": {
           type: "Card",

--- a/packages/protocol/src/testing/__tests__/primitives.test.ts
+++ b/packages/protocol/src/testing/__tests__/primitives.test.ts
@@ -31,6 +31,9 @@ import {
   arbitraryAnyCall,
 } from "../arbitraries/index.js";
 
+import { Connect } from "../../schema/methods/auth.js";
+import { ConversationsList } from "../../schema/methods/conversations.js";
+
 describe("codec", () => {
   it("round-trips a valid request frame", async () => {
     const frame: AnyFrame = {
@@ -38,7 +41,7 @@ describe("codec", () => {
       direction: "c2s",
       jsonrpc: "2.0",
       id: "req-1",
-      method: "auth/connect",
+      method: Connect.name,
       params: { agentKey: "k", agentId: "a" },
     };
     const raw = encodeFrame(frame);
@@ -67,7 +70,7 @@ describe("codec", () => {
       direction: "c2s",
       jsonrpc: "2.0",
       id: "r",
-      method: "auth/connect",
+      method: Connect.name,
       params: {},
     };
     const kinds = [
@@ -144,7 +147,7 @@ describe("reference model", () => {
   });
 
   it("authorizationOutcome denies unknown agent for non-auth methods", () => {
-    const [call] = fc.sample(arbitraryCallFor("conversations/list"), {
+    const [call] = fc.sample(arbitraryCallFor(ConversationsList.name), {
       numRuns: 1,
       seed: 1,
     });

--- a/packages/protocol/src/testing/__tests__/test-client.s2c.test.ts
+++ b/packages/protocol/src/testing/__tests__/test-client.s2c.test.ts
@@ -23,6 +23,12 @@ import { makeTestClient, type TestClient } from "../test-client.js";
 import { RpcResponseError } from "../errors.js";
 import type { RequestFrame, ResponseFrame } from "../../schema/frames.js";
 
+import {
+  AppsOnClose,
+  AppsOnJoin,
+  AppsOnSessionActive,
+} from "../../schema/methods/apps.js";
+
 interface ScriptedServerHandle {
   readonly wsUrl: string;
   /** Push an arbitrary frame to the connected client. */
@@ -189,14 +195,14 @@ describe("TestClient — handleServerRpc", () => {
   it("dispatches an inbound s2c request to the registered handler and writes the response back", async () => {
     await withClient((client, server) =>
       Effect.gen(function* () {
-        yield* client.handleServerRpc("apps/onJoin", (params) =>
+        yield* client.handleServerRpc(AppsOnJoin.name, (params) =>
           Effect.succeed({
             ack: true,
             saw: (params as { sessionId: string }).sessionId,
           }),
         );
         yield* server.send(
-          s2cRequest("srv-1", "apps/onJoin", { sessionId: "S" }),
+          s2cRequest("srv-1", AppsOnJoin.name, { sessionId: "S" }),
         );
         const reply = yield* waitForResponse(server, "srv-1");
         expect(reply.direction).toBe("s2c");
@@ -209,10 +215,10 @@ describe("TestClient — handleServerRpc", () => {
   it("encodes a typed RpcResponseError from the handler as a `response` frame with `error`", async () => {
     await withClient((client, server) =>
       Effect.gen(function* () {
-        yield* client.handleServerRpc("apps/onClose", () =>
+        yield* client.handleServerRpc(AppsOnClose.name, () =>
           Effect.fail(
             new RpcResponseError({
-              method: "apps/onClose",
+              method: AppsOnClose.name,
               requestId: "srv-2",
               code: -32099,
               message: "domain-rejected",
@@ -220,7 +226,7 @@ describe("TestClient — handleServerRpc", () => {
             }),
           ),
         );
-        yield* server.send(s2cRequest("srv-2", "apps/onClose", {}));
+        yield* server.send(s2cRequest("srv-2", AppsOnClose.name, {}));
         const reply = yield* waitForResponse(server, "srv-2");
         expect(reply.error).toBeDefined();
         expect(reply.error?.code).toBe(-32099);
@@ -235,12 +241,12 @@ describe("TestClient — handleServerRpc", () => {
     await withClient((_client, server) =>
       Effect.gen(function* () {
         yield* server.send(
-          s2cRequest("srv-3", "apps/onSessionActive", { foo: 1 }),
+          s2cRequest("srv-3", AppsOnSessionActive.name, { foo: 1 }),
         );
         const reply = yield* waitForResponse(server, "srv-3");
         expect(reply.error).toBeDefined();
         expect(reply.error?.code).toBe(-32601);
-        expect(reply.error?.message).toContain("apps/onSessionActive");
+        expect(reply.error?.message).toContain(AppsOnSessionActive.name);
       }),
     );
   });
@@ -253,13 +259,13 @@ describe("TestClient — handleServerRpc", () => {
         // `MoltZapWsClient.handleServerRpc`, which raises
         // `DuplicateServerRpcHandlerError`. Tests routinely swap handler
         // bodies mid-scenario.
-        yield* client.handleServerRpc("apps/onJoin", () =>
+        yield* client.handleServerRpc(AppsOnJoin.name, () =>
           Effect.succeed({ winner: "first" }),
         );
-        yield* client.handleServerRpc("apps/onJoin", () =>
+        yield* client.handleServerRpc(AppsOnJoin.name, () =>
           Effect.succeed({ winner: "second" }),
         );
-        yield* server.send(s2cRequest("srv-4", "apps/onJoin", {}));
+        yield* server.send(s2cRequest("srv-4", AppsOnJoin.name, {}));
         const reply = yield* waitForResponse(server, "srv-4");
         expect(reply.result).toEqual({ winner: "second" });
       }),
@@ -271,19 +277,19 @@ describe("TestClient — awaitServerRequest", () => {
   it("resolves with the inbound request params and runs the handler in parallel", async () => {
     await withClient((client, server) =>
       Effect.gen(function* () {
-        yield* client.handleServerRpc("apps/onJoin", (params) =>
+        yield* client.handleServerRpc(AppsOnJoin.name, (params) =>
           Effect.succeed({ saw: (params as { sessionId: string }).sessionId }),
         );
         // Set up the awaiter BEFORE sending the request — the awaiter
         // notification fires from `notifyAwaiters` during `handleInbound`,
         // which runs synchronously per inbound frame.
         const awaitFiber = yield* Effect.fork(
-          client.awaitServerRequest("apps/onJoin"),
+          client.awaitServerRequest(AppsOnJoin.name),
         );
         // Tiny yield so the awaiter has a chance to enrol.
         yield* Effect.sleep("10 millis");
         yield* server.send(
-          s2cRequest("srv-5", "apps/onJoin", { sessionId: "Z" }),
+          s2cRequest("srv-5", AppsOnJoin.name, { sessionId: "Z" }),
         );
 
         const observed = yield* awaitFiber;
@@ -299,22 +305,24 @@ describe("TestClient — awaitServerRequest", () => {
   it("predicate selects the FIRST matching request and skips earlier non-matches", async () => {
     await withClient((client, server) =>
       Effect.gen(function* () {
-        yield* client.handleServerRpc("apps/onJoin", () => Effect.succeed({}));
+        yield* client.handleServerRpc(AppsOnJoin.name, () =>
+          Effect.succeed({}),
+        );
         // Predicate matches sessionId === "WANTED".
         const awaitFiber = yield* Effect.fork(
           client.awaitServerRequest(
-            "apps/onJoin",
+            AppsOnJoin.name,
             (p) => (p as { sessionId?: string }).sessionId === "WANTED",
           ),
         );
         yield* Effect.sleep("10 millis");
         // Send a non-matching request first.
         yield* server.send(
-          s2cRequest("srv-skip", "apps/onJoin", { sessionId: "OTHER" }),
+          s2cRequest("srv-skip", AppsOnJoin.name, { sessionId: "OTHER" }),
         );
         // Then the wanted one.
         yield* server.send(
-          s2cRequest("srv-want", "apps/onJoin", { sessionId: "WANTED" }),
+          s2cRequest("srv-want", AppsOnJoin.name, { sessionId: "WANTED" }),
         );
 
         const observed = yield* awaitFiber;
@@ -329,7 +337,7 @@ describe("TestClient — awaitServerRequest", () => {
         // Caller-controlled timeout. No s2c request is ever sent — the
         // awaiter must terminate by the timeout, not hang.
         return yield* Effect.exit(
-          client.awaitServerRequest("apps/onJoin", undefined, 50),
+          client.awaitServerRequest(AppsOnJoin.name, undefined, 50),
         );
       }),
     );
@@ -352,7 +360,7 @@ describe("TestClient — awaitServerRequest", () => {
         // this as the supported pattern: "Effect.timeout at call site,
         // not schema cap."
         return yield* Effect.exit(
-          client.awaitServerRequest("apps/onJoin", undefined, 60_000).pipe(
+          client.awaitServerRequest(AppsOnJoin.name, undefined, 60_000).pipe(
             Effect.timeoutFail({
               duration: "30 millis",
               onTimeout: () => new Error("call-site-timeout"),

--- a/packages/protocol/src/testing/agent-registration.ts
+++ b/packages/protocol/src/testing/agent-registration.ts
@@ -13,6 +13,10 @@
  */
 import { Data, Effect } from "effect";
 
+const UNIQUE_SUFFIX_RADIX = 36;
+const UNIQUE_SUFFIX_START = 2;
+const UNIQUE_SUFFIX_END = 8;
+
 export interface TestAgent {
   readonly agentId: string;
   readonly apiKey: string;
@@ -50,7 +54,7 @@ export function registerTestAgent(opts: {
     opts.uniqueSuffix === false
       ? ""
       : (opts.uniqueSuffix ??
-        `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`);
+        `${Date.now().toString(UNIQUE_SUFFIX_RADIX)}-${Math.random().toString(UNIQUE_SUFFIX_RADIX).slice(UNIQUE_SUFFIX_START, UNIQUE_SUFFIX_END)}`);
   const name = suffix === "" ? opts.name : `${opts.name}-${suffix}`;
   const requestBody: Record<string, string> = { name };
   if (opts.description !== undefined) {

--- a/packages/protocol/src/testing/arbitraries/frames.ts
+++ b/packages/protocol/src/testing/arbitraries/frames.ts
@@ -17,6 +17,8 @@ import {
 import type { MalformedFrameKind, AnyFrame } from "../codec.js";
 import { arbitraryFromSchema } from "./from-typebox.js";
 
+const FRAME_SEED_MAX = 2_147_483_647;
+
 const malformedKinds = [
   "bit-flip",
   "truncated",
@@ -57,6 +59,6 @@ export function arbitraryMalformedFrame(): fc.Arbitrary<ArbitraryMalformedFrame>
   return fc.record({
     base: baseArb,
     kind: fc.constantFrom(...malformedKinds),
-    seed: fc.integer({ min: 1, max: 2 ** 31 - 1 }),
+    seed: fc.integer({ min: 1, max: FRAME_SEED_MAX }),
   });
 }

--- a/packages/protocol/src/testing/arbitraries/from-typebox.ts
+++ b/packages/protocol/src/testing/arbitraries/from-typebox.ts
@@ -19,6 +19,14 @@ import type { TSchema, Static } from "@sinclair/typebox";
 import { Kind, OptionalKind } from "@sinclair/typebox";
 import * as fc from "fast-check";
 
+const DEFAULT_ARRAY_MAX_LENGTH = 5;
+const DEFAULT_NUMERIC_MIN = -1000;
+const DEFAULT_NUMERIC_MAX = 1000;
+const DEFAULT_JSON_MAX_DEPTH = 2;
+const DEFAULT_DATE_MIN_YEAR = 2000;
+const DEFAULT_DATE_MAX_YEAR = 2100;
+const DEFAULT_STRING_MAX_LENGTH = 16;
+
 type TBNode = TSchema & {
   readonly type?: string;
   readonly [Kind]?: string;
@@ -91,19 +99,21 @@ function walk(node: TBNode): fc.Arbitrary<unknown> {
       return objectArbitrary(node);
     case "array":
       return node.items
-        ? fc.array(walk(node.items as TBNode), { maxLength: 5 })
-        : fc.array(fc.anything(), { maxLength: 5 });
+        ? fc.array(walk(node.items as TBNode), {
+            maxLength: DEFAULT_ARRAY_MAX_LENGTH,
+          })
+        : fc.array(fc.anything(), { maxLength: DEFAULT_ARRAY_MAX_LENGTH });
     case "string":
       return stringArbitrary(node);
     case "integer":
       return fc.integer({
-        min: node.minimum ?? -1000,
-        max: node.maximum ?? 1000,
+        min: node.minimum ?? DEFAULT_NUMERIC_MIN,
+        max: node.maximum ?? DEFAULT_NUMERIC_MAX,
       });
     case "number":
       return fc.double({
-        min: node.minimum ?? -1000,
-        max: node.maximum ?? 1000,
+        min: node.minimum ?? DEFAULT_NUMERIC_MIN,
+        max: node.maximum ?? DEFAULT_NUMERIC_MAX,
         noNaN: true,
       });
     case "boolean":
@@ -113,7 +123,7 @@ function walk(node: TBNode): fc.Arbitrary<unknown> {
     default:
       // Unknown / Any / missing type → a biased "small JSON value" tree so
       // schema-permitted payloads stay small.
-      return fc.jsonValue({ maxDepth: 2 });
+      return fc.jsonValue({ maxDepth: DEFAULT_JSON_MAX_DEPTH });
   }
 }
 
@@ -122,13 +132,13 @@ function stringArbitrary(node: TBNode): fc.Arbitrary<string> {
     return fc.uuid();
   }
   if (node.format === "date-time") {
-    const min = Date.UTC(2000, 0, 1);
-    const max = Date.UTC(2100, 0, 1);
+    const min = Date.UTC(DEFAULT_DATE_MIN_YEAR, 0, 1);
+    const max = Date.UTC(DEFAULT_DATE_MAX_YEAR, 0, 1);
     return fc.integer({ min, max }).map((ms) => new Date(ms).toISOString());
   }
   return fc.string({
     minLength: node.minLength ?? 0,
-    maxLength: node.maxLength ?? 16,
+    maxLength: node.maxLength ?? DEFAULT_STRING_MAX_LENGTH,
   });
 }
 

--- a/packages/protocol/src/testing/arbitraries/rpc.ts
+++ b/packages/protocol/src/testing/arbitraries/rpc.ts
@@ -6,6 +6,7 @@
  * property bodies compiler-checked against `RpcMap`.
  */
 import * as fc from "fast-check";
+import { Data } from "effect";
 import {
   rpcMethods,
   type RpcMap,
@@ -14,6 +15,12 @@ import {
 import { applyCall } from "../models/dispatch.js";
 import { initialReferenceState } from "../models/state.js";
 import { arbitraryForParams } from "./from-typebox.js";
+
+class RpcArbitraryInvariantError extends Data.TaggedError(
+  "RpcArbitraryInvariantError",
+)<{
+  readonly message: string;
+}> {}
 
 /**
  * A single drawn RPC invocation: the method name carries through to the
@@ -42,7 +49,9 @@ export function arbitraryCallFor<M extends RpcMethodName>(
 ): fc.Arbitrary<ArbitraryRpcCall<M>> {
   const def = methodByName.get(method);
   if (def === undefined) {
-    throw new Error(`arbitraryCallFor: unknown method ${String(method)}`);
+    throw new RpcArbitraryInvariantError({
+      message: `arbitraryCallFor: unknown method ${String(method)}`,
+    });
   }
   return arbitraryForParams(def.paramsSchema).map(
     (params) =>
@@ -59,7 +68,9 @@ export function arbitraryCallFor<M extends RpcMethodName>(
  */
 export function arbitraryAnyCall(): fc.Arbitrary<ArbitraryRpcCall> {
   if (allRpcMethods.length === 0) {
-    throw new Error("arbitraryAnyCall: rpcMethods empty");
+    throw new RpcArbitraryInvariantError({
+      message: "arbitraryAnyCall: rpcMethods empty",
+    });
   }
   return fc.constantFrom(...allRpcMethods).chain((m) => arbitraryCallFor(m));
 }
@@ -113,9 +124,10 @@ export const confidentOracleMethods: ReadonlyArray<RpcMethodName> = (() => {
  */
 export function arbitraryConfidentCall(): fc.Arbitrary<ArbitraryRpcCall> {
   if (confidentOracleMethods.length === 0) {
-    throw new Error(
-      "arbitraryConfidentCall: model has zero confident-oracle methods; flag needs-structural-rework",
-    );
+    throw new RpcArbitraryInvariantError({
+      message:
+        "arbitraryConfidentCall: model has zero confident-oracle methods; flag needs-structural-rework",
+    });
   }
   return fc
     .constantFrom(...confidentOracleMethods)

--- a/packages/protocol/src/testing/captures.ts
+++ b/packages/protocol/src/testing/captures.ts
@@ -12,6 +12,8 @@
 import { Effect, Ref, Stream, PubSub } from "effect";
 import type { AnyFrame, MalformedFrameKind } from "./codec.js";
 
+const CAPTURE_FANOUT_CONCURRENCY = 8;
+
 export type CaptureKind = "inbound" | "outbound";
 
 /**
@@ -97,7 +99,7 @@ export function mergeCaptures(
     const snapshot: Effect.Effect<ReadonlyArray<CapturedFrame>> = Effect.gen(
       function* () {
         const snaps = yield* Effect.forEach(buffers, (b) => b.snapshot, {
-          concurrency: "unbounded",
+          concurrency: CAPTURE_FANOUT_CONCURRENCY,
         });
         const flat = snaps.flat();
         return [...flat].sort((a, b) => a.at - b.at);
@@ -106,10 +108,10 @@ export function mergeCaptures(
 
     const stream = Stream.mergeAll(
       buffers.map((b) => b.stream),
-      { concurrency: "unbounded" },
+      { concurrency: CAPTURE_FANOUT_CONCURRENCY },
     );
     const clear = Effect.forEach(buffers, (b) => b.clear, {
-      concurrency: "unbounded",
+      concurrency: CAPTURE_FANOUT_CONCURRENCY,
     }).pipe(Effect.asVoid);
 
     return {

--- a/packages/protocol/src/testing/codec.ts
+++ b/packages/protocol/src/testing/codec.ts
@@ -19,6 +19,12 @@ import {
 } from "../schema/frames.js";
 import { FrameSchemaError } from "./errors.js";
 
+const BIT_FLIP_VARIANTS = 8;
+const OVERSIZED_PADDING_BYTES = 65_536;
+const LCG_MULTIPLIER = 1_664_525;
+const LCG_INCREMENT = 1_013_904_223;
+const LCG_MODULUS = 0x100000000;
+
 /**
  * Valid-frame kinds exposed on the wire. The string literal discriminator
  * matches the `type` field in `RequestFrameSchema` / `ResponseFrameSchema`
@@ -168,7 +174,7 @@ export function malformFrame(
       const pos = Math.floor(rand() * rawJson.length);
       const ch = rawJson.charCodeAt(pos);
       // Flip one bit in the low byte (XOR with 1<<bit).
-      const bit = Math.floor(rand() * 8);
+      const bit = Math.floor(rand() * BIT_FLIP_VARIANTS);
       const flipped = String.fromCharCode(ch ^ (1 << bit));
       return rawJson.slice(0, pos) + flipped + rawJson.slice(pos + 1);
     }
@@ -182,7 +188,7 @@ export function malformFrame(
       // Uses `_padding` field at top level of the JSON object, which
       // `additionalProperties: false` rejects — also triggers "extra-property"
       // under different framing, but here the point is byte-size.
-      const padLen = 64 * 1024;
+      const padLen = OVERSIZED_PADDING_BYTES;
       const pad = "X".repeat(padLen);
       // Splice "_padding":"...", before the closing `}`.
       const idx = rawJson.lastIndexOf("}");
@@ -206,9 +212,13 @@ export function malformFrame(
     }
     default: {
       const _exhaustive: never = kind;
-      throw new Error(`malformFrame: unexpected kind ${String(_exhaustive)}`);
+      return absurdMalformedFrameKind(_exhaustive);
     }
   }
+}
+
+function absurdMalformedFrameKind(kind: never): never {
+  throw new Error(`malformFrame: unexpected kind ${String(kind)}`);
 }
 
 /**
@@ -219,7 +229,7 @@ export function malformFrame(
 function lcg(seed: number): () => number {
   let s = seed >>> 0 || 1;
   return () => {
-    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
-    return s / 0x100000000;
+    s = (Math.imul(s, LCG_MULTIPLIER) + LCG_INCREMENT) >>> 0;
+    return s / LCG_MODULUS;
   };
 }

--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/executable-proof-helpers.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/executable-proof-helpers.ts
@@ -6,6 +6,10 @@ import {
   type RegisteredProperty,
 } from "../registry.js";
 
+class ProofExpectationError extends Error {
+  override readonly name = "ProofExpectationError";
+}
+
 export function runExpectingFailure(
   property: RegisteredProperty,
 ): Effect.Effect<PropertyFailure> {
@@ -32,10 +36,14 @@ export function expectInvariant(
   propertyName: string,
 ): void {
   if (!(failure instanceof PropertyInvariantViolation)) {
-    throw new Error(`expected invariant failure, got ${failure._tag}`);
+    throw new ProofExpectationError(
+      `expected invariant failure, got ${failure._tag}`,
+    );
   }
   if (failure.name !== propertyName) {
-    throw new Error(`expected ${propertyName}, got ${failure.name}`);
+    throw new ProofExpectationError(
+      `expected ${propertyName}, got ${failure.name}`,
+    );
   }
 }
 
@@ -44,9 +52,13 @@ export function expectAssertionFailure(
   propertyName: string,
 ): void {
   if (!(failure instanceof PropertyAssertionFailure)) {
-    throw new Error(`expected assertion failure, got ${failure._tag}`);
+    throw new ProofExpectationError(
+      `expected assertion failure, got ${failure._tag}`,
+    );
   }
   if (failure.name !== propertyName) {
-    throw new Error(`expected ${propertyName}, got ${failure.name}`);
+    throw new ProofExpectationError(
+      `expected ${propertyName}, got ${failure.name}`,
+    );
   }
 }

--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
@@ -52,6 +52,14 @@ import {
   runExpectingFailure,
 } from "./executable-proof-helpers.js";
 
+import { AgentsList, Connect } from "../../../schema/methods/auth.js";
+import { ContactsList } from "../../../schema/methods/contacts.js";
+import { ConversationsList } from "../../../schema/methods/conversations.js";
+import {
+  PresenceSubscribe,
+  PresenceUpdate,
+} from "../../../schema/methods/presence.js";
+
 type BadServerBehavior =
   | "allow-unauthenticated"
   | "duplicate-response-id"
@@ -220,14 +228,14 @@ function makeBadServerContext(
     const realServer: RealServerHandle = {
       baseUrl: httpHandle.baseUrl,
       wsUrl: wsHandle.wsUrl,
-      close: () => Promise.resolve(),
+      close: Effect.void,
     };
     return {
       realServer,
       toxiproxy: null,
       opts: {
         tiers: ["A", "B", "C", "E"],
-        realServer: () => Promise.resolve(realServer),
+        realServer: Effect.succeed(realServer),
         numRuns: 1,
       },
       seed: 42,
@@ -330,7 +338,7 @@ function makeBadWebSocketServer(
                 yield* writer(encodeFrame(response)).pipe(Effect.orDie);
                 if (
                   behavior === "duplicate-response-id" &&
-                  decoded.right.method === "conversations/list"
+                  decoded.right.method === ConversationsList.name
                 ) {
                   yield* writer(encodeFrame(response)).pipe(Effect.orDie);
                 }
@@ -356,21 +364,24 @@ function makeBadResponse(
   behavior: BadServerBehavior,
   ordinal: number,
 ): ResponseFrame | null {
-  if (behavior === "drop-contacts-list" && request.method === "contacts/list") {
+  if (
+    behavior === "drop-contacts-list" &&
+    request.method === ContactsList.name
+  ) {
     return null;
   }
   if (
     behavior === "drop-sampled-response" &&
     ordinal > 1 &&
-    request.method !== "auth/connect"
+    request.method !== Connect.name
   ) {
     return null;
   }
   if (
     (behavior === "reject-confident-model-call" &&
-      request.method === "agents/list") ||
+      request.method === AgentsList.name) ||
     (behavior === "reject-authorized" &&
-      request.method === "conversations/list")
+      request.method === ConversationsList.name)
   ) {
     return responseFrame("c2s", request.id, {
       error: {
@@ -402,7 +413,7 @@ function makeBadResult(
     behavior === "presence-silent" ||
     behavior === "presence-stale-snapshot"
   ) {
-    if (request.method === "presence/subscribe") {
+    if (request.method === PresenceSubscribe.name) {
       // Always reports offline — fails P6's online-snapshot expectation
       // and seeds the snapshot empty for the silent-broadcast cases.
       const params = request.params as { agentIds?: ReadonlyArray<unknown> };
@@ -413,16 +424,16 @@ function makeBadResult(
           .map((agentId) => ({ agentId, status: "offline" as const })),
       };
     }
-    if (request.method === "presence/update") {
+    if (request.method === PresenceUpdate.name) {
       return {};
     }
   }
   switch (request.method) {
-    case "auth/connect":
+    case Connect.name:
       return {};
-    case "agents/list":
+    case AgentsList.name:
       return { agents: {} };
-    case "conversations/list":
+    case ConversationsList.name:
       return behavior === "drift-idempotent-result"
         ? { conversations: [{ id: `drift-${ordinal}`, name: "drift" }] }
         : { conversations: [] };

--- a/packages/protocol/src/testing/conformance/_helpers.ts
+++ b/packages/protocol/src/testing/conformance/_helpers.ts
@@ -3,7 +3,7 @@
  * property modules. Keep this file thin; promote utilities here only
  * when they would otherwise be duplicated verbatim.
  */
-import type { Effect } from "effect";
+import { Effect, Either } from "effect";
 import type { TestClient } from "../test-client.js";
 import type {
   FrameSchemaError,
@@ -46,3 +46,29 @@ type UntypedSendRpc = (
   | TransportIoError
   | FrameSchemaError
 >;
+
+export function requireRight<A, E, F>(
+  value: Either.Either<A, E>,
+  onLeft: (error: E) => F,
+): Effect.Effect<A, F> {
+  return Either.match(value, {
+    onLeft: (error) => Effect.fail(onLeft(error)),
+    onRight: (success) => Effect.succeed(success),
+  });
+}
+
+export function leftOrNull<A, E>(value: Either.Either<A, E>): E | null {
+  return Either.match(value, {
+    onLeft: (error) => error,
+    onRight: () => null,
+  });
+}
+
+export function eitherTag<A, E extends { readonly _tag: string }>(
+  value: Either.Either<A, E>,
+): "Right" | E["_tag"] {
+  return Either.match(value, {
+    onLeft: (error) => error._tag,
+    onRight: () => "Right",
+  });
+}

--- a/packages/protocol/src/testing/conformance/adversity.ts
+++ b/packages/protocol/src/testing/conformance/adversity.ts
@@ -18,12 +18,13 @@
  * Principle 3: every property body is `Effect<void, PropertyFailure>`
  * — no bare throws, no `Effect.void` shortcuts.
  */
-import { Clock, Effect, type Scope } from "effect";
+import { Clock, Effect, Either, type Scope } from "effect";
 import { defaultToxicProfile } from "../toxics/defaults.js";
 import type { Proxy } from "../toxics/client.js";
 import type { ToxicProfile } from "../toxics/profile.js";
 import { makeTestClient, type TestClient } from "../test-client.js";
 import { registerTestAgent, type TestAgent } from "../agent-registration.js";
+import { TransportClosedError } from "../errors.js";
 import type { ConformanceRunContext } from "./runner.js";
 import {
   PropertyDeferred,
@@ -32,8 +33,41 @@ import {
   registerProperty,
 } from "./registry.js";
 
+import {
+  ConversationsCreate,
+  ConversationsList,
+} from "../../schema/methods/conversations.js";
+import { MessagesSend } from "../../schema/methods/messages.js";
+
 const CATEGORY = "adversity" as const;
 const DEFAULT_CAPTURE_CAPACITY = 128;
+const ID_RADIX = 36;
+const RANDOM_SUFFIX_START = 2;
+const RANDOM_SUFFIX_END = 8;
+const LATENCY_CLIENT_TIMEOUT_MS = 6_000;
+const SLICER_CLIENT_TIMEOUT_MS = 8_000;
+const RESET_CLIENT_TIMEOUT_MS = 4_000;
+const RESET_POLL_ATTEMPTS = 10;
+const RESET_CLOSE_BUDGET_MS = 3_500;
+const TIMEOUT_CLIENT_TIMEOUT_MS = 1_500;
+const TIMEOUT_EXPECTED_BUDGET_MS = 3_000;
+const SLOW_CLOSE_CLIENT_TIMEOUT_MS = 2_000;
+const SLOW_CLOSE_BUDGET_MS = 5_000;
+const TIMEOUT_SURFACE_PROPERTY = "timeout-surface";
+
+function violation(name: string, reason: string): PropertyInvariantViolation {
+  return new PropertyInvariantViolation({ category: CATEGORY, name, reason });
+}
+
+function randomIdSuffix(): string {
+  return Math.random()
+    .toString(ID_RADIX)
+    .slice(RANDOM_SUFFIX_START, RANDOM_SUFFIX_END);
+}
+
+function proxyName(prefix: string, seed: number): string {
+  return `${prefix}-${seed}-${randomIdSuffix()}`;
+}
 
 /** Acquire a TestClient that routes through the Toxiproxy proxy. */
 function acquireProxiedClient(
@@ -174,7 +208,7 @@ export function registerLatencyResilience(ctx: ConformanceRunContext): void {
     ctx,
     propertyName: "latency-resilience",
     description: "fan-out delivery survives added latency + jitter",
-    proxyName: `lat-${ctx.seed}-${Math.random().toString(36).slice(2, 8)}`,
+    proxyName: proxyName("lat", ctx.seed),
     profile: defaultToxicProfile.latency,
     body: ({ proxy, unavailable, attachToxic }) =>
       Effect.gen(function* () {
@@ -182,32 +216,27 @@ export function registerLatencyResilience(ctx: ConformanceRunContext): void {
           ctx,
           proxy,
           `lat-${ctx.seed}-o`,
-          6000,
+          LATENCY_CLIENT_TIMEOUT_MS,
           unavailable,
         );
         const participant = yield* acquireProxiedClient(
           ctx,
           proxy,
           `lat-${ctx.seed}-p`,
-          6000,
+          LATENCY_CLIENT_TIMEOUT_MS,
           unavailable,
         );
-        const conv = yield* createOneOnOneConversation(owner, participant);
-        if (conv.kind !== "ok") {
-          return yield* Effect.fail(
-            new PropertyInvariantViolation({
-              category: CATEGORY,
-              name: "latency-resilience",
-              reason: conv.reason,
-            }),
-          );
-        }
+        const conversationId = yield* createOneOnOneConversation(
+          owner,
+          participant,
+          "latency-resilience",
+        );
         yield* Effect.scoped(
           Effect.gen(function* () {
             yield* attachToxic;
             yield* owner.client
-              .sendRpc("messages/send", {
-                conversationId: conv.conversationId,
+              .sendRpc(MessagesSend.name, {
+                conversationId,
                 parts: [{ type: "text", text: "lat-ping" }],
               })
               .pipe(Effect.either);
@@ -263,7 +292,7 @@ export function registerSlicerFraming(ctx: ConformanceRunContext): void {
     ctx,
     propertyName: "slicer-framing",
     description: "partial-frame slicing preserves payload byte-identity",
-    proxyName: `sli-${ctx.seed}-${Math.random().toString(36).slice(2, 8)}`,
+    proxyName: proxyName("sli", ctx.seed),
     profile: defaultToxicProfile.slicer,
     body: ({ proxy, unavailable, attachToxic }) =>
       Effect.gen(function* () {
@@ -271,33 +300,28 @@ export function registerSlicerFraming(ctx: ConformanceRunContext): void {
           ctx,
           proxy,
           `sli-${ctx.seed}-o`,
-          8000,
+          SLICER_CLIENT_TIMEOUT_MS,
           unavailable,
         );
         const participant = yield* acquireProxiedClient(
           ctx,
           proxy,
           `sli-${ctx.seed}-p`,
-          8000,
+          SLICER_CLIENT_TIMEOUT_MS,
           unavailable,
         );
-        const conv = yield* createOneOnOneConversation(owner, participant);
-        if (conv.kind !== "ok") {
-          return yield* Effect.fail(
-            new PropertyInvariantViolation({
-              category: CATEGORY,
-              name: "slicer-framing",
-              reason: conv.reason,
-            }),
-          );
-        }
-        const token = `sli-token-${ctx.seed}-${Date.now().toString(36)}`;
+        const conversationId = yield* createOneOnOneConversation(
+          owner,
+          participant,
+          "slicer-framing",
+        );
+        const token = `sli-token-${ctx.seed}-${Date.now().toString(ID_RADIX)}`;
         yield* Effect.scoped(
           Effect.gen(function* () {
             yield* attachToxic;
             yield* owner.client
-              .sendRpc("messages/send", {
-                conversationId: conv.conversationId,
+              .sendRpc(MessagesSend.name, {
+                conversationId,
                 parts: [{ type: "text", text: token }],
               })
               .pipe(Effect.either);
@@ -337,7 +361,7 @@ export function registerResetPeerRecovery(ctx: ConformanceRunContext): void {
     ctx,
     propertyName: "reset-peer-recovery",
     description: "reset_peer surfaces TransportClosedError without hanging",
-    proxyName: `rst-${ctx.seed}-${Math.random().toString(36).slice(2, 8)}`,
+    proxyName: proxyName("rst", ctx.seed),
     profile: defaultToxicProfile.reset_peer,
     body: ({ proxy, unavailable, attachToxic }) =>
       Effect.gen(function* () {
@@ -347,26 +371,27 @@ export function registerResetPeerRecovery(ctx: ConformanceRunContext): void {
           `rst-${ctx.seed}-s`,
           // Deadline > reset_peer.timeoutMs (2000); bounded so a
           // never-firing reset doesn't hang the suite.
-          4000,
+          RESET_CLIENT_TIMEOUT_MS,
           unavailable,
         );
         const observed = yield* Effect.scoped(
           Effect.gen(function* () {
             yield* attachToxic;
             const start = yield* Clock.currentTimeMillis;
-            for (let i = 0; i < 10; i++) {
+            for (let i = 0; i < RESET_POLL_ATTEMPTS; i++) {
               const outcome = yield* sender.client
-                .sendRpc("conversations/list", {})
+                .sendRpc(ConversationsList.name, {})
                 .pipe(Effect.either);
-              if (
-                outcome._tag === "Left" &&
-                outcome.left._tag === "TestingTransportClosedError"
-              ) {
+              const transportClosed = Either.match(outcome, {
+                onLeft: (error) => error instanceof TransportClosedError,
+                onRight: () => false,
+              });
+              if (transportClosed) {
                 return true;
               }
               yield* Effect.sleep("300 millis");
               const elapsed = (yield* Clock.currentTimeMillis) - start;
-              if (elapsed > 3500) return false;
+              if (elapsed > RESET_CLOSE_BUDGET_MS) return false;
             }
             return false;
           }),
@@ -391,9 +416,9 @@ export function registerResetPeerRecovery(ctx: ConformanceRunContext): void {
 export function registerTimeoutSurface(ctx: ConformanceRunContext): void {
   withToxicProxy({
     ctx,
-    propertyName: "timeout-surface",
+    propertyName: TIMEOUT_SURFACE_PROPERTY,
     description: "timeout toxic surfaces typed RpcTimeoutError within budget",
-    proxyName: `to-${ctx.seed}-${Math.random().toString(36).slice(2, 8)}`,
+    proxyName: proxyName("to", ctx.seed),
     profile: defaultToxicProfile.timeout,
     body: ({ proxy, unavailable, attachToxic }) =>
       Effect.gen(function* () {
@@ -405,7 +430,7 @@ export function registerTimeoutSurface(ctx: ConformanceRunContext): void {
           ctx,
           proxy,
           `to-${ctx.seed}-c`,
-          1500,
+          TIMEOUT_CLIENT_TIMEOUT_MS,
           unavailable,
         );
         const { outcomeTag, elapsed } = yield* Effect.scoped(
@@ -413,12 +438,14 @@ export function registerTimeoutSurface(ctx: ConformanceRunContext): void {
             yield* attachToxic;
             const start = yield* Clock.currentTimeMillis;
             const outcome = yield* proxied.client
-              .sendRpc("conversations/list", {})
+              .sendRpc(ConversationsList.name, {})
               .pipe(Effect.either);
             const elapsed = (yield* Clock.currentTimeMillis) - start;
             return {
-              outcomeTag:
-                outcome._tag === "Right" ? "success" : outcome.left._tag,
+              outcomeTag: Either.match(outcome, {
+                onLeft: (error) => error._tag,
+                onRight: () => "success",
+              }),
               elapsed,
             };
           }),
@@ -427,7 +454,7 @@ export function registerTimeoutSurface(ctx: ConformanceRunContext): void {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "timeout-surface",
+              name: TIMEOUT_SURFACE_PROPERTY,
               reason: "RPC through timeout toxic unexpectedly succeeded",
             }),
           );
@@ -436,17 +463,17 @@ export function registerTimeoutSurface(ctx: ConformanceRunContext): void {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "timeout-surface",
+              name: TIMEOUT_SURFACE_PROPERTY,
               reason: `expected RpcTimeoutError, got ${outcomeTag}`,
             }),
           );
         }
-        if (elapsed > 3000) {
+        if (elapsed > TIMEOUT_EXPECTED_BUDGET_MS) {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "timeout-surface",
-              reason: `timeout fired at ${elapsed}ms, expected <3000ms`,
+              name: TIMEOUT_SURFACE_PROPERTY,
+              reason: `timeout fired at ${elapsed}ms, expected <${TIMEOUT_EXPECTED_BUDGET_MS}ms`,
             }),
           );
         }
@@ -464,7 +491,7 @@ export function registerSlowCloseCleanup(ctx: ConformanceRunContext): void {
     ctx,
     propertyName: "slow-close-cleanup",
     description: "slow_close toxic does not leak descriptors beyond 2s",
-    proxyName: `sc-${ctx.seed}-${Math.random().toString(36).slice(2, 8)}`,
+    proxyName: proxyName("sc", ctx.seed),
     profile: defaultToxicProfile.slow_close,
     body: ({ proxy, unavailable, attachToxic }) =>
       Effect.gen(function* () {
@@ -479,22 +506,22 @@ export function registerSlowCloseCleanup(ctx: ConformanceRunContext): void {
               ctx,
               proxy,
               `sc-${ctx.seed}-c`,
-              2000,
+              SLOW_CLOSE_CLIENT_TIMEOUT_MS,
               unavailable,
             );
             // A single RPC proves the socket is alive before close.
             yield* _client.client
-              .sendRpc("conversations/list", {})
+              .sendRpc(ConversationsList.name, {})
               .pipe(Effect.either);
           }),
         );
         const elapsed = (yield* Clock.currentTimeMillis) - start;
-        if (elapsed > 5000) {
+        if (elapsed > SLOW_CLOSE_BUDGET_MS) {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
               name: "slow-close-cleanup",
-              reason: `scope release took ${elapsed}ms under slow_close (budget 5000ms)`,
+              reason: `scope release took ${elapsed}ms under slow_close (budget ${SLOW_CLOSE_BUDGET_MS}ms)`,
             }),
           );
         }
@@ -504,38 +531,37 @@ export function registerSlowCloseCleanup(ctx: ConformanceRunContext): void {
 
 // ── helpers ──────────────────────────────────────────────────────────
 
-type ConvResult =
-  | { readonly kind: "ok"; readonly conversationId: string }
-  | { readonly kind: "error"; readonly reason: string };
-
 function createOneOnOneConversation(
   owner: { agent: TestAgent; client: TestClient },
   participant: { agent: TestAgent; client: TestClient },
-): Effect.Effect<ConvResult> {
+  propertyName: string,
+): Effect.Effect<string, PropertyInvariantViolation> {
   return Effect.gen(function* () {
     const create = yield* owner.client
-      .sendRpc("conversations/create", {
+      .sendRpc(ConversationsCreate.name, {
         type: "group",
         name: `adv-conv-${owner.agent.name}`,
         participants: [
           { type: "agent" as const, id: participant.agent.agentId },
         ],
       })
-      .pipe(Effect.either);
-    if (create._tag === "Left") {
-      return {
-        kind: "error",
-        reason: `conversations/create under toxic: ${create.left._tag}`,
-      } satisfies ConvResult;
-    }
-    const id = (create.right as { conversation?: { id?: string } }).conversation
-      ?.id;
+      .pipe(
+        Effect.mapError((error) =>
+          violation(
+            propertyName,
+            `conversations/create under toxic: ${error._tag}`,
+          ),
+        ),
+      );
+    const id = (create as { conversation?: { id?: string } }).conversation?.id;
     if (typeof id !== "string" || id.length === 0) {
-      return {
-        kind: "error",
-        reason: "conversations/create returned no conversation.id",
-      } satisfies ConvResult;
+      return yield* Effect.fail(
+        violation(
+          propertyName,
+          "conversations/create returned no conversation.id",
+        ),
+      );
     }
-    return { kind: "ok", conversationId: id } satisfies ConvResult;
+    return id;
   });
 }

--- a/packages/protocol/src/testing/conformance/boundary.ts
+++ b/packages/protocol/src/testing/conformance/boundary.ts
@@ -8,19 +8,27 @@
  * — is registered as `app-disconnect-fail-policy` below.
  */
 import * as fc from "fast-check";
-import { Duration, Effect, Exit, Scope } from "effect";
+import { Data, Duration, Effect, Either, Exit, Scope } from "effect";
 import { allRpcMethods, arbitraryCallFor } from "../arbitraries/rpc.js";
 import { makeTestClient } from "../test-client.js";
 import { registerTestAgent } from "../agent-registration.js";
 import type { ConformanceRunContext } from "./runner.js";
-import { Data } from "effect";
 import {
   PropertyDeferred,
   PropertyInvariantViolation,
   PropertyUnavailable,
   registerProperty,
 } from "./registry.js";
-import { sendUntypedRpc } from "./_helpers.js";
+import { leftOrNull, sendUntypedRpc } from "./_helpers.js";
+
+import { AgentsList } from "../../schema/methods/auth.js";
+import {
+  AppsAuthorizeDispatch,
+  AppsCreate,
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsRegister,
+} from "../../schema/methods/apps.js";
 
 /**
  * Tagged sentinel for "the dispatch RPC did not reply within the
@@ -35,6 +43,10 @@ class DispatchHungError extends Data.TaggedError(
 const CATEGORY = "boundary" as const;
 const DEFAULT_TIMEOUT_MS = 3000;
 const DEFAULT_CAPTURE_CAPACITY = 32;
+const SCHEMA_EXHAUSTIVE_FUZZ_PROPERTY = "schema-exhaustive-fuzz";
+const APP_DISCONNECT_FAIL_POLICY_PROPERTY = "app-disconnect-fail-policy";
+const FUZZ_CAPTURE_CAPACITY_PER_METHOD = 4;
+const DATE_ID_RADIX = 36;
 
 /**
  * Schema-exhaustive fuzz — for every `RpcMethodName`, draws arbitrary
@@ -51,7 +63,7 @@ export function registerSchemaExhaustiveFuzz(ctx: ConformanceRunContext): void {
   registerProperty(
     ctx,
     CATEGORY,
-    "schema-exhaustive-fuzz",
+    SCHEMA_EXHAUSTIVE_FUZZ_PROPERTY,
     "every RpcMethodName drawn → server survives & stays responsive",
     Effect.scoped(
       Effect.gen(function* () {
@@ -63,7 +75,7 @@ export function registerSchemaExhaustiveFuzz(ctx: ConformanceRunContext): void {
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "schema-exhaustive-fuzz",
+                name: SCHEMA_EXHAUSTIVE_FUZZ_PROPERTY,
                 reason: `register agent: ${e.body}`,
               }),
           ),
@@ -73,13 +85,14 @@ export function registerSchemaExhaustiveFuzz(ctx: ConformanceRunContext): void {
           agentKey: agent.apiKey,
           agentId: agent.agentId,
           defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-          captureCapacity: allRpcMethods.length * 4,
+          captureCapacity:
+            allRpcMethods.length * FUZZ_CAPTURE_CAPACITY_PER_METHOD,
         }).pipe(
           Effect.mapError(
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "schema-exhaustive-fuzz",
+                name: SCHEMA_EXHAUSTIVE_FUZZ_PROPERTY,
                 reason: `client acquire: ${String(e)}`,
               }),
           ),
@@ -95,7 +108,7 @@ export function registerSchemaExhaustiveFuzz(ctx: ConformanceRunContext): void {
             return yield* Effect.fail(
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "schema-exhaustive-fuzz",
+                name: SCHEMA_EXHAUSTIVE_FUZZ_PROPERTY,
                 reason: `failed to sample call for ${method}`,
               }),
             );
@@ -110,14 +123,15 @@ export function registerSchemaExhaustiveFuzz(ctx: ConformanceRunContext): void {
             // exactly what the property must reject. Require the post
             // call to SUCCEED; timeouts are failures here.
             const post = yield* client
-              .sendRpc("agents/list", {})
+              .sendRpc(AgentsList.name, {})
               .pipe(Effect.either);
-            if (post._tag !== "Right") {
+            const postFailure = leftOrNull(post);
+            if (postFailure !== null) {
               return yield* Effect.fail(
                 new PropertyInvariantViolation({
                   category: CATEGORY,
-                  name: "schema-exhaustive-fuzz",
-                  reason: `server became unresponsive after ${method} (post-call ${post._tag === "Left" ? post.left._tag : "unknown"})`,
+                  name: SCHEMA_EXHAUSTIVE_FUZZ_PROPERTY,
+                  reason: `server became unresponsive after ${method} (post-call ${postFailure._tag})`,
                 }),
               );
             }
@@ -167,7 +181,7 @@ export function registerAppDisconnectFailPolicy(
   registerProperty(
     ctx,
     CATEGORY,
-    "app-disconnect-fail-policy",
+    APP_DISCONNECT_FAIL_POLICY_PROPERTY,
     "app WS sever ⇒ pending s2c Deferreds fail-closed; no leaks",
     Effect.scoped(
       Effect.gen(function* () {
@@ -181,7 +195,7 @@ export function registerAppDisconnectFailPolicy(
             (e) =>
               new PropertyUnavailable({
                 category: CATEGORY,
-                name: "app-disconnect-fail-policy",
+                name: APP_DISCONNECT_FAIL_POLICY_PROPERTY,
                 reason: `app agent register: ${e.body}`,
               }),
           ),
@@ -205,7 +219,7 @@ export function registerAppDisconnectFailPolicy(
             (e) =>
               new PropertyUnavailable({
                 category: CATEGORY,
-                name: "app-disconnect-fail-policy",
+                name: APP_DISCONNECT_FAIL_POLICY_PROPERTY,
                 reason: `app client acquire: ${String(e)}`,
               }),
           ),
@@ -214,7 +228,7 @@ export function registerAppDisconnectFailPolicy(
         // Step 3: register a manifest. apps/register is owner-agnostic
         // (see apps.handlers.ts:25-41) — succeeds even when the agent's
         // owner_user_id is null.
-        const appId = `adfp-${Date.now().toString(36)}`;
+        const appId = `adfp-${Date.now().toString(DATE_ID_RADIX)}`;
         // `apps/register` is server-handled but absent from the typed
         // `rpcMethods` registry today (see `rpc-registry.ts:60-118`);
         // app-sdk and `34-rpc-additions.integration.test.ts:48` use the
@@ -222,7 +236,7 @@ export function registerAppDisconnectFailPolicy(
         // accretive change outside this sub-issue's scope.
         const registerOutcome = yield* sendUntypedRpc(
           appClient,
-          "apps/register",
+          AppsRegister.name,
           {
             manifest: {
               appId,
@@ -238,13 +252,14 @@ export function registerAppDisconnectFailPolicy(
             },
           },
         ).pipe(Effect.either);
-        if (registerOutcome._tag === "Left") {
+        const registerFailure = leftOrNull(registerOutcome);
+        if (registerFailure !== null) {
           yield* Scope.close(appScope, Exit.void);
           return yield* Effect.fail(
             new PropertyUnavailable({
               category: CATEGORY,
-              name: "app-disconnect-fail-policy",
-              reason: `apps/register failed: ${registerOutcome.left._tag}`,
+              name: APP_DISCONNECT_FAIL_POLICY_PROPERTY,
+              reason: `apps/register failed: ${registerFailure._tag}`,
             }),
           );
         }
@@ -253,11 +268,11 @@ export function registerAppDisconnectFailPolicy(
         // the server-side Deferred is parked. The sever in step 6 is the
         // event the property exercises.
         yield* appClient.handleServerRpc(
-          "apps/onBeforeDispatch",
+          AppsOnBeforeDispatch.name,
           () => Effect.never,
         );
         yield* appClient.handleServerRpc(
-          "apps/onBeforeMessageDelivery",
+          AppsOnBeforeMessageDelivery.name,
           () => Effect.never,
         );
 
@@ -275,7 +290,7 @@ export function registerAppDisconnectFailPolicy(
             (e) =>
               new PropertyUnavailable({
                 category: CATEGORY,
-                name: "app-disconnect-fail-policy",
+                name: APP_DISCONNECT_FAIL_POLICY_PROPERTY,
                 reason: `sender register: ${e.body}`,
               }),
           ),
@@ -291,24 +306,29 @@ export function registerAppDisconnectFailPolicy(
             (e) =>
               new PropertyUnavailable({
                 category: CATEGORY,
-                name: "app-disconnect-fail-policy",
+                name: APP_DISCONNECT_FAIL_POLICY_PROPERTY,
                 reason: `sender client acquire: ${String(e)}`,
               }),
           ),
         );
         const sessionOutcome = yield* senderClient
-          .sendRpc("apps/create", { appId, invitedAgentIds: [] })
+          .sendRpc(AppsCreate.name, { appId, invitedAgentIds: [] })
           .pipe(Effect.either);
-        if (sessionOutcome._tag === "Left") {
-          yield* Scope.close(appScope, Exit.void);
-          return yield* Effect.fail(
-            new PropertyUnavailable({
-              category: CATEGORY,
-              name: "app-disconnect-fail-policy",
-              reason: `apps/create failed (likely owner_user_id null on sender; B.9 covers via DB seeding): ${sessionOutcome.left._tag}`,
-            }),
-          );
-        }
+        const sessionResult = yield* Either.match(sessionOutcome, {
+          onLeft: (error) =>
+            Scope.close(appScope, Exit.void).pipe(
+              Effect.zipRight(
+                Effect.fail(
+                  new PropertyUnavailable({
+                    category: CATEGORY,
+                    name: APP_DISCONNECT_FAIL_POLICY_PROPERTY,
+                    reason: `apps/create failed (likely owner_user_id null on sender; B.9 covers via DB seeding): ${error._tag}`,
+                  }),
+                ),
+              ),
+            ),
+          onRight: (success) => Effect.succeed(success),
+        });
 
         // Step 6: sever the app's WS. Closing the inner scope closes the
         // socket; the server's connection-scope finalizer runs through
@@ -324,13 +344,13 @@ export function registerAppDisconnectFailPolicy(
         // the (now severed) admission path.
         // `apps/create` result: `{ session: { conversations: { [key]: convId } } }`
         // — a Record map, not an array. Pull the first id deterministically.
-        const session = sessionOutcome.right.session;
+        const session = sessionResult.session;
         const sessionConvId = Object.values(session.conversations)[0];
         if (typeof sessionConvId !== "string" || sessionConvId.length === 0) {
           return yield* Effect.fail(
             new PropertyDeferred({
               category: CATEGORY,
-              name: "app-disconnect-fail-policy",
+              name: APP_DISCONNECT_FAIL_POLICY_PROPERTY,
               followUp:
                 "apps/create response did not surface a session conversation id; B.9 (#318) covers via DB-seeded fixture",
             }),
@@ -344,7 +364,7 @@ export function registerAppDisconnectFailPolicy(
         // class makes the leak observable in the Left branch.
         const dispatchStarted = Date.now();
         const dispatchOutcome = yield* senderClient
-          .sendRpc("apps/authorizeDispatch", {
+          .sendRpc(AppsAuthorizeDispatch.name, {
             conversationId:
               sessionConvId as `${string}-${string}-${string}-${string}-${string}`,
             messageId: `00000000-0000-0000-0000-000000000001`,
@@ -360,15 +380,17 @@ export function registerAppDisconnectFailPolicy(
             }),
             Effect.either,
           );
-        if (
-          dispatchOutcome._tag === "Left" &&
-          dispatchOutcome.left instanceof DispatchHungError
-        ) {
+        const dispatchHung = Either.match(dispatchOutcome, {
+          onLeft: (error) =>
+            error instanceof DispatchHungError ? error : null,
+          onRight: () => null,
+        });
+        if (dispatchHung !== null) {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "app-disconnect-fail-policy",
-              reason: `dispatch hung ${dispatchOutcome.left.elapsedMs}ms after app sever — Deferred leak suspected`,
+              name: APP_DISCONNECT_FAIL_POLICY_PROPERTY,
+              reason: `dispatch hung ${dispatchHung.elapsedMs}ms after app sever — Deferred leak suspected`,
             }),
           );
         }

--- a/packages/protocol/src/testing/conformance/client/adversity.ts
+++ b/packages/protocol/src/testing/conformance/client/adversity.ts
@@ -36,8 +36,14 @@ import {
   subscribeAll,
 } from "./_fixtures.js";
 
+import { AgentsList } from "../../../schema/methods/auth.js";
+
 const CATEGORY = "adversity" as const;
 const PROPERTY_BUDGET_MS = 10_000;
+const TIMEOUT_ERROR_PREVIEW_CHARS = 200;
+const PROPERTY_LATENCY_RESILIENCE_CLIENT = "latency-resilience-client";
+const PROPERTY_TIMEOUT_SURFACE_CLIENT = "timeout-surface-client";
+const PROPERTY_SLOW_CLOSE_CLEANUP_CLIENT = "slow-close-cleanup-client";
 
 function unavailable(name: string, reason: string): PropertyUnavailable {
   return new PropertyUnavailable({ category: CATEGORY, name, reason });
@@ -55,14 +61,14 @@ export function registerLatencyResilienceClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "latency-resilience-client",
+    PROPERTY_LATENCY_RESILIENCE_CLIENT,
     "fan-out survives latency (Toxiproxy) or degrades to cardinality check",
     Effect.scoped(
       Effect.gen(function* () {
         if (ctx.toxiproxy === null) {
           return yield* Effect.fail(
             unavailable(
-              "latency-resilience-client",
+              PROPERTY_LATENCY_RESILIENCE_CLIENT,
               "Toxiproxy not provisioned; client-side latency toxic unavailable in this run",
             ),
           );
@@ -70,7 +76,7 @@ export function registerLatencyResilienceClient(
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "latency-resilience-client",
+          PROPERTY_LATENCY_RESILIENCE_CLIENT,
         );
         yield* subscribeAll(fx.handle);
         const base: EventFrame = {
@@ -100,7 +106,7 @@ export function registerLatencyResilienceClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "latency-resilience-client",
+              PROPERTY_LATENCY_RESILIENCE_CLIENT,
               `expected ${N} under latency, got ${observed.length}`,
             ),
           );
@@ -172,14 +178,14 @@ export function registerTimeoutSurfaceClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "timeout-surface-client",
+    PROPERTY_TIMEOUT_SURFACE_CLIENT,
     "never-responded RPC surfaces typed RpcTimeoutError on the real client",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "timeout-surface-client",
+          PROPERTY_TIMEOUT_SURFACE_CLIENT,
         );
         // Do NOT start a responder — TestServer silently absorbs the
         // request. The real client's internal timeout must fire.
@@ -190,12 +196,12 @@ export function registerTimeoutSurfaceClient(
         // than pretending to assert the client-internal deadline.
         const start = yield* Clock.currentTimeMillis;
         const outcome = yield* Effect.exit(
-          fx.handle.call.call("agents/list", {}).pipe(
+          fx.handle.call.call(AgentsList.name, {}).pipe(
             Effect.timeoutFail({
               duration: `${PROPERTY_BUDGET_MS} millis`,
               onTimeout: () =>
                 unavailable(
-                  "timeout-surface-client",
+                  PROPERTY_TIMEOUT_SURFACE_CLIENT,
                   `client timeout > ${PROPERTY_BUDGET_MS}ms suite budget`,
                 ),
             }),
@@ -206,7 +212,7 @@ export function registerTimeoutSurfaceClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "timeout-surface-client",
+              PROPERTY_TIMEOUT_SURFACE_CLIENT,
               "RPC unexpectedly resolved without a response",
             ),
           );
@@ -218,7 +224,7 @@ export function registerTimeoutSurfaceClient(
         if (causeStr.includes("PropertyUnavailable")) {
           return yield* Effect.fail(
             unavailable(
-              "timeout-surface-client",
+              PROPERTY_TIMEOUT_SURFACE_CLIENT,
               `client timeout exceeded suite budget (${elapsed}ms)`,
             ),
           );
@@ -230,8 +236,8 @@ export function registerTimeoutSurfaceClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "timeout-surface-client",
-              `expected timeout-shape rejection, got: ${causeStr.slice(0, 200)}`,
+              PROPERTY_TIMEOUT_SURFACE_CLIENT,
+              `expected timeout-shape rejection, got: ${causeStr.slice(0, TIMEOUT_ERROR_PREVIEW_CHARS)}`,
             ),
           );
         }
@@ -254,14 +260,14 @@ export function registerSlowCloseCleanupClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "slow-close-cleanup-client",
+    PROPERTY_SLOW_CLOSE_CLEANUP_CLIENT,
     "slow close completes; real client's closeSignal resolves and Scope releases",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "slow-close-cleanup-client",
+          PROPERTY_SLOW_CLOSE_CLEANUP_CLIENT,
         );
         // Initiate a close from the TestServer side.
         yield* fx.connection
@@ -276,7 +282,7 @@ export function registerSlowCloseCleanupClient(
               onTimeout: () =>
                 invariant(
                   CATEGORY,
-                  "slow-close-cleanup-client",
+                  PROPERTY_SLOW_CLOSE_CLEANUP_CLIENT,
                   `closeSignal did not resolve within ${closeBudget}ms`,
                 ),
             }),
@@ -288,7 +294,7 @@ export function registerSlowCloseCleanupClient(
             return yield* Effect.fail(
               invariant(
                 CATEGORY,
-                "slow-close-cleanup-client",
+                PROPERTY_SLOW_CLOSE_CLEANUP_CLIENT,
                 `closeSignal timed out (${closeBudget}ms budget)`,
               ),
             );

--- a/packages/protocol/src/testing/conformance/client/boundary.ts
+++ b/packages/protocol/src/testing/conformance/client/boundary.ts
@@ -21,6 +21,8 @@ import {
 
 const CATEGORY = "boundary" as const;
 const PROPERTY_BUDGET_MS = 12_000;
+const DEFAULT_FUZZ_BURST_RUNS = 10;
+const PROPERTY_SCHEMA_EXHAUSTIVE_FUZZ_CLIENT = "schema-exhaustive-fuzz-client";
 
 /**
  * E2 client half — TestServer emits arbitrary `EventFrame`s across
@@ -37,19 +39,19 @@ export function registerSchemaExhaustiveFuzzClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "schema-exhaustive-fuzz-client",
+    PROPERTY_SCHEMA_EXHAUSTIVE_FUZZ_CLIENT,
     "real client absorbs arbitrary EventFrames; liveness and boundary hold",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "schema-exhaustive-fuzz-client",
+          PROPERTY_SCHEMA_EXHAUSTIVE_FUZZ_CLIENT,
         );
         yield* subscribeAll(fx.handle);
         // Fuzz burst: default 10 frames; stress mode scales with
         // CONFORMANCE_NUM_RUNS through ctx.opts.numRuns.
-        const fuzzRuns = ctx.opts.numRuns ?? 10;
+        const fuzzRuns = ctx.opts.numRuns ?? DEFAULT_FUZZ_BURST_RUNS;
         const burst = fc.sample(arbitraryEventFrame(), {
           numRuns: fuzzRuns,
           seed: ctx.seed,
@@ -68,7 +70,7 @@ export function registerSchemaExhaustiveFuzzClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "schema-exhaustive-fuzz-client",
+              PROPERTY_SCHEMA_EXHAUSTIVE_FUZZ_CLIENT,
               "real client closed during fuzz burst",
             ),
           );
@@ -93,7 +95,7 @@ export function registerSchemaExhaustiveFuzzClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "schema-exhaustive-fuzz-client",
+              PROPERTY_SCHEMA_EXHAUSTIVE_FUZZ_CLIENT,
               "liveness probe never surfaced after fuzz burst",
             ),
           );

--- a/packages/protocol/src/testing/conformance/client/delivery.ts
+++ b/packages/protocol/src/testing/conformance/client/delivery.ts
@@ -35,6 +35,13 @@ import {
 
 const CATEGORY = "delivery" as const;
 const PROPERTY_BUDGET_MS = 8_000;
+const PROPERTY_FAN_OUT_CARDINALITY_CLIENT = "fan-out-cardinality-client";
+const PROPERTY_PAYLOAD_OPACITY_CLIENT = "payload-opacity-client";
+const PROPERTY_TASK_BOUNDARY_ISOLATION_CLIENT =
+  "task-boundary-isolation-client";
+const PAYLOAD_TOKEN_RADIX = 36;
+const TASK_BOUNDARY_EMISSION_COUNT = 3;
+const LIFECYCLE_OBSERVATION_COUNT = 2;
 
 function isStringKeyedRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -64,14 +71,14 @@ export function registerFanOutCardinalityClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "fan-out-cardinality-client",
+    PROPERTY_FAN_OUT_CARDINALITY_CLIENT,
     "N fan-out events surface on real client in emission order, no drops, no dups",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "fan-out-cardinality-client",
+          PROPERTY_FAN_OUT_CARDINALITY_CLIENT,
         );
         yield* subscribeAll(fx.handle);
         const base = fc.sample(arbitraryEventFrame(), {
@@ -80,7 +87,11 @@ export function registerFanOutCardinalityClient(
         })[0];
         if (base === undefined) {
           return yield* Effect.fail(
-            invariant(CATEGORY, "fan-out-cardinality-client", "sample failed"),
+            invariant(
+              CATEGORY,
+              PROPERTY_FAN_OUT_CARDINALITY_CLIENT,
+              "sample failed",
+            ),
           );
         }
         const N = 5;
@@ -106,7 +117,7 @@ export function registerFanOutCardinalityClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "fan-out-cardinality-client",
+              PROPERTY_FAN_OUT_CARDINALITY_CLIENT,
               `expected ${N} observations, got ${observed.length}`,
             ),
           );
@@ -121,7 +132,7 @@ export function registerFanOutCardinalityClient(
             return yield* Effect.fail(
               invariant(
                 CATEGORY,
-                "fan-out-cardinality-client",
+                PROPERTY_FAN_OUT_CARDINALITY_CLIENT,
                 `order mismatch at slot ${i}: got ${String(indices[i])}`,
               ),
             );
@@ -149,17 +160,17 @@ export function registerPayloadOpacityClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "payload-opacity-client",
+    PROPERTY_PAYLOAD_OPACITY_CLIENT,
     "opaque payload token round-trips byte-identical through the real client",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "payload-opacity-client",
+          PROPERTY_PAYLOAD_OPACITY_CLIENT,
         );
         yield* subscribeAll(fx.handle);
-        const token = `opq-${ctx.seed.toString(36)}-${Date.now().toString(36)}`;
+        const token = `opq-${ctx.seed.toString(PAYLOAD_TOKEN_RADIX)}-${Date.now().toString(PAYLOAD_TOKEN_RADIX)}`;
         const base: EventFrame = {
           jsonrpc: "2.0",
           type: "event",
@@ -180,7 +191,7 @@ export function registerPayloadOpacityClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "payload-opacity-client",
+              PROPERTY_PAYLOAD_OPACITY_CLIENT,
               `token ${token} emission not surfaced by real client`,
             ),
           );
@@ -191,7 +202,7 @@ export function registerPayloadOpacityClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "payload-opacity-client",
+              PROPERTY_PAYLOAD_OPACITY_CLIENT,
               `token ${token} not present byte-for-byte in surfaced raw frame`,
             ),
           );
@@ -215,14 +226,14 @@ export function registerTaskBoundaryIsolationClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "task-boundary-isolation-client",
+    PROPERTY_TASK_BOUNDARY_ISOLATION_CLIENT,
     "task-A subscriber does not surface task-B events — no leakage",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "task-boundary-isolation-client",
+          PROPERTY_TASK_BOUNDARY_ISOLATION_CLIENT,
         );
         yield* subscribeAll(fx.handle);
         const baseEvent = fc.sample(arbitraryEventFrame(), {
@@ -233,7 +244,7 @@ export function registerTaskBoundaryIsolationClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "task-boundary-isolation-client",
+              PROPERTY_TASK_BOUNDARY_ISOLATION_CLIENT,
               "sample failed",
             ),
           );
@@ -244,7 +255,7 @@ export function registerTaskBoundaryIsolationClient(
         const taskB = `task-b-${ctx.seed}`;
         const baseEventData = eventDataRecord(baseEvent.data);
         // Emit task-A frames.
-        for (let i = 0; i < 3; i++) {
+        for (let i = 0; i < TASK_BOUNDARY_EMISSION_COUNT; i++) {
           yield* fx.window.emitTaggedEvent({
             connection: fx.connection,
             base: {
@@ -256,7 +267,7 @@ export function registerTaskBoundaryIsolationClient(
         }
         // Emit task-B frames that must be filtered out by the client's
         // subscription (via conversationId filter).
-        for (let i = 0; i < 3; i++) {
+        for (let i = 0; i < TASK_BOUNDARY_EMISSION_COUNT; i++) {
           yield* fx.window.emitTaggedEvent({
             connection: fx.connection,
             base: {
@@ -297,7 +308,7 @@ export function registerTaskBoundaryIsolationClient(
             return yield* Effect.fail(
               invariant(
                 CATEGORY,
-                "task-boundary-isolation-client",
+                PROPERTY_TASK_BOUNDARY_ISOLATION_CLIENT,
                 `task-A emission surfaced with conversationId ${String(cid)}`,
               ),
             );
@@ -315,7 +326,7 @@ export function registerTaskBoundaryIsolationClient(
             return yield* Effect.fail(
               invariant(
                 CATEGORY,
-                "task-boundary-isolation-client",
+                PROPERTY_TASK_BOUNDARY_ISOLATION_CLIENT,
                 `task-B emission surfaced with conversationId ${String(cid)} (cross-wiring)`,
               ),
             );
@@ -366,15 +377,15 @@ export function registerArchiveLifecycleClient(
         });
 
         const observed = yield* collectTagged(fx.handle, (t) => t === tag, {
-          expected: 2,
+          expected: LIFECYCLE_OBSERVATION_COUNT,
           budgetMs: PROPERTY_BUDGET_MS,
         });
-        if (observed.length !== 2) {
+        if (observed.length !== LIFECYCLE_OBSERVATION_COUNT) {
           return yield* Effect.fail(
             invariant(
               CATEGORY,
               name,
-              `expected 2 lifecycle observations, got ${observed.length}`,
+              `expected ${LIFECYCLE_OBSERVATION_COUNT} lifecycle observations, got ${observed.length}`,
             ),
           );
         }

--- a/packages/protocol/src/testing/conformance/client/rpc-semantics.ts
+++ b/packages/protocol/src/testing/conformance/client/rpc-semantics.ts
@@ -19,8 +19,12 @@ import type { ClientConformanceRunContext } from "./runner.js";
 import { registerProperty } from "../registry.js";
 import { acquireFixture, invariant } from "./_fixtures.js";
 
+import { AgentsList } from "../../../schema/methods/auth.js";
+
 const CATEGORY = "rpc-semantics" as const;
 const CALL_BUDGET_MS = 5_000;
+const PROPERTY_MODEL_EQUIVALENCE_CLIENT = "model-equivalence-client";
+const PROPERTY_REQUEST_ID_UNIQUENESS_CLIENT = "request-id-uniqueness-client";
 
 /**
  * B1 client half — property issues `realClient.call("agents/list", {})`;
@@ -37,14 +41,14 @@ export function registerModelEquivalenceClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "model-equivalence-client",
+    PROPERTY_MODEL_EQUIVALENCE_CLIENT,
     "scripted response to sampled RPC resolves the real client's pending call",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "model-equivalence-client",
+          PROPERTY_MODEL_EQUIVALENCE_CLIENT,
         );
         // Fork a background responder that watches inbound requests and
         // replies with an empty-agents-list result as soon as the sampled
@@ -60,7 +64,7 @@ export function registerModelEquivalenceClient(
                   entry.kind === "inbound" &&
                   entry.frame !== null &&
                   entry.frame.type === "request" &&
-                  entry.frame.method === "agents/list"
+                  entry.frame.method === AgentsList.name
                 ) {
                   const response: ResponseFrame = {
                     jsonrpc: "2.0",
@@ -81,13 +85,13 @@ export function registerModelEquivalenceClient(
             }
           }),
         );
-        const result = yield* fx.handle.call.call("agents/list", {}).pipe(
+        const result = yield* fx.handle.call.call(AgentsList.name, {}).pipe(
           Effect.timeoutFail({
             duration: `${CALL_BUDGET_MS} millis`,
             onTimeout: () =>
               invariant(
                 CATEGORY,
-                "model-equivalence-client",
+                PROPERTY_MODEL_EQUIVALENCE_CLIENT,
                 `agents/list call did not resolve within ${CALL_BUDGET_MS}ms`,
               ),
           }),
@@ -95,7 +99,7 @@ export function registerModelEquivalenceClient(
             "_tag" in e && e._tag === "RealClientRpcError"
               ? invariant(
                   CATEGORY,
-                  "model-equivalence-client",
+                  PROPERTY_MODEL_EQUIVALENCE_CLIENT,
                   `agents/list rejected: ${e.kind} (${e.documentedErrorTag ?? "null"})`,
                 )
               : e,
@@ -105,7 +109,7 @@ export function registerModelEquivalenceClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "model-equivalence-client",
+              PROPERTY_MODEL_EQUIVALENCE_CLIENT,
               "real client surfaced non-response frame",
             ),
           );
@@ -134,14 +138,14 @@ export function registerRequestIdUniquenessClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "request-id-uniqueness-client",
+    PROPERTY_REQUEST_ID_UNIQUENESS_CLIENT,
     "spurious response ids don't resolve pending calls; matching ids do",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "request-id-uniqueness-client",
+          PROPERTY_REQUEST_ID_UNIQUENESS_CLIENT,
         );
         // Emit a spurious response with an id the client never sent.
         const spuriousId = "spurious-id-that-was-never-requested";
@@ -166,7 +170,7 @@ export function registerRequestIdUniquenessClient(
                   entry.kind === "inbound" &&
                   entry.frame !== null &&
                   entry.frame.type === "request" &&
-                  entry.frame.method === "agents/list"
+                  entry.frame.method === AgentsList.name
                 ) {
                   yield* fx.connection
                     .emitResponse({
@@ -185,13 +189,13 @@ export function registerRequestIdUniquenessClient(
           }),
         );
         // Issue the RPC: must resolve via the matching id, not the spurious one.
-        const result = yield* fx.handle.call.call("agents/list", {}).pipe(
+        const result = yield* fx.handle.call.call(AgentsList.name, {}).pipe(
           Effect.timeoutFail({
             duration: `${CALL_BUDGET_MS} millis`,
             onTimeout: () =>
               invariant(
                 CATEGORY,
-                "request-id-uniqueness-client",
+                PROPERTY_REQUEST_ID_UNIQUENESS_CLIENT,
                 `agents/list did not resolve within ${CALL_BUDGET_MS}ms despite matching response`,
               ),
           }),
@@ -199,7 +203,7 @@ export function registerRequestIdUniquenessClient(
             "_tag" in e && e._tag === "RealClientRpcError"
               ? invariant(
                   CATEGORY,
-                  "request-id-uniqueness-client",
+                  PROPERTY_REQUEST_ID_UNIQUENESS_CLIENT,
                   `agents/list rejected: ${e.kind}`,
                 )
               : e,
@@ -213,7 +217,7 @@ export function registerRequestIdUniquenessClient(
             return yield* Effect.fail(
               invariant(
                 CATEGORY,
-                "request-id-uniqueness-client",
+                PROPERTY_REQUEST_ID_UNIQUENESS_CLIENT,
                 `resolved id ${result.id} absent from outboundIdFeed (cross-wire)`,
               ),
             );
@@ -222,7 +226,7 @@ export function registerRequestIdUniquenessClient(
             return yield* Effect.fail(
               invariant(
                 CATEGORY,
-                "request-id-uniqueness-client",
+                PROPERTY_REQUEST_ID_UNIQUENESS_CLIENT,
                 "pending call resolved via spurious id",
               ),
             );

--- a/packages/protocol/src/testing/conformance/client/runner.ts
+++ b/packages/protocol/src/testing/conformance/client/runner.ts
@@ -16,7 +16,15 @@
  * export (see §4 O5 resolution in the design doc) that returns the same
  * factory shape.
  */
-import { Context, Effect, Ref, type Scope } from "effect";
+import {
+  Config,
+  ConfigProvider,
+  Context,
+  Data,
+  Effect,
+  Ref,
+  type Scope,
+} from "effect";
 import type { EventFrame, ResponseFrame } from "../../../schema/frames.js";
 import {
   makeTestServer,
@@ -35,6 +43,21 @@ import {
 import { conformanceNumRunsFromEnv } from "../env.js";
 import type { ConformanceArtifact } from "../runner.js";
 import { PROTOCOL_VERSION } from "../../../version.js";
+
+import { Connect } from "../../../schema/methods/auth.js";
+
+const DEFAULT_ACCEPT_TIMEOUT_MS = 5_000;
+const RANDOM_TAG_RADIX = 36;
+const RANDOM_TAG_SLICE_END = 10;
+const RANDOM_TAG_SLICE_START = 2;
+const REPLAY_SEED_MASK = 0x7fffffff;
+
+const loadFastCheckSeed: Effect.Effect<number, never> = Config.integer(
+  "FC_SEED",
+).pipe(
+  Effect.withConfigProvider(ConfigProvider.fromEnv()),
+  Effect.orElseSucceed(() => Date.now() & REPLAY_SEED_MASK),
+);
 
 /**
  * Opaque handle to a live real MoltZap client connected to `TestServer`.
@@ -148,25 +171,23 @@ export interface RealClientRpcCaller {
  * Real-client lifecycle error tag. All three cover the Principle 3 error
  * channel; no raw throws escape the factory's Scope.
  */
-export class RealClientLifecycleError {
-  readonly _tag = "RealClientLifecycleError";
-  constructor(readonly cause: unknown) {}
-}
+export class RealClientLifecycleError extends Data.TaggedError(
+  "RealClientLifecycleError",
+)<{
+  readonly cause: unknown;
+}> {}
 
 /** Typed error surface for real-client RPC calls (D5 predicate target). */
-export class RealClientRpcError {
-  readonly _tag = "RealClientRpcError";
-  constructor(
-    readonly kind:
-      | "timeout"
-      | "server-error"
-      | "malformed-response"
-      | "disconnected",
-    readonly method: string,
-    readonly documentedErrorTag: string | null,
-    readonly cause: unknown,
-  ) {}
-}
+export class RealClientRpcError extends Data.TaggedError("RealClientRpcError")<{
+  readonly cause: unknown;
+  readonly documentedErrorTag: string | null;
+  readonly kind:
+    | "timeout"
+    | "server-error"
+    | "malformed-response"
+    | "disconnected";
+  readonly method: string;
+}> {}
 
 /** Close-event shape surfaced by `RealClientHandle.closeSignal`. */
 export interface RealClientCloseEvent {
@@ -281,9 +302,7 @@ export function acquireClientRunContext(
       ...opts,
       numRuns: opts.numRuns ?? conformanceNumRunsFromEnv(),
     };
-    const seed =
-      effectiveOpts.replaySeed ??
-      Number(process.env.FC_SEED ?? Date.now() & 0x7fffffff);
+    const seed = effectiveOpts.replaySeed ?? (yield* loadFastCheckSeed);
     const artifacts = yield* Ref.make<ReadonlyArray<ConformanceArtifact>>([]);
 
     // Bind the TestServer under the ambient Scope. Server-close on teardown.
@@ -320,7 +339,10 @@ export function acquireClientRunContext(
     // hold; each property body still binds a per-handle window.
     const handshakeWindow: ClientHandshakeWindow = {
       freshEmissionTag: Effect.sync(
-        () => `tag-${Math.random().toString(36).slice(2, 10)}`,
+        () =>
+          `tag-${Math.random()
+            .toString(RANDOM_TAG_RADIX)
+            .slice(RANDOM_TAG_SLICE_START, RANDOM_TAG_SLICE_END)}`,
       ),
       emitTaggedEvent: ({ connection, base, emissionTag }) =>
         emitTaggedEventDefault(connection, base, emissionTag),
@@ -376,6 +398,7 @@ function emitTaggedResponseDefault(
   base: ResponseFrame,
   _emissionTag: string,
 ): Effect.Effect<string> {
+  void _emissionTag;
   // Response frames don't carry a free-form `data` field; responses are
   // correlated by `id` instead — the response's `id` IS its emission tag
   // from the property's perspective (see B1 / B4 / D5 predicates).
@@ -435,7 +458,7 @@ export function runAutoHandshakeResponder(
             entry.kind === "inbound" &&
             entry.frame !== null &&
             entry.frame.type === "request" &&
-            entry.frame.method === "auth/connect"
+            entry.frame.method === Connect.name
           ) {
             const helloOk = {
               protocolVersion: PROTOCOL_VERSION,
@@ -488,7 +511,7 @@ export function freshTag(window: ClientHandshakeWindow): Effect.Effect<string> {
  */
 export function awaitConnection(
   testServer: TestServer,
-  timeoutMs = 5000,
+  timeoutMs = DEFAULT_ACCEPT_TIMEOUT_MS,
 ): Effect.Effect<TestServerConnection, TransportIoError> {
   return testServer.accept.pipe(
     Effect.timeoutFail({

--- a/packages/protocol/src/testing/conformance/client/schema-conformance.ts
+++ b/packages/protocol/src/testing/conformance/client/schema-conformance.ts
@@ -34,6 +34,9 @@ import {
 } from "./_fixtures.js";
 
 const CATEGORY = "schema-conformance" as const;
+const PROPERTY_EVENT_WELL_FORMEDNESS_CLIENT = "event-well-formedness-client";
+const PROPERTY_MALFORMED_FRAME_HANDLING_CLIENT =
+  "malformed-frame-handling-client";
 const PROPERTY_BUDGET_MS = 8_000;
 
 /**
@@ -54,14 +57,14 @@ export function registerEventWellFormednessClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "event-well-formedness-client",
+    PROPERTY_EVENT_WELL_FORMEDNESS_CLIENT,
     "valid EventFrame emitted by TestServer surfaces schema-clean on real client",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "event-well-formedness-client",
+          PROPERTY_EVENT_WELL_FORMEDNESS_CLIENT,
         );
         yield* subscribeAll(fx.handle);
         const sampled = fc.sample(arbitraryEventFrame(), {
@@ -72,7 +75,7 @@ export function registerEventWellFormednessClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "event-well-formedness-client",
+              PROPERTY_EVENT_WELL_FORMEDNESS_CLIENT,
               "failed to sample EventFrame",
             ),
           );
@@ -91,7 +94,7 @@ export function registerEventWellFormednessClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "event-well-formedness-client",
+              PROPERTY_EVENT_WELL_FORMEDNESS_CLIENT,
               `tagged event ${tag} not surfaced within ${PROPERTY_BUDGET_MS}ms`,
             ),
           );
@@ -107,7 +110,7 @@ export function registerEventWellFormednessClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "event-well-formedness-client",
+              PROPERTY_EVENT_WELL_FORMEDNESS_CLIENT,
               "real client surfaced event that fails EventFrameSchema",
             ),
           );
@@ -132,14 +135,14 @@ export function registerMalformedFrameHandlingClient(
   registerProperty(
     ctx,
     CATEGORY,
-    "malformed-frame-handling-client",
+    PROPERTY_MALFORMED_FRAME_HANDLING_CLIENT,
     "malformed TestServer emission absorbed silently; liveness intact",
     Effect.scoped(
       Effect.gen(function* () {
         const fx = yield* acquireFixture(
           ctx,
           CATEGORY,
-          "malformed-frame-handling-client",
+          PROPERTY_MALFORMED_FRAME_HANDLING_CLIENT,
         );
         yield* subscribeAll(fx.handle);
         const baseEvent = fc.sample(arbitraryEventFrame(), {
@@ -150,7 +153,7 @@ export function registerMalformedFrameHandlingClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "malformed-frame-handling-client",
+              PROPERTY_MALFORMED_FRAME_HANDLING_CLIENT,
               "failed to sample base EventFrame",
             ),
           );
@@ -178,7 +181,7 @@ export function registerMalformedFrameHandlingClient(
           return yield* Effect.fail(
             invariant(
               CATEGORY,
-              "malformed-frame-handling-client",
+              PROPERTY_MALFORMED_FRAME_HANDLING_CLIENT,
               "liveness failed: no tagged event after malformed emission",
             ),
           );

--- a/packages/protocol/src/testing/conformance/client/suite.ts
+++ b/packages/protocol/src/testing/conformance/client/suite.ts
@@ -68,6 +68,8 @@ import {
 } from "./adversity.js";
 import { registerSchemaExhaustiveFuzzClient } from "./boundary.js";
 
+const JSON_INDENT_SPACES = 2;
+
 /**
  * Consumer-facing options. Mirror of `ConformanceSuiteOptions` on the
  * server side; only the factory name differs.
@@ -331,7 +333,7 @@ function writeArtifact(
         ...payload,
       },
       null,
-      2,
+      JSON_INDENT_SPACES,
     ),
   );
 }

--- a/packages/protocol/src/testing/conformance/delivery.ts
+++ b/packages/protocol/src/testing/conformance/delivery.ts
@@ -9,7 +9,7 @@
  * Principle 3: every property body is `Effect<void, PropertyFailure>`.
  */
 import * as fc from "fast-check";
-import { Effect, Ref, type Scope } from "effect";
+import { Effect, Either, Ref, type Scope } from "effect";
 import { ErrorCodes } from "../../schema/errors.js";
 import { EventNames } from "../../schema/events.js";
 import {
@@ -24,6 +24,7 @@ import {
   ConversationsUpdate,
 } from "../../schema/methods/conversations.js";
 import { MessagesSend } from "../../schema/methods/messages.js";
+import { RpcResponseError } from "../errors.js";
 import { makeTestClient, type TestClient } from "../test-client.js";
 import { registerTestAgent, type TestAgent } from "../agent-registration.js";
 import type { ConformanceRunContext } from "./runner.js";
@@ -34,15 +35,19 @@ import {
   assertProperty,
   registerProperty,
 } from "./registry.js";
-import { sendUntypedRpc } from "./_helpers.js";
+import { leftOrNull, requireRight, sendUntypedRpc } from "./_helpers.js";
 
 const CATEGORY = "delivery" as const;
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_CAPTURE_CAPACITY = 256;
+const DEFAULT_PROPERTY_NUM_RUNS = 3;
+const DATE_ID_RADIX = 36;
 const MAX_N = 4;
 const CONVERSATION_LIFECYCLE_PROPERTY = "conversation-lifecycle";
 const APP_SESSION_CLOSE_LIFECYCLE_PROPERTY = "app-session-close-lifecycle";
 const ARCHIVE_LIFECYCLE_PROPERTY = "archive-lifecycle";
+const STORE_AND_REPLAY_PROPERTY = "store-and-replay";
+const TASK_BOUNDARY_ISOLATION_PROPERTY = "task-boundary-isolation";
 
 interface ConversationFixture {
   readonly owner: { agent: TestAgent; client: TestClient };
@@ -316,25 +321,28 @@ function assertConversationRejectsMessages(
       conversationId,
       "must-fail-while-archived",
     ).pipe(Effect.either);
-    if (outcome._tag === "Right") {
-      return yield* Effect.fail(
+    const outcomeViolation = Either.match(outcome, {
+      onRight: () =>
         violation(propertyName, "messages/send succeeded while archived"),
-      );
-    }
-    if (
-      outcome.left._tag !== "TestingRpcResponseError" ||
-      outcome.left.code !== ErrorCodes.ConversationArchived
-    ) {
-      const errorLabel =
-        outcome.left._tag === "TestingRpcResponseError"
-          ? `${outcome.left._tag}/${outcome.left.code}`
-          : outcome.left._tag;
-      return yield* Effect.fail(
-        violation(
+      onLeft: (error) => {
+        if (
+          error instanceof RpcResponseError &&
+          error.code === ErrorCodes.ConversationArchived
+        ) {
+          return null;
+        }
+        const errorLabel =
+          error instanceof RpcResponseError
+            ? `${error._tag}/${error.code}`
+            : error._tag;
+        return violation(
           propertyName,
           `messages/send returned ${errorLabel}, expected ConversationArchived`,
-        ),
-      );
+        );
+      },
+    });
+    if (outcomeViolation !== null) {
+      return yield* Effect.fail(outcomeViolation);
     }
   });
 }
@@ -386,12 +394,10 @@ function acquireConversation(
         })),
       })
       .pipe(Effect.either);
-    if (createResult._tag === "Left") {
-      return yield* Effect.fail(
-        `conversations/create failed: ${createResult.left._tag}`,
-      );
-    }
-    const created = createResult.right as {
+    const created = (yield* requireRight(
+      createResult,
+      (error) => `conversations/create failed: ${error._tag}`,
+    )) as {
       conversation?: { id?: string };
     };
     const conversationId = created.conversation?.id;
@@ -425,7 +431,9 @@ export function registerFanOutCardinality(ctx: ConformanceRunContext): void {
             Effect.scoped(
               Effect.gen(function* () {
                 const fixture = yield* acquireConversation(ctx, n, "fan").pipe(
-                  Effect.mapError((e) => new Error(e)),
+                  Effect.mapError((e) =>
+                    violation("fan-out-cardinality", `fixture: ${e}`),
+                  ),
                 );
                 const send = yield* fixture.owner.client
                   .sendRpc(MessagesSend.name, {
@@ -433,7 +441,7 @@ export function registerFanOutCardinality(ctx: ConformanceRunContext): void {
                     parts: [{ type: "text", text: "fan-out-ping" }],
                   })
                   .pipe(Effect.either);
-                if (send._tag === "Left") {
+                if (leftOrNull(send) !== null) {
                   return { kind: "send-failed" as const };
                 }
                 yield* Effect.sleep("250 millis");
@@ -465,7 +473,10 @@ export function registerFanOutCardinality(ctx: ConformanceRunContext): void {
             ),
           ),
         ),
-        { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 3 },
+        {
+          seed: ctx.seed,
+          numRuns: ctx.opts.numRuns ?? DEFAULT_PROPERTY_NUM_RUNS,
+        },
       ),
     ),
   );
@@ -503,7 +514,7 @@ export function registerStoreAndReplay(ctx: ConformanceRunContext): void {
   registerProperty(
     ctx,
     CATEGORY,
-    "store-and-replay",
+    STORE_AND_REPLAY_PROPERTY,
     "every messages/send lands in a live participant's capture buffer (basic-delivery-landing; #186 tracks C2 offline-replay)",
     Effect.scoped(
       Effect.gen(function* () {
@@ -512,7 +523,7 @@ export function registerStoreAndReplay(ctx: ConformanceRunContext): void {
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "store-and-replay",
+                name: STORE_AND_REPLAY_PROPERTY,
                 reason: `fixture: ${e}`,
               }),
           ),
@@ -522,7 +533,7 @@ export function registerStoreAndReplay(ctx: ConformanceRunContext): void {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "store-and-replay",
+              name: STORE_AND_REPLAY_PROPERTY,
               reason: "fixture missing participant",
             }),
           );
@@ -549,7 +560,7 @@ export function registerStoreAndReplay(ctx: ConformanceRunContext): void {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "store-and-replay",
+              name: STORE_AND_REPLAY_PROPERTY,
               reason: `sent ${sent}, live participant observed ${delivered}`,
             }),
           );
@@ -578,16 +589,16 @@ export function registerPayloadOpacity(ctx: ConformanceRunContext): void {
               Effect.scoped(
                 Effect.gen(function* () {
                   const fixture = yield* acquireConversation(ctx, 1, "po").pipe(
-                    Effect.mapError((e) => new Error(e)),
+                    Effect.mapError((e) =>
+                      violation("payload-opacity", `fixture: ${e}`),
+                    ),
                   );
                   const participant = fixture.participants[0];
                   if (participant === undefined) return false;
-                  yield* fixture.owner.client
-                    .sendRpc(MessagesSend.name, {
-                      conversationId: fixture.conversationId,
-                      parts: [{ type: "text", text }],
-                    })
-                    .pipe(Effect.either);
+                  yield* fixture.owner.client.sendRpc(MessagesSend.name, {
+                    conversationId: fixture.conversationId,
+                    parts: [{ type: "text", text }],
+                  });
                   yield* Effect.sleep("250 millis");
                   const snap = yield* participant.client.snapshot;
                   return snap.some(
@@ -600,7 +611,10 @@ export function registerPayloadOpacity(ctx: ConformanceRunContext): void {
               ).pipe(Effect.catchAll(() => Effect.succeed(false))),
             ),
         ),
-        { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 3 },
+        {
+          seed: ctx.seed,
+          numRuns: ctx.opts.numRuns ?? DEFAULT_PROPERTY_NUM_RUNS,
+        },
       ),
     ),
   );
@@ -641,9 +655,7 @@ export function registerHookGatedDelivery(ctx: ConformanceRunContext): void {
           "hgd",
           "hook-gated-delivery",
         ).pipe(Effect.either);
-        if (fixture._tag === "Left") {
-          return yield* Effect.fail(fixture.left);
-        }
+        yield* requireRight(fixture, (error) => error);
         // Codex review (#327, finding 4): the protocol fixture cannot
         // drive the deny/patch/attach scenarios end-to-end (no DB seam
         // to inspect the recipient view; `apps/attachConversation` is a
@@ -690,9 +702,7 @@ export function registerMultiAppFifoShortCircuit(
           "mfs",
           "multi-app-fifo-short-circuit",
         ).pipe(Effect.either);
-        if (fixture._tag === "Left") {
-          return yield* Effect.fail(fixture.left);
-        }
+        yield* requireRight(fixture, (error) => error);
         // Codex review (#327, finding 5): once apps/create succeeds, the
         // FIFO short-circuit assertion requires registering a SECOND
         // app on the same hook and observing the second handler is NOT
@@ -765,7 +775,7 @@ function acquireAppSessionFixture(
       Effect.mapError((e) => unavailable(`app client acquire: ${String(e)}`)),
     );
 
-    const appId = `${namePrefix}-${Date.now().toString(36)}`;
+    const appId = `${namePrefix}-${Date.now().toString(DATE_ID_RADIX)}`;
     const registerOutcome = yield* sendUntypedRpc(
       appClient,
       AppsRegister.name,
@@ -784,11 +794,9 @@ function acquireAppSessionFixture(
         },
       },
     ).pipe(Effect.either);
-    if (registerOutcome._tag === "Left") {
-      return yield* Effect.fail(
-        unavailable(`apps/register failed: ${registerOutcome.left._tag}`),
-      );
-    }
+    yield* requireRight(registerOutcome, (error) =>
+      unavailable(`apps/register failed: ${error._tag}`),
+    );
 
     const senderAgent = yield* registerTestAgent({
       baseUrl: ctx.realServer.baseUrl,
@@ -809,19 +817,16 @@ function acquireAppSessionFixture(
     const createOutcome = yield* senderClient
       .sendRpc(AppsCreate.name, { appId, invitedAgentIds: [] })
       .pipe(Effect.either);
-    if (createOutcome._tag === "Left") {
-      // Most common cause: owner_user_id is null on the sender (see
-      // app-host.ts:629). The default `startCoreTestServer` does not
-      // configure `devModeUserId`; B.9 fills the gap via DB seeding.
-      return yield* Effect.fail(
-        unavailable(
-          `apps/create failed (likely sender owner_user_id null; B.9 covers via DB seeding): ${createOutcome.left._tag}`,
-        ),
-      );
-    }
+    const createResult = yield* requireRight(createOutcome, (error) =>
+      unavailable(
+        // Most common cause: owner_user_id is null on the sender (see
+        // app-host.ts:629). The default `startCoreTestServer` does not
+        // configure `devModeUserId`; B.9 fills the gap via DB seeding.
+        `apps/create failed (likely sender owner_user_id null; B.9 covers via DB seeding): ${error._tag}`,
+      ),
+    );
 
-    const session = (createOutcome.right as { session?: { id?: string } })
-      .session;
+    const session = (createResult as { session?: { id?: string } }).session;
     const sessionId = session?.id;
     if (typeof sessionId !== "string" || sessionId.length === 0) {
       return yield* Effect.fail(
@@ -867,7 +872,7 @@ function acquireAppSessionCloseFixture(
       Effect.mapError((e) => unavailable(`app client acquire: ${String(e)}`)),
     );
 
-    const appId = `close-life-${Date.now().toString(36)}`;
+    const appId = `close-life-${Date.now().toString(DATE_ID_RADIX)}`;
     const registerOutcome = yield* sendUntypedRpc(
       appClient,
       AppsRegister.name,
@@ -882,11 +887,9 @@ function acquireAppSessionCloseFixture(
         },
       },
     ).pipe(Effect.either);
-    if (registerOutcome._tag === "Left") {
-      return yield* Effect.fail(
-        unavailable(`apps/register failed: ${registerOutcome.left._tag}`),
-      );
-    }
+    yield* requireRight(registerOutcome, (error) =>
+      unavailable(`apps/register failed: ${error._tag}`),
+    );
 
     const initiatorAgent = yield* registerTestAgent({
       baseUrl: ctx.realServer.baseUrl,
@@ -930,15 +933,13 @@ function acquireAppSessionCloseFixture(
         invitedAgentIds: [inviteeAgent.agentId],
       })
       .pipe(Effect.either);
-    if (createOutcome._tag === "Left") {
-      return yield* Effect.fail(
-        unavailable(
-          `apps/create failed (likely agents lack owner_user_id): ${createOutcome.left._tag}`,
-        ),
-      );
-    }
+    const createResult = yield* requireRight(createOutcome, (error) =>
+      unavailable(
+        `apps/create failed (likely agents lack owner_user_id): ${error._tag}`,
+      ),
+    );
 
-    const session = (createOutcome.right as AppCreateResultData).session;
+    const session = (createResult as AppCreateResultData).session;
     const sessionId = session?.id;
     const mainConversationId = session?.conversations?.["main"];
     if (
@@ -948,7 +949,7 @@ function acquireAppSessionCloseFixture(
       return yield* Effect.fail(
         violation(
           propertyName,
-          `apps/create response missing session id or main conversation: ${JSON.stringify(createOutcome.right)}`,
+          `apps/create response missing session id or main conversation: ${JSON.stringify(createResult)}`,
         ),
       );
     }
@@ -969,7 +970,7 @@ export function registerTaskBoundaryIsolation(
   registerProperty(
     ctx,
     CATEGORY,
-    "task-boundary-isolation",
+    TASK_BOUNDARY_ISOLATION_PROPERTY,
     "participants in conversation B observe zero leaks from conversation A",
     Effect.scoped(
       Effect.gen(function* () {
@@ -978,7 +979,7 @@ export function registerTaskBoundaryIsolation(
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "task-boundary-isolation",
+                name: TASK_BOUNDARY_ISOLATION_PROPERTY,
                 reason: `fixture A: ${e}`,
               }),
           ),
@@ -988,7 +989,7 @@ export function registerTaskBoundaryIsolation(
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "task-boundary-isolation",
+                name: TASK_BOUNDARY_ISOLATION_PROPERTY,
                 reason: `fixture B: ${e}`,
               }),
           ),
@@ -1010,7 +1011,7 @@ export function registerTaskBoundaryIsolation(
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "task-boundary-isolation",
+              name: TASK_BOUNDARY_ISOLATION_PROPERTY,
               reason: `conversation ${fxA.conversationId} leaked into outsider ${outsider.agent.agentId}`,
             }),
           );
@@ -1061,14 +1062,12 @@ export function registerConversationLifecycle(
           fixture.conversationId,
           "lifecycle-before-update",
         ).pipe(Effect.either);
-        if (firstSend._tag === "Left") {
-          return yield* Effect.fail(
-            violation(
-              CONVERSATION_LIFECYCLE_PROPERTY,
-              `messages/send failed before archive: ${firstSend.left._tag}`,
-            ),
-          );
-        }
+        yield* requireRight(firstSend, (error) =>
+          violation(
+            CONVERSATION_LIFECYCLE_PROPERTY,
+            `messages/send failed before archive: ${error._tag}`,
+          ),
+        );
         yield* waitForMessageReceivedEvent(
           participant,
           fixture.conversationId,
@@ -1081,14 +1080,12 @@ export function registerConversationLifecycle(
           fixture.conversationId,
           updatedName,
         ).pipe(Effect.either);
-        if (update._tag === "Left") {
-          return yield* Effect.fail(
-            violation(
-              CONVERSATION_LIFECYCLE_PROPERTY,
-              `conversations/update failed: ${update.left._tag}`,
-            ),
-          );
-        }
+        yield* requireRight(update, (error) =>
+          violation(
+            CONVERSATION_LIFECYCLE_PROPERTY,
+            `conversations/update failed: ${error._tag}`,
+          ),
+        );
         yield* waitForConversationUpdatedEvent(
           participant,
           fixture.conversationId,
@@ -1100,14 +1097,12 @@ export function registerConversationLifecycle(
           fixture.owner,
           fixture.conversationId,
         ).pipe(Effect.either);
-        if (archive._tag === "Left") {
-          return yield* Effect.fail(
-            violation(
-              CONVERSATION_LIFECYCLE_PROPERTY,
-              `archive failed: ${archive.left._tag}`,
-            ),
-          );
-        }
+        yield* requireRight(archive, (error) =>
+          violation(
+            CONVERSATION_LIFECYCLE_PROPERTY,
+            `archive failed: ${error._tag}`,
+          ),
+        );
         yield* waitForArchivedEvent(
           participant,
           fixture.conversationId,
@@ -1124,14 +1119,12 @@ export function registerConversationLifecycle(
           fixture.owner,
           fixture.conversationId,
         ).pipe(Effect.either);
-        if (unarchive._tag === "Left") {
-          return yield* Effect.fail(
-            violation(
-              CONVERSATION_LIFECYCLE_PROPERTY,
-              `unarchive failed: ${unarchive.left._tag}`,
-            ),
-          );
-        }
+        yield* requireRight(unarchive, (error) =>
+          violation(
+            CONVERSATION_LIFECYCLE_PROPERTY,
+            `unarchive failed: ${error._tag}`,
+          ),
+        );
         yield* waitForUnarchivedEvent(
           participant,
           fixture.conversationId,
@@ -1144,14 +1137,12 @@ export function registerConversationLifecycle(
           fixture.conversationId,
           "lifecycle-after-unarchive",
         ).pipe(Effect.either);
-        if (resumedSend._tag === "Left") {
-          return yield* Effect.fail(
-            violation(
-              CONVERSATION_LIFECYCLE_PROPERTY,
-              `messages/send failed after unarchive: ${resumedSend.left._tag}`,
-            ),
-          );
-        }
+        yield* requireRight(resumedSend, (error) =>
+          violation(
+            CONVERSATION_LIFECYCLE_PROPERTY,
+            `messages/send failed after unarchive: ${error._tag}`,
+          ),
+        );
       }),
     ),
   );
@@ -1177,19 +1168,17 @@ export function registerAppSessionCloseLifecycle(
         const close = yield* fixture.initiator.client
           .sendRpc(AppsCloseSession.name, { sessionId: fixture.sessionId })
           .pipe(Effect.either);
-        if (close._tag === "Left") {
+        const closeResult = yield* requireRight(close, (error) =>
+          violation(
+            APP_SESSION_CLOSE_LIFECYCLE_PROPERTY,
+            `apps/closeSession failed: ${error._tag}`,
+          ),
+        );
+        if ((closeResult as { closed?: unknown }).closed !== true) {
           return yield* Effect.fail(
             violation(
               APP_SESSION_CLOSE_LIFECYCLE_PROPERTY,
-              `apps/closeSession failed: ${close.left._tag}`,
-            ),
-          );
-        }
-        if ((close.right as { closed?: unknown }).closed !== true) {
-          return yield* Effect.fail(
-            violation(
-              APP_SESSION_CLOSE_LIFECYCLE_PROPERTY,
-              `apps/closeSession returned unexpected result: ${JSON.stringify(close.right)}`,
+              `apps/closeSession returned unexpected result: ${JSON.stringify(closeResult)}`,
             ),
           );
         }
@@ -1246,14 +1235,12 @@ export function registerArchiveLifecycle(ctx: ConformanceRunContext): void {
           fixture.owner,
           fixture.conversationId,
         ).pipe(Effect.either);
-        if (archive._tag === "Left") {
-          return yield* Effect.fail(
-            violation(
-              ARCHIVE_LIFECYCLE_PROPERTY,
-              `archive failed: ${archive.left._tag}`,
-            ),
-          );
-        }
+        yield* requireRight(archive, (error) =>
+          violation(
+            ARCHIVE_LIFECYCLE_PROPERTY,
+            `archive failed: ${error._tag}`,
+          ),
+        );
         yield* waitForArchivedEvent(
           participant,
           fixture.conversationId,
@@ -1270,14 +1257,12 @@ export function registerArchiveLifecycle(ctx: ConformanceRunContext): void {
           fixture.owner,
           fixture.conversationId,
         ).pipe(Effect.either);
-        if (unarchive._tag === "Left") {
-          return yield* Effect.fail(
-            violation(
-              ARCHIVE_LIFECYCLE_PROPERTY,
-              `unarchive failed: ${unarchive.left._tag}`,
-            ),
-          );
-        }
+        yield* requireRight(unarchive, (error) =>
+          violation(
+            ARCHIVE_LIFECYCLE_PROPERTY,
+            `unarchive failed: ${error._tag}`,
+          ),
+        );
         yield* waitForUnarchivedEvent(
           participant,
           fixture.conversationId,
@@ -1290,14 +1275,12 @@ export function registerArchiveLifecycle(ctx: ConformanceRunContext): void {
           fixture.conversationId,
           "must-succeed-after-unarchive",
         ).pipe(Effect.either);
-        if (resumedSend._tag === "Left") {
-          return yield* Effect.fail(
-            violation(
-              ARCHIVE_LIFECYCLE_PROPERTY,
-              `messages/send failed after unarchive: ${resumedSend.left._tag}`,
-            ),
-          );
-        }
+        yield* requireRight(resumedSend, (error) =>
+          violation(
+            ARCHIVE_LIFECYCLE_PROPERTY,
+            `messages/send failed after unarchive: ${error._tag}`,
+          ),
+        );
       }),
     ),
   );

--- a/packages/protocol/src/testing/conformance/env.ts
+++ b/packages/protocol/src/testing/conformance/env.ts
@@ -1,13 +1,47 @@
+import { Config, ConfigProvider, Data, Effect, Option } from "effect";
+
+export class ConformanceEnvError extends Data.TaggedError(
+  "ConformanceEnvError",
+)<{
+  readonly key: string;
+  readonly message: string;
+}> {}
+
+const ConformanceNumRuns = Config.option(Config.string("CONFORMANCE_NUM_RUNS"));
+const ConformanceArtifactDir = Config.all({
+  artifactDir: Config.option(Config.string("ARTIFACT_DIR")),
+  conformanceArtifactDir: Config.option(
+    Config.string("CONFORMANCE_ARTIFACT_DIR"),
+  ),
+});
+
 export function conformanceNumRunsFromEnv(): number | undefined {
-  const raw = process.env.CONFORMANCE_NUM_RUNS;
+  const raw = Option.getOrUndefined(
+    Effect.runSync(
+      ConformanceNumRuns.pipe(
+        Effect.withConfigProvider(ConfigProvider.fromEnv()),
+      ),
+    ),
+  );
   if (raw === undefined || raw === "") return undefined;
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed < 1) {
-    throw new Error(`CONFORMANCE_NUM_RUNS must be a positive integer: ${raw}`);
+    throw new ConformanceEnvError({
+      key: "CONFORMANCE_NUM_RUNS",
+      message: `CONFORMANCE_NUM_RUNS must be a positive integer: ${raw}`,
+    });
   }
   return parsed;
 }
 
 export function conformanceArtifactDirFromEnv(): string | undefined {
-  return process.env.CONFORMANCE_ARTIFACT_DIR ?? process.env.ARTIFACT_DIR;
+  const env = Effect.runSync(
+    ConformanceArtifactDir.pipe(
+      Effect.withConfigProvider(ConfigProvider.fromEnv()),
+    ),
+  );
+  return (
+    Option.getOrUndefined(env.conformanceArtifactDir) ??
+    Option.getOrUndefined(env.artifactDir)
+  );
 }

--- a/packages/protocol/src/testing/conformance/presence.ts
+++ b/packages/protocol/src/testing/conformance/presence.ts
@@ -19,9 +19,12 @@ import { registerTestAgent, type TestAgent } from "../agent-registration.js";
 import type { ConformanceRunContext } from "./runner.js";
 import { PropertyInvariantViolation, registerProperty } from "./registry.js";
 
+import { Connect } from "../../schema/methods/auth.js";
+
 const CATEGORY = "presence" as const;
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_CAPTURE_CAPACITY = 256;
+const EXPECTED_PRESENCE_SEQUENCE_LENGTH = 3;
 
 type PresenceStatus = "online" | "offline" | "away";
 
@@ -293,7 +296,7 @@ export function registerReconnectStorm(ctx: ConformanceRunContext): void {
 
         const sequence = yield* presenceStatusesFor(sub.client, a.agentId);
         if (
-          sequence.length !== 3 ||
+          sequence.length !== EXPECTED_PRESENCE_SEQUENCE_LENGTH ||
           sequence[0] !== "online" ||
           sequence[1] !== "offline" ||
           sequence[2] !== "online"
@@ -342,7 +345,7 @@ export function registerSameStateNoDoubleFire(
         );
 
         yield* aClient
-          .sendRpc("auth/connect", {
+          .sendRpc(Connect.name, {
             agentKey: a.apiKey,
             minProtocol: PROTOCOL_VERSION,
             maxProtocol: PROTOCOL_VERSION,

--- a/packages/protocol/src/testing/conformance/registry.ts
+++ b/packages/protocol/src/testing/conformance/registry.ts
@@ -138,10 +138,10 @@ export function collectProperties(
 export function assertProperty(
   category: PropertyCategory,
   name: string,
-  body: () => Promise<void>,
+  body: () => void | PromiseLike<void>,
 ): PropertyRun {
   return Effect.tryPromise({
-    try: body,
+    try: () => Promise.resolve(body()),
     catch: (cause) => new PropertyAssertionFailure({ category, name, cause }),
   });
 }

--- a/packages/protocol/src/testing/conformance/rpc-semantics.ts
+++ b/packages/protocol/src/testing/conformance/rpc-semantics.ts
@@ -9,7 +9,7 @@
  * Principle 3: every property body is `Effect<void, PropertyFailure>`.
  */
 import * as fc from "fast-check";
-import { Effect } from "effect";
+import { Effect, Either } from "effect";
 import {
   arbitraryAnyCall,
   arbitraryConfidentCall,
@@ -22,7 +22,11 @@ import {
 } from "../models/dispatch.js";
 import { initialReferenceState } from "../models/state.js";
 import { ErrorCodes } from "../../schema/errors.js";
+import { AgentsList } from "../../schema/methods/auth.js";
+import { AppsOnBeforeDispatch } from "../../schema/methods/apps.js";
+import { ConversationsList } from "../../schema/methods/conversations.js";
 import { canonicalJson, sortJsonArray } from "../canonicalize.js";
+import { RpcResponseError } from "../errors.js";
 import { makeTestClient } from "../test-client.js";
 import { registerTestAgent } from "../agent-registration.js";
 import { allRpcMethods } from "../arbitraries/rpc.js";
@@ -34,10 +38,23 @@ import {
   PropertyUnavailable,
   registerProperty,
 } from "./registry.js";
+import { eitherTag, leftOrNull } from "./_helpers.js";
 
 const CATEGORY = "rpc-semantics" as const;
 const DEFAULT_TIMEOUT_MS = 3000;
 const DEFAULT_CAPTURE_CAPACITY = 64;
+const MODEL_EQUIVALENCE_PROPERTY = "model-equivalence";
+const AUTHORITY_POSITIVE_PROPERTY = "authority-positive";
+const AUTHORITY_NEGATIVE_PROPERTY = "authority-negative";
+const REQUEST_ID_UNIQUENESS_PROPERTY = "request-id-uniqueness";
+const CALLER_CONTROLLED_S2C_TIMEOUT_PROPERTY = "caller-controlled-s2c-timeout";
+const IDEMPOTENCE_PROPERTY = "idempotence";
+const MODEL_NUM_RUNS_FLOOR = 10;
+const MODEL_RUNS_PER_CONFIDENT_METHOD = 2;
+const RESPONSE_CAPTURE_CAPACITY_PER_REQUEST = 4;
+const REQUEST_ID_UNIQUENESS_NUM_RUNS = 5;
+const TIMEOUT_LOWER_MARGIN_MS = 20;
+const TIMEOUT_UPPER_MULTIPLIER = 4;
 
 /**
  * Model-equivalence — conditional oracle over the model-derived
@@ -73,13 +90,16 @@ const DEFAULT_CAPTURE_CAPACITY = 64;
  */
 export function registerModelEquivalence(ctx: ConformanceRunContext): void {
   const K = confidentOracleMethods.length;
-  const numRunsFloor = Math.max(10, 2 * K);
+  const numRunsFloor = Math.max(
+    MODEL_NUM_RUNS_FLOOR,
+    MODEL_RUNS_PER_CONFIDENT_METHOD * K,
+  );
   registerProperty(
     ctx,
     CATEGORY,
-    "model-equivalence",
+    MODEL_EQUIVALENCE_PROPERTY,
     `when model predicts ok, server MUST return ok (K=${K} confident methods)`,
-    assertProperty(CATEGORY, "model-equivalence", () =>
+    assertProperty(CATEGORY, MODEL_EQUIVALENCE_PROPERTY, () =>
       fc.assert(
         fc.asyncProperty(arbitraryConfidentCall(), (call) => {
           const modelTag = applyCall(initialReferenceState, call).outcome._tag;
@@ -89,8 +109,14 @@ export function registerModelEquivalence(ctx: ConformanceRunContext): void {
             // disagrees, applyCall became param-sensitive for the
             // kept method and the derivation must widen. Surface
             // loudly instead of silent short-circuit.
-            throw new Error(
-              `arbitraryConfidentCall drew ${call.method} with params ${JSON.stringify(call.params)} → model _tag: "error" — param-invariance contract broken; widen derivation to fc.sample-based check per architect #197 §2.2`,
+            return Effect.runPromise(
+              Effect.fail(
+                new PropertyInvariantViolation({
+                  category: CATEGORY,
+                  name: MODEL_EQUIVALENCE_PROPERTY,
+                  reason: `arbitraryConfidentCall drew ${call.method} with params ${JSON.stringify(call.params)} → model _tag: "error" — param-invariance contract broken; widen derivation to fc.sample-based check per architect #197 §2.2`,
+                }),
+              ),
             );
           }
           return Effect.runPromise(
@@ -110,7 +136,10 @@ export function registerModelEquivalence(ctx: ConformanceRunContext): void {
                 const outcome = yield* client
                   .sendRpc(call.method, call.params)
                   .pipe(Effect.either);
-                return outcome._tag === "Right" ? "ok" : "error";
+                return Either.match(outcome, {
+                  onLeft: () => "error" as const,
+                  onRight: () => "ok" as const,
+                });
               }),
             ).pipe(Effect.map((serverTag) => serverTag === "ok")),
           );
@@ -133,7 +162,7 @@ export function registerAuthorityPositive(ctx: ConformanceRunContext): void {
   registerProperty(
     ctx,
     CATEGORY,
-    "authority-positive",
+    AUTHORITY_POSITIVE_PROPERTY,
     "authorized agent → typed success on conversations/list",
     Effect.scoped(
       Effect.gen(function* () {
@@ -145,7 +174,7 @@ export function registerAuthorityPositive(ctx: ConformanceRunContext): void {
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "authority-positive",
+                name: AUTHORITY_POSITIVE_PROPERTY,
                 reason: `agent registration failed: ${e.body}`,
               }),
           ),
@@ -161,20 +190,21 @@ export function registerAuthorityPositive(ctx: ConformanceRunContext): void {
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "authority-positive",
+                name: AUTHORITY_POSITIVE_PROPERTY,
                 reason: `client acquire failed: ${String(e)}`,
               }),
           ),
         );
         const outcome = yield* client
-          .sendRpc("conversations/list", {})
+          .sendRpc(ConversationsList.name, {})
           .pipe(Effect.either);
-        if (outcome._tag === "Left") {
+        const failure = leftOrNull(outcome);
+        if (failure !== null) {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "authority-positive",
-              reason: `authorized conversations/list failed: ${outcome.left._tag}`,
+              name: AUTHORITY_POSITIVE_PROPERTY,
+              reason: `authorized conversations/list failed: ${failure._tag}`,
             }),
           );
         }
@@ -193,7 +223,7 @@ export function registerAuthorityNegative(ctx: ConformanceRunContext): void {
   registerProperty(
     ctx,
     CATEGORY,
-    "authority-negative",
+    AUTHORITY_NEGATIVE_PROPERTY,
     "unauthenticated agent → typed denial on conversations/list",
     Effect.scoped(
       Effect.gen(function* () {
@@ -207,7 +237,7 @@ export function registerAuthorityNegative(ctx: ConformanceRunContext): void {
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "authority-negative",
+                name: AUTHORITY_NEGATIVE_PROPERTY,
                 reason: `agent registration failed: ${e.body}`,
               }),
           ),
@@ -224,45 +254,47 @@ export function registerAuthorityNegative(ctx: ConformanceRunContext): void {
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "authority-negative",
+                name: AUTHORITY_NEGATIVE_PROPERTY,
                 reason: `client acquire failed: ${String(e)}`,
               }),
           ),
         );
         const outcome = yield* client
-          .sendRpc("conversations/list", {})
+          .sendRpc(ConversationsList.name, {})
           .pipe(Effect.either);
-        if (outcome._tag === "Right") {
-          return yield* Effect.fail(
-            new PropertyInvariantViolation({
-              category: CATEGORY,
-              name: "authority-negative",
-              reason:
-                "pre-handshake conversations/list returned success — expected typed denial",
-            }),
-          );
-        }
+        const error = yield* Either.match(outcome, {
+          onLeft: (failure) => Effect.succeed(failure),
+          onRight: () =>
+            Effect.fail(
+              new PropertyInvariantViolation({
+                category: CATEGORY,
+                name: AUTHORITY_NEGATIVE_PROPERTY,
+                reason:
+                  "pre-handshake conversations/list returned success — expected typed denial",
+              }),
+            ),
+        });
         // Narrow the Left: must be a typed auth-shaped RpcResponseError
         // (Unauthorized / Forbidden). A timeout or transport-close
         // would also surface as `Left` but does NOT satisfy the
         // property — it proves nothing about authorization.
-        if (outcome.left._tag !== "TestingRpcResponseError") {
+        if (!(error instanceof RpcResponseError)) {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "authority-negative",
-              reason: `expected RpcResponseError, got ${outcome.left._tag}`,
+              name: AUTHORITY_NEGATIVE_PROPERTY,
+              reason: `expected RpcResponseError, got ${error._tag}`,
             }),
           );
         }
-        const code = outcome.left.code;
+        const code = error.code;
         const isAuthShaped =
           code === ErrorCodes.Unauthorized || code === ErrorCodes.Forbidden;
         if (!isAuthShaped) {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "authority-negative",
+              name: AUTHORITY_NEGATIVE_PROPERTY,
               reason: `expected Unauthorized/Forbidden code (${ErrorCodes.Unauthorized} / ${ErrorCodes.Forbidden}), got ${code}`,
             }),
           );
@@ -272,14 +304,14 @@ export function registerAuthorityNegative(ctx: ConformanceRunContext): void {
         // server.
         const modelVerdict = authorizationOutcome(
           initialReferenceState,
-          { method: "conversations/list", params: {} },
+          { method: ConversationsList.name, params: {} },
           "unknown-agent",
         );
         if (modelVerdict !== "deny-unauthenticated") {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "authority-negative",
+              name: AUTHORITY_NEGATIVE_PROPERTY,
               reason: `model oracle disagrees: expected deny-unauthenticated, got ${modelVerdict}`,
             }),
           );
@@ -297,9 +329,9 @@ export function registerRequestIdUniqueness(ctx: ConformanceRunContext): void {
   registerProperty(
     ctx,
     CATEGORY,
-    "request-id-uniqueness",
+    REQUEST_ID_UNIQUENESS_PROPERTY,
     "every request-id appears in exactly one response",
-    assertProperty(CATEGORY, "request-id-uniqueness", () =>
+    assertProperty(CATEGORY, REQUEST_ID_UNIQUENESS_PROPERTY, () =>
       fc.assert(
         fc.asyncProperty(fc.integer({ min: 2, max: 6 }), (n) =>
           Effect.runPromise(
@@ -314,7 +346,7 @@ export function registerRequestIdUniqueness(ctx: ConformanceRunContext): void {
                   agentKey: agent.apiKey,
                   agentId: agent.agentId,
                   defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-                  captureCapacity: n * 4,
+                  captureCapacity: n * RESPONSE_CAPTURE_CAPACITY_PER_REQUEST,
                 });
                 // Snapshot the capture boundary after handshake so we
                 // only tally response ids for the N RPCs below — not
@@ -324,7 +356,7 @@ export function registerRequestIdUniqueness(ctx: ConformanceRunContext): void {
                   Array.from({ length: n }, (_, i) => i),
                   () =>
                     client
-                      .sendRpc("conversations/list", {})
+                      .sendRpc(ConversationsList.name, {})
                       .pipe(Effect.either),
                   { concurrency: n },
                 );
@@ -374,7 +406,10 @@ export function registerRequestIdUniqueness(ctx: ConformanceRunContext): void {
             ),
           ),
         ),
-        { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 5 },
+        {
+          seed: ctx.seed,
+          numRuns: ctx.opts.numRuns ?? REQUEST_ID_UNIQUENESS_NUM_RUNS,
+        },
       ),
     ),
   );
@@ -433,7 +468,7 @@ export function registerCallerControlledS2cTimeout(
   registerProperty(
     ctx,
     CATEGORY,
-    "caller-controlled-s2c-timeout",
+    CALLER_CONTROLLED_S2C_TIMEOUT_PROPERTY,
     "awaitServerRequest(_, _, timeoutMs) fires within the caller's window",
     Effect.scoped(
       Effect.gen(function* () {
@@ -445,7 +480,7 @@ export function registerCallerControlledS2cTimeout(
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "caller-controlled-s2c-timeout",
+                name: CALLER_CONTROLLED_S2C_TIMEOUT_PROPERTY,
                 reason: `register agent: ${e.body}`,
               }),
           ),
@@ -461,7 +496,7 @@ export function registerCallerControlledS2cTimeout(
             (e) =>
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "caller-controlled-s2c-timeout",
+                name: CALLER_CONTROLLED_S2C_TIMEOUT_PROPERTY,
                 reason: `client acquire: ${String(e)}`,
               }),
           ),
@@ -471,28 +506,30 @@ export function registerCallerControlledS2cTimeout(
         // 200–500ms on a 100ms timer, while a 250ms timer with the same
         // 4× upper bound stays well clear of the flake band.
         const timeoutMs = 250;
-        const lowerBoundMs = timeoutMs - 20;
-        const upperBoundMs = timeoutMs * 4;
+        const lowerBoundMs = timeoutMs - TIMEOUT_LOWER_MARGIN_MS;
+        const upperBoundMs = timeoutMs * TIMEOUT_UPPER_MULTIPLIER;
         const before = Date.now();
         const outcome = yield* client
-          .awaitServerRequest("apps/onBeforeDispatch", undefined, timeoutMs)
+          .awaitServerRequest(AppsOnBeforeDispatch.name, undefined, timeoutMs)
           .pipe(Effect.either);
         const elapsed = Date.now() - before;
-        if (outcome._tag !== "Left") {
+        const timeoutError = yield* Either.match(outcome, {
+          onLeft: (error) => Effect.succeed(error),
+          onRight: () =>
+            Effect.fail(
+              new PropertyInvariantViolation({
+                category: CATEGORY,
+                name: CALLER_CONTROLLED_S2C_TIMEOUT_PROPERTY,
+                reason: `expected Left (timeout); got Right (s2c request fired)`,
+              }),
+            ),
+        });
+        if (!/Timeout/i.test(timeoutError.message)) {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "caller-controlled-s2c-timeout",
-              reason: `expected Left (timeout); got Right (s2c request fired)`,
-            }),
-          );
-        }
-        if (!/Timeout/i.test(outcome.left.message)) {
-          return yield* Effect.fail(
-            new PropertyInvariantViolation({
-              category: CATEGORY,
-              name: "caller-controlled-s2c-timeout",
-              reason: `expected timeout error; got ${outcome.left.message}`,
+              name: CALLER_CONTROLLED_S2C_TIMEOUT_PROPERTY,
+              reason: `expected timeout error; got ${timeoutError.message}`,
             }),
           );
         }
@@ -505,7 +542,7 @@ export function registerCallerControlledS2cTimeout(
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "caller-controlled-s2c-timeout",
+              name: CALLER_CONTROLLED_S2C_TIMEOUT_PROPERTY,
               reason: `timeout fired at ${elapsed}ms; caller asked for ${timeoutMs}ms (window: ${lowerBoundMs}–${upperBoundMs}ms)`,
             }),
           );
@@ -531,19 +568,19 @@ export function registerIdempotence(ctx: ConformanceRunContext): void {
   registerProperty(
     ctx,
     CATEGORY,
-    "idempotence",
+    IDEMPOTENCE_PROPERTY,
     "isIdempotent methods: two sends yield identical response bodies",
     Effect.gen(function* () {
       const emptyParamIdempotents = [
-        "agents/list",
-        "conversations/list",
+        AgentsList.name,
+        ConversationsList.name,
       ] as const;
       for (const method of emptyParamIdempotents) {
         if (!isIdempotent(method)) {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "idempotence",
+              name: IDEMPOTENCE_PROPERTY,
               reason: `isIdempotent(${method}) is false — oracle disagreement`,
             }),
           );
@@ -571,7 +608,7 @@ export function registerIdempotence(ctx: ConformanceRunContext): void {
               Effect.fail(
                 new PropertyUnavailable({
                   category: CATEGORY,
-                  name: "idempotence",
+                  name: IDEMPOTENCE_PROPERTY,
                   reason: `register: ${e.body}`,
                 }),
               ),
@@ -579,7 +616,7 @@ export function registerIdempotence(ctx: ConformanceRunContext): void {
               Effect.fail(
                 new PropertyUnavailable({
                   category: CATEGORY,
-                  name: "idempotence",
+                  name: IDEMPOTENCE_PROPERTY,
                   reason: `transport io: ${String(e.cause)}`,
                 }),
               ),
@@ -587,7 +624,7 @@ export function registerIdempotence(ctx: ConformanceRunContext): void {
               Effect.fail(
                 new PropertyUnavailable({
                   category: CATEGORY,
-                  name: "idempotence",
+                  name: IDEMPOTENCE_PROPERTY,
                   reason: `transport closed: ${e.reason}`,
                 }),
               ),
@@ -595,33 +632,43 @@ export function registerIdempotence(ctx: ConformanceRunContext): void {
               Effect.fail(
                 new PropertyUnavailable({
                   category: CATEGORY,
-                  name: "idempotence",
+                  name: IDEMPOTENCE_PROPERTY,
                   reason: `rpc response error: ${e.message}`,
                 }),
               ),
           }),
         );
-        if (pair.a._tag !== pair.b._tag) {
+        const aTag = eitherTag(pair.a);
+        const bTag = eitherTag(pair.b);
+        if (aTag !== bTag) {
           return yield* Effect.fail(
             new PropertyInvariantViolation({
               category: CATEGORY,
-              name: "idempotence",
-              reason: `${method}: replay outcome-tag mismatch ${pair.a._tag} → ${pair.b._tag}`,
+              name: IDEMPOTENCE_PROPERTY,
+              reason: `${method}: replay outcome-tag mismatch ${aTag} → ${bTag}`,
             }),
           );
         }
-        if (pair.a._tag === "Right" && pair.b._tag === "Right") {
+        const successPair = Either.match(pair.a, {
+          onLeft: () => null,
+          onRight: (a) =>
+            Either.match(pair.b, {
+              onLeft: () => null,
+              onRight: (b) => ({ a, b }),
+            }),
+        });
+        if (successPair !== null) {
           // Canonical-projection comparison per architect #197 §3.3.
           // Direct JSON.stringify on wire-derived values is byte-
           // equality, not semantic equality; a conforming server may
           // return the list in a different row order across replays.
-          const aCanon = canonIdempotenceResult(method, pair.a.right);
-          const bCanon = canonIdempotenceResult(method, pair.b.right);
+          const aCanon = canonIdempotenceResult(method, successPair.a);
+          const bCanon = canonIdempotenceResult(method, successPair.b);
           if (aCanon !== bCanon) {
             return yield* Effect.fail(
               new PropertyInvariantViolation({
                 category: CATEGORY,
-                name: "idempotence",
+                name: IDEMPOTENCE_PROPERTY,
                 reason: `${method}: replay bodies diverge under canonical projection`,
               }),
             );
@@ -649,10 +696,10 @@ export function registerIdempotence(ctx: ConformanceRunContext): void {
  * fails the property.
  */
 function canonIdempotenceResult(
-  method: "agents/list" | "conversations/list",
+  method: typeof AgentsList.name | typeof ConversationsList.name,
   result: unknown,
 ): string {
-  if (method === "agents/list") {
+  if (method === AgentsList.name) {
     const r = result as { agents?: unknown[] };
     return canonicalJson({
       ...r,

--- a/packages/protocol/src/testing/conformance/runner.ts
+++ b/packages/protocol/src/testing/conformance/runner.ts
@@ -12,10 +12,19 @@
  *   - pin fast-check seeds and export them on failure (AC10);
  *   - tear everything down in reverse order.
  */
-import { Effect, Ref, Scope } from "effect";
+import { Config, ConfigProvider, Effect, Ref, Scope } from "effect";
 import { makeToxiproxyClient, type ToxiproxyClient } from "../toxics/client.js";
 import { RealServerAcquireError, ToxicControlError } from "../errors.js";
 import { conformanceNumRunsFromEnv } from "./env.js";
+
+const REPLAY_SEED_MASK = 0x7fffffff;
+
+const loadFastCheckSeed: Effect.Effect<number, never> = Config.integer(
+  "FC_SEED",
+).pipe(
+  Effect.withConfigProvider(ConfigProvider.fromEnv()),
+  Effect.orElseSucceed(() => Date.now() & REPLAY_SEED_MASK),
+);
 
 /**
  * Opaque handle to a running real MoltZap server. The conformance runner
@@ -27,13 +36,13 @@ export interface RealServerHandle {
   readonly wsUrl: string;
   readonly baseUrl: string;
   /** Teardown hook; the runner's Scope calls this on release. */
-  readonly close: () => Promise<void>;
+  readonly close: Effect.Effect<void>;
 }
 
 export interface ConformanceRunOptions {
   readonly tiers: ReadonlyArray<"A" | "B" | "C" | "D" | "E">;
   /** Supplier for the real server; invoked once per run. */
-  readonly realServer: () => Promise<RealServerHandle>;
+  readonly realServer: Effect.Effect<RealServerHandle, RealServerAcquireError>;
   /** If provided, replay this exact fast-check seed (AC10 reproducibility). */
   readonly replaySeed?: number;
   /** Number of runs per property; fast-check default is 100. */
@@ -85,24 +94,11 @@ export function acquireRunContext(
       ...opts,
       numRuns: opts.numRuns ?? conformanceNumRunsFromEnv(),
     };
-    const seed =
-      effectiveOpts.replaySeed ??
-      Number(process.env.FC_SEED ?? Date.now() & 0x7fffffff);
+    const seed = effectiveOpts.replaySeed ?? (yield* loadFastCheckSeed);
     const artifacts = yield* Ref.make<ReadonlyArray<ConformanceArtifact>>([]);
 
-    const realServer = yield* Effect.acquireRelease(
-      Effect.tryPromise({
-        try: () => opts.realServer(),
-        catch: (cause) => new RealServerAcquireError({ cause }),
-      }),
-      (handle) =>
-        Effect.tryPromise({
-          try: () => handle.close(),
-          catch: () => new Error("realServer.close() threw"),
-        }).pipe(
-          Effect.orElseSucceed(() => undefined),
-          Effect.asVoid,
-        ),
+    const realServer = yield* Effect.acquireRelease(opts.realServer, (handle) =>
+      handle.close.pipe(Effect.orElseSucceed(() => undefined)),
     );
 
     let toxiproxy: ToxiproxyClient | null = null;

--- a/packages/protocol/src/testing/conformance/schema-conformance.ts
+++ b/packages/protocol/src/testing/conformance/schema-conformance.ts
@@ -12,7 +12,7 @@
  * `PropertyInvariantViolation`.
  */
 import * as fc from "fast-check";
-import { Effect } from "effect";
+import { Effect, Either } from "effect";
 import { Value } from "@sinclair/typebox/value";
 import {
   allRpcMethods,
@@ -25,6 +25,7 @@ import {
   arbitraryMalformedFrame,
 } from "../arbitraries/frames.js";
 import { decodeFrame, encodeFrame } from "../codec.js";
+import { FrameSchemaError } from "../errors.js";
 import {
   EventFrameSchema,
   RequestFrameSchema,
@@ -41,7 +42,17 @@ import {
   registerProperty,
 } from "./registry.js";
 
+import { AgentsList, Connect } from "../../schema/methods/auth.js";
+import { ContactsList } from "../../schema/methods/contacts.js";
+import { ConversationsList } from "../../schema/methods/conversations.js";
+
 const CATEGORY = "schema-conformance" as const;
+const DEFAULT_MALFORMED_RESPONSE_RUNS = 3;
+const DEFAULT_EVENT_SCHEMA_RUNS = 20;
+const DEFAULT_ROUNDTRIP_RUNS = 50;
+const DEFAULT_MALFORMED_S2C_RUNS = 50;
+const DEFAULT_RESPONSE_VALIDATION_RUNS = 50;
+const DEFAULT_DIRECTION_PARTITION_RUNS = 30;
 const DEFAULT_TIMEOUT_MS = 3000;
 const DEFAULT_CAPTURE_CAPACITY = 64;
 
@@ -122,7 +133,7 @@ export function registerRequestWellFormedness(
         ),
         {
           seed: ctx.seed,
-          numRuns: ctx.opts.numRuns ?? 3,
+          numRuns: ctx.opts.numRuns ?? DEFAULT_MALFORMED_RESPONSE_RUNS,
           // Dropped-response counterexamples pay the client RPC timeout.
           // Shrinking repeats that timeout and makes executable proofs
           // timing-sensitive under stress without increasing coverage.
@@ -159,13 +170,16 @@ export function registerEventWellFormedness(ctx: ConformanceRunContext): void {
             const decoded = Effect.runSync(
               Effect.either(decodeFrame(raw, "inbound")),
             );
-            if (decoded._tag !== "Right") return false;
-            return (
-              decoded.right.type === "event" &&
-              Value.Check(EventFrameSchema, decoded.right)
-            );
+            return Either.match(decoded, {
+              onLeft: () => false,
+              onRight: (frame) =>
+                frame.type === "event" && Value.Check(EventFrameSchema, frame),
+            });
           }),
-          { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 20 },
+          {
+            seed: ctx.seed,
+            numRuns: ctx.opts.numRuns ?? DEFAULT_EVENT_SCHEMA_RUNS,
+          },
         ),
       ),
     ),
@@ -189,15 +203,22 @@ export function registerRoundTripIdentity(ctx: ConformanceRunContext): void {
               const re = Effect.runSync(
                 Effect.either(decodeFrame(raw, "inbound")),
               );
-              if (re._tag === "Left") return true; // generator-side drift
-              const redone = encodeFrame(re.right);
-              return (
-                JSON.stringify(JSON.parse(raw)) ===
-                JSON.stringify(JSON.parse(redone))
-              );
+              return Either.match(re, {
+                onLeft: () => true, // generator-side drift
+                onRight: (frame) => {
+                  const redone = encodeFrame(frame);
+                  return (
+                    JSON.stringify(JSON.parse(raw)) ===
+                    JSON.stringify(JSON.parse(redone))
+                  );
+                },
+              });
             },
           ),
-          { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 50 },
+          {
+            seed: ctx.seed,
+            numRuns: ctx.opts.numRuns ?? DEFAULT_ROUNDTRIP_RUNS,
+          },
         ),
       ),
     ),
@@ -236,7 +257,7 @@ export function registerMalformedFrameHandling(
                   malformedQuiescenceMs: 500,
                 });
                 const response = yield* client.sendMalformed({
-                  baseMethod: "agents/list",
+                  baseMethod: AgentsList.name,
                   kind,
                   seed,
                 });
@@ -244,7 +265,7 @@ export function registerMalformedFrameHandling(
                 // normal RPC — proves the server didn't crash or
                 // poison its state.
                 const post = yield* client
-                  .sendRpc("agents/list", {})
+                  .sendRpc(AgentsList.name, {})
                   .pipe(Effect.either);
                 return { malformedReply: response, post };
               }),
@@ -260,13 +281,19 @@ export function registerMalformedFrameHandling(
                 // to count as server-alive, which is exactly what the
                 // property must reject. Require the post-malformed call to
                 // return cleanly.
-                const stillAlive = result.post._tag === "Right";
+                const stillAlive = Either.match(result.post, {
+                  onLeft: () => false,
+                  onRight: () => true,
+                });
                 return validReply && stillAlive;
               }),
             ),
           ),
         ),
-        { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 3 },
+        {
+          seed: ctx.seed,
+          numRuns: ctx.opts.numRuns ?? DEFAULT_MALFORMED_RESPONSE_RUNS,
+        },
       ),
     ),
   );
@@ -280,10 +307,10 @@ export function registerMalformedFrameHandling(
  * render every RPC unreachable.
  */
 const COVERAGE_SAMPLE = [
-  "auth/connect",
-  "agents/list",
-  "conversations/list",
-  "contacts/list",
+  Connect.name,
+  AgentsList.name,
+  ConversationsList.name,
+  ContactsList.name,
 ] as const;
 
 /**
@@ -312,16 +339,23 @@ export function registerS2cRequestRoundTripIdentity(
             const decoded = Effect.runSync(
               Effect.either(decodeFrame(raw, "inbound")),
             );
-            if (decoded._tag !== "Right") return false;
-            if (decoded.right.type !== "request") return false;
-            if (decoded.right.direction !== "s2c") return false;
-            const redone = encodeFrame(decoded.right);
-            return (
-              JSON.stringify(JSON.parse(raw)) ===
-              JSON.stringify(JSON.parse(redone))
-            );
+            return Either.match(decoded, {
+              onLeft: () => false,
+              onRight: (frame) => {
+                if (frame.type !== "request") return false;
+                if (frame.direction !== "s2c") return false;
+                const redone = encodeFrame(frame);
+                return (
+                  JSON.stringify(JSON.parse(raw)) ===
+                  JSON.stringify(JSON.parse(redone))
+                );
+              },
+            });
           }),
-          { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 50 },
+          {
+            seed: ctx.seed,
+            numRuns: ctx.opts.numRuns ?? DEFAULT_ROUNDTRIP_RUNS,
+          },
         ),
       ),
     ),
@@ -349,7 +383,10 @@ export function registerS2cResponseValidation(
             if (!Value.Check(ResponseFrameSchema, frame)) return false;
             return frame.direction === "s2c";
           }),
-          { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 50 },
+          {
+            seed: ctx.seed,
+            numRuns: ctx.opts.numRuns ?? DEFAULT_RESPONSE_VALIDATION_RUNS,
+          },
         ),
       ),
     ),
@@ -377,21 +414,26 @@ export function registerS2cMalformedRequestHandling(
             const decoded = Effect.runSync(
               Effect.either(decodeFrame(raw, "inbound")),
             );
-            // Either decode fails with FrameSchemaError (rejected at the
-            // edge) or succeeds with a typed frame — both are fine. The
-            // crash-free contract is what this property enforces.
-            if (decoded._tag === "Left") {
-              return decoded.left._tag === "TestingFrameSchemaError";
-            }
-            // If decode succeeds, the frame must validate against its
-            // schema; the codec must not surface an in-between value.
-            const f = decoded.right;
-            if (f.type === "request") return Value.Check(RequestFrameSchema, f);
-            if (f.type === "response")
-              return Value.Check(ResponseFrameSchema, f);
-            return Value.Check(EventFrameSchema, f);
+            return Either.match(decoded, {
+              // Either decode fails with FrameSchemaError (rejected at the
+              // edge) or succeeds with a typed frame — both are fine. The
+              // crash-free contract is what this property enforces.
+              onLeft: (err) => err instanceof FrameSchemaError,
+              onRight: (frame) => {
+                // If decode succeeds, the frame must validate against its
+                // schema; the codec must not surface an in-between value.
+                if (frame.type === "request")
+                  return Value.Check(RequestFrameSchema, frame);
+                if (frame.type === "response")
+                  return Value.Check(ResponseFrameSchema, frame);
+                return Value.Check(EventFrameSchema, frame);
+              },
+            });
           }),
-          { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 50 },
+          {
+            seed: ctx.seed,
+            numRuns: ctx.opts.numRuns ?? DEFAULT_MALFORMED_S2C_RUNS,
+          },
         ),
       ),
     ),
@@ -428,8 +470,8 @@ export function registerDualDirectionIdCollision(
                 .string({ minLength: 1, maxLength: 32 })
                 .filter((s) => /^[a-zA-Z0-9_\-:.]+$/.test(s)),
               fc.constantFrom<string>(
-                "auth/connect",
-                "agents/list",
+                Connect.name,
+                AgentsList.name,
                 ...s2cRpcMethods.map((m) => m.name),
               ),
             ),
@@ -456,28 +498,37 @@ export function registerDualDirectionIdCollision(
               const decS2c = Effect.runSync(
                 Effect.either(decodeFrame(encodeFrame(s2c), "inbound")),
               );
-              if (decC2s._tag !== "Right" || decS2c._tag !== "Right") {
-                return false;
-              }
-              if (
-                decC2s.right.type !== "request" ||
-                decS2c.right.type !== "request"
-              ) {
-                return false;
-              }
-              // Same id, different direction — they are NOT equal frames
-              // and a pending map keyed on (direction, id) yields disjoint
-              // entries.
-              if (decC2s.right.id !== decS2c.right.id) return false;
-              if (decC2s.right.direction === decS2c.right.direction) {
-                return false;
-              }
-              const keyC2s = `${decC2s.right.direction}:${decC2s.right.id}`;
-              const keyS2c = `${decS2c.right.direction}:${decS2c.right.id}`;
-              return keyC2s !== keyS2c;
+              return Either.match(decC2s, {
+                onLeft: () => false,
+                onRight: (c2sFrame) =>
+                  Either.match(decS2c, {
+                    onLeft: () => false,
+                    onRight: (s2cFrame) => {
+                      if (
+                        c2sFrame.type !== "request" ||
+                        s2cFrame.type !== "request"
+                      ) {
+                        return false;
+                      }
+                      // Same id, different direction — they are NOT equal
+                      // frames and a pending map keyed on (direction, id)
+                      // yields disjoint entries.
+                      if (c2sFrame.id !== s2cFrame.id) return false;
+                      if (c2sFrame.direction === s2cFrame.direction) {
+                        return false;
+                      }
+                      const keyC2s = `${c2sFrame.direction}:${c2sFrame.id}`;
+                      const keyS2c = `${s2cFrame.direction}:${s2cFrame.id}`;
+                      return keyC2s !== keyS2c;
+                    },
+                  }),
+              });
             },
           ),
-          { seed: ctx.seed, numRuns: ctx.opts.numRuns ?? 30 },
+          {
+            seed: ctx.seed,
+            numRuns: ctx.opts.numRuns ?? DEFAULT_DIRECTION_PARTITION_RUNS,
+          },
         ),
       ),
     ),

--- a/packages/protocol/src/testing/conformance/suite.ts
+++ b/packages/protocol/src/testing/conformance/suite.ts
@@ -45,13 +45,18 @@ import {
 } from "./coverage-policy.js";
 import { conformanceArtifactDirFromEnv } from "./env.js";
 
+import { AppsCreate } from "../../schema/methods/apps.js";
+
+const JSON_INDENT_SPACES = 2;
+const TOXIPROXY_NOT_PROVISIONED = "Toxiproxy client not provisioned";
+
 /**
  * Input shape — consumer names the concrete implementation under test and
  * any optional capabilities they can provide (Toxiproxy).
  */
 export interface ConformanceSuiteOptions {
   /** Factory for the implementation under test (server handle). */
-  readonly realServer: () => Promise<RealServerHandle>;
+  readonly realServer: Effect.Effect<RealServerHandle, RealServerAcquireError>;
   /**
    * Toxiproxy control-plane URL. When `null`, the adversity category is
    * skipped (registered properties return `PropertyUnavailable`).
@@ -289,7 +294,7 @@ function allowedServerCoverageGaps(
     {
       kind: "unavailable",
       id: "delivery/hook-gated-delivery",
-      reasonIncludes: "apps/create",
+      reasonIncludes: AppsCreate.name,
     },
     {
       kind: "deferred",
@@ -299,7 +304,7 @@ function allowedServerCoverageGaps(
     {
       kind: "unavailable",
       id: "delivery/multi-app-fifo-short-circuit",
-      reasonIncludes: "apps/create",
+      reasonIncludes: AppsCreate.name,
     },
     {
       kind: "deferred",
@@ -309,7 +314,7 @@ function allowedServerCoverageGaps(
     {
       kind: "unavailable",
       id: "boundary/app-disconnect-fail-policy",
-      reasonIncludes: "apps/create",
+      reasonIncludes: AppsCreate.name,
     },
     {
       kind: "deferred",
@@ -330,27 +335,27 @@ function allowedServerCoverageGaps(
       {
         kind: "unavailable",
         id: "adversity/latency-resilience",
-        reasonIncludes: "Toxiproxy client not provisioned",
+        reasonIncludes: TOXIPROXY_NOT_PROVISIONED,
       },
       {
         kind: "unavailable",
         id: "adversity/slicer-framing",
-        reasonIncludes: "Toxiproxy client not provisioned",
+        reasonIncludes: TOXIPROXY_NOT_PROVISIONED,
       },
       {
         kind: "unavailable",
         id: "adversity/reset-peer-recovery",
-        reasonIncludes: "Toxiproxy client not provisioned",
+        reasonIncludes: TOXIPROXY_NOT_PROVISIONED,
       },
       {
         kind: "unavailable",
         id: "adversity/timeout-surface",
-        reasonIncludes: "Toxiproxy client not provisioned",
+        reasonIncludes: TOXIPROXY_NOT_PROVISIONED,
       },
       {
         kind: "unavailable",
         id: "adversity/slow-close-cleanup",
-        reasonIncludes: "Toxiproxy client not provisioned",
+        reasonIncludes: TOXIPROXY_NOT_PROVISIONED,
       },
     );
   }
@@ -408,7 +413,7 @@ function writeArtifact(
         ...payload,
       },
       null,
-      2,
+      JSON_INDENT_SPACES,
     ),
   );
 }

--- a/packages/protocol/src/testing/models/dispatch.ts
+++ b/packages/protocol/src/testing/models/dispatch.ts
@@ -16,6 +16,53 @@ import { ErrorCodes } from "../../schema/errors.js";
 import type { ArbitraryRpcCall } from "../arbitraries/rpc.js";
 import { mkTick, type ReferenceState } from "./state.js";
 
+import {
+  AgentsList,
+  AgentsLookup,
+  AgentsLookupByName,
+  Connect,
+  InviteAgent,
+  Register,
+  SelectAgent,
+} from "../../schema/methods/auth.js";
+import {
+  AppsAttachConversation,
+  AppsAttestSkill,
+  AppsAuthorizeDispatch,
+  AppsCloseSession,
+  AppsCreate,
+  AppsGetSession,
+  AppsListSessions,
+  PermissionsGrant,
+  PermissionsList,
+  PermissionsRevoke,
+} from "../../schema/methods/apps.js";
+import {
+  ContactsAccept,
+  ContactsAdd,
+  ContactsList,
+} from "../../schema/methods/contacts.js";
+import {
+  ConversationsAddParticipant,
+  ConversationsArchive,
+  ConversationsCreate,
+  ConversationsGet,
+  ConversationsLeave,
+  ConversationsList,
+  ConversationsMute,
+  ConversationsRemoveParticipant,
+  ConversationsUnarchive,
+  ConversationsUnmute,
+  ConversationsUpdate,
+} from "../../schema/methods/conversations.js";
+import { InvitesCreateAgent } from "../../schema/methods/invites.js";
+import { MessagesList, MessagesSend } from "../../schema/methods/messages.js";
+import {
+  PresenceSubscribe,
+  PresenceUpdate,
+} from "../../schema/methods/presence.js";
+import { PushRegister, PushUnregister } from "../../schema/methods/push.js";
+
 /**
  * Observable outcome of one RPC against the model, in the same shape the
  * real server puts on the wire. Tier B's B1 asserts
@@ -44,17 +91,17 @@ export type RpcModelResult<M extends RpcMethodName = RpcMethodName> =
  * against the real server.
  */
 const IDEMPOTENT_METHODS: ReadonlySet<RpcMethodName> = new Set([
-  "agents/lookup",
-  "agents/lookupByName",
-  "agents/list",
-  "conversations/list",
-  "conversations/get",
-  "messages/list",
-  "contacts/list",
-  "presence/subscribe",
-  "apps/listSessions",
-  "apps/getSession",
-  "permissions/list",
+  AgentsLookup.name,
+  AgentsLookupByName.name,
+  AgentsList.name,
+  ConversationsList.name,
+  ConversationsGet.name,
+  MessagesList.name,
+  ContactsList.name,
+  PresenceSubscribe.name,
+  AppsListSessions.name,
+  AppsGetSession.name,
+  PermissionsList.name,
   "surface/get",
 ] satisfies readonly RpcMethodName[]);
 
@@ -78,7 +125,7 @@ export function authorizationOutcome(
   agentId: string,
 ): "allow" | "deny-unauthenticated" | "deny-forbidden" {
   // `connect` + `register` establish identity; pre-identity they are always allowed.
-  if (call.method === "auth/connect" || call.method === "auth/register")
+  if (call.method === Connect.name || call.method === Register.name)
     return "allow";
   if (!state.agents.has(agentId)) return "deny-unauthenticated";
 
@@ -161,19 +208,19 @@ export function applyCall<M extends RpcMethodName>(
   const m: RpcMethodName = call.method;
   switch (m) {
     // Auth — model isn't sure what auth shape the caller has.
-    case "auth/connect":
-    case "auth/register":
-    case "auth/invite-agent":
-    case "auth/selectAgent":
+    case Connect.name:
+    case Register.name:
+    case InviteAgent.name:
+    case SelectAgent.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Agents list-shaped — honest "ok" for a fresh authenticated agent.
-    case "agents/list":
+    case AgentsList.name:
       return { next: baseNext, outcome: allowNoEvents() };
 
     // Agents lookup-shaped — need a target; uncertain.
-    case "agents/lookup":
-    case "agents/lookupByName":
+    case AgentsLookup.name:
+    case AgentsLookupByName.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Conversations list — NOT oracle-confident across arbitrary
@@ -185,59 +232,59 @@ export function applyCall<M extends RpcMethodName>(
     // to `uncertainError`; K=1 today (agents/list only). Widening
     // K requires either per-method param filters at the arbitrary
     // layer OR a server-side cursor-parse fix; tracked under #186.
-    case "conversations/list":
+    case ConversationsList.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Conversations with required fields or state — uncertain.
-    case "conversations/create":
-    case "conversations/get":
-    case "conversations/update":
-    case "conversations/mute":
-    case "conversations/unmute":
-    case "conversations/addParticipant":
-    case "conversations/removeParticipant":
-    case "conversations/leave":
-    case "conversations/archive":
-    case "conversations/unarchive":
+    case ConversationsCreate.name:
+    case ConversationsGet.name:
+    case ConversationsUpdate.name:
+    case ConversationsMute.name:
+    case ConversationsUnmute.name:
+    case ConversationsAddParticipant.name:
+    case ConversationsRemoveParticipant.name:
+    case ConversationsLeave.name:
+    case ConversationsArchive.name:
+    case ConversationsUnarchive.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Messages — both require a valid conversationId. Uncertain.
-    case "messages/send":
-    case "messages/list":
+    case MessagesSend.name:
+    case MessagesList.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Contacts list — requires user context for a fresh agent, so
     // server returns an error. Uncertain.
-    case "contacts/list":
-    case "contacts/add":
-    case "contacts/accept":
+    case ContactsList.name:
+    case ContactsAdd.name:
+    case ContactsAccept.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Invites — requires state. Uncertain.
-    case "invites/createAgent":
+    case InvitesCreateAgent.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Presence — state-dependent. Uncertain.
-    case "presence/update":
-    case "presence/subscribe":
+    case PresenceUpdate.name:
+    case PresenceSubscribe.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Push — requires endpoint registration. Uncertain.
-    case "push/register":
-    case "push/unregister":
+    case PushRegister.name:
+    case PushUnregister.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Apps — require app/user context the fresh agent doesn't have.
-    case "apps/create":
-    case "apps/attestSkill":
-    case "permissions/grant":
-    case "permissions/list":
-    case "permissions/revoke":
-    case "apps/closeSession":
-    case "apps/getSession":
-    case "apps/listSessions":
-    case "apps/authorizeDispatch":
-    case "apps/attachConversation":
+    case AppsCreate.name:
+    case AppsAttestSkill.name:
+    case PermissionsGrant.name:
+    case PermissionsList.name:
+    case PermissionsRevoke.name:
+    case AppsCloseSession.name:
+    case AppsGetSession.name:
+    case AppsListSessions.name:
+    case AppsAuthorizeDispatch.name:
+    case AppsAttachConversation.name:
       return { next: baseNext, outcome: uncertainError() };
 
     // Surfaces — require surface/app context. Uncertain.

--- a/packages/protocol/src/testing/models/state.ts
+++ b/packages/protocol/src/testing/models/state.ts
@@ -9,15 +9,17 @@
  * Shape: a pure data record keyed by agent id + conversation id. No fibers,
  * no network, no clocks — all actions are total functions.
  */
+import { Brand } from "effect";
 import type { Agent, Conversation, Message } from "../../types.js";
 import type { EventFrame } from "../../schema/frames.js";
 
 /** Monotonic logical clock — the model does not read wall time. */
-export type LogicalTick = number & { readonly __brand: "LogicalTick" };
+export type LogicalTick = number & Brand.Brand<"LogicalTick">;
+export const LogicalTick = Brand.nominal<LogicalTick>();
 
 /** Construct a `LogicalTick` from a raw number. Only call in this module. */
 export function mkTick(n: number): LogicalTick {
-  return n as LogicalTick;
+  return LogicalTick(n);
 }
 
 /** Every kind of entity the model tracks. */

--- a/packages/protocol/src/testing/test-client.ts
+++ b/packages/protocol/src/testing/test-client.ts
@@ -13,9 +13,11 @@ import {
   Cause,
   Chunk,
   Context,
+  Data,
   Deferred,
   Duration,
   Effect,
+  Either,
   Exit,
   HashMap,
   Option,
@@ -55,6 +57,8 @@ import {
   TransportClosedError,
   TransportIoError,
 } from "./errors.js";
+
+import { Connect } from "../schema/methods/auth.js";
 
 /**
  * Options for connecting a TestClient. `serverUrl` is the `ws://…` URL of
@@ -111,7 +115,7 @@ export interface TestClient {
   readonly waitForEvent: (
     eventName: string,
     timeoutMs?: number,
-  ) => Effect.Effect<EventFrame, Error>;
+  ) => Effect.Effect<EventFrame, EventWaitError>;
   readonly drainEvents: Effect.Effect<ReadonlyArray<EventFrame>>;
 
   /**
@@ -160,8 +164,22 @@ export interface TestClient {
     method: M,
     predicate?: (params: ServerRpcParams<M>) => boolean,
     timeoutMs?: number,
-  ) => Effect.Effect<ServerRpcParams<M>, Error>;
+  ) => Effect.Effect<ServerRpcParams<M>, ServerRequestWaitError>;
 }
+
+export class EventWaitError extends Data.TaggedError("TestingEventWaitError")<{
+  readonly eventName: string;
+  readonly message: string;
+  readonly reason: "closed" | "timeout";
+}> {}
+
+export class ServerRequestWaitError extends Data.TaggedError(
+  "TestingServerRequestWaitError",
+)<{
+  readonly message: string;
+  readonly method: string;
+  readonly reason: "timeout";
+}> {}
 
 /**
  * Method-name constraint for server-initiated RPC test surface. Narrows to
@@ -220,9 +238,16 @@ interface CloseState {
 
 let requestIdCounter = 0;
 
+const DEFAULT_AWAIT_SERVER_REQUEST_TIMEOUT_MS = 5_000;
+const DEFAULT_MALFORMED_QUIESCENCE_MS = 500;
+const DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS = 5_000;
+const HANDLER_DEFECT_MESSAGE_LIMIT = 200;
+const POLL_INTERVAL_MS = 10;
+const REQUEST_ID_RADIX = 36;
+
 function nextRequestId(): string {
   requestIdCounter += 1;
-  return `tc-${Date.now().toString(36)}-${requestIdCounter.toString(36)}`;
+  return `tc-${Date.now().toString(REQUEST_ID_RADIX)}-${requestIdCounter.toString(REQUEST_ID_RADIX)}`;
 }
 
 /**
@@ -277,7 +302,7 @@ export function makeTestClient(
     // params satisfy it.
     interface AwaitEntry {
       readonly predicate?: (params: unknown) => boolean;
-      readonly deferred: Deferred.Deferred<unknown, Error>;
+      readonly deferred: Deferred.Deferred<unknown, ServerRequestWaitError>;
     }
     const awaitersRef = yield* Ref.make<
       HashMap.HashMap<string, ReadonlyArray<AwaitEntry>>
@@ -306,12 +331,19 @@ export function makeTestClient(
 
     const handleInbound = (raw: string): Effect.Effect<void> =>
       Effect.gen(function* () {
-        const decoded = yield* Effect.either(decodeFrame(raw, "inbound"));
-        if (decoded._tag === "Left") {
-          yield* recordMalformed(captures, raw, "bit-flip");
-          return;
-        }
-        const frame = decoded.right;
+        const frame = yield* decodeFrame(raw, "inbound").pipe(
+          Effect.either,
+          Effect.flatMap(
+            Either.match({
+              onLeft: () =>
+                recordMalformed(captures, raw, "bit-flip").pipe(
+                  Effect.as(null),
+                ),
+              onRight: (value) => Effect.succeed(value),
+            }),
+          ),
+        );
+        if (frame === null) return;
         yield* recordFrame(captures, "inbound", raw, frame);
 
         if (frame.type === "response") {
@@ -406,7 +438,7 @@ export function makeTestClient(
                     responseFrame("s2c", requestId, {
                       error: {
                         code: -32603,
-                        message: `Handler defected: ${Cause.pretty(cause).slice(0, 200)}`,
+                        message: `Handler defected: ${Cause.pretty(cause).slice(0, HANDLER_DEFECT_MESSAGE_LIMIT)}`,
                       },
                     }),
                   ),
@@ -425,27 +457,22 @@ export function makeTestClient(
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
         const matched = yield* Ref.modify(awaitersRef, (m) => {
-          const bucket = HashMap.get(m, method);
-          if (Option.isNone(bucket)) return [Option.none<AwaitEntry>(), m];
-          const idx = bucket.value.findIndex(
+          const bucket = Option.getOrUndefined(HashMap.get(m, method));
+          if (bucket === undefined) return [undefined, m];
+          const idx = bucket.findIndex(
             (e) => e.predicate === undefined || e.predicate(params),
           );
-          if (idx === -1) return [Option.none<AwaitEntry>(), m];
-          const chosen = bucket.value[idx]!;
-          const rest = [
-            ...bucket.value.slice(0, idx),
-            ...bucket.value.slice(idx + 1),
-          ];
+          if (idx === -1) return [undefined, m];
+          const chosen = bucket[idx]!;
+          const rest = [...bucket.slice(0, idx), ...bucket.slice(idx + 1)];
           const next =
             rest.length === 0
               ? HashMap.remove(m, method)
               : HashMap.set(m, method, rest);
-          return [Option.some(chosen), next];
+          return [chosen, next];
         });
-        if (Option.isNone(matched)) return;
-        yield* Deferred.succeed(matched.value.deferred, params).pipe(
-          Effect.ignore,
-        );
+        if (matched === undefined) return;
+        yield* Deferred.succeed(matched.deferred, params).pipe(Effect.ignore);
       });
 
     // Fork the reader fiber into the ambient scope. `socket.runRaw` yields
@@ -559,7 +586,7 @@ export function makeTestClient(
 
     const waitForEvent: TestClient["waitForEvent"] = (
       eventName,
-      timeoutMs = 5000,
+      timeoutMs = DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS,
     ) =>
       Effect.gen(function* () {
         while (true) {
@@ -569,18 +596,25 @@ export function makeTestClient(
           const state = yield* Ref.get(closeRef);
           if (state.closed) {
             return yield* Effect.fail(
-              new Error(
-                `Connection closed while waiting for event: ${eventName}`,
-              ),
+              new EventWaitError({
+                eventName,
+                message: `Connection closed while waiting for event: ${eventName}`,
+                reason: "closed",
+              }),
             );
           }
 
-          yield* Effect.sleep(Duration.millis(10));
+          yield* Effect.sleep(Duration.millis(POLL_INTERVAL_MS));
         }
       }).pipe(
         Effect.timeoutFail({
           duration: Duration.millis(timeoutMs),
-          onTimeout: () => new Error(`Timeout waiting for event: ${eventName}`),
+          onTimeout: () =>
+            new EventWaitError({
+              eventName,
+              message: `Timeout waiting for event: ${eventName}`,
+              reason: "timeout",
+            }),
         }),
       );
 
@@ -615,7 +649,8 @@ export function makeTestClient(
         yield* recordMalformed(captures, raw, opts.kind);
         yield* writeFrame(raw);
 
-        const waitMs = config.malformedQuiescenceMs ?? 500;
+        const waitMs =
+          config.malformedQuiescenceMs ?? DEFAULT_MALFORMED_QUIESCENCE_MS;
 
         // Race the pending Deferred against a quiescence timeout. Clean up
         // the pending entry on both legs so no slot leaks when the server
@@ -625,7 +660,7 @@ export function makeTestClient(
             Effect.matchEffect({
               onSuccess: () => Effect.succeed(null as RpcResponseError | null),
               onFailure: (err) =>
-                err._tag === "TestingRpcResponseError"
+                err instanceof RpcResponseError
                   ? Effect.succeed(err as RpcResponseError | null)
                   : Effect.fail(err),
             }),
@@ -664,7 +699,7 @@ export function makeTestClient(
               }
               const q = yield* Ref.getAndSet(eventQueue, []);
               if (q.length > 0) return q;
-              yield* Effect.sleep(Duration.millis(10));
+              yield* Effect.sleep(Duration.millis(POLL_INTERVAL_MS));
             }
           });
           return Stream.repeatEffectChunk(
@@ -683,10 +718,13 @@ export function makeTestClient(
     >(
       method: M,
       predicate?: (params: ServerRpcParams<M>) => boolean,
-      timeoutMs = 5_000,
-    ): Effect.Effect<ServerRpcParams<M>, Error> =>
+      timeoutMs = DEFAULT_AWAIT_SERVER_REQUEST_TIMEOUT_MS,
+    ): Effect.Effect<ServerRpcParams<M>, ServerRequestWaitError> =>
       Effect.gen(function* () {
-        const deferred = yield* Deferred.make<unknown, Error>();
+        const deferred = yield* Deferred.make<
+          unknown,
+          ServerRequestWaitError
+        >();
         const entry: AwaitEntry = {
           deferred,
           ...(predicate !== undefined
@@ -705,9 +743,11 @@ export function makeTestClient(
           Effect.timeoutFail({
             duration: Duration.millis(timeoutMs),
             onTimeout: () =>
-              new Error(
-                `Timeout waiting for server-initiated request: ${method}`,
-              ),
+              new ServerRequestWaitError({
+                message: `Timeout waiting for server-initiated request: ${method}`,
+                method,
+                reason: "timeout",
+              }),
           }),
           Effect.onExit((exit) =>
             exit._tag === "Failure"
@@ -743,12 +783,12 @@ export function makeTestClient(
     // unauthenticated traffic (e.g., authority-negative) can skip
     // autoConnect without the acquire path faulting.
     if (config.autoConnect !== false) {
-      const handshakeParams: RpcMap["auth/connect"]["params"] = {
+      const handshakeParams: RpcMap[typeof Connect.name]["params"] = {
         agentKey: config.agentKey,
         minProtocol: PROTOCOL_VERSION,
         maxProtocol: PROTOCOL_VERSION,
       };
-      const handshake = sendRpc("auth/connect", handshakeParams).pipe(
+      const handshake = sendRpc(Connect.name, handshakeParams).pipe(
         Effect.catchTag("TestingRpcTimeoutError", () => Effect.void),
         Effect.catchTag("TestingFrameSchemaError", () => Effect.void),
         Effect.catchTag("TestingRpcResponseError", () => Effect.void),

--- a/packages/protocol/src/testing/test-server.ts
+++ b/packages/protocol/src/testing/test-server.ts
@@ -84,6 +84,7 @@ export const TestServer = Context.GenericTag<TestServer>(
 );
 
 let connectionCounter = 0;
+const TEST_SERVER_SNAPSHOT_CONCURRENCY = 8;
 
 type Writer = (
   chunk: string | Uint8Array | Socket.CloseEvent,
@@ -110,10 +111,7 @@ function makeConnection(
       Effect.gen(function* () {
         const raw = encodeFrame(frame);
         // Validate on the way out as well — Invariant I3.
-        const check = yield* Effect.either(decodeFrame(raw, "outbound"));
-        if (check._tag === "Left") {
-          return yield* Effect.fail(check.left);
-        }
+        yield* decodeFrame(raw, "outbound");
         yield* writer(raw).pipe(
           Effect.mapError(
             (err) =>
@@ -201,14 +199,14 @@ export function makeTestServer(
                   typeof data === "string"
                     ? data
                     : new TextDecoder("utf-8").decode(data);
-                const decoded = yield* Effect.either(
-                  decodeFrame(raw, "inbound"),
+                yield* decodeFrame(raw, "inbound").pipe(
+                  Effect.matchEffect({
+                    onFailure: () =>
+                      recordMalformed(conn.inbound, raw, "bit-flip"),
+                    onSuccess: (frame) =>
+                      recordFrame(conn.inbound, "inbound", raw, frame),
+                  }),
                 );
-                if (decoded._tag === "Left") {
-                  yield* recordMalformed(conn.inbound, raw, "bit-flip");
-                  return;
-                }
-                yield* recordFrame(conn.inbound, "inbound", raw, decoded.right);
               }),
             );
           }),
@@ -246,7 +244,7 @@ export function makeTestServer(
       function* () {
         const conns = yield* Ref.get(serverState);
         const snaps = yield* Effect.forEach(conns, (c) => c.inbound.snapshot, {
-          concurrency: "unbounded",
+          concurrency: TEST_SERVER_SNAPSHOT_CONCURRENCY,
         });
         return snaps.flat();
       },

--- a/packages/protocol/src/testing/toxics/client.ts
+++ b/packages/protocol/src/testing/toxics/client.ts
@@ -13,6 +13,10 @@ import { Effect, Scope } from "effect";
 import { ToxicControlError } from "../errors.js";
 import type { ToxicProfile } from "./profile.js";
 
+const HTTP_SUCCESS_MIN = 200;
+const HTTP_REDIRECT_MIN = 300;
+const TOXIC_NAME_RANDOM_MAX = 1e9;
+
 export interface ToxiproxyConfig {
   /** Control-plane URL, e.g. `http://localhost:8474`. */
   readonly apiUrl: string;
@@ -88,7 +92,7 @@ function httpJson(
       try: () => res.text(),
       catch: toToxicError,
     });
-    if (res.status < 200 || res.status >= 300) {
+    if (res.status < HTTP_SUCCESS_MIN || res.status >= HTTP_REDIRECT_MIN) {
       return yield* Effect.fail(
         new ToxicControlError({ op, status: res.status, body }),
       );
@@ -142,11 +146,13 @@ function profileToAttributes(profile: ToxicProfile): {
       };
     default: {
       const _exhaustive: never = profile;
-      throw new Error(
-        `profileToAttributes: unexpected toxic ${String(_exhaustive)}`,
-      );
+      return absurdToxicProfile(_exhaustive);
     }
   }
+}
+
+function absurdToxicProfile(profile: never): never {
+  throw new Error(`profileToAttributes: unexpected toxic ${String(profile)}`);
 }
 
 export function makeToxiproxyClient(
@@ -183,7 +189,7 @@ export function makeToxiproxyClient(
               Effect.acquireRelease(
                 Effect.suspend(() => {
                   const { type, attributes } = profileToAttributes(profile);
-                  const toxicName = `${profile._tag}-${Math.floor(Math.random() * 1e9)}`;
+                  const toxicName = `${profile._tag}-${Math.floor(Math.random() * TOXIC_NAME_RANDOM_MAX)}`;
                   return httpJson(
                     "add-toxic",
                     `${base}/proxies/${encodeURIComponent(opts.name)}/toxics`,

--- a/packages/protocol/src/testing/toxics/profile.ts
+++ b/packages/protocol/src/testing/toxics/profile.ts
@@ -101,9 +101,11 @@ export function deliveryInvariantFor(toxic: ToxicTag): DeliveryInvariantName {
       return "task-boundary-isolation";
     default: {
       const _exhaustive: never = toxic;
-      throw new Error(
-        `deliveryInvariantFor: unexpected toxic ${String(_exhaustive)}`,
-      );
+      return absurdToxicTag(_exhaustive);
     }
   }
+}
+
+function absurdToxicTag(toxic: never): never {
+  throw new Error(`deliveryInvariantFor: unexpected toxic ${String(toxic)}`);
 }

--- a/packages/runtimes/package.json
+++ b/packages/runtimes/package.json
@@ -23,6 +23,7 @@
     "@effect/platform": "^0.96.0",
     "@effect/platform-node": "^0.106.0",
     "@moltzap/claude-code-channel": "workspace:*",
+    "@moltzap/protocol": "workspace:*",
     "effect": "3.21.0",
     "openclaw": "2026.3.31"
   },

--- a/packages/runtimes/src/await-agent-ready.ts
+++ b/packages/runtimes/src/await-agent-ready.ts
@@ -101,11 +101,13 @@ interface PollingConnections {
  * }
  * ```
  */
+const DEFAULT_POLL_INTERVAL_MS = 500;
+
 export function awaitAgentReadyByPolling(
   connections: PollingConnections,
   agentId: string,
   timeoutMs: number,
-  pollIntervalMs: number = 500,
+  pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
 ): Effect.Effect<ReadyOutcome, never, never> {
   const tick = Effect.sync(() => {
     const conns = connections.getByAgent(agentId);

--- a/packages/runtimes/src/channel-plugin-install.ts
+++ b/packages/runtimes/src/channel-plugin-install.ts
@@ -21,7 +21,14 @@
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
+import { Data } from "effect";
 import type { SpawnInput } from "./runtime.js";
+
+class ChannelPluginInstallError extends Data.TaggedError(
+  "ChannelPluginInstallError",
+)<{
+  readonly message: string;
+}> {}
 
 export interface PluginSymlinkSpec {
   /** Path inside the plugin's `node_modules/` (e.g. `effect`, `@x/y`). */
@@ -154,9 +161,9 @@ function symlinkPreferring(
       return;
     }
   }
-  throw new Error(
-    `channel-plugin-install: none of the candidate paths exist for ${target}: ${candidates.join(", ")}`,
-  );
+  throw new ChannelPluginInstallError({
+    message: `channel-plugin-install: none of the candidate paths exist for ${target}: ${candidates.join(", ")}`,
+  });
 }
 
 /**

--- a/packages/runtimes/src/claude-code-adapter.ts
+++ b/packages/runtimes/src/claude-code-adapter.ts
@@ -27,7 +27,7 @@
  */
 import { Command } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { Effect, Exit, Fiber, Option, Scope, Stream, pipe } from "effect";
+import { Data, Effect, Exit, Fiber, Option, Scope, Stream, pipe } from "effect";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -46,6 +46,10 @@ import {
   resolveChannelDependency,
   seedWorkspaceFiles,
 } from "./channel-plugin-install.js";
+
+class WorkspaceRootNotFound extends Data.TaggedError("WorkspaceRootNotFound")<{
+  readonly message: string;
+}> {}
 import { writeClaudeCodeMcpConfig } from "./claude-code-process.js";
 
 export interface ClaudeCodeAdapterDeps {
@@ -181,32 +185,6 @@ function spawnClaudeProcess(opts: {
   );
 }
 
-/**
- * `Fiber.poll` returns `Effect<Option<Exit<A, E>>>` — None while running,
- * Some(Exit) once resolved. We project to `Option<number>` so callers
- * stay in plain-number land (matching the underlying exit-code surface).
- */
-function pollExitCode(
-  fiber: Fiber.RuntimeFiber<number, never>,
-): Effect.Effect<Option.Option<number>, never, never> {
-  return pipe(
-    Fiber.poll(fiber),
-    Effect.map(
-      Option.match({
-        onNone: () => Option.none<number>(),
-        onSome: (exit: Exit.Exit<number, never>): Option.Option<number> =>
-          Exit.match(exit, {
-            onSuccess: (code) => Option.some(code),
-            // Defects (incl. fiber interrupt on scope close) collapse to
-            // -1 — same shape `proc.exitCode.pipe(catchAll → -1)` produces
-            // for PlatformError, so callers see one consistent number.
-            onFailure: () => Option.some(-1),
-          }),
-      }),
-    ),
-  );
-}
-
 export class ClaudeCodeAdapter implements Runtime {
   private state: AdapterState | null = null;
 
@@ -214,17 +192,21 @@ export class ClaudeCodeAdapter implements Runtime {
 
   spawn(input: SpawnInput): Effect.Effect<void, SpawnFailed, never> {
     // Wrap each fs/spawn step in an `Effect.try` that maps the cause to
-    // `SpawnFailed(agentName, ...)`. Hoisted to a single helper so the
+    // `SpawnFailed`. Hoisted to a single helper so the
     // four sequential steps don't repeat the same boilerplate (issue
     // #272 item 4).
     const tryStep = <A>(fn: () => A): Effect.Effect<A, SpawnFailed, never> =>
       Effect.try({
         try: fn,
-        catch: (cause) =>
-          new SpawnFailed(
-            input.agentName,
-            cause instanceof Error ? cause : new Error(String(cause)),
-          ),
+        catch: (cause) => {
+          const error =
+            cause instanceof Error ? cause : new Error(String(cause));
+          return new SpawnFailed({
+            agentName: input.agentName,
+            cause: error,
+            message: `Failed to spawn agent "${input.agentName}": ${error.message}`,
+          });
+        },
       });
 
     return Effect.gen(this, function* () {
@@ -344,7 +326,14 @@ export class ClaudeCodeAdapter implements Runtime {
         }),
         logBuffer,
       }).pipe(
-        Effect.mapError((cause) => new SpawnFailed(input.agentName, cause)),
+        Effect.mapError(
+          (cause) =>
+            new SpawnFailed({
+              agentName: input.agentName,
+              cause,
+              message: `Failed to spawn agent "${input.agentName}": ${cause.message}`,
+            }),
+        ),
       );
 
       this.state = {
@@ -375,7 +364,18 @@ export class ClaudeCodeAdapter implements Runtime {
     // side resolves the other gets cancelled cleanly.
     const exitTick: Effect.Effect<ReadyOutcome | null, never, never> =
       Effect.gen(function* () {
-        const exitOpt = yield* pollExitCode(proc.exitFiber);
+        const exitOpt = yield* Fiber.poll(proc.exitFiber).pipe(
+          Effect.map(
+            Option.match({
+              onNone: () => Option.none<number>(),
+              onSome: (exit: Exit.Exit<number, never>) =>
+                Exit.match(exit, {
+                  onSuccess: (code) => Option.some(code),
+                  onFailure: () => Option.some(-1),
+                }),
+            }),
+          ),
+        );
         if (Option.isSome(exitOpt)) {
           return {
             _tag: "ProcessExited" as const,
@@ -408,7 +408,18 @@ export class ClaudeCodeAdapter implements Runtime {
         outcome._tag !== "Timeout"
           ? Effect.succeed(outcome)
           : pipe(
-              pollExitCode(proc.exitFiber),
+              Fiber.poll(proc.exitFiber).pipe(
+                Effect.map(
+                  Option.match({
+                    onNone: () => Option.none<number>(),
+                    onSome: (exit: Exit.Exit<number, never>) =>
+                      Exit.match(exit, {
+                        onSuccess: (code) => Option.some(code),
+                        onFailure: () => Option.some(-1),
+                      }),
+                  }),
+                ),
+              ),
               Effect.map(
                 (exitOpt): ReadyOutcome =>
                   Option.isSome(exitOpt)
@@ -468,7 +479,18 @@ export class ClaudeCodeAdapter implements Runtime {
     // finalizer + the stream-consumer fiber finalizers.
     const exitCodeEffect = Fiber.join(proc.exitFiber);
     const killAndWait = pipe(
-      pollExitCode(proc.exitFiber),
+      Fiber.poll(proc.exitFiber).pipe(
+        Effect.map(
+          Option.match({
+            onNone: () => Option.none<number>(),
+            onSome: (exit: Exit.Exit<number, never>) =>
+              Exit.match(exit, {
+                onSuccess: (code) => Option.some(code),
+                onFailure: () => Option.some(-1),
+              }),
+          }),
+        ),
+      ),
       Effect.flatMap((exitOpt) =>
         Option.isSome(exitOpt)
           ? Effect.void
@@ -524,7 +546,9 @@ function resolveWorkspacePackageRoot(): string {
     }
     current = path.dirname(current);
   }
-  throw new Error("Unable to resolve packages/runtimes workspace root");
+  throw new WorkspaceRootNotFound({
+    message: "Unable to resolve packages/runtimes workspace root",
+  });
 }
 
 function resolveWorkspaceClaudeBin(

--- a/packages/runtimes/src/claude-code-process.ts
+++ b/packages/runtimes/src/claude-code-process.ts
@@ -9,6 +9,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+const JSON_INDENT_SPACES = 2;
+
 export interface WriteClaudeCodeMcpConfigOpts {
   readonly stateDir: string;
   readonly extDir: string;
@@ -62,6 +64,9 @@ export function writeClaudeCodeMcpConfig(
   };
 
   const configPath = path.join(opts.stateDir, "mcp-config.json");
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify(config, null, JSON_INDENT_SPACES),
+  );
   return configPath;
 }

--- a/packages/runtimes/src/errors.ts
+++ b/packages/runtimes/src/errors.ts
@@ -1,40 +1,27 @@
-// Tagged error classes for the Runtime interface.
-// Each names the failure mode and carries the data the CLI needs to print.
+import { Data } from "effect";
 
-export class SpawnFailed extends Error {
-  readonly _tag = "SpawnFailed" as const;
-  constructor(
-    readonly agentName: string,
-    override readonly cause: Error,
-  ) {
-    super(`Failed to spawn agent "${agentName}": ${cause.message}`, { cause });
-  }
-}
+export class SpawnFailed extends Data.TaggedError("SpawnFailed")<{
+  readonly agentName: string;
+  readonly message: string;
+  readonly cause: Error;
+}> {}
 
-export class RuntimeReadyTimedOut extends Error {
-  readonly _tag = "RuntimeReadyTimedOut" as const;
-  constructor(
-    readonly agentName: string,
-    readonly timeoutMs: number,
-  ) {
-    super(
-      `Runtime for agent "${agentName}" did not become ready within ${String(timeoutMs)}ms`,
-    );
-  }
-}
+export class RuntimeReadyTimedOut extends Data.TaggedError(
+  "RuntimeReadyTimedOut",
+)<{
+  readonly agentName: string;
+  readonly timeoutMs: number;
+  readonly message: string;
+}> {}
 
-export class RuntimeExitedBeforeReady extends Error {
-  readonly _tag = "RuntimeExitedBeforeReady" as const;
-  constructor(
-    readonly agentName: string,
-    readonly exitCode: number | null,
-    readonly stderr: string,
-  ) {
-    super(
-      `Runtime for agent "${agentName}" exited before readiness (exitCode=${String(exitCode)})`,
-    );
-  }
-}
+export class RuntimeExitedBeforeReady extends Data.TaggedError(
+  "RuntimeExitedBeforeReady",
+)<{
+  readonly agentName: string;
+  readonly exitCode: number | null;
+  readonly stderr: string;
+  readonly message: string;
+}> {}
 
 export type RuntimeLaunchFailed =
   | SpawnFailed

--- a/packages/runtimes/src/fleet.ts
+++ b/packages/runtimes/src/fleet.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Fiber } from "effect";
+import { Data, Effect, Exit, Fiber } from "effect";
 import {
   RuntimeExitedBeforeReady,
   RuntimeReadyTimedOut,
@@ -76,13 +76,12 @@ export interface RuntimeFleet {
   getLogs(name: string): string;
 }
 
-export class RuntimeFleetStartupInterrupted extends Error {
-  readonly _tag = "RuntimeFleetStartupInterrupted" as const;
-
-  constructor(readonly signal: NodeJS.Signals) {
-    super(`Runtime fleet startup interrupted by ${signal}`);
-  }
-}
+export class RuntimeFleetStartupInterrupted extends Data.TaggedError(
+  "RuntimeFleetStartupInterrupted",
+)<{
+  readonly signal: NodeJS.Signals;
+  readonly message: string;
+}> {}
 
 interface StartedRuntimeAgent {
   readonly spec: RuntimeAgentSpec;
@@ -94,18 +93,11 @@ interface PendingRuntimeAgent {
   readonly releaseStartupCleanup: Effect.Effect<void, never, never>;
 }
 
-class UnknownRuntimeAgent extends Error {
-  readonly _tag = "UnknownRuntimeAgent" as const;
-
-  constructor(
-    readonly agentName: string,
-    readonly knownAgents: ReadonlyArray<string>,
-  ) {
-    super(
-      `Unknown runtime agent "${agentName}". Known agents: ${knownAgents.join(", ")}`,
-    );
-  }
-}
+class UnknownRuntimeAgent extends Data.TaggedError("UnknownRuntimeAgent")<{
+  readonly agentName: string;
+  readonly knownAgents: ReadonlyArray<string>;
+  readonly message: string;
+}> {}
 
 function createRuntime(options: RuntimeStartOptions): Runtime {
   switch (options.kind) {
@@ -178,15 +170,20 @@ function startPendingRuntimeAgent(options: RuntimeStartOptions) {
         } satisfies PendingRuntimeAgent;
       case "Timeout":
         return yield* Effect.fail(
-          new RuntimeReadyTimedOut(options.agent.agentName, ready.timeoutMs),
+          new RuntimeReadyTimedOut({
+            agentName: options.agent.agentName,
+            timeoutMs: ready.timeoutMs,
+            message: `Runtime for agent "${options.agent.agentName}" did not become ready within ${String(ready.timeoutMs)}ms`,
+          }),
         );
       case "ProcessExited":
         return yield* Effect.fail(
-          new RuntimeExitedBeforeReady(
-            options.agent.agentName,
-            ready.exitCode,
-            ready.stderr,
-          ),
+          new RuntimeExitedBeforeReady({
+            agentName: options.agent.agentName,
+            exitCode: ready.exitCode,
+            stderr: ready.stderr,
+            message: `Runtime for agent "${options.agent.agentName}" exited before readiness (exitCode=${String(ready.exitCode)})`,
+          }),
         );
     }
   });
@@ -257,10 +254,14 @@ export function launchRuntimeFleet(
             (candidate) => candidate.spec.agentName === name,
           );
           if (startedAgent === undefined) {
-            throw new UnknownRuntimeAgent(
-              name,
-              started.map((candidate) => candidate.spec.agentName),
+            const knownAgents = started.map(
+              (candidate) => candidate.spec.agentName,
             );
+            throw new UnknownRuntimeAgent({
+              agentName: name,
+              knownAgents,
+              message: `Unknown runtime agent "${name}". Known agents: ${knownAgents.join(", ")}`,
+            });
           }
           return startedAgent.runtime.getLogs(LOG_START_OFFSET).text;
         },
@@ -309,7 +310,14 @@ export function launchRuntimeFleetWithProcessSignals(
         return;
       }
       if (shutdownSignal !== null && Exit.isInterrupted(exit)) {
-        resume(Effect.fail(new RuntimeFleetStartupInterrupted(shutdownSignal)));
+        resume(
+          Effect.fail(
+            new RuntimeFleetStartupInterrupted({
+              signal: shutdownSignal,
+              message: `Runtime fleet startup interrupted by ${shutdownSignal}`,
+            }),
+          ),
+        );
         return;
       }
       resume(Effect.failCause(exit.cause));

--- a/packages/runtimes/src/nanoclaw-adapter.ts
+++ b/packages/runtimes/src/nanoclaw-adapter.ts
@@ -33,11 +33,14 @@ export class NanoclawAdapter implements Runtime {
   constructor(private readonly deps: NanoclawAdapterDeps) {}
 
   spawn(input: SpawnInput): Effect.Effect<void, SpawnFailed, never> {
-    const toSpawnFailed = (cause: unknown) =>
-      new SpawnFailed(
-        input.agentName,
-        cause instanceof Error ? cause : new Error(String(cause)),
-      );
+    const toSpawnFailed = (cause: unknown) => {
+      const error = cause instanceof Error ? cause : new Error(String(cause));
+      return new SpawnFailed({
+        agentName: input.agentName,
+        cause: error,
+        message: `Failed to spawn agent "${input.agentName}": ${error.message}`,
+      });
+    };
 
     return Effect.gen(this, function* () {
       yield* Effect.tryPromise({

--- a/packages/runtimes/src/openclaw-adapter.ts
+++ b/packages/runtimes/src/openclaw-adapter.ts
@@ -1,4 +1,4 @@
-import { Effect, pipe } from "effect";
+import { Data, Effect, pipe } from "effect";
 import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
@@ -24,6 +24,17 @@ const OPENCLAW_TERM_WAIT_MS = 10_000;
 const OPENCLAW_KILL_WAIT_MS = 5_000;
 const PROCESS_GROUP_POLL_INTERVAL_MS = 100;
 const DEFAULT_OPENCLAW_MODEL_ID = "openai-codex/gpt-5.4";
+const TOKEN_RADIX = 36;
+const JSON_INDENT_SPACES = 2;
+
+class WorkspaceRootNotFound extends Data.TaggedError("WorkspaceRootNotFound")<{
+  readonly message: string;
+}> {}
+
+class PortAllocationFailed extends Data.TaggedError("PortAllocationFailed")<{
+  readonly message: string;
+  readonly cause?: Error;
+}> {}
 
 export interface OpenClawAdapterDeps {
   readonly server: RuntimeServerHandle;
@@ -53,11 +64,14 @@ export class OpenClawAdapter implements Runtime {
   constructor(private readonly deps: OpenClawAdapterDeps) {}
 
   spawn(input: SpawnInput): Effect.Effect<void, SpawnFailed, never> {
-    const toSpawnFailed = (cause: unknown) =>
-      new SpawnFailed(
-        input.agentName,
-        cause instanceof Error ? cause : new Error(String(cause)),
-      );
+    const toSpawnFailed = (cause: unknown) => {
+      const error = cause instanceof Error ? cause : new Error(String(cause));
+      return new SpawnFailed({
+        agentName: input.agentName,
+        cause: error,
+        message: `Failed to spawn agent "${input.agentName}": ${error.message}`,
+      });
+    };
 
     return Effect.gen(this, function* () {
       const port = yield* allocateFreePort().pipe(
@@ -95,11 +109,10 @@ export class OpenClawAdapter implements Runtime {
 
           const child = nodeSpawn(command, args, {
             cwd: stateDir,
-            env: {
-              ...process.env,
+            env: filterDefinedEnv(globalThis.process.env, {
               OPENCLAW_STATE_DIR: stateDir,
               OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
-            },
+            }),
             stdio: ["ignore", "pipe", "pipe"],
             // detached:true makes the child the leader of its own process group.
             // This lets teardown kill the entire group via process.kill(-pid, signal).
@@ -309,7 +322,9 @@ function resolveWorkspacePackageRoot(): string {
     }
     current = path.dirname(current);
   }
-  throw new Error("Unable to resolve packages/runtimes workspace root");
+  throw new WorkspaceRootNotFound({
+    message: "Unable to resolve packages/runtimes workspace root",
+  });
 }
 
 function resolveWorkspaceOpenClawBin(
@@ -323,12 +338,16 @@ function resolveWorkspaceOpenClawBin(
   return path.join(repoRoot, "node_modules/.bin/openclaw");
 }
 
-function allocateFreePort(): Effect.Effect<number, Error, never> {
-  return Effect.async<number, Error>((resume) => {
+function allocateFreePort(): Effect.Effect<
+  number,
+  PortAllocationFailed,
+  never
+> {
+  return Effect.async<number, PortAllocationFailed>((resume) => {
     const server = net.createServer();
     let settled = false;
     const settle = (
-      effect: Effect.Effect<number, Error>,
+      effect: Effect.Effect<number, PortAllocationFailed>,
       closeServer = true,
     ): void => {
       if (settled) return;
@@ -342,17 +361,40 @@ function allocateFreePort(): Effect.Effect<number, Error, never> {
     server.listen(0, () => {
       const addr = server.address();
       if (addr === null || typeof addr === "string") {
-        settle(Effect.fail(new Error("Unable to allocate TCP port")));
+        settle(
+          Effect.fail(
+            new PortAllocationFailed({
+              message: "Unable to allocate TCP port",
+            }),
+          ),
+        );
         return;
       }
       const port = addr.port;
       server.close((closeErr) =>
         closeErr
-          ? settle(Effect.fail(closeErr), false)
+          ? settle(
+              Effect.fail(
+                new PortAllocationFailed({
+                  message: closeErr.message,
+                  cause: closeErr,
+                }),
+              ),
+              false,
+            )
           : settle(Effect.succeed(port), false),
       );
     });
-    server.on("error", (err) => settle(Effect.fail(err)));
+    server.on("error", (err) =>
+      settle(
+        Effect.fail(
+          new PortAllocationFailed({
+            message: err.message,
+            cause: err,
+          }),
+        ),
+      ),
+    );
     return Effect.sync(() => {
       if (settled) return;
       settled = true;
@@ -360,6 +402,22 @@ function allocateFreePort(): Effect.Effect<number, Error, never> {
       server.close();
     });
   });
+}
+
+function filterDefinedEnv(
+  source: NodeJS.ProcessEnv,
+  extras: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value === "string") {
+      out[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(extras)) {
+    out[key] = value;
+  }
+  return out;
 }
 
 // --- Config and plugin install (module-private) ---
@@ -429,7 +487,10 @@ function writeOpenClawConfig(opts: {
     },
     gateway: {
       mode: "local",
-      auth: { mode: "token", token: `runtime-${Date.now().toString(36)}` },
+      auth: {
+        mode: "token",
+        token: `runtime-${Date.now().toString(TOKEN_RADIX)}`,
+      },
     },
   };
 
@@ -437,7 +498,7 @@ function writeOpenClawConfig(opts: {
   fs.mkdirSync(path.join(opts.stateDir, "logs"), { recursive: true });
   fs.writeFileSync(
     path.join(opts.stateDir, "openclaw.json"),
-    JSON.stringify(config, null, 2),
+    JSON.stringify(config, null, JSON_INDENT_SPACES),
   );
 }
 

--- a/packages/runtimes/src/runtimes.test.ts
+++ b/packages/runtimes/src/runtimes.test.ts
@@ -348,7 +348,11 @@ describe("branded types", () => {
 describe("SpawnFailed", () => {
   it("carries agentName and cause", () => {
     const cause = new Error("ENOENT");
-    const err = new SpawnFailed("alice", cause);
+    const err = new SpawnFailed({
+      agentName: "alice",
+      cause,
+      message: `Failed to spawn agent "alice": ${cause.message}`,
+    });
     expect(err._tag).toBe("SpawnFailed");
     expect(err.agentName).toBe("alice");
     expect(err.cause).toBe(cause);

--- a/packages/runtimes/src/trace-capture-harness.ts
+++ b/packages/runtimes/src/trace-capture-harness.ts
@@ -1,17 +1,38 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { Effect } from "effect";
+import { Data, Effect, Either } from "effect";
 import { startRuntimeAgent, type RuntimeKind } from "./fleet.js";
 import type { Runtime } from "./runtime.js";
+import { RuntimeReadyTimedOut, SpawnFailed } from "./errors.js";
+
+import { ConversationsCreate, MessagesSend } from "@moltzap/protocol";
 
 const DEFAULT_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_RESPONSE_TIMEOUT_MS = 120_000;
+const MIN_EVENT_WAIT_MS = 1_000;
 const DEFAULT_GROUP_NAME = "cc-judge-group";
 const PLACEHOLDER_AGENT_ID = "target-agent";
 const PLACEHOLDER_IMAGE = "managed/by-moltzap-trace-capture";
+const RUNTIME_KIND_CLAUDE_CODE = "claude-code";
 
 let activeRun = false;
+
+class WorkspacePackagesDirNotFound extends Data.TaggedError(
+  "WorkspacePackagesDirNotFound",
+)<{
+  readonly message: string;
+}> {}
+
+class ActiveTraceCaptureRunExists extends Data.TaggedError(
+  "ActiveTraceCaptureRunExists",
+)<{
+  readonly message: string;
+}> {}
+
+class ExecutionFailed extends Data.TaggedError("ExecutionFailed")<{
+  readonly message: string;
+}> {}
 
 interface HarnessLoadArgs {
   readonly sourcePath: string;
@@ -209,19 +230,13 @@ function failLoad(
 function failHarness(message: string): {
   readonly cause: {
     readonly _tag: "HarnessFailed";
-    readonly detail: {
-      readonly _tag: "ExecutionFailed";
-      readonly message: string;
-    };
+    readonly detail: ExecutionFailed;
   };
 } {
   return {
     cause: {
       _tag: "HarnessFailed",
-      detail: {
-        _tag: "ExecutionFailed",
-        message,
-      },
+      detail: new ExecutionFailed({ message }),
     },
   };
 }
@@ -271,7 +286,9 @@ function packagesDir(): string {
     }
     current = path.dirname(current);
   }
-  throw new Error("Unable to resolve workspace packages directory");
+  throw new WorkspacePackagesDirNotFound({
+    message: "Unable to resolve workspace packages directory",
+  });
 }
 
 function packageModuleUrl(...segments: ReadonlyArray<string>): string {
@@ -372,7 +389,7 @@ function decodePayload(
   if (
     runtimeKind !== "openclaw" &&
     runtimeKind !== "nanoclaw" &&
-    runtimeKind !== "claude-code"
+    runtimeKind !== RUNTIME_KIND_CLAUDE_CODE
   ) {
     issues.push(
       "runtime.kind must be 'openclaw', 'nanoclaw', or 'claude-code'",
@@ -529,8 +546,8 @@ function decodePayload(
   const narrowedRuntimeKind: RuntimeKind =
     runtimeKind === "openclaw"
       ? "openclaw"
-      : runtimeKind === "claude-code"
-        ? "claude-code"
+      : runtimeKind === RUNTIME_KIND_CLAUDE_CODE
+        ? RUNTIME_KIND_CLAUDE_CODE
         : "nanoclaw";
   const targetAgentName =
     typeof runtime?.targetAgentName === "string"
@@ -603,7 +620,7 @@ function defaultTargetAgentName(kind: RuntimeKind): string {
       return "openclaw-eval-agent";
     case "nanoclaw":
       return "nanoclaw-eval-agent";
-    case "claude-code":
+    case RUNTIME_KIND_CLAUDE_CODE:
       return "claude-code-eval-agent";
   }
 }
@@ -645,14 +662,17 @@ function waitForTargetResponse(input: {
   return Effect.gen(function* () {
     const deadline = Date.now() + input.timeoutMs;
     while (Date.now() < deadline) {
-      const remaining = Math.max(1_000, deadline - Date.now());
+      const remaining = Math.max(MIN_EVENT_WAIT_MS, deadline - Date.now());
       const next = yield* Effect.either(
         input.client.waitForEvent("messages/received", remaining),
       );
-      if (next._tag === "Left") {
+      const data = Either.match(next, {
+        onLeft: () => null,
+        onRight: (event) => event.data,
+      });
+      if (data === null) {
         continue;
       }
-      const data = next.right.data;
       if (
         data.message.senderId === input.targetAgentId &&
         data.message.conversationId === input.conversationId
@@ -694,7 +714,7 @@ function sendMessageAndWait(input: {
 > {
   return Effect.gen(function* () {
     yield* input.sender.client
-      .sendRpc("messages/send", {
+      .sendRpc(MessagesSend.name, {
         conversationId: input.conversationId,
         parts: [{ type: "text", text: input.message }],
       })
@@ -753,7 +773,7 @@ function createDirectConversation(
   never
 > {
   return sender.client
-    .sendRpc("conversations/create", {
+    .sendRpc(ConversationsCreate.name, {
       type: "dm",
       participants: [{ type: "agent", id: targetAgentId }],
     })
@@ -787,7 +807,7 @@ function createGroupConversation(input: {
   never
 > {
   return input.sender.client
-    .sendRpc("conversations/create", {
+    .sendRpc(ConversationsCreate.name, {
       type: "group",
       name: input.groupName,
       participants: [
@@ -1039,9 +1059,10 @@ function withExclusiveRun<A, E>(
     Effect.try({
       try: () => {
         if (activeRun) {
-          throw new Error(
-            "MoltZap trace-capture harness only supports one active run at a time",
-          );
+          throw new ActiveTraceCaptureRunExists({
+            message:
+              "MoltZap trace-capture harness only supports one active run at a time",
+          });
         }
         activeRun = true;
       },
@@ -1128,27 +1149,27 @@ function createCoordinator(sourcePath: string, payload: HarnessPayload) {
                   },
                 }).pipe(
                   Effect.mapError((error) => {
-                    switch (error._tag) {
-                      case "SpawnFailed":
-                        return failAgentStart({
-                          _tag: "ContainerStartFailed",
-                          message: error.message,
-                        });
-                      case "RuntimeReadyTimedOut":
-                        return failAgentStart({
-                          _tag: "ContainerStartFailed",
-                          message: `runtime did not authenticate within ${String(error.timeoutMs)}ms`,
-                        });
-                      case "RuntimeExitedBeforeReady":
-                        return failAgentStart({
-                          _tag: "ContainerStartFailed",
-                          message: `runtime exited before readiness: ${error.stderr}`,
-                        });
+                    if (error instanceof SpawnFailed) {
+                      return failAgentStart({
+                        _tag: "ContainerStartFailed",
+                        message: error.message,
+                      });
                     }
+                    if (error instanceof RuntimeReadyTimedOut) {
+                      return failAgentStart({
+                        _tag: "ContainerStartFailed",
+                        message: `runtime did not authenticate within ${String(error.timeoutMs)}ms`,
+                      });
+                    }
+                    return failAgentStart({
+                      _tag: "ContainerStartFailed",
+                      message: `runtime exited before readiness: ${error.stderr}`,
+                    });
                   }),
                 ),
-                (_runtime: Runtime) =>
+                (runtime: Runtime) =>
                   Effect.gen(function* () {
+                    void runtime;
                     const conversationRun = yield* executeConversationPlan({
                       payload,
                       baseUrl: server.baseUrl,
@@ -1267,11 +1288,12 @@ const traceCaptureHarness = {
           harness: {
             name: "moltzap-trace-capture",
             run: () =>
-              Effect.fail({
-                _tag: "ExecutionFailed",
-                message:
-                  "MoltZap trace-capture plans require the custom coordinator path",
-              }),
+              Effect.fail(
+                new ExecutionFailed({
+                  message:
+                    "MoltZap trace-capture plans require the custom coordinator path",
+                }),
+              ),
           },
           coordinator: createCoordinator(args.sourcePath, payload),
         };

--- a/packages/server/src/__tests__/conformance/suite.test.ts
+++ b/packages/server/src/__tests__/conformance/suite.test.ts
@@ -17,6 +17,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import {
+  RealServerAcquireError,
   runConformanceSuite,
   type SuiteResult,
 } from "@moltzap/protocol/testing";
@@ -152,16 +153,22 @@ describe("moltzap-server-core conformance", () => {
   it("every protocol conformance property passes against the core server", async () => {
     const exit = await Effect.runPromiseExit(
       runConformanceSuite({
-        realServer: async () => {
-          const handle = await startCoreTestServer({
-            devModeUserId: CONFORMANCE_DEV_MODE_USER_ID,
-          });
-          return {
+        realServer: Effect.tryPromise({
+          try: () =>
+            startCoreTestServer({
+              devModeUserId: CONFORMANCE_DEV_MODE_USER_ID,
+            }),
+          catch: (cause) => new RealServerAcquireError({ cause }),
+        }).pipe(
+          Effect.map((handle) => ({
             wsUrl: handle.wsUrl,
             baseUrl: handle.baseUrl,
-            close: () => stopCoreTestServer(),
-          };
-        },
+            close: Effect.tryPromise({
+              try: () => stopCoreTestServer(),
+              catch: () => undefined,
+            }).pipe(Effect.orElseSucceed(() => undefined)),
+          })),
+        ),
         toxiproxyUrl,
       }),
     );

--- a/packages/server/src/__tests__/integration/01-registration.integration.test.ts
+++ b/packages/server/src/__tests__/integration/01-registration.integration.test.ts
@@ -11,6 +11,8 @@ import {
 } from "./helpers.js";
 import { getCoreDb } from "../../test-utils/index.js";
 
+import { Connect, ConversationsList } from "@moltzap/protocol";
+
 let baseUrl: string;
 let wsUrl: string;
 
@@ -59,7 +61,7 @@ describe("Scenario 1: Registration", () => {
           autoConnect: false,
         });
 
-        const hello = (yield* client.sendRpc("auth/connect", {
+        const hello = (yield* client.sendRpc(Connect.name, {
           agentKey: reg.apiKey,
           minProtocol: PROTOCOL_VERSION,
           maxProtocol: PROTOCOL_VERSION,
@@ -67,7 +69,7 @@ describe("Scenario 1: Registration", () => {
         expect(hello.protocolVersion).toBeDefined();
         expect(hello.agentId).toBe(reg.agentId);
 
-        const result = (yield* client.sendRpc("conversations/list", {})) as {
+        const result = (yield* client.sendRpc(ConversationsList.name, {})) as {
           conversations: unknown[];
         };
         expect(result.conversations).toEqual([]);
@@ -96,7 +98,7 @@ describe("Scenario 1: Registration", () => {
         autoConnect: false,
       });
       const result = yield* Effect.exit(
-        client.sendRpc("auth/connect", {
+        client.sendRpc(Connect.name, {
           agentKey: reg.apiKey,
           minProtocol: PROTOCOL_VERSION,
           maxProtocol: PROTOCOL_VERSION,

--- a/packages/server/src/__tests__/integration/03-dm-messaging.integration.test.ts
+++ b/packages/server/src/__tests__/integration/03-dm-messaging.integration.test.ts
@@ -9,6 +9,12 @@ import {
   getKyselyDb,
 } from "./helpers.js";
 
+import {
+  ConversationsCreate,
+  MessagesList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let _baseUrl: string;
 let _wsUrl: string;
 
@@ -33,7 +39,7 @@ describe("Scenario 3: DM Messaging", () => {
       const bob = yield* registerAndConnect("bob-dm");
 
       // Alice creates a DM conversation with Bob
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       })) as { conversation: { id: string; type: string } };
@@ -42,7 +48,7 @@ describe("Scenario 3: DM Messaging", () => {
       const conversationId = conv.conversation.id;
 
       // Alice sends a message
-      const sendResult = (yield* alice.client.sendRpc("messages/send", {
+      const sendResult = (yield* alice.client.sendRpc(MessagesSend.name, {
         conversationId,
         parts: [{ type: "text", text: "Hello Bob!" }],
       })) as { message: { id: string; parts: unknown[] } };
@@ -53,7 +59,7 @@ describe("Scenario 3: DM Messaging", () => {
       ]);
 
       // Alice lists messages
-      const messages = (yield* alice.client.sendRpc("messages/list", {
+      const messages = (yield* alice.client.sendRpc(MessagesList.name, {
         conversationId,
       })) as { messages: Array<{ id: string; parts: unknown[] }> };
 

--- a/packages/server/src/__tests__/integration/04-group-chat.integration.test.ts
+++ b/packages/server/src/__tests__/integration/04-group-chat.integration.test.ts
@@ -8,6 +8,13 @@ import {
   registerAndConnect,
 } from "./helpers.js";
 
+import {
+  ConversationsAddParticipant,
+  ConversationsCreate,
+  MessagesList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let _baseUrl: string;
 let _wsUrl: string;
 
@@ -32,7 +39,7 @@ describe("Scenario 4: Group Chat", () => {
       const bob = yield* registerAndConnect("bob-grp");
 
       // Alice creates a group
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "group",
         name: "Test Group",
         participants: [{ type: "agent", id: bob.agentId }],
@@ -46,7 +53,7 @@ describe("Scenario 4: Group Chat", () => {
       // Alice sends multiple messages
       const seqs: string[] = [];
       for (let i = 0; i < 3; i++) {
-        const result = (yield* alice.client.sendRpc("messages/send", {
+        const result = (yield* alice.client.sendRpc(MessagesSend.name, {
           conversationId,
           parts: [{ type: "text", text: `Message ${i + 1}` }],
         })) as { message: { id: string } };
@@ -54,7 +61,7 @@ describe("Scenario 4: Group Chat", () => {
       }
 
       // List messages
-      const messages = (yield* alice.client.sendRpc("messages/list", {
+      const messages = (yield* alice.client.sendRpc(MessagesList.name, {
         conversationId,
       })) as { messages: Array<{ parts: Array<{ text: string }> }> };
 
@@ -73,7 +80,7 @@ describe("Scenario 4: Group Chat", () => {
       const bob = yield* registerAndConnect("bob-addp");
 
       // Create group with just Alice
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "group",
         name: "Add Test",
         participants: [{ type: "agent", id: alice.agentId }],
@@ -81,7 +88,7 @@ describe("Scenario 4: Group Chat", () => {
 
       // Add Bob
       const result = (yield* alice.client.sendRpc(
-        "conversations/addParticipant",
+        ConversationsAddParticipant.name,
         {
           conversationId: conv.conversation.id,
           participant: { type: "agent", id: bob.agentId },

--- a/packages/server/src/__tests__/integration/07-encryption.integration.test.ts
+++ b/packages/server/src/__tests__/integration/07-encryption.integration.test.ts
@@ -9,6 +9,12 @@ import {
   getKyselyDb,
 } from "./helpers.js";
 
+import {
+  ConversationsCreate,
+  MessagesList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let _baseUrl: string;
 let _wsUrl: string;
 
@@ -34,14 +40,14 @@ describe("Scenario 7: Encryption", () => {
         const { client, agentId } = yield* registerAndConnect("enc-agent");
 
         // Create conversation
-        const conv = (yield* client.sendRpc("conversations/create", {
+        const conv = (yield* client.sendRpc(ConversationsCreate.name, {
           type: "group",
           name: "Enc Test",
           participants: [{ type: "agent", id: agentId }],
         })) as { conversation: { id: string } };
 
         // Send a message
-        const msg = (yield* client.sendRpc("messages/send", {
+        const msg = (yield* client.sendRpc(MessagesSend.name, {
           conversationId: conv.conversation.id,
           parts: [{ type: "text", text: "This should be encrypted" }],
         })) as { message: { id: string } };
@@ -79,7 +85,7 @@ describe("Scenario 7: Encryption", () => {
         expect(rawStr).not.toContain("This should be encrypted");
 
         // But we can still decrypt it via the API
-        const messages = (yield* client.sendRpc("messages/list", {
+        const messages = (yield* client.sendRpc(MessagesList.name, {
           conversationId: conv.conversation.id,
         })) as {
           messages: Array<{ parts: Array<{ text: string }> }>;

--- a/packages/server/src/__tests__/integration/08-pending-restrictions.integration.test.ts
+++ b/packages/server/src/__tests__/integration/08-pending-restrictions.integration.test.ts
@@ -12,6 +12,8 @@ import {
   connectTestClient,
 } from "./helpers.js";
 
+import { Connect, ConversationsList } from "@moltzap/protocol";
+
 let baseUrl: string;
 let wsUrl: string;
 
@@ -52,7 +54,7 @@ describe("Scenario 8: Suspended Agent Restrictions", () => {
         autoConnect: false,
       });
       const result = yield* Effect.exit(
-        client.sendRpc("auth/connect", {
+        client.sendRpc(Connect.name, {
           agentKey: reg.apiKey,
           minProtocol: PROTOCOL_VERSION,
           maxProtocol: PROTOCOL_VERSION,
@@ -72,7 +74,7 @@ describe("Scenario 8: Suspended Agent Restrictions", () => {
       const { client } = yield* registerAndConnect("active-agent");
 
       // Should work immediately — agents are active on registration in core
-      const result = (yield* client.sendRpc("conversations/list", {})) as {
+      const result = (yield* client.sendRpc(ConversationsList.name, {})) as {
         conversations: unknown[];
       };
       expect(result.conversations).toEqual([]);

--- a/packages/server/src/__tests__/integration/09-agent-to-agent.integration.test.ts
+++ b/packages/server/src/__tests__/integration/09-agent-to-agent.integration.test.ts
@@ -8,6 +8,12 @@ import {
   registerAndConnect,
 } from "./helpers.js";
 
+import {
+  ConversationsCreate,
+  MessagesList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let _baseUrl: string;
 let _wsUrl: string;
 
@@ -34,7 +40,7 @@ describe("Scenario 1: Full Agent-to-Agent DM Flow", () => {
         const bob = yield* registerAndConnect("bob-a2a");
 
         // Alice creates DM — server subscribes Bob's already-open connection
-        const conv = (yield* alice.client.sendRpc("conversations/create", {
+        const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: bob.agentId }],
         })) as { conversation: { id: string; type: string } };
@@ -42,7 +48,7 @@ describe("Scenario 1: Full Agent-to-Agent DM Flow", () => {
         const conversationId = conv.conversation.id;
 
         // Set up waiter before send
-        yield* alice.client.sendRpc("messages/send", {
+        yield* alice.client.sendRpc(MessagesSend.name, {
           conversationId,
           parts: [{ type: "text", text: "Hello Bob!" }],
         });
@@ -52,7 +58,7 @@ describe("Scenario 1: Full Agent-to-Agent DM Flow", () => {
             .message.parts[0]!.text,
         ).toBe("Hello Bob!");
 
-        yield* bob.client.sendRpc("messages/send", {
+        yield* bob.client.sendRpc(MessagesSend.name, {
           conversationId,
           parts: [{ type: "text", text: "Hey Alice!" }],
         });
@@ -64,7 +70,7 @@ describe("Scenario 1: Full Agent-to-Agent DM Flow", () => {
         ).toBe("Hey Alice!");
 
         // Both list messages
-        const msgs = (yield* alice.client.sendRpc("messages/list", {
+        const msgs = (yield* alice.client.sendRpc(MessagesList.name, {
           conversationId,
         })) as {
           messages: Array<{ parts: Array<{ text: string }> }>;
@@ -86,7 +92,7 @@ describe("Scenario 5: Group Chat Fan-Out", () => {
       const bob = yield* registerAndConnect("bob-fan");
       const eve = yield* registerAndConnect("eve-fan");
 
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "group",
         name: "Team Chat",
         participants: [
@@ -97,7 +103,7 @@ describe("Scenario 5: Group Chat Fan-Out", () => {
       const conversationId = conv.conversation.id;
 
       // Set up waiters before send
-      yield* alice.client.sendRpc("messages/send", {
+      yield* alice.client.sendRpc(MessagesSend.name, {
         conversationId,
         parts: [{ type: "text", text: "Team standup" }],
       });
@@ -114,7 +120,7 @@ describe("Scenario 5: Group Chat Fan-Out", () => {
       ).toBe("Team standup");
 
       // Set up waiters for Bob's reply
-      yield* bob.client.sendRpc("messages/send", {
+      yield* bob.client.sendRpc(MessagesSend.name, {
         conversationId,
         parts: [{ type: "text", text: "All clear" }],
       });
@@ -146,7 +152,7 @@ describe("Regression: conversations/create subscribes connected participants", (
         const bob = yield* registerAndConnect("bob-sub");
 
         // Bob is already connected when Alice creates the DM
-        const conv = (yield* alice.client.sendRpc("conversations/create", {
+        const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: bob.agentId }],
         })) as { conversation: { id: string } };
@@ -158,7 +164,7 @@ describe("Regression: conversations/create subscribes connected participants", (
         expect(createdEvent).toBeDefined();
 
         // Bob should also receive messages WITHOUT reconnecting
-        yield* alice.client.sendRpc("messages/send", {
+        yield* alice.client.sendRpc(MessagesSend.name, {
           conversationId: conv.conversation.id,
           parts: [{ type: "text", text: "No reconnect needed" }],
         });
@@ -182,13 +188,13 @@ describe("Regression: waitForEvent does not double-consume buffered events", () 
         const alice = yield* registerAndConnect("alice-buf");
         const bob = yield* registerAndConnect("bob-buf");
 
-        const conv = (yield* alice.client.sendRpc("conversations/create", {
+        const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: bob.agentId }],
         })) as { conversation: { id: string } };
 
         // Set up waiter for first message
-        yield* alice.client.sendRpc("messages/send", {
+        yield* alice.client.sendRpc(MessagesSend.name, {
           conversationId: conv.conversation.id,
           parts: [{ type: "text", text: "First" }],
         });
@@ -199,7 +205,7 @@ describe("Regression: waitForEvent does not double-consume buffered events", () 
         ).toBe("First");
 
         // Set up waiter for second message — must NOT return "First" again
-        yield* alice.client.sendRpc("messages/send", {
+        yield* alice.client.sendRpc(MessagesSend.name, {
           conversationId: conv.conversation.id,
           parts: [{ type: "text", text: "Second" }],
         });
@@ -221,7 +227,7 @@ describe("Regression: messages/send excludes sender from broadcast", () => {
       const alice = yield* registerAndConnect("alice-noecho");
       const bob = yield* registerAndConnect("bob-noecho");
 
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       })) as { conversation: { id: string } };
@@ -229,7 +235,7 @@ describe("Regression: messages/send excludes sender from broadcast", () => {
       // Bob waits for the message
 
       // Alice sends
-      yield* alice.client.sendRpc("messages/send", {
+      yield* alice.client.sendRpc(MessagesSend.name, {
         conversationId: conv.conversation.id,
         parts: [{ type: "text", text: "Only Bob should see this event" }],
       });

--- a/packages/server/src/__tests__/integration/12-send-existing-conv.integration.test.ts
+++ b/packages/server/src/__tests__/integration/12-send-existing-conv.integration.test.ts
@@ -8,6 +8,8 @@ import {
   setupAgentPair,
 } from "./helpers.js";
 
+import { ConversationsCreate, MessagesSend } from "@moltzap/protocol";
+
 beforeAll(async () => {
   await startTestServer();
 }, 60_000);
@@ -27,20 +29,20 @@ describe("Send to Existing Conversation", () => {
       Effect.gen(function* () {
         const { alice, bob } = yield* setupAgentPair();
 
-        const conv = (yield* alice.client.sendRpc("conversations/create", {
+        const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: bob.agentId }],
         })) as { conversation: { id: string } };
         const conversationId = conv.conversation.id;
 
-        yield* alice.client.sendRpc("messages/send", {
+        yield* alice.client.sendRpc(MessagesSend.name, {
           conversationId,
           parts: [{ type: "text", text: "First message" }],
         });
         yield* bob.client.waitForEvent("messages/received");
 
         // Send second message using conversationId
-        const send2 = (yield* alice.client.sendRpc("messages/send", {
+        const send2 = (yield* alice.client.sendRpc(MessagesSend.name, {
           conversationId,
           parts: [{ type: "text", text: "Second message" }],
         })) as {

--- a/packages/server/src/__tests__/integration/13-message-history.integration.test.ts
+++ b/packages/server/src/__tests__/integration/13-message-history.integration.test.ts
@@ -8,6 +8,12 @@ import {
   setupAgentPair,
 } from "./helpers.js";
 
+import {
+  ConversationsCreate,
+  MessagesList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 beforeAll(async () => {
   await startTestServer();
 }, 60_000);
@@ -27,7 +33,7 @@ describe("Message History", () => {
       Effect.gen(function* () {
         const { alice, bob } = yield* setupAgentPair();
 
-        const conv = (yield* alice.client.sendRpc("conversations/create", {
+        const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: bob.agentId }],
         })) as { conversation: { id: string } };
@@ -35,14 +41,14 @@ describe("Message History", () => {
 
         // Send 15 messages
         for (let i = 1; i <= 15; i++) {
-          yield* alice.client.sendRpc("messages/send", {
+          yield* alice.client.sendRpc(MessagesSend.name, {
             conversationId,
             parts: [{ type: "text", text: `Message ${i}` }],
           });
         }
 
         // List with limit=10 — should get newest 10 and hasMore=true
-        const page1 = (yield* alice.client.sendRpc("messages/list", {
+        const page1 = (yield* alice.client.sendRpc(MessagesList.name, {
           conversationId,
           limit: 10,
         })) as {
@@ -72,7 +78,7 @@ describe("Message History", () => {
         expect(new Set(ids).size).toBe(10);
 
         // List all — should get all 15
-        const all = (yield* alice.client.sendRpc("messages/list", {
+        const all = (yield* alice.client.sendRpc(MessagesList.name, {
           conversationId,
           limit: 100,
         })) as {

--- a/packages/server/src/__tests__/integration/14-multipart-message.integration.test.ts
+++ b/packages/server/src/__tests__/integration/14-multipart-message.integration.test.ts
@@ -8,6 +8,12 @@ import {
   setupAgentPair,
 } from "./helpers.js";
 
+import {
+  ConversationsCreate,
+  MessagesList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 beforeAll(async () => {
   await startTestServer();
 }, 60_000);
@@ -25,7 +31,7 @@ describe("Multipart Message", () => {
     Effect.gen(function* () {
       const { alice, bob } = yield* setupAgentPair();
 
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       })) as { conversation: { id: string } };
@@ -39,7 +45,7 @@ describe("Multipart Message", () => {
 
       // Set up Bob's event waiter BEFORE send
 
-      const sendResult = (yield* alice.client.sendRpc("messages/send", {
+      const sendResult = (yield* alice.client.sendRpc(MessagesSend.name, {
         conversationId,
         parts,
       })) as {
@@ -62,7 +68,7 @@ describe("Multipart Message", () => {
       expect(received.parts[2]!.text).toBe("Part 3: Conclusion");
 
       // Verify via message listing
-      const history = (yield* bob.client.sendRpc("messages/list", {
+      const history = (yield* bob.client.sendRpc(MessagesList.name, {
         conversationId,
       })) as {
         messages: Array<{ parts: Array<{ type: string; text: string }> }>;

--- a/packages/server/src/__tests__/integration/15-group-events.integration.test.ts
+++ b/packages/server/src/__tests__/integration/15-group-events.integration.test.ts
@@ -9,6 +9,8 @@ import {
 } from "./helpers.js";
 import type { ConnectedAgent } from "./helpers.js";
 
+import { ConversationsCreate } from "@moltzap/protocol";
+
 beforeAll(async () => {
   await startTestServer();
 }, 60_000);
@@ -35,7 +37,7 @@ describe("Group Creation Events", () => {
 
         // Set up event waiters on Bob and Eve BEFORE creating the group
 
-        const conv = (yield* alice.client.sendRpc("conversations/create", {
+        const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
           type: "group",
           name: "Eval Group",
           participants: [

--- a/packages/server/src/__tests__/integration/16-mute-unmute.integration.test.ts
+++ b/packages/server/src/__tests__/integration/16-mute-unmute.integration.test.ts
@@ -9,6 +9,12 @@ import {
 } from "./helpers.js";
 import type { ConnectedAgent } from "./helpers.js";
 
+import {
+  ConversationsMute,
+  ConversationsUnmute,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 beforeAll(async () => {
   await startTestServer();
 }, 60_000);
@@ -37,10 +43,10 @@ describe("Mute and Unmute", () => {
         const conversationId = group.conversationId!;
 
         // Alice mutes the conversation
-        yield* alice.client.sendRpc("conversations/mute", { conversationId });
+        yield* alice.client.sendRpc(ConversationsMute.name, { conversationId });
 
         // Bob sends a message — Eve should receive, Alice should NOT
-        yield* bob.client.sendRpc("messages/send", {
+        yield* bob.client.sendRpc(MessagesSend.name, {
           conversationId,
           parts: [{ type: "text", text: "Alice is muted" }],
         });
@@ -54,10 +60,12 @@ describe("Mute and Unmute", () => {
         expect(aliceMutedEvents).toHaveLength(0);
 
         // Alice unmutes
-        yield* alice.client.sendRpc("conversations/unmute", { conversationId });
+        yield* alice.client.sendRpc(ConversationsUnmute.name, {
+          conversationId,
+        });
 
         // Bob sends another message — Alice SHOULD receive it now
-        yield* bob.client.sendRpc("messages/send", {
+        yield* bob.client.sendRpc(MessagesSend.name, {
           conversationId,
           parts: [{ type: "text", text: "Alice is back" }],
         });

--- a/packages/server/src/__tests__/integration/17-update-conv-name.integration.test.ts
+++ b/packages/server/src/__tests__/integration/17-update-conv-name.integration.test.ts
@@ -9,6 +9,8 @@ import {
 } from "./helpers.js";
 import type { ConnectedAgent } from "./helpers.js";
 
+import { ConversationsList, ConversationsUpdate } from "@moltzap/protocol";
+
 beforeAll(async () => {
   await startTestServer();
 }, 60_000);
@@ -37,7 +39,7 @@ describe("Update Conversation Name", () => {
       // Set up event waiters on Bob and Eve BEFORE the update
 
       const updateResult = (yield* alice.client.sendRpc(
-        "conversations/update",
+        ConversationsUpdate.name,
         {
           conversationId,
           name: "New Name",
@@ -64,7 +66,7 @@ describe("Update Conversation Name", () => {
 
       // Verify persistence via conversations/list
       const listResult = (yield* alice.client.sendRpc(
-        "conversations/list",
+        ConversationsList.name,
         {},
       )) as {
         conversations: Array<{ id: string; name?: string }>;

--- a/packages/server/src/__tests__/integration/18-reconnection.integration.test.ts
+++ b/packages/server/src/__tests__/integration/18-reconnection.integration.test.ts
@@ -10,6 +10,12 @@ import {
   type ServerTestClient,
 } from "./helpers.js";
 
+import {
+  ConversationsCreate,
+  MessagesList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let wsUrl: string;
 
 beforeAll(async () => {
@@ -34,13 +40,13 @@ describe("Reconnection", () => {
         let bobClient2: ServerTestClient | null = null;
 
         try {
-          const conv = (yield* alice.client.sendRpc("conversations/create", {
+          const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: bob.agentId }],
           })) as { conversation: { id: string } };
           const conversationId = conv.conversation.id;
 
-          yield* alice.client.sendRpc("messages/send", {
+          yield* alice.client.sendRpc(MessagesSend.name, {
             conversationId,
             parts: [{ type: "text", text: "Pre-disconnect" }],
           });
@@ -50,7 +56,7 @@ describe("Reconnection", () => {
           yield* bob.client.close();
 
           // Alice sends a message while Bob is offline
-          yield* alice.client.sendRpc("messages/send", {
+          yield* alice.client.sendRpc(MessagesSend.name, {
             conversationId,
             parts: [{ type: "text", text: "Sent while you were away" }],
           });
@@ -63,7 +69,7 @@ describe("Reconnection", () => {
           });
 
           // Bob fetches messages — should see both
-          const msgs = (yield* bobClient2.sendRpc("messages/list", {
+          const msgs = (yield* bobClient2.sendRpc(MessagesList.name, {
             conversationId,
           })) as {
             messages: Array<{ parts: Array<{ text: string }> }>;
@@ -76,7 +82,7 @@ describe("Reconnection", () => {
           );
 
           // Verify real-time messaging works after reconnect
-          yield* bobClient2.sendRpc("messages/send", {
+          yield* bobClient2.sendRpc(MessagesSend.name, {
             conversationId,
             parts: [{ type: "text", text: "I am back online" }],
           });

--- a/packages/server/src/__tests__/integration/19-concurrent-messages.integration.test.ts
+++ b/packages/server/src/__tests__/integration/19-concurrent-messages.integration.test.ts
@@ -8,6 +8,8 @@ import {
   setupAgentGroup,
 } from "./helpers.js";
 
+import { ConversationsCreate, MessagesSend } from "@moltzap/protocol";
+
 let _baseUrl: string;
 let _wsUrl: string;
 
@@ -38,7 +40,7 @@ describe("Concurrent Messages", () => {
         // Create 4 separate DM conversations between agent-0 and each of agents 1-4
         const conversations: Array<{ id: string; receiverIdx: number }> = [];
         for (let i = 0; i < receivers.length; i++) {
-          const conv = (yield* sender.client.sendRpc("conversations/create", {
+          const conv = (yield* sender.client.sendRpc(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: receivers[i]!.agentId }],
           })) as { conversation: { id: string } };
@@ -50,7 +52,7 @@ describe("Concurrent Messages", () => {
         // Send messages to all 4 conversations simultaneously
         yield* Effect.all(
           conversations.map((conv, i) =>
-            sender.client.sendRpc("messages/send", {
+            sender.client.sendRpc(MessagesSend.name, {
               conversationId: conv.id,
               parts: [{ type: "text", text: `Hello receiver-${i + 1}` }],
             }),

--- a/packages/server/src/__tests__/integration/21-auth-failure.integration.test.ts
+++ b/packages/server/src/__tests__/integration/21-auth-failure.integration.test.ts
@@ -11,6 +11,8 @@ import {
 } from "./helpers.js";
 import { getCoreDb } from "../../test-utils/index.js";
 
+import { Connect } from "@moltzap/protocol";
+
 let baseUrl: string;
 let wsUrl: string;
 
@@ -39,7 +41,7 @@ describe("Auth Failure", () => {
       });
 
       const result = yield* Effect.exit(
-        client.sendRpc("auth/connect", {
+        client.sendRpc(Connect.name, {
           agentKey: "invalid_key_12345",
           minProtocol: PROTOCOL_VERSION,
           maxProtocol: PROTOCOL_VERSION,
@@ -64,7 +66,7 @@ describe("Auth Failure", () => {
       });
 
       const result = yield* Effect.exit(
-        client.sendRpc("auth/connect", {
+        client.sendRpc(Connect.name, {
           agentKey: "mz_totally_fake_api_key_000000000000",
           minProtocol: PROTOCOL_VERSION,
           maxProtocol: PROTOCOL_VERSION,
@@ -100,7 +102,7 @@ describe("Auth Failure", () => {
         autoConnect: false,
       });
       const result = yield* Effect.exit(
-        client.sendRpc("auth/connect", {
+        client.sendRpc(Connect.name, {
           agentKey: reg.apiKey,
           minProtocol: PROTOCOL_VERSION,
           maxProtocol: PROTOCOL_VERSION,

--- a/packages/server/src/__tests__/integration/22-heartbeat.integration.test.ts
+++ b/packages/server/src/__tests__/integration/22-heartbeat.integration.test.ts
@@ -8,6 +8,8 @@ import {
   setupAgentPair,
 } from "./helpers.js";
 
+import { ConversationsCreate, MessagesSend } from "@moltzap/protocol";
+
 beforeAll(async () => {
   await startTestServer();
 }, 60_000);
@@ -25,7 +27,7 @@ describe("Heartbeat / Idle Connection", () => {
     Effect.gen(function* () {
       const { alice, bob } = yield* setupAgentPair();
 
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       })) as { conversation: { id: string } };
@@ -37,7 +39,7 @@ describe("Heartbeat / Idle Connection", () => {
       );
 
       // After idle period, Alice sends a message
-      yield* alice.client.sendRpc("messages/send", {
+      yield* alice.client.sendRpc(MessagesSend.name, {
         conversationId,
         parts: [{ type: "text", text: "Still alive after idle" }],
       });
@@ -49,7 +51,7 @@ describe("Heartbeat / Idle Connection", () => {
       expect(received.parts[0]!.text).toBe("Still alive after idle");
 
       // Verify bidirectional: Bob replies after idle
-      yield* bob.client.sendRpc("messages/send", {
+      yield* bob.client.sendRpc(MessagesSend.name, {
         conversationId,
         parts: [{ type: "text", text: "Reply after idle" }],
       });

--- a/packages/server/src/__tests__/integration/23-coalesce-race.integration.test.ts
+++ b/packages/server/src/__tests__/integration/23-coalesce-race.integration.test.ts
@@ -33,6 +33,8 @@ import {
 } from "./helpers.js";
 import type { PermissionService } from "../../app/app-host.js";
 
+import { AppsCreate } from "@moltzap/protocol";
+
 let db: Kysely<Database>;
 
 const USER_ALICE = "00000000-0000-4000-a000-000000000101";
@@ -130,7 +132,7 @@ describe("Scenario 23: coalesce race on permission requests", () => {
         // `${USER_BOB}:coalesce-race-app:calendar`, identical across all N.
         const N = 5;
         const createEffects = Array.from({ length: N }, () =>
-          alice.client.sendRpc("apps/create", {
+          alice.client.sendRpc(AppsCreate.name, {
             appId: "coalesce-race-app",
             invitedAgentIds: [bob.agentId],
           }),

--- a/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
+++ b/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
@@ -10,6 +10,8 @@ import {
 } from "./helpers.js";
 import { getBaseUrl } from "../../test-utils/index.js";
 
+import { PresenceSubscribe, PresenceUpdate } from "@moltzap/protocol";
+
 beforeAll(async () => {
   await startTestServer();
 }, 60_000);
@@ -28,7 +30,7 @@ describe("Presence Lifecycle", () => {
       const alice = yield* registerAndConnect("alice-pres");
       const bob = yield* registerAndConnect("bob-pres");
 
-      const result = (yield* alice.client.sendRpc("presence/subscribe", {
+      const result = (yield* alice.client.sendRpc(PresenceSubscribe.name, {
         agentIds: [bob.agentId],
       })) as { statuses: Array<{ agentId: string; status: string }> };
 
@@ -42,11 +44,11 @@ describe("Presence Lifecycle", () => {
       const alice = yield* registerAndConnect("alice-away");
       const bob = yield* registerAndConnect("bob-away");
 
-      yield* alice.client.sendRpc("presence/subscribe", {
+      yield* alice.client.sendRpc(PresenceSubscribe.name, {
         agentIds: [bob.agentId],
       });
 
-      yield* bob.client.sendRpc("presence/update", { status: "away" });
+      yield* bob.client.sendRpc(PresenceUpdate.name, { status: "away" });
 
       const event = yield* alice.client.waitForEvent("presence/changed");
       const data = event.data as {
@@ -63,22 +65,22 @@ describe("Presence Lifecycle", () => {
       const alice = yield* registerAndConnect("alice-cycle");
       const bob = yield* registerAndConnect("bob-cycle");
 
-      yield* alice.client.sendRpc("presence/subscribe", {
+      yield* alice.client.sendRpc(PresenceSubscribe.name, {
         agentIds: [bob.agentId],
       });
 
       // away
-      yield* bob.client.sendRpc("presence/update", { status: "away" });
+      yield* bob.client.sendRpc(PresenceUpdate.name, { status: "away" });
       const awayEvent = yield* alice.client.waitForEvent("presence/changed");
       expect((awayEvent.data as { status: string }).status).toBe("away");
 
       // back online
-      yield* bob.client.sendRpc("presence/update", { status: "online" });
+      yield* bob.client.sendRpc(PresenceUpdate.name, { status: "online" });
       const onlineEvent = yield* alice.client.waitForEvent("presence/changed");
       expect((onlineEvent.data as { status: string }).status).toBe("online");
 
       // offline
-      yield* bob.client.sendRpc("presence/update", { status: "offline" });
+      yield* bob.client.sendRpc(PresenceUpdate.name, { status: "offline" });
       const offlineEvent = yield* alice.client.waitForEvent("presence/changed");
       expect((offlineEvent.data as { status: string }).status).toBe("offline");
     }),
@@ -93,7 +95,7 @@ describe("Presence Lifecycle", () => {
 
         // Subscribe BEFORE target connects so the snapshot reads offline.
         const target = yield* registerAgent(getBaseUrl(), "target-connect");
-        const sub = (yield* watcher.client.sendRpc("presence/subscribe", {
+        const sub = (yield* watcher.client.sendRpc(PresenceSubscribe.name, {
           agentIds: [target.agentId],
         })) as { statuses: Array<{ agentId: string; status: string }> };
         expect(sub.statuses[0]!.status).toBe("offline");
@@ -117,7 +119,7 @@ describe("Presence Lifecycle", () => {
       const target = yield* registerAndConnect("target-disconnect");
 
       // Subscribe AFTER target is online; close is the only offline trigger.
-      yield* watcher.client.sendRpc("presence/subscribe", {
+      yield* watcher.client.sendRpc(PresenceSubscribe.name, {
         agentIds: [target.agentId],
       });
 

--- a/packages/server/src/__tests__/integration/28-conversations-get.integration.test.ts
+++ b/packages/server/src/__tests__/integration/28-conversations-get.integration.test.ts
@@ -8,6 +8,8 @@ import {
   registerAndConnect,
 } from "./helpers.js";
 
+import { ConversationsCreate, ConversationsGet } from "@moltzap/protocol";
+
 let _baseUrl: string;
 let _wsUrl: string;
 
@@ -32,7 +34,7 @@ describe("Scenario 28: conversations/get with UUID columns", () => {
       const bob = yield* registerAndConnect("bob-get");
 
       // Create a DM
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       })) as { conversation: { id: string; type: string } };
@@ -40,7 +42,7 @@ describe("Scenario 28: conversations/get with UUID columns", () => {
       const conversationId = conv.conversation.id;
 
       // Get the conversation — this exercises the LEFT JOIN with UUID columns
-      const result = (yield* alice.client.sendRpc("conversations/get", {
+      const result = (yield* alice.client.sendRpc(ConversationsGet.name, {
         conversationId,
       })) as {
         conversation: { id: string; type: string; name: string | null };
@@ -66,7 +68,7 @@ describe("Scenario 28: conversations/get with UUID columns", () => {
       const bob = yield* registerAndConnect("bob-grp-get");
 
       // Create a group
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "group",
         name: "Test Group",
         participants: [{ type: "agent", id: bob.agentId }],
@@ -75,7 +77,7 @@ describe("Scenario 28: conversations/get with UUID columns", () => {
       const conversationId = conv.conversation.id;
 
       // Get the conversation — the LEFT JOIN on agents table must work with UUID columns
-      const result = (yield* alice.client.sendRpc("conversations/get", {
+      const result = (yield* alice.client.sendRpc(ConversationsGet.name, {
         conversationId,
       })) as {
         conversation: { id: string; type: string; name: string };

--- a/packages/server/src/__tests__/integration/29-agents-list.integration.test.ts
+++ b/packages/server/src/__tests__/integration/29-agents-list.integration.test.ts
@@ -13,6 +13,13 @@ import {
 } from "./helpers.js";
 import type { AgentCard } from "@moltzap/protocol";
 
+import {
+  AgentsList,
+  AgentsLookup,
+  AgentsLookupByName,
+  ConversationsCreate,
+} from "@moltzap/protocol";
+
 type AgentsListResult = { agents: Record<string, AgentCard> };
 type AgentsArrayResult = { agents: AgentCard[] };
 
@@ -52,26 +59,26 @@ function registerWithOpts(name: string, opts: { description?: string }) {
   });
 }
 
-describe("agents/list", () => {
+describe(AgentsList.name, () => {
   it.live("returns co-participant agents from shared conversations", () =>
     Effect.gen(function* () {
       const alice = yield* registerAndConnect("alice-ag");
       const bob = yield* registerAndConnect("bob-agent");
       const carol = yield* registerAndConnect("carol-ag");
 
-      yield* alice.client.sendRpc("conversations/create", {
+      yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       });
 
-      yield* alice.client.sendRpc("conversations/create", {
+      yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "group",
         name: "test-group",
         participants: [{ type: "agent", id: carol.agentId }],
       });
 
       const aliceResult = (yield* alice.client.sendRpc(
-        "agents/list",
+        AgentsList.name,
         {},
       )) as AgentsListResult;
       const aliceAgentIds = Object.keys(aliceResult.agents);
@@ -80,7 +87,7 @@ describe("agents/list", () => {
       expect(aliceAgentIds).not.toContain(alice.agentId);
 
       const bobResult = (yield* bob.client.sendRpc(
-        "agents/list",
+        AgentsList.name,
         {},
       )) as AgentsListResult;
       const bobAgentIds = Object.keys(bobResult.agents);
@@ -88,7 +95,7 @@ describe("agents/list", () => {
       expect(bobAgentIds).not.toContain(carol.agentId);
 
       const carolResult = (yield* carol.client.sendRpc(
-        "agents/list",
+        AgentsList.name,
         {},
       )) as AgentsListResult;
       const carolAgentIds = Object.keys(carolResult.agents);
@@ -102,7 +109,7 @@ describe("agents/list", () => {
       const loner = yield* registerAndConnect("loner-ag");
 
       const result = (yield* loner.client.sendRpc(
-        "agents/list",
+        AgentsList.name,
         {},
       )) as AgentsListResult;
       expect(result.agents).toEqual({});
@@ -114,19 +121,19 @@ describe("agents/list", () => {
       const alice = yield* registerAndConnect("alice-ag");
       const bob = yield* registerAndConnect("bob-agent");
 
-      yield* alice.client.sendRpc("conversations/create", {
+      yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       });
 
-      yield* alice.client.sendRpc("conversations/create", {
+      yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "group",
         name: "shared-group",
         participants: [{ type: "agent", id: bob.agentId }],
       });
 
       const result = (yield* alice.client.sendRpc(
-        "agents/list",
+        AgentsList.name,
         {},
       )) as AgentsListResult;
       const agentIds = Object.keys(result.agents);
@@ -140,13 +147,13 @@ describe("agents/list", () => {
       const alice = yield* registerAndConnect("alice-ag");
       const bob = yield* registerAndConnect("bob-agent");
 
-      yield* alice.client.sendRpc("conversations/create", {
+      yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       });
 
       const result = (yield* alice.client.sendRpc(
-        "agents/list",
+        AgentsList.name,
         {},
       )) as AgentsListResult;
       expect(result.agents[alice.agentId]).toBeUndefined();
@@ -161,13 +168,13 @@ describe("agents/list", () => {
       });
       const other = yield* registerAndConnect("other-ag");
 
-      yield* described.client.sendRpc("conversations/create", {
+      yield* described.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: other.agentId }],
       });
 
       const result = (yield* other.client.sendRpc(
-        "agents/list",
+        AgentsList.name,
         {},
       )) as AgentsListResult;
       const card = result.agents[described.agentId];
@@ -180,12 +187,12 @@ describe("agents/list", () => {
   );
 });
 
-describe("agents/lookup", () => {
+describe(AgentsLookup.name, () => {
   it.live("returns agent cards by ID", () =>
     Effect.gen(function* () {
       const alice = yield* registerAndConnect("alice-ag");
 
-      const result = (yield* alice.client.sendRpc("agents/lookup", {
+      const result = (yield* alice.client.sendRpc(AgentsLookup.name, {
         agentIds: [alice.agentId],
       })) as AgentsArrayResult;
 
@@ -200,7 +207,7 @@ describe("agents/lookup", () => {
     Effect.gen(function* () {
       const alice = yield* registerAndConnect("alice-ag");
 
-      const result = (yield* alice.client.sendRpc("agents/lookup", {
+      const result = (yield* alice.client.sendRpc(AgentsLookup.name, {
         agentIds: ["00000000-0000-0000-0000-000000000000"],
       })) as AgentsArrayResult;
 
@@ -214,7 +221,7 @@ describe("agents/lookup", () => {
         description: "Has a description",
       });
 
-      const result = (yield* described.client.sendRpc("agents/lookup", {
+      const result = (yield* described.client.sendRpc(AgentsLookup.name, {
         agentIds: [described.agentId],
       })) as AgentsArrayResult;
 
@@ -223,12 +230,12 @@ describe("agents/lookup", () => {
   );
 });
 
-describe("agents/lookupByName", () => {
+describe(AgentsLookupByName.name, () => {
   it.live("returns agent cards by name", () =>
     Effect.gen(function* () {
       const alice = yield* registerAndConnect("alice-ag");
 
-      const result = (yield* alice.client.sendRpc("agents/lookupByName", {
+      const result = (yield* alice.client.sendRpc(AgentsLookupByName.name, {
         names: ["alice-ag"],
       })) as AgentsArrayResult;
 
@@ -252,7 +259,7 @@ describe("agents/lookupByName", () => {
       );
 
       const bob = yield* registerAndConnect("bob-agent");
-      const result = (yield* bob.client.sendRpc("agents/lookupByName", {
+      const result = (yield* bob.client.sendRpc(AgentsLookupByName.name, {
         names: ["alice-ag"],
       })) as AgentsArrayResult;
 
@@ -264,7 +271,7 @@ describe("agents/lookupByName", () => {
     Effect.gen(function* () {
       const alice = yield* registerAndConnect("alice-ag");
 
-      const result = (yield* alice.client.sendRpc("agents/lookupByName", {
+      const result = (yield* alice.client.sendRpc(AgentsLookupByName.name, {
         names: ["nonexistent"],
       })) as AgentsArrayResult;
 

--- a/packages/server/src/__tests__/integration/30-app-hooks-rpc.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-app-hooks-rpc.integration.test.ts
@@ -54,6 +54,21 @@ import {
 import { expectRpcFailure } from "../../test-utils/index.js";
 import { getBaseUrl } from "../../test-utils/index.js";
 
+import {
+  AppsAttachConversation,
+  AppsAuthorizeDispatch,
+  AppsCloseSession,
+  AppsCreate,
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnClose,
+  AppsOnJoin,
+  AppsOnSessionActive,
+  AppsRegister,
+  ConversationsCreate,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 // Mirror of `app-sdk/src/app.ts:extractAttachCode`'s numeric-code map.
 // Server-core doesn't depend on `@moltzap/app-sdk` (would create a
 // downstream-on-downstream dep cycle through protocol), so we replicate
@@ -175,28 +190,28 @@ function registerAppClient(opts: {
     const h = opts.handlers;
 
     yield* client.handleServerRpc(
-      "apps/onBeforeDispatch",
+      AppsOnBeforeDispatch.name,
       h.onBeforeDispatch ??
         (() => Effect.succeed({ admission: { decision: "grant" as const } })),
     );
     yield* client.handleServerRpc(
-      "apps/onBeforeMessageDelivery",
+      AppsOnBeforeMessageDelivery.name,
       h.onBeforeMessageDelivery ?? (() => Effect.succeed({ block: false })),
     );
     yield* client.handleServerRpc(
-      "apps/onSessionActive",
+      AppsOnSessionActive.name,
       h.onSessionActive ?? (() => Effect.succeed({})),
     );
     yield* client.handleServerRpc(
-      "apps/onJoin",
+      AppsOnJoin.name,
       h.onJoin ?? (() => Effect.succeed({})),
     );
     yield* client.handleServerRpc(
-      "apps/onClose",
+      AppsOnClose.name,
       h.onClose ?? (() => Effect.succeed({})),
     );
 
-    yield* client.sendRpc("apps/register", { manifest: opts.manifest });
+    yield* client.sendRpc(AppsRegister.name, { manifest: opts.manifest });
 
     return { appAgentId: reg.agentId, appAgentKey: reg.apiKey, client };
   });
@@ -260,7 +275,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
             },
           });
 
-          const session = (yield* userAgent.client.sendRpc("apps/create", {
+          const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
             appId: "rpc-fixture-app",
             invitedAgentIds: [],
           })) as {
@@ -269,7 +284,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
 
           const convId = session.session.conversations["main"]!;
 
-          yield* userAgent.client.sendRpc("messages/send", {
+          yield* userAgent.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "fixture round-trip" }],
           });
@@ -327,7 +342,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           },
         });
 
-        const session = (yield* userAgent.client.sendRpc("apps/create", {
+        const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
           appId: "bd-grant-app",
           invitedAgentIds: [],
         })) as {
@@ -336,7 +351,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
         const convId = session.session.conversations["main"]!;
 
         const result = (yield* userAgent.client.sendRpc(
-          "apps/authorizeDispatch",
+          AppsAuthorizeDispatch.name,
           authorizeDispatchParams(convId, userAgent.agentId),
         )) as { admission: DispatchAdmissionResult };
 
@@ -362,7 +377,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           },
         });
 
-        const session = (yield* userAgent.client.sendRpc("apps/create", {
+        const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
           appId: "bd-deny-app",
           invitedAgentIds: [],
         })) as {
@@ -371,7 +386,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
         const convId = session.session.conversations["main"]!;
 
         const result = (yield* userAgent.client.sendRpc(
-          "apps/authorizeDispatch",
+          AppsAuthorizeDispatch.name,
           authorizeDispatchParams(convId, userAgent.agentId),
         )) as { admission: DispatchAdmissionResult };
 
@@ -407,7 +422,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           },
         });
 
-        const session = (yield* userAgent.client.sendRpc("apps/create", {
+        const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
           appId: "bd-hold-app",
           invitedAgentIds: [],
         })) as {
@@ -416,7 +431,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
         const convId = session.session.conversations["main"]!;
 
         const result = (yield* userAgent.client.sendRpc(
-          "apps/authorizeDispatch",
+          AppsAuthorizeDispatch.name,
           authorizeDispatchParams(convId, userAgent.agentId),
         )) as { admission: DispatchAdmissionResult };
 
@@ -451,7 +466,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
             },
           });
 
-          const session = (yield* userAgent.client.sendRpc("apps/create", {
+          const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
             appId: "bd-lease-app",
             invitedAgentIds: [],
           })) as {
@@ -460,7 +475,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           const convId = session.session.conversations["main"]!;
 
           const result = (yield* userAgent.client.sendRpc(
-            "apps/authorizeDispatch",
+            AppsAuthorizeDispatch.name,
             authorizeDispatchParams(convId, userAgent.agentId),
           )) as { admission: DispatchAdmissionResult };
 
@@ -497,7 +512,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
             },
           });
 
-          const session = (yield* userAgent.client.sendRpc("apps/create", {
+          const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
             appId: "bd-disco-app",
             invitedAgentIds: [],
           })) as {
@@ -510,7 +525,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           // (fail-closed), not hang indefinitely.
           const callFiber = Effect.runFork(
             userAgent.client.sendRpc(
-              "apps/authorizeDispatch",
+              AppsAuthorizeDispatch.name,
               authorizeDispatchParams(convId, userAgent.agentId),
             ),
           );
@@ -542,7 +557,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
   });
 
   // ── before_message_delivery ────────────────────────────────────────
-  describe("apps/onBeforeMessageDelivery", () => {
+  describe(AppsOnBeforeMessageDelivery.name, () => {
     it.live(
       "block + reason rejects with HookBlocked + structured feedback",
       () =>
@@ -570,7 +585,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
             },
           });
 
-          const session = (yield* userAgent.client.sendRpc("apps/create", {
+          const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
             appId: "bmd-block-app",
             invitedAgentIds: [],
           })) as {
@@ -579,7 +594,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           const convId = session.session.conversations["main"]!;
 
           const rpcErr = yield* expectRpcFailure(
-            userAgent.client.sendRpc("messages/send", {
+            userAgent.client.sendRpc(MessagesSend.name, {
               conversationId: convId,
               parts: [{ type: "text", text: "bad command" }],
             }),
@@ -621,7 +636,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           },
         });
 
-        const session = (yield* userAgent.client.sendRpc("apps/create", {
+        const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
           appId: "bmd-patch-app",
           invitedAgentIds: [],
         })) as {
@@ -629,7 +644,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
         };
         const convId = session.session.conversations["main"]!;
 
-        const result = (yield* userAgent.client.sendRpc("messages/send", {
+        const result = (yield* userAgent.client.sendRpc(MessagesSend.name, {
           conversationId: convId,
           parts: [{ type: "text", text: "secret info" }],
         })) as {
@@ -668,7 +683,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
             },
           });
 
-          const session = (yield* userAgent.client.sendRpc("apps/create", {
+          const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
             appId: "bmd-feedback-app",
             invitedAgentIds: [],
           })) as {
@@ -677,7 +692,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           const convId = session.session.conversations["main"]!;
 
           const rpcErr = yield* expectRpcFailure(
-            userAgent.client.sendRpc("messages/send", {
+            userAgent.client.sendRpc(MessagesSend.name, {
               conversationId: convId,
               parts: [{ type: "text", text: "raw input" }],
             }),
@@ -708,7 +723,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           },
         });
 
-        const session = (yield* userAgent.client.sendRpc("apps/create", {
+        const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
           appId: "bmd-timeout-app",
           invitedAgentIds: [],
         })) as {
@@ -717,7 +732,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
         const convId = session.session.conversations["main"]!;
 
         yield* expectRpcFailure(
-          userAgent.client.sendRpc("messages/send", {
+          userAgent.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "should-be-blocked" }],
           }),
@@ -742,7 +757,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
   });
 
   // ── on_session_active ──────────────────────────────────────────────
-  describe("apps/onSessionActive", () => {
+  describe(AppsOnSessionActive.name, () => {
     it.live(
       "hook completes BEFORE app/sessionReady reaches the initiator",
       () =>
@@ -773,7 +788,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
             },
           });
 
-          yield* userAgent.client.sendRpc("apps/create", {
+          yield* userAgent.client.sendRpc(AppsCreate.name, {
             appId: "osa-order-app",
             invitedAgentIds: [invitee.agentId],
           });
@@ -787,7 +802,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
   });
 
   // ── on_join ────────────────────────────────────────────────────────
-  describe("apps/onJoin", () => {
+  describe(AppsOnJoin.name, () => {
     it.live("fires on_join with correct context when invitee is admitted", () =>
       Effect.gen(function* () {
         // Migrated from deleted 32-webhook-hooks.integration.test.ts
@@ -809,7 +824,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           },
         });
 
-        yield* userAgent.client.sendRpc("apps/create", {
+        yield* userAgent.client.sendRpc(AppsCreate.name, {
           appId: "oj-app",
           invitedAgentIds: [invitee.agentId],
         });
@@ -828,7 +843,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
   });
 
   // ── on_close ───────────────────────────────────────────────────────
-  describe("apps/onClose", () => {
+  describe(AppsOnClose.name, () => {
     it.live("fires on_close with correct context when session closes", () =>
       Effect.gen(function* () {
         // Migrated from deleted 32-webhook-hooks.integration.test.ts
@@ -849,12 +864,12 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           },
         });
 
-        const session = (yield* userAgent.client.sendRpc("apps/create", {
+        const session = (yield* userAgent.client.sendRpc(AppsCreate.name, {
           appId: "oc-app",
           invitedAgentIds: [],
         })) as { session: { id: string } };
 
-        yield* userAgent.client.sendRpc("apps/closeSession", {
+        yield* userAgent.client.sendRpc(AppsCloseSession.name, {
           sessionId: session.session.id,
         });
 
@@ -922,12 +937,12 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           // as the initiator and the same connection holds the remote-app
           // registration, so the session has the app as both initiator and
           // app-of-record. (Production SDK callers follow the same shape.)
-          const session = (yield* app.client.sendRpc("apps/create", {
+          const session = (yield* app.client.sendRpc(AppsCreate.name, {
             appId: "att-happy-app",
             invitedAgentIds: [],
           })) as { session: { id: string } };
 
-          const dm = (yield* app.client.sendRpc("conversations/create", {
+          const dm = (yield* app.client.sendRpc(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: peer.agentId }],
           })) as { conversation: { id: string } };
@@ -935,7 +950,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           // Wire shape for `apps/attachConversation` carries no `key`
           // field; the server handler uses `conversationId` as the key
           // (deterministic 1:1; see apps.handlers.ts comment).
-          yield* app.client.sendRpc("apps/attachConversation", {
+          yield* app.client.sendRpc(AppsAttachConversation.name, {
             sessionId: session.session.id,
             conversationId: dm.conversation.id,
           });
@@ -961,7 +976,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
 
           // A well-formed UUID that does not refer to any session.
           const rpcErr = yield* expectRpcFailure(
-            userAgent.client.sendRpc("apps/attachConversation", {
+            userAgent.client.sendRpc(AppsAttachConversation.name, {
               sessionId: crypto.randomUUID(),
               conversationId: crypto.randomUUID(),
             }),
@@ -994,15 +1009,18 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
             ],
           });
 
-          const session = (yield* initiator.client.sendRpc("apps/create", {
+          const session = (yield* initiator.client.sendRpc(AppsCreate.name, {
             appId: "att-na-app",
             invitedAgentIds: [],
           })) as { session: { id: string } };
 
-          const dm = (yield* initiator.client.sendRpc("conversations/create", {
-            type: "dm",
-            participants: [{ type: "agent", id: peer.agentId }],
-          })) as { conversation: { id: string } };
+          const dm = (yield* initiator.client.sendRpc(
+            ConversationsCreate.name,
+            {
+              type: "dm",
+              participants: [{ type: "agent", id: peer.agentId }],
+            },
+          )) as { conversation: { id: string } };
 
           // Stranger calls against a session they don't own and aren't
           // the app of record for. The wire RPC handler authorizes via
@@ -1014,7 +1032,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           // wire surface; in-process callers must use
           // `attachAppConversation` directly.)
           const rpcErr = yield* expectRpcFailure(
-            stranger.client.sendRpc("apps/attachConversation", {
+            stranger.client.sendRpc(AppsAttachConversation.name, {
               sessionId: session.session.id,
               conversationId: dm.conversation.id,
             }),
@@ -1081,7 +1099,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           // NOT the app of record (App-A is); App-B is a participant.
           // AppHost runs admission for invitees inline; with owner_user_id
           // set, App-B passes the identity check and lands as `admitted`.
-          const session = (yield* appA.client.sendRpc("apps/create", {
+          const session = (yield* appA.client.sendRpc(AppsCreate.name, {
             appId: "att-xtenant-app-a",
             invitedAgentIds: [appB.appAgentId],
           })) as { session: { id: string } };
@@ -1096,7 +1114,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           // App-A's session. Pre-fix this would succeed; post-fix the
           // app-of-record check rejects with Forbidden.
           const rpcErr = yield* expectRpcFailure(
-            appB.client.sendRpc("apps/attachConversation", {
+            appB.client.sendRpc(AppsAttachConversation.name, {
               sessionId: session.session.id,
               conversationId: targetConvId,
             }),
@@ -1146,13 +1164,13 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
               .execute(),
           );
 
-          const session = (yield* app.client.sendRpc("apps/create", {
+          const session = (yield* app.client.sendRpc(AppsCreate.name, {
             appId: "att-cnf-app",
             invitedAgentIds: [],
           })) as { session: { id: string } };
 
           const rpcErr = yield* expectRpcFailure(
-            app.client.sendRpc("apps/attachConversation", {
+            app.client.sendRpc(AppsAttachConversation.name, {
               sessionId: session.session.id,
               conversationId: crypto.randomUUID(),
             }),
@@ -1189,22 +1207,22 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
               .execute(),
           );
 
-          const sessionA = (yield* app.client.sendRpc("apps/create", {
+          const sessionA = (yield* app.client.sendRpc(AppsCreate.name, {
             appId: "att-aa-app",
             invitedAgentIds: [],
           })) as { session: { id: string } };
-          const sessionB = (yield* app.client.sendRpc("apps/create", {
+          const sessionB = (yield* app.client.sendRpc(AppsCreate.name, {
             appId: "att-aa-app",
             invitedAgentIds: [],
           })) as { session: { id: string } };
 
-          const dm = (yield* app.client.sendRpc("conversations/create", {
+          const dm = (yield* app.client.sendRpc(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: peer.agentId }],
           })) as { conversation: { id: string } };
 
           // First attach: succeeds, binds dm.conversation.id → sessionA.
-          yield* app.client.sendRpc("apps/attachConversation", {
+          yield* app.client.sendRpc(AppsAttachConversation.name, {
             sessionId: sessionA.session.id,
             conversationId: dm.conversation.id,
           });
@@ -1212,7 +1230,7 @@ describe("Scenario 30b: App hook RPC pipeline (B.9 — Phase 1.8)", () => {
           // Second attach for the same convId against sessionB collides
           // with the cross-session map; AppHost emits Conflict (-32003).
           const rpcErr = yield* expectRpcFailure(
-            app.client.sendRpc("apps/attachConversation", {
+            app.client.sendRpc(AppsAttachConversation.name, {
               sessionId: sessionB.session.id,
               conversationId: dm.conversation.id,
             }),

--- a/packages/server/src/__tests__/integration/30-app-hooks.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-app-hooks.integration.test.ts
@@ -52,6 +52,12 @@ import { ErrorCodes } from "@moltzap/protocol";
 import type { ConnectedAgent } from "../../test-utils/helpers.js";
 import { expectRpcFailure } from "../../test-utils/index.js";
 
+import {
+  AppsCreate,
+  ConversationsCreate,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let coreApp: CoreApp;
 
 beforeAll(async () => {
@@ -125,7 +131,7 @@ describe("Scenario 30: App Hooks", () => {
           },
         }));
 
-        const session = (yield* orchestrator.client.sendRpc("apps/create", {
+        const session = (yield* orchestrator.client.sendRpc(AppsCreate.name, {
           appId: "test-blocker",
           invitedAgentIds: [],
         })) as {
@@ -135,7 +141,7 @@ describe("Scenario 30: App Hooks", () => {
         const convId = session.session.conversations["main"]!;
 
         const rpcErr = yield* expectRpcFailure(
-          orchestrator.client.sendRpc("messages/send", {
+          orchestrator.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "bad command" }],
           }),
@@ -172,7 +178,7 @@ describe("Scenario 30: App Hooks", () => {
           },
         }));
 
-        const session = (yield* alice.client.sendRpc("apps/create", {
+        const session = (yield* alice.client.sendRpc(AppsCreate.name, {
           appId: "test-patcher",
           invitedAgentIds: [],
         })) as {
@@ -181,7 +187,7 @@ describe("Scenario 30: App Hooks", () => {
 
         const convId = session.session.conversations["main"]!;
 
-        const result = (yield* alice.client.sendRpc("messages/send", {
+        const result = (yield* alice.client.sendRpc(MessagesSend.name, {
           conversationId: convId,
           parts: [{ type: "text", text: "secret info" }],
         })) as {
@@ -206,7 +212,7 @@ describe("Scenario 30: App Hooks", () => {
           block: false,
         }));
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "test-passthrough",
           invitedAgentIds: [],
         })) as {
@@ -215,7 +221,7 @@ describe("Scenario 30: App Hooks", () => {
 
         const convId = session.session.conversations["main"]!;
 
-        const result = (yield* agent.client.sendRpc("messages/send", {
+        const result = (yield* agent.client.sendRpc(MessagesSend.name, {
           conversationId: convId,
           parts: [{ type: "text", text: "hello" }],
         })) as {
@@ -237,7 +243,7 @@ describe("Scenario 30: App Hooks", () => {
           return { block: true, reason: "Should never reach" };
         });
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "test-timeout",
           invitedAgentIds: [],
         })) as {
@@ -250,7 +256,7 @@ describe("Scenario 30: App Hooks", () => {
         // The app/hookTimeout event (asserted below) is what distinguishes
         // a timeout from a throw — the wire code alone doesn't.
         yield* expectRpcFailure(
-          agent.client.sendRpc("messages/send", {
+          agent.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "should be blocked" }],
           }),
@@ -277,12 +283,12 @@ describe("Scenario 30: App Hooks", () => {
         const alice = yield* registerAppAgent("alice-noapp");
         const bob = yield* registerAppAgent("bob-noapp");
 
-        const conv = (yield* alice.client.sendRpc("conversations/create", {
+        const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: bob.agentId }],
         })) as { conversation: { id: string } };
 
-        const result = (yield* alice.client.sendRpc("messages/send", {
+        const result = (yield* alice.client.sendRpc(MessagesSend.name, {
           conversationId: conv.conversation.id,
           parts: [{ type: "text", text: "normal DM" }],
         })) as {
@@ -303,7 +309,7 @@ describe("Scenario 30: App Hooks", () => {
           throw new Error("Hook crashed!");
         });
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "test-error",
           invitedAgentIds: [],
         })) as {
@@ -313,7 +319,7 @@ describe("Scenario 30: App Hooks", () => {
         const convId = session.session.conversations["main"]!;
 
         yield* expectRpcFailure(
-          agent.client.sendRpc("messages/send", {
+          agent.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "should be blocked" }],
           }),
@@ -337,7 +343,7 @@ describe("Scenario 30: App Hooks", () => {
             return Promise.reject(new Error("async hook crash"));
           });
 
-          const session = (yield* agent.client.sendRpc("apps/create", {
+          const session = (yield* agent.client.sendRpc(AppsCreate.name, {
             appId: "test-async-error",
             invitedAgentIds: [],
           })) as {
@@ -347,7 +353,7 @@ describe("Scenario 30: App Hooks", () => {
           const convId = session.session.conversations["main"]!;
 
           yield* expectRpcFailure(
-            agent.client.sendRpc("messages/send", {
+            agent.client.sendRpc(MessagesSend.name, {
               conversationId: convId,
               parts: [{ type: "text", text: "should be blocked" }],
             }),
@@ -374,7 +380,7 @@ describe("Scenario 30: App Hooks", () => {
           return { block: false };
         });
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "test-abort-timeout",
           invitedAgentIds: [],
         })) as {
@@ -384,7 +390,7 @@ describe("Scenario 30: App Hooks", () => {
         const convId = session.session.conversations["main"]!;
 
         yield* expectRpcFailure(
-          agent.client.sendRpc("messages/send", {
+          agent.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "blocked-by-timeout" }],
           }),
@@ -409,7 +415,7 @@ describe("Scenario 30: App Hooks", () => {
           throw new Error("boom");
         });
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "test-abort-throw",
           invitedAgentIds: [],
         })) as {
@@ -419,7 +425,7 @@ describe("Scenario 30: App Hooks", () => {
         const convId = session.session.conversations["main"]!;
 
         yield* expectRpcFailure(
-          agent.client.sendRpc("messages/send", {
+          agent.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "blocked-by-throw" }],
           }),
@@ -447,7 +453,7 @@ describe("Scenario 30: App Hooks", () => {
           reason: "policy/no-secrets",
         }));
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "test-explicit-block",
           invitedAgentIds: [],
         })) as {
@@ -457,7 +463,7 @@ describe("Scenario 30: App Hooks", () => {
         const convId = session.session.conversations["main"]!;
 
         const rpcErr = yield* expectRpcFailure(
-          agent.client.sendRpc("messages/send", {
+          agent.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "secret" }],
           }),
@@ -490,7 +496,7 @@ describe("Scenario 30: App Hooks", () => {
           joinCtx = ctx;
         });
 
-        yield* initiator.client.sendRpc("apps/create", {
+        yield* initiator.client.sendRpc(AppsCreate.name, {
           appId: "test-join",
           invitedAgentIds: [invitee.agentId],
         });

--- a/packages/server/src/__tests__/integration/30-permissions.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-permissions.integration.test.ts
@@ -16,6 +16,13 @@ import {
   type ServerTestClient,
 } from "./helpers.js";
 
+import {
+  AppsCreate,
+  PermissionsGrant,
+  PermissionsList,
+  PermissionsRevoke,
+} from "@moltzap/protocol";
+
 let db: Kysely<Database>;
 
 // Stable UUIDs for test users (owner_user_id is a UUID column)
@@ -98,7 +105,7 @@ describe("Permission grant flow (DefaultPermissionService)", () => {
         const alice = yield* registerWithOwner("alice-pf", USER_ALICE);
         const bob = yield* registerWithOwner("bob-pf", USER_BOB);
 
-        const session = (yield* alice.client.sendRpc("apps/create", {
+        const session = (yield* alice.client.sendRpc(AppsCreate.name, {
           appId: "perm-test-app",
           invitedAgentIds: [bob.agentId],
         })) as { session: { id: string; status: string } };
@@ -119,7 +126,7 @@ describe("Permission grant flow (DefaultPermissionService)", () => {
         expect(perm.access).toEqual(["read", "write"]);
         expect(perm.targetUserId).toBe(USER_BOB);
 
-        yield* bob.client.sendRpc("permissions/grant", {
+        yield* bob.client.sendRpc(PermissionsGrant.name, {
           sessionId: perm.sessionId,
           agentId: bob.agentId,
           resource: "calendar",
@@ -146,13 +153,13 @@ describe("Permission grant flow (DefaultPermissionService)", () => {
       const bob = yield* registerWithOwner("bob-c", USER_BOB);
 
       // Session 1: grant
-      yield* alice.client.sendRpc("apps/create", {
+      yield* alice.client.sendRpc(AppsCreate.name, {
         appId: "perm-test-app",
         invitedAgentIds: [bob.agentId],
       });
       const p1 = (yield* bob.client.waitForEvent("permissions/required"))
         .data as { sessionId: string };
-      yield* bob.client.sendRpc("permissions/grant", {
+      yield* bob.client.sendRpc(PermissionsGrant.name, {
         sessionId: p1.sessionId,
         agentId: bob.agentId,
         resource: "calendar",
@@ -173,7 +180,7 @@ describe("Permission grant flow (DefaultPermissionService)", () => {
       expect(rows[0]!.resource).toBe("calendar");
 
       // Session 2: should be admitted immediately (cached grant)
-      yield* alice.client.sendRpc("apps/create", {
+      yield* alice.client.sendRpc(AppsCreate.name, {
         appId: "perm-test-app",
         invitedAgentIds: [bob.agentId],
       });
@@ -201,13 +208,13 @@ describe("permissions/list and permissions/revoke RPCs", () => {
       const bob = yield* registerWithOwner("bob-lr", USER_BOB);
 
       // Grant via session flow
-      yield* alice.client.sendRpc("apps/create", {
+      yield* alice.client.sendRpc(AppsCreate.name, {
         appId: "perm-test-app",
         invitedAgentIds: [bob.agentId],
       });
       const p = (yield* bob.client.waitForEvent("permissions/required"))
         .data as { sessionId: string };
-      yield* bob.client.sendRpc("permissions/grant", {
+      yield* bob.client.sendRpc(PermissionsGrant.name, {
         sessionId: p.sessionId,
         agentId: bob.agentId,
         resource: "calendar",
@@ -216,7 +223,7 @@ describe("permissions/list and permissions/revoke RPCs", () => {
       yield* bob.client.waitForEvent("app/participantAdmitted");
 
       // List
-      const list = (yield* bob.client.sendRpc("permissions/list", {
+      const list = (yield* bob.client.sendRpc(PermissionsList.name, {
         appId: "perm-test-app",
       })) as {
         grants: Array<{
@@ -232,13 +239,13 @@ describe("permissions/list and permissions/revoke RPCs", () => {
       expect(list.grants[0]!.grantedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
 
       // Revoke
-      yield* bob.client.sendRpc("permissions/revoke", {
+      yield* bob.client.sendRpc(PermissionsRevoke.name, {
         appId: "perm-test-app",
         resource: "calendar",
       });
 
       // Verify empty
-      const after = (yield* bob.client.sendRpc("permissions/list", {
+      const after = (yield* bob.client.sendRpc(PermissionsList.name, {
         appId: "perm-test-app",
       })) as { grants: unknown[] };
       expect(after.grants).toHaveLength(0);
@@ -262,7 +269,7 @@ describe("Permission rejection", () => {
       const alice = yield* registerWithOwner("alice-to", USER_ALICE);
       const bob = yield* registerWithOwner("bob-to", USER_BOB);
 
-      yield* alice.client.sendRpc("apps/create", {
+      yield* alice.client.sendRpc(AppsCreate.name, {
         appId: "timeout-app",
         invitedAgentIds: [bob.agentId],
       });
@@ -305,7 +312,7 @@ describe("Set-containment: partial grant triggers re-prompt", () => {
         );
 
         // Bob should still get prompted
-        yield* alice.client.sendRpc("apps/create", {
+        yield* alice.client.sendRpc(AppsCreate.name, {
           appId: "perm-test-app",
           invitedAgentIds: [bob.agentId],
         });
@@ -320,7 +327,7 @@ describe("Set-containment: partial grant triggers re-prompt", () => {
         expect(perm.access).toEqual(["read", "write"]);
 
         // Grant full access
-        yield* bob.client.sendRpc("permissions/grant", {
+        yield* bob.client.sendRpc(PermissionsGrant.name, {
           sessionId: perm.sessionId,
           agentId: bob.agentId,
           resource: "calendar",

--- a/packages/server/src/__tests__/integration/30-user-validation-cache.integration.test.ts
+++ b/packages/server/src/__tests__/integration/30-user-validation-cache.integration.test.ts
@@ -25,6 +25,8 @@ import type { CoreApp, UserId } from "../../app/types.js";
 import type { UserService } from "../../services/user.service.js";
 import type { ConnectedAgent } from "../../test-utils/helpers.js";
 
+import { AppsCreate } from "@moltzap/protocol";
+
 let coreApp: CoreApp;
 /** Observable counter — assertion target for the coalescing behavior. */
 let validateCalls: Array<{ userId: UserId }>;
@@ -108,7 +110,7 @@ describe("AppHost: userValidationCache coalesces concurrent admissions", () => {
       // Initiator-validate call happens synchronously in createSession before
       // the admitAgentsAsync fiber forks. Record and clear it so the
       // assertion below measures only the concurrent-invitee branch.
-      yield* initiator.client.sendRpc("apps/create", {
+      yield* initiator.client.sendRpc(AppsCreate.name, {
         appId: "cache-test",
         invitedAgentIds: [inviteeA.agentId, inviteeB.agentId, inviteeC.agentId],
       });
@@ -161,7 +163,7 @@ describe("AppHost: userValidationCache coalesces concurrent admissions", () => {
 
       registerTestApp(coreApp, "no-cache-test");
 
-      yield* initiator.client.sendRpc("apps/create", {
+      yield* initiator.client.sendRpc(AppsCreate.name, {
         appId: "no-cache-test",
         invitedAgentIds: [inviteeA.agentId, inviteeB.agentId, inviteeC.agentId],
       });

--- a/packages/server/src/__tests__/integration/31-on-session-active.integration.test.ts
+++ b/packages/server/src/__tests__/integration/31-on-session-active.integration.test.ts
@@ -25,6 +25,8 @@ import {
 import type { CoreApp } from "../../app/types.js";
 import type { ConnectedAgent } from "../../test-utils/helpers.js";
 
+import { AppsCreate } from "@moltzap/protocol";
+
 let coreApp: CoreApp;
 
 beforeAll(async () => {
@@ -103,7 +105,7 @@ describe("Scenario 31b: on_session_active hook", () => {
         });
       });
 
-      const session = (yield* initiator.client.sendRpc("apps/create", {
+      const session = (yield* initiator.client.sendRpc(AppsCreate.name, {
         appId: "osa-fire-once",
         invitedAgentIds: [inviteeA.agentId, inviteeB.agentId],
       })) as {
@@ -142,7 +144,7 @@ describe("Scenario 31b: on_session_active hook", () => {
         hookFinishedAt = Date.now();
       });
 
-      yield* initiator.client.sendRpc("apps/create", {
+      yield* initiator.client.sendRpc(AppsCreate.name, {
         appId: "osa-order",
         invitedAgentIds: [invitee.agentId],
       });
@@ -172,7 +174,7 @@ describe("Scenario 31b: on_session_active hook", () => {
         await new Promise((r) => setTimeout(r, 600));
       });
 
-      const session = (yield* initiator.client.sendRpc("apps/create", {
+      const session = (yield* initiator.client.sendRpc(AppsCreate.name, {
         appId: "osa-timeout-app",
         invitedAgentIds: [invitee.agentId],
       })) as { session: { id: string } };
@@ -217,7 +219,7 @@ describe("Scenario 31b: on_session_active hook", () => {
         throw new Error("boom from on_session_active");
       });
 
-      const session = (yield* initiator.client.sendRpc("apps/create", {
+      const session = (yield* initiator.client.sendRpc(AppsCreate.name, {
         appId: "osa-throw-app",
         invitedAgentIds: [invitee.agentId],
       })) as { session: { id: string } };

--- a/packages/server/src/__tests__/integration/31-session-close.integration.test.ts
+++ b/packages/server/src/__tests__/integration/31-session-close.integration.test.ts
@@ -19,6 +19,13 @@ import {
 import type { ConnectedAgent } from "../../test-utils/helpers.js";
 import { expectRpcFailure } from "../../test-utils/index.js";
 
+import {
+  AppsGetSession,
+  AppsListSessions,
+  ConversationsList,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let coreApp: CoreApp;
 
 beforeAll(async () => {
@@ -86,7 +93,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
           return { block: true, reason: "never" };
         });
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "bmd-timeout-app",
           invitedAgentIds: [],
         })) as {
@@ -98,7 +105,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
         // Fail-closed: send rejects with HookBlocked. The app/hookTimeout
         // event asserted below is what distinguishes timeout from throw.
         yield* expectRpcFailure(
-          agent.client.sendRpc("messages/send", {
+          agent.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "trigger timeout" }],
           }),
@@ -134,14 +141,14 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
           await new Promise((r) => setTimeout(r, 1000));
         });
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "close-timeout-app",
           invitedAgentIds: [],
         })) as {
           session: { id: string; conversations: Record<string, string> };
         };
 
-        yield* agent.client.sendRpc("apps/closeSession", {
+        yield* agent.client.sendRpc(AppsCloseSession.name, {
           sessionId: session.session.id,
         });
 
@@ -170,14 +177,14 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         registerTestApp(coreApp, "close-basic-app");
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "close-basic-app",
           invitedAgentIds: [],
         })) as {
           session: { id: string; conversations: Record<string, string> };
         };
 
-        const result = (yield* agent.client.sendRpc("apps/closeSession", {
+        const result = (yield* agent.client.sendRpc(AppsCloseSession.name, {
           sessionId: session.session.id,
         })) as { closed: boolean };
 
@@ -226,14 +233,14 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
           hookCtx = ctx;
         });
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "close-hook-app",
           invitedAgentIds: [],
         })) as {
           session: { id: string; conversations: Record<string, string> };
         };
 
-        yield* agent.client.sendRpc("apps/closeSession", {
+        yield* agent.client.sendRpc(AppsCloseSession.name, {
           sessionId: session.session.id,
         });
 
@@ -251,19 +258,19 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         registerTestApp(coreApp, "double-close-app");
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "double-close-app",
           invitedAgentIds: [],
         })) as {
           session: { id: string; conversations: Record<string, string> };
         };
 
-        yield* agent.client.sendRpc("apps/closeSession", {
+        yield* agent.client.sendRpc(AppsCloseSession.name, {
           sessionId: session.session.id,
         });
 
         yield* expectRpcFailure(
-          agent.client.sendRpc("apps/closeSession", {
+          agent.client.sendRpc(AppsCloseSession.name, {
             sessionId: session.session.id,
           }),
           ErrorCodes.SessionClosed,
@@ -278,7 +285,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         registerTestApp(coreApp, "close-forbidden-app");
 
-        const session = (yield* initiator.client.sendRpc("apps/create", {
+        const session = (yield* initiator.client.sendRpc(AppsCreate.name, {
           appId: "close-forbidden-app",
           invitedAgentIds: [],
         })) as {
@@ -286,7 +293,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
         };
 
         yield* expectRpcFailure(
-          stranger.client.sendRpc("apps/closeSession", {
+          stranger.client.sendRpc(AppsCloseSession.name, {
             sessionId: session.session.id,
           }),
           ErrorCodes.Forbidden,
@@ -299,7 +306,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
         const agent = yield* registerAppAgent("close-notfound");
 
         yield* expectRpcFailure(
-          agent.client.sendRpc("apps/closeSession", {
+          agent.client.sendRpc(AppsCloseSession.name, {
             sessionId: crypto.randomUUID(),
           }),
           ErrorCodes.SessionNotFound,
@@ -318,7 +325,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
           coreApp.onAppJoin("close-broadcast-app", () => {});
 
-          const session = (yield* initiator.client.sendRpc("apps/create", {
+          const session = (yield* initiator.client.sendRpc(AppsCreate.name, {
             appId: "close-broadcast-app",
             invitedAgentIds: [invitee.agentId],
           })) as {
@@ -327,7 +334,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
           yield* invitee.client.waitForEvent("app/participantAdmitted", 5000);
 
-          yield* initiator.client.sendRpc("apps/closeSession", {
+          yield* initiator.client.sendRpc(AppsCloseSession.name, {
             sessionId: session.session.id,
           });
 
@@ -400,7 +407,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         registerTestApp(coreApp, "archived-msg-app");
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "archived-msg-app",
           invitedAgentIds: [],
         })) as {
@@ -409,12 +416,12 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         const convId = session.session.conversations["main"]!;
 
-        yield* agent.client.sendRpc("apps/closeSession", {
+        yield* agent.client.sendRpc(AppsCloseSession.name, {
           sessionId: session.session.id,
         });
 
         yield* expectRpcFailure(
-          agent.client.sendRpc("messages/send", {
+          agent.client.sendRpc(MessagesSend.name, {
             conversationId: convId,
             parts: [{ type: "text", text: "should fail" }],
           }),
@@ -473,7 +480,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         registerTestApp(coreApp, "archived-list-app");
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "archived-list-app",
           invitedAgentIds: [],
         })) as {
@@ -482,7 +489,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         // Verify conversation appears before close
         const beforeList = (yield* agent.client.sendRpc(
-          "conversations/list",
+          ConversationsList.name,
           {},
         )) as {
           conversations: Array<{ id: string }>;
@@ -492,12 +499,12 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
           true,
         );
 
-        yield* agent.client.sendRpc("apps/closeSession", {
+        yield* agent.client.sendRpc(AppsCloseSession.name, {
           sessionId: session.session.id,
         });
 
         const afterList = (yield* agent.client.sendRpc(
-          "conversations/list",
+          ConversationsList.name,
           {},
         )) as {
           conversations: Array<{ id: string }>;
@@ -519,7 +526,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
           const mainConvId = ctx.conversations["main"];
           if (mainConvId) {
             await Effect.runPromise(
-              agent.client.sendRpc("messages/send", {
+              agent.client.sendRpc(MessagesSend.name, {
                 conversationId: mainConvId,
                 parts: [{ type: "text", text: "Final message before close" }],
               }),
@@ -528,14 +535,14 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
           }
         });
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "close-final-msg-app",
           invitedAgentIds: [],
         })) as {
           session: { id: string; conversations: Record<string, string> };
         };
 
-        yield* agent.client.sendRpc("apps/closeSession", {
+        yield* agent.client.sendRpc(AppsCloseSession.name, {
           sessionId: session.session.id,
         });
 
@@ -563,14 +570,14 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         registerTestApp(coreApp, "get-init-app");
 
-        const created = (yield* agent.client.sendRpc("apps/create", {
+        const created = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "get-init-app",
           invitedAgentIds: [],
         })) as {
           session: { id: string; conversations: Record<string, string> };
         };
 
-        const result = (yield* agent.client.sendRpc("apps/getSession", {
+        const result = (yield* agent.client.sendRpc(AppsGetSession.name, {
           sessionId: created.session.id,
         })) as {
           session: {
@@ -596,7 +603,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
         registerTestApp(coreApp, "get-part-app");
         coreApp.onAppJoin("get-part-app", () => {});
 
-        const session = (yield* initiator.client.sendRpc("apps/create", {
+        const session = (yield* initiator.client.sendRpc(AppsCreate.name, {
           appId: "get-part-app",
           invitedAgentIds: [invitee.agentId],
         })) as {
@@ -605,7 +612,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         yield* invitee.client.waitForEvent("app/participantAdmitted", 5000);
 
-        const result = (yield* invitee.client.sendRpc("apps/getSession", {
+        const result = (yield* invitee.client.sendRpc(AppsGetSession.name, {
           sessionId: session.session.id,
         })) as {
           session: { id: string; appId: string };
@@ -623,7 +630,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
           const agent = yield* registerAppAgent("get-notfound");
 
           yield* expectRpcFailure(
-            agent.client.sendRpc("apps/getSession", {
+            agent.client.sendRpc(AppsGetSession.name, {
               sessionId: crypto.randomUUID(),
             }),
             ErrorCodes.SessionNotFound,
@@ -638,7 +645,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         registerTestApp(coreApp, "get-stranger-app");
 
-        const session = (yield* initiator.client.sendRpc("apps/create", {
+        const session = (yield* initiator.client.sendRpc(AppsCreate.name, {
           appId: "get-stranger-app",
           invitedAgentIds: [],
         })) as {
@@ -646,7 +653,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
         };
 
         yield* expectRpcFailure(
-          stranger.client.sendRpc("apps/getSession", {
+          stranger.client.sendRpc(AppsGetSession.name, {
             sessionId: session.session.id,
           }),
           ErrorCodes.Forbidden,
@@ -663,18 +670,18 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         registerTestApp(coreApp, "list-app");
 
-        yield* alice.client.sendRpc("apps/create", {
+        yield* alice.client.sendRpc(AppsCreate.name, {
           appId: "list-app",
           invitedAgentIds: [],
         });
 
-        yield* bob.client.sendRpc("apps/create", {
+        yield* bob.client.sendRpc(AppsCreate.name, {
           appId: "list-app",
           invitedAgentIds: [],
         });
 
         const aliceResult = (yield* alice.client.sendRpc(
-          "apps/listSessions",
+          AppsListSessions.name,
           {},
         )) as {
           sessions: Array<{ id: string; initiatorAgentId: string }>;
@@ -684,7 +691,7 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
         expect(aliceResult.sessions[0]!.initiatorAgentId).toBe(alice.agentId);
 
         const bobResult = (yield* bob.client.sendRpc(
-          "apps/listSessions",
+          AppsListSessions.name,
           {},
         )) as {
           sessions: Array<{ id: string; initiatorAgentId: string }>;
@@ -702,36 +709,36 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
         registerTestApp(coreApp, "list-filter-a");
         registerTestApp(coreApp, "list-filter-b");
 
-        const sessionA = (yield* agent.client.sendRpc("apps/create", {
+        const sessionA = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "list-filter-a",
           invitedAgentIds: [],
         })) as { session: { id: string } };
 
-        yield* agent.client.sendRpc("apps/create", {
+        yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "list-filter-b",
           invitedAgentIds: [],
         });
 
         // Close session A
-        yield* agent.client.sendRpc("apps/closeSession", {
+        yield* agent.client.sendRpc(AppsCloseSession.name, {
           sessionId: sessionA.session.id,
         });
 
         // Filter by appId
-        const byApp = (yield* agent.client.sendRpc("apps/listSessions", {
+        const byApp = (yield* agent.client.sendRpc(AppsListSessions.name, {
           appId: "list-filter-a",
         })) as { sessions: Array<{ appId: string }> };
         expect(byApp.sessions.length).toBe(1);
         expect(byApp.sessions[0]!.appId).toBe("list-filter-a");
 
         // Filter by status
-        const active = (yield* agent.client.sendRpc("apps/listSessions", {
+        const active = (yield* agent.client.sendRpc(AppsListSessions.name, {
           status: "active",
         })) as { sessions: Array<{ status: string }> };
         expect(active.sessions.length).toBe(1);
         expect(active.sessions[0]!.status).toBe("active");
 
-        const closed = (yield* agent.client.sendRpc("apps/listSessions", {
+        const closed = (yield* agent.client.sendRpc(AppsListSessions.name, {
           status: "closed",
         })) as { sessions: Array<{ status: string }> };
         expect(closed.sessions.length).toBe(1);
@@ -747,19 +754,22 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         // Create 3 sessions, request limit of 2
         for (let i = 0; i < 3; i++) {
-          yield* agent.client.sendRpc("apps/create", {
+          yield* agent.client.sendRpc(AppsCreate.name, {
             appId: "list-limit-app",
             invitedAgentIds: [],
           });
         }
 
-        const limited = (yield* agent.client.sendRpc("apps/listSessions", {
+        const limited = (yield* agent.client.sendRpc(AppsListSessions.name, {
           limit: 2,
         })) as { sessions: Array<{ id: string }> };
         expect(limited.sessions.length).toBe(2);
 
         // Default (no limit param) returns all 3
-        const all = (yield* agent.client.sendRpc("apps/listSessions", {})) as {
+        const all = (yield* agent.client.sendRpc(
+          AppsListSessions.name,
+          {},
+        )) as {
           sessions: Array<{ id: string }>;
         };
         expect(all.sessions.length).toBe(3);
@@ -774,18 +784,18 @@ describe("Scenario 31: Session Close + Conversation Archival", () => {
 
         registerTestApp(coreApp, "get-closed-app");
 
-        const session = (yield* agent.client.sendRpc("apps/create", {
+        const session = (yield* agent.client.sendRpc(AppsCreate.name, {
           appId: "get-closed-app",
           invitedAgentIds: [],
         })) as {
           session: { id: string };
         };
 
-        yield* agent.client.sendRpc("apps/closeSession", {
+        yield* agent.client.sendRpc(AppsCloseSession.name, {
           sessionId: session.session.id,
         });
 
-        const result = (yield* agent.client.sendRpc("apps/getSession", {
+        const result = (yield* agent.client.sendRpc(AppsGetSession.name, {
           sessionId: session.session.id,
         })) as {
           session: {

--- a/packages/server/src/__tests__/integration/33-attach-conversation.integration.test.ts
+++ b/packages/server/src/__tests__/integration/33-attach-conversation.integration.test.ts
@@ -27,6 +27,13 @@ import type { ConnectedAgent } from "../../test-utils/helpers.js";
 import { ErrorCodes } from "@moltzap/protocol";
 import { RpcFailure } from "../../runtime/index.js";
 
+import {
+  AppsCloseSession,
+  AppsCreate,
+  ConversationsCreate,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let coreApp: CoreApp;
 
 beforeAll(async () => {
@@ -78,7 +85,7 @@ function createSoloSession(
   appId: string,
 ): Effect.Effect<{ sessionId: string }, Error> {
   return Effect.gen(function* () {
-    const res = (yield* agent.client.sendRpc("apps/create", {
+    const res = (yield* agent.client.sendRpc(AppsCreate.name, {
       appId,
       invitedAgentIds: [],
     })) as { session: { id: string } };
@@ -100,7 +107,7 @@ describe("Scenario 33: attachConversation", () => {
         "attach-basic",
       );
 
-      const dm = (yield* initiator.client.sendRpc("conversations/create", {
+      const dm = (yield* initiator.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: peer.agentId }],
       })) as { conversation: { id: string } };
@@ -135,7 +142,7 @@ describe("Scenario 33: attachConversation", () => {
         "attach-idem",
       );
 
-      const dm = (yield* initiator.client.sendRpc("conversations/create", {
+      const dm = (yield* initiator.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: peer.agentId }],
       })) as { conversation: { id: string } };
@@ -172,7 +179,7 @@ describe("Scenario 33: attachConversation", () => {
           "attach-keyswap",
         );
 
-        const dm = (yield* initiator.client.sendRpc("conversations/create", {
+        const dm = (yield* initiator.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: peer.agentId }],
         })) as { conversation: { id: string } };
@@ -209,11 +216,11 @@ describe("Scenario 33: attachConversation", () => {
           "attach-convswap",
         );
 
-        const dmA = (yield* initiator.client.sendRpc("conversations/create", {
+        const dmA = (yield* initiator.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: peerA.agentId }],
         })) as { conversation: { id: string } };
-        const dmB = (yield* initiator.client.sendRpc("conversations/create", {
+        const dmB = (yield* initiator.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: peerB.agentId }],
         })) as { conversation: { id: string } };
@@ -253,9 +260,9 @@ describe("Scenario 33: attachConversation", () => {
         "attach-closed",
       );
 
-      yield* initiator.client.sendRpc("apps/closeSession", { sessionId });
+      yield* initiator.client.sendRpc(AppsCloseSession.name, { sessionId });
 
-      const dm = (yield* initiator.client.sendRpc("conversations/create", {
+      const dm = (yield* initiator.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: peer.agentId }],
       })) as { conversation: { id: string } };
@@ -284,7 +291,7 @@ describe("Scenario 33: attachConversation", () => {
         const a = yield* createSoloSession(coreApp, initiator, "attach-xsess");
         const b = yield* createSoloSession(coreApp, initiator, "attach-xsess");
 
-        const dm = (yield* initiator.client.sendRpc("conversations/create", {
+        const dm = (yield* initiator.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: peer.agentId }],
         })) as { conversation: { id: string } };
@@ -338,7 +345,7 @@ describe("Scenario 33: attachConversation", () => {
           "attach-hook",
         );
 
-        const dm = (yield* initiator.client.sendRpc("conversations/create", {
+        const dm = (yield* initiator.client.sendRpc(ConversationsCreate.name, {
           type: "dm",
           participants: [{ type: "agent", id: peer.agentId }],
         })) as { conversation: { id: string } };
@@ -347,7 +354,7 @@ describe("Scenario 33: attachConversation", () => {
         // Sanity: before attaching, the hook is bypassed — the convId is not
         // in AppHost.conversationToSession, so runBeforeMessageDelivery
         // returns null and the message passes through unchanged.
-        const preAttach = (yield* initiator.client.sendRpc("messages/send", {
+        const preAttach = (yield* initiator.client.sendRpc(MessagesSend.name, {
           conversationId: dmId,
           parts: [{ type: "text", text: "pre-attach" }],
         })) as { message: { parts: Array<{ text: string }> } };
@@ -356,7 +363,7 @@ describe("Scenario 33: attachConversation", () => {
         yield* coreApp.attachAppConversation(sessionId, dmId, "role_dm");
 
         // Post-attach: hook fires and patches the parts.
-        const postAttach = (yield* initiator.client.sendRpc("messages/send", {
+        const postAttach = (yield* initiator.client.sendRpc(MessagesSend.name, {
           conversationId: dmId,
           parts: [{ type: "text", text: "post-attach" }],
         })) as {
@@ -384,7 +391,7 @@ describe("Scenario 33: attachConversation", () => {
         initiator,
         "attach-ecode",
       );
-      const dm = (yield* initiator.client.sendRpc("conversations/create", {
+      const dm = (yield* initiator.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: peer.agentId }],
       })) as { conversation: { id: string } };

--- a/packages/server/src/__tests__/integration/33-session-failure.integration.test.ts
+++ b/packages/server/src/__tests__/integration/33-session-failure.integration.test.ts
@@ -16,6 +16,8 @@ import {
   type ServerTestClient,
 } from "./helpers.js";
 
+import { AppsCreate } from "@moltzap/protocol";
+
 let db: Kysely<Database>;
 
 const USER_ALICE = "00000000-0000-4000-a000-000000000010";
@@ -82,7 +84,7 @@ describe("Session failure state", () => {
       const alice = yield* registerWithOwner("alice-sf", USER_ALICE);
 
       // Invite an agent that doesn't exist — will be rejected at identity stage
-      yield* alice.client.sendRpc("apps/create", {
+      yield* alice.client.sendRpc(AppsCreate.name, {
         appId: "fail-test-app",
         invitedAgentIds: ["00000000-0000-4000-dead-000000000001"],
       });
@@ -124,7 +126,7 @@ describe("Session failure state", () => {
       };
       getTestCoreApp().registerApp(noPermManifest);
 
-      yield* alice.client.sendRpc("apps/create", {
+      yield* alice.client.sendRpc(AppsCreate.name, {
         appId: "no-perm-app",
         invitedAgentIds: [bob.agentId],
       });
@@ -155,7 +157,7 @@ describe("Session failure state", () => {
 
       const bob = yield* registerWithOwner("bob-mx", USER_ALICE);
 
-      yield* alice.client.sendRpc("apps/create", {
+      yield* alice.client.sendRpc(AppsCreate.name, {
         appId: "mixed-app",
         invitedAgentIds: [bob.agentId, "00000000-0000-4000-dead-000000000002"],
       });

--- a/packages/server/src/__tests__/integration/34-rpc-additions.integration.test.ts
+++ b/packages/server/src/__tests__/integration/34-rpc-additions.integration.test.ts
@@ -9,6 +9,13 @@ import {
   setupAgentPair,
 } from "./helpers.js";
 
+import {
+  AppsRegister,
+  ConversationsCreate,
+  MessagesSend,
+  SystemPing,
+} from "@moltzap/protocol";
+
 beforeAll(async () => {
   await startTestServer();
 }, 60_000);
@@ -22,12 +29,12 @@ beforeEach(async () => {
 });
 
 describe("Scenario 34: apps/register + system/ping RPCs", () => {
-  describe("system/ping", () => {
+  describe(SystemPing.name, () => {
     it.live("returns an ISO8601 ts string", () =>
       Effect.gen(function* () {
         const agent = yield* registerAndConnect("alice");
 
-        const result = (yield* agent.client.sendRpc("system/ping", {})) as {
+        const result = (yield* agent.client.sendRpc(SystemPing.name, {})) as {
           ts: string;
         };
 
@@ -40,12 +47,12 @@ describe("Scenario 34: apps/register + system/ping RPCs", () => {
     );
   });
 
-  describe("apps/register", () => {
+  describe(AppsRegister.name, () => {
     it.live("registers a valid manifest and returns the appId", () =>
       Effect.gen(function* () {
         const agent = yield* registerAndConnect("alice");
 
-        const result = (yield* agent.client.sendRpc("apps/register", {
+        const result = (yield* agent.client.sendRpc(AppsRegister.name, {
           manifest: {
             appId: "my-test-app",
             name: "My Test App",
@@ -65,7 +72,7 @@ describe("Scenario 34: apps/register + system/ping RPCs", () => {
         const agent = yield* registerAndConnect("alice");
 
         const exit = yield* Effect.exit(
-          agent.client.sendRpc("apps/register", {
+          agent.client.sendRpc(AppsRegister.name, {
             manifest: { appId: "broken" },
           }),
         );
@@ -78,7 +85,7 @@ describe("Scenario 34: apps/register + system/ping RPCs", () => {
         const agent = yield* registerAndConnect("alice");
 
         const exit = yield* Effect.exit(
-          agent.client.sendRpc("apps/register", {}),
+          agent.client.sendRpc(AppsRegister.name, {}),
         );
         expect(Exit.isFailure(exit)).toBe(true);
       }),
@@ -92,18 +99,18 @@ describe("Scenario 34: apps/register + system/ping RPCs", () => {
         Effect.gen(function* () {
           const { alice, bob } = yield* setupAgentPair();
 
-          const conv = (yield* alice.client.sendRpc("conversations/create", {
+          const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
             type: "dm",
             participants: [{ type: "agent", id: bob.agentId }],
           })) as { conversation: { id: string } };
           const conversationId = conv.conversation.id;
 
-          const sent = (yield* alice.client.sendRpc("messages/send", {
+          const sent = (yield* alice.client.sendRpc(MessagesSend.name, {
             conversationId,
             parts: [{ type: "text", text: "question" }],
           })) as { message: { id: string } };
 
-          const replied = (yield* bob.client.sendRpc("messages/send", {
+          const replied = (yield* bob.client.sendRpc(MessagesSend.name, {
             replyToId: sent.message.id,
             parts: [{ type: "text", text: "answer" }],
           })) as {
@@ -121,7 +128,7 @@ describe("Scenario 34: apps/register + system/ping RPCs", () => {
         const unknownId = "00000000-0000-0000-0000-000000000000";
 
         const exit = yield* Effect.exit(
-          agent.client.sendRpc("messages/send", {
+          agent.client.sendRpc(MessagesSend.name, {
             replyToId: unknownId,
             parts: [{ type: "text", text: "orphan" }],
           }),

--- a/packages/server/src/__tests__/integration/35-conversations-archive.integration.test.ts
+++ b/packages/server/src/__tests__/integration/35-conversations-archive.integration.test.ts
@@ -13,6 +13,13 @@ import type { ConnectedAgent } from "./helpers.js";
 import type { CoreApp } from "../../app/types.js";
 import { getCoreDb, expectRpcFailure } from "../../test-utils/index.js";
 
+import {
+  AppsCreate,
+  ConversationsArchive,
+  ConversationsList,
+  ConversationsUnarchive,
+} from "@moltzap/protocol";
+
 let coreApp: CoreApp;
 
 beforeAll(async () => {
@@ -39,7 +46,9 @@ describe("conversations/archive + /unarchive", () => {
       ];
       const conversationId = group.conversationId!;
 
-      yield* alice.client.sendRpc("conversations/archive", { conversationId });
+      yield* alice.client.sendRpc(ConversationsArchive.name, {
+        conversationId,
+      });
 
       const bobArchived = yield* bob.client.waitForEvent(
         "conversations/archived",
@@ -58,27 +67,27 @@ describe("conversations/archive + /unarchive", () => {
       expect((eveArchived.data as { by: string }).by).toBe(alice.agentId);
 
       const listDefault = (yield* bob.client.sendRpc(
-        "conversations/list",
+        ConversationsList.name,
         {},
       )) as { conversations: Array<{ id: string }> };
       expect(
         listDefault.conversations.find((c) => c.id === conversationId),
       ).toBeUndefined();
 
-      const listInclude = (yield* bob.client.sendRpc("conversations/list", {
+      const listInclude = (yield* bob.client.sendRpc(ConversationsList.name, {
         archived: "include",
       })) as { conversations: Array<{ id: string }> };
       expect(
         listInclude.conversations.find((c) => c.id === conversationId),
       ).toBeDefined();
 
-      const listOnly = (yield* bob.client.sendRpc("conversations/list", {
+      const listOnly = (yield* bob.client.sendRpc(ConversationsList.name, {
         archived: "only",
       })) as { conversations: Array<{ id: string }> };
       expect(listOnly.conversations.length).toBe(1);
       expect(listOnly.conversations[0]!.id).toBe(conversationId);
 
-      yield* alice.client.sendRpc("conversations/unarchive", {
+      yield* alice.client.sendRpc(ConversationsUnarchive.name, {
         conversationId,
       });
       const bobUnarchived = yield* bob.client.waitForEvent(
@@ -89,7 +98,7 @@ describe("conversations/archive + /unarchive", () => {
       ).toBe(conversationId);
 
       const listAfter = (yield* bob.client.sendRpc(
-        "conversations/list",
+        ConversationsList.name,
         {},
       )) as { conversations: Array<{ id: string }> };
       expect(
@@ -105,7 +114,7 @@ describe("conversations/archive + /unarchive", () => {
       const conversationId = group.conversationId!;
 
       yield* expectRpcFailure(
-        bob.client.sendRpc("conversations/archive", { conversationId }),
+        bob.client.sendRpc(ConversationsArchive.name, { conversationId }),
         ErrorCodes.Forbidden,
       );
     }),
@@ -129,7 +138,7 @@ describe("conversations/archive + /unarchive", () => {
           .execute(),
       );
 
-      yield* bob.client.sendRpc("conversations/archive", { conversationId });
+      yield* bob.client.sendRpc(ConversationsArchive.name, { conversationId });
     }),
   );
 
@@ -139,8 +148,12 @@ describe("conversations/archive + /unarchive", () => {
       const [alice] = group.agents as [ConnectedAgent, ConnectedAgent];
       const conversationId = group.conversationId!;
 
-      yield* alice.client.sendRpc("conversations/archive", { conversationId });
-      yield* alice.client.sendRpc("conversations/archive", { conversationId });
+      yield* alice.client.sendRpc(ConversationsArchive.name, {
+        conversationId,
+      });
+      yield* alice.client.sendRpc(ConversationsArchive.name, {
+        conversationId,
+      });
     }),
   );
 
@@ -150,7 +163,7 @@ describe("conversations/archive + /unarchive", () => {
       const [alice] = group.agents as [ConnectedAgent, ConnectedAgent];
       const conversationId = group.conversationId!;
 
-      yield* alice.client.sendRpc("conversations/unarchive", {
+      yield* alice.client.sendRpc(ConversationsUnarchive.name, {
         conversationId,
       });
     }),
@@ -184,7 +197,7 @@ describe("conversations/archive + /unarchive", () => {
           .execute(),
       );
 
-      const session = (yield* alice.client.sendRpc("apps/create", {
+      const session = (yield* alice.client.sendRpc(AppsCreate.name, {
         appId,
         invitedAgentIds: [],
       })) as {
@@ -193,7 +206,7 @@ describe("conversations/archive + /unarchive", () => {
       const convId = session.session.conversations["main"]!;
 
       const err = yield* expectRpcFailure(
-        alice.client.sendRpc("conversations/archive", {
+        alice.client.sendRpc(ConversationsArchive.name, {
           conversationId: convId,
         }),
         ErrorCodes.Conflict,
@@ -220,8 +233,8 @@ describe("conversations/archive + /unarchive", () => {
 
       const [r1, r2] = yield* Effect.all(
         [
-          alice.client.sendRpc("conversations/archive", { conversationId }),
-          bob.client.sendRpc("conversations/archive", { conversationId }),
+          alice.client.sendRpc(ConversationsArchive.name, { conversationId }),
+          bob.client.sendRpc(ConversationsArchive.name, { conversationId }),
         ],
         { concurrency: "unbounded" },
       );

--- a/packages/server/src/__tests__/integration/36-trace-capture.integration.test.ts
+++ b/packages/server/src/__tests__/integration/36-trace-capture.integration.test.ts
@@ -18,6 +18,12 @@ import type { CoreApp } from "../../app/types.js";
 import { ErrorCodes } from "@moltzap/protocol";
 import { expectRpcFailure } from "../../test-utils/index.js";
 
+import {
+  AppsCreate,
+  ConversationsCreate,
+  MessagesSend,
+} from "@moltzap/protocol";
+
 let traceCapture: TraceCapture;
 let coreApp: CoreApp;
 
@@ -73,12 +79,12 @@ describe("trace capture", () => {
       const alice = yield* registerAndConnect("alice-trace-capture");
       const bob = yield* registerAndConnect("bob-trace-capture");
 
-      const conv = (yield* alice.client.sendRpc("conversations/create", {
+      const conv = (yield* alice.client.sendRpc(ConversationsCreate.name, {
         type: "dm",
         participants: [{ type: "agent", id: bob.agentId }],
       })) as { conversation: { id: string } };
 
-      yield* alice.client.sendRpc("messages/send", {
+      yield* alice.client.sendRpc(MessagesSend.name, {
         conversationId: conv.conversation.id,
         parts: [{ type: "text", text: "hello from trace capture test" }],
       });
@@ -115,7 +121,7 @@ describe("trace capture", () => {
         reason: "trace_blocked_command",
       }));
 
-      const session = (yield* orchestrator.client.sendRpc("apps/create", {
+      const session = (yield* orchestrator.client.sendRpc(AppsCreate.name, {
         appId,
         invitedAgentIds: [],
       })) as {
@@ -124,7 +130,7 @@ describe("trace capture", () => {
       const conversationId = session.session.conversations["main"]!;
 
       yield* expectRpcFailure(
-        orchestrator.client.sendRpc("messages/send", {
+        orchestrator.client.sendRpc(MessagesSend.name, {
           conversationId,
           parts: [{ type: "text", text: "bad command for trace" }],
         }),

--- a/packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts
+++ b/packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts
@@ -16,6 +16,8 @@ import {
   registerAgent,
 } from "./helpers.js";
 
+import { AppsCreate, Connect } from "@moltzap/protocol";
+
 const REGISTRATION_SECRET = "admin-test-secret-zxcv";
 // Arbitrary v4 UUID used as the "system user" identity in arena. moltzap's
 // schema has no users table; this UUID is just a label that satisfies the
@@ -149,7 +151,7 @@ describe("/api/v1/admin/register-agent — secret-gated ownerUserId", () => {
         });
         trackClient(client);
 
-        const session = (yield* client.sendRpc("apps/create", {
+        const session = (yield* client.sendRpc(AppsCreate.name, {
           appId: ADMIN_TEST_MANIFEST.appId,
           invitedAgentIds: [invitee.agentId],
         })) as { session: { id: string; status: string } };
@@ -276,7 +278,7 @@ describe("/api/v1/admin/register-agent — secret-gated ownerUserId", () => {
       });
       trackClient(staleClient);
       const staleResult = yield* Effect.exit(
-        staleClient.sendRpc("auth/connect", {
+        staleClient.sendRpc(Connect.name, {
           agentKey: oldKey,
           minProtocol: PROTOCOL_VERSION,
           maxProtocol: PROTOCOL_VERSION,
@@ -291,7 +293,7 @@ describe("/api/v1/admin/register-agent — secret-gated ownerUserId", () => {
         autoConnect: false,
       });
       trackClient(freshClient);
-      const hello = (yield* freshClient.sendRpc("auth/connect", {
+      const hello = (yield* freshClient.sendRpc(Connect.name, {
         agentKey: rotated.apiKey,
         minProtocol: PROTOCOL_VERSION,
         maxProtocol: PROTOCOL_VERSION,

--- a/packages/server/src/__tests__/integration/helpers.ts
+++ b/packages/server/src/__tests__/integration/helpers.ts
@@ -20,13 +20,13 @@ import {
   trackClient,
   registerAgent,
   connectTestClient,
-  type ConnectedAgent,
   type ServerTestClient,
 } from "../../test-utils/helpers.js";
 import type { Database } from "../../db/database.js";
 import type { Kysely } from "kysely";
 import type { CoreApp } from "../../app/types.js";
-import type { Layer } from "effect";
+import { Effect, type Layer } from "effect";
+import { inject } from "vitest";
 
 export type { ConnectedAgent } from "../../test-utils/helpers.js";
 export {
@@ -42,10 +42,7 @@ export type { ServerTestClient };
 
 let _coreApp: CoreApp | null = null;
 
-/**
- * Start the core test server using the shared Postgres from globalSetup.
- */
-export async function startTestServer(_opts?: {
+type StartTestServerOptions = {
   devMode?: boolean;
   encryption?: boolean;
   /** Optional validator forwarded to `startCoreTestServer` — see its docs. */
@@ -53,48 +50,92 @@ export async function startTestServer(_opts?: {
   /** Optional secret forwarded to `startCoreTestServer` — see its docs. */
   registrationSecret?: string;
   traceCaptureLayer?: Layer.Layer<TraceCaptureTag>;
-}): Promise<{
-  baseUrl: string;
-  wsUrl: string;
-  coreApp: CoreApp;
-}> {
+};
+
+class IntegrationTestHelperError extends Error {
+  override readonly name = "IntegrationTestHelperError";
+
+  constructor(
+    message: string,
+    override readonly cause?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Start the core test server using the shared Postgres from globalSetup.
+ */
+export function startTestServer(_opts?: StartTestServerOptions) {
   // Get pgHost/pgPort from vitest's globalSetup via inject()
-  const { inject } = await import("vitest");
   const pgHost = inject("testPgHost");
   const pgPort = inject("testPgPort");
 
-  const server = await startCoreTestServer({
-    pgHost,
-    pgPort,
-    encryption: _opts?.encryption,
-    userService: _opts?.userService,
-    registrationSecret: _opts?.registrationSecret,
-    traceCaptureLayer: _opts?.traceCaptureLayer,
-  });
-  _coreApp = server.coreApp;
-  return {
-    baseUrl: server.baseUrl,
-    wsUrl: server.wsUrl,
-    coreApp: server.coreApp,
-  };
+  return Effect.runPromise(
+    Effect.tryPromise({
+      try: () =>
+        startCoreTestServer({
+          pgHost,
+          pgPort,
+          encryption: _opts?.encryption,
+          userService: _opts?.userService,
+          registrationSecret: _opts?.registrationSecret,
+          traceCaptureLayer: _opts?.traceCaptureLayer,
+        }),
+      catch: (cause) =>
+        new IntegrationTestHelperError(
+          "Core test server failed to start",
+          cause,
+        ),
+    }).pipe(
+      Effect.tap((server) =>
+        Effect.sync(() => {
+          _coreApp = server.coreApp;
+        }),
+      ),
+      Effect.map((server) => ({
+        baseUrl: server.baseUrl,
+        wsUrl: server.wsUrl,
+        coreApp: server.coreApp,
+      })),
+    ),
+  );
 }
 
 export function getCoreApp(): CoreApp {
-  if (!_coreApp) throw new Error("Test server not running.");
+  if (!_coreApp)
+    throw new IntegrationTestHelperError("Test server not running.");
   return _coreApp;
 }
 
-export async function stopTestServer(): Promise<void> {
-  const { Effect } = await import("effect");
-  await Effect.runPromise(closeAllClients());
-  _coreApp = null;
-  await stopCoreTestServer();
+export function stopTestServer() {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* closeAllClients();
+      _coreApp = null;
+      yield* Effect.tryPromise({
+        try: () => stopCoreTestServer(),
+        catch: (cause) =>
+          new IntegrationTestHelperError(
+            "Core test server failed to stop",
+            cause,
+          ),
+      });
+    }),
+  );
 }
 
-export async function resetTestDb(): Promise<void> {
-  const { Effect } = await import("effect");
-  await Effect.runPromise(closeAllClients());
-  await resetCoreTestDb();
+export function resetTestDb() {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* closeAllClients();
+      yield* Effect.tryPromise({
+        try: () => resetCoreTestDb(),
+        catch: (cause) =>
+          new IntegrationTestHelperError("Core test DB failed to reset", cause),
+      });
+    }),
+  );
 }
 
 export function getKyselyDb(): Kysely<Database> {
@@ -105,21 +146,18 @@ export function getTestCoreApp() {
   return getCoreApp();
 }
 
-export async function createTestUser(
-  _displayName: string,
-): Promise<{ id: string; supabaseUid: string }> {
+export function createTestUser(displayName: string) {
+  void displayName;
   return { id: crypto.randomUUID(), supabaseUid: crypto.randomUUID() };
 }
 
-export async function createAgentInvite(
-  _inviterId: string,
-): Promise<{ token: string; inviteId: string }> {
+export function createAgentInvite(inviterId: string) {
+  void inviterId;
   return { token: "not-needed-in-core", inviteId: crypto.randomUUID() };
 }
 
-export async function claimTestAgent(
-  _claimToken: string,
-  _userId: string,
-): Promise<void> {
+export function claimTestAgent(claimToken: string, userId: string): void {
+  void claimToken;
+  void userId;
   // No-op — agents are active immediately in core
 }

--- a/packages/server/src/adapters/webhook.ts
+++ b/packages/server/src/adapters/webhook.ts
@@ -14,6 +14,10 @@ import { createHmac } from "node:crypto";
 import type { ContactService, PermissionService } from "../app/app-host.js";
 import type { Logger } from "../logger.js";
 
+const DEFAULT_WEBHOOK_CONCURRENCY = 10;
+const RESOLVED_TTL_MS = 300_000;
+const HTTP_ACCEPTED = 202;
+
 /**
  * HMAC-SHA256-sign a webhook payload and return the `X-MoltZap-Signature`
  * header value (`sha256=<hex>`). Receivers recompute over the exact JSON
@@ -179,7 +183,7 @@ function readResponseText(response: Response): Effect.Effect<string, never> {
 export class WebhookClient {
   private readonly permits: Effect.Semaphore;
 
-  constructor(concurrency = 10) {
+  constructor(concurrency = DEFAULT_WEBHOOK_CONCURRENCY) {
     // `Effect.makeSemaphore` is pure, so `runSync` in the constructor
     // is safe and keeps the `new WebhookClient()` construction surface
     // unchanged for call sites.
@@ -291,9 +295,6 @@ export class WebhookContactService implements ContactService {
 
 // -- Async webhook adapter (Permissions) --------------------------------------
 
-/** How long we remember a resolved request-id so repeat callbacks are idempotent. */
-const RESOLVED_TTL_MS = 5 * 60 * 1000;
-
 /** Internal map entry — a Deferred that the HTTP callback route completes. */
 type PendingMap = HashMap.HashMap<
   string,
@@ -325,7 +326,7 @@ export class AsyncWebhookAdapter {
   private readonly resolved = new Map<string, number>();
   private readonly permits: Effect.Semaphore;
 
-  constructor(concurrency = 10) {
+  constructor(concurrency = DEFAULT_WEBHOOK_CONCURRENCY) {
     this.pending = Effect.runSync(Ref.make<PendingMap>(HashMap.empty()));
     this.permits = Effect.runSync(Effect.makeSemaphore(concurrency));
   }
@@ -370,7 +371,7 @@ export class AsyncWebhookAdapter {
           catch: (err) => new WebhookNetworkError({ url, event, cause: err }),
         }).pipe(
           Effect.flatMap((response) => {
-            if (response.status === 202) return Effect.void;
+            if (response.status === HTTP_ACCEPTED) return Effect.void;
             return readResponseText(response).pipe(
               Effect.flatMap((text) =>
                 Effect.fail(

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -45,6 +45,7 @@ import {
   Data,
   Deferred,
   Duration,
+  Either,
   Effect,
   Exit,
   HashMap,
@@ -68,6 +69,17 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+const SEMVER_PART_COUNT = 3;
+const MAX_AGENT_ADMISSION_CONCURRENCY = 16;
+const MAX_AGENT_ADMISSION_CHECK_CONCURRENCY = 2;
+const MAX_PERMISSION_REQUEST_CONCURRENCY = 8;
+const DEFAULT_CHALLENGE_TIMEOUT_MS = 30_000;
+const DEFAULT_PERMISSION_TIMEOUT_MS = 120_000;
+const DEFAULT_APP_MAX_PARTICIPANTS = 50;
+const DEFAULT_SESSION_LIST_LIMIT = 50;
+const DEFAULT_APP_HOOK_TIMEOUT_MS = 5000;
+const MSG_SESSION_NOT_FOUND = "Session not found";
+
 /**
  * True iff `stored` contains every access string in `required`. Missing or
  * empty `stored` always fails. Used both for existing-grant coverage checks
@@ -86,7 +98,7 @@ function grantsAllRequiredAccess(
 function compareSemver(a: string, b: string): number {
   const pa = a.split(".").map(Number);
   const pb = b.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < SEMVER_PART_COUNT; i++) {
     const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
     if (diff !== 0) return diff;
   }
@@ -139,6 +151,18 @@ class AttestationTimeoutError extends Data.TaggedError("AttestationTimeout")<{
 
 class SkillAttestationError extends Data.TaggedError("SkillAttestation")<{
   readonly reason: string;
+}> {
+  override get message(): string {
+    return this.reason;
+  }
+}
+
+class RemoteHookError extends Data.TaggedError("RemoteHookError")<{
+  readonly appId: string;
+  readonly method: string;
+  readonly connectionId: string;
+  readonly reason: string;
+  readonly cause?: unknown;
 }> {
   override get message(): string {
     return this.reason;
@@ -441,7 +465,7 @@ export class AppHost {
           return yield* Effect.fail(
             new RpcFailure({
               code: ErrorCodes.SessionNotFound,
-              message: "Session not found",
+              message: MSG_SESSION_NOT_FOUND,
             }),
           );
         }
@@ -687,7 +711,8 @@ export class AppHost {
           );
         }
 
-        const maxParticipants = manifest.limits?.maxParticipants ?? 50;
+        const maxParticipants =
+          manifest.limits?.maxParticipants ?? DEFAULT_APP_MAX_PARTICIPANTS;
         if (invitedAgentIds.length > maxParticipants) {
           return yield* Effect.fail(
             new RpcFailure({
@@ -886,7 +911,7 @@ export class AppHost {
           return yield* Effect.fail(
             new RpcFailure({
               code: ErrorCodes.SessionNotFound,
-              message: "Session not found",
+              message: MSG_SESSION_NOT_FOUND,
             }),
           );
         }
@@ -1055,7 +1080,7 @@ export class AppHost {
           return yield* Effect.fail(
             new RpcFailure({
               code: ErrorCodes.SessionNotFound,
-              message: "Session not found",
+              message: MSG_SESSION_NOT_FOUND,
             }),
           );
         }
@@ -1201,7 +1226,7 @@ export class AppHost {
           return yield* Effect.fail(
             new RpcFailure({
               code: ErrorCodes.SessionNotFound,
-              message: "Session not found",
+              message: MSG_SESSION_NOT_FOUND,
             }),
           );
         }
@@ -1270,7 +1295,7 @@ export class AppHost {
           query = query.where("status", "=", opts.status as AppSessionStatus);
         }
 
-        const limit = opts?.limit ?? 50;
+        const limit = opts?.limit ?? DEFAULT_SESSION_LIST_LIMIT;
         query = query.limit(limit);
 
         const rows = yield* query;
@@ -1454,7 +1479,7 @@ export class AppHost {
      * this is the per-message hot path.
      */
     decode: (raw: unknown) => Effect.Effect<T, unknown, never>;
-  }): Effect.Effect<T, Error> {
+  }): Effect.Effect<T, RemoteHookError> {
     return Effect.gen(this, function* () {
       const conn: MoltZapConnection | undefined = this.connections.get(
         opts.connectionId,
@@ -1464,24 +1489,38 @@ export class AppHost {
         // gone away. Treat identically to mid-flight `AppDisconnected`
         // so the dispatch envelope folds it into fail-closed.
         return yield* Effect.fail(
-          new Error(
-            `Remote app ${opts.appId} connection ${opts.connectionId} is gone`,
-          ),
+          new RemoteHookError({
+            appId: opts.appId,
+            method: opts.method,
+            connectionId: opts.connectionId,
+            reason: `Remote app ${opts.appId} connection ${opts.connectionId} is gone`,
+          }),
         );
       }
       const raw = yield* sendRpcToClient(conn, opts.method, opts.params).pipe(
-        Effect.mapError((err) => new Error(`s2c RPC failed: ${err._tag}`)),
+        Effect.mapError(
+          (err) =>
+            new RemoteHookError({
+              appId: opts.appId,
+              method: opts.method,
+              connectionId: opts.connectionId,
+              reason: `s2c RPC failed: ${errorMessage(err)}`,
+              cause: err,
+            }),
+        ),
       );
-      return yield* opts
-        .decode(raw)
-        .pipe(
-          Effect.mapError(
-            (err) =>
-              new Error(
-                `s2c RPC ${opts.method} response decode failed: ${String(err)}`,
-              ),
-          ),
-        );
+      return yield* opts.decode(raw).pipe(
+        Effect.mapError(
+          (err) =>
+            new RemoteHookError({
+              appId: opts.appId,
+              method: opts.method,
+              connectionId: opts.connectionId,
+              reason: `s2c RPC ${opts.method} response decode failed: ${String(err)}`,
+              cause: err,
+            }),
+        ),
+      );
     });
   }
 
@@ -1556,7 +1595,9 @@ export class AppHost {
       return Effect.succeed({ decision: "grant" as const });
     }
     const manifest = this.manifests.get(appId);
-    const timeoutMs = manifest?.hooks?.before_dispatch?.timeout_ms ?? 5000;
+    const timeoutMs =
+      manifest?.hooks?.before_dispatch?.timeout_ms ??
+      DEFAULT_APP_HOOK_TIMEOUT_MS;
     const sessionId = ctx.sessionId;
 
     const raw: Effect.Effect<DispatchAdmissionResult, Error> = remote
@@ -1618,7 +1659,8 @@ export class AppHost {
     }
     const manifest = this.manifests.get(appId);
     const timeoutMs =
-      manifest?.hooks?.before_message_delivery?.timeout_ms ?? 5000;
+      manifest?.hooks?.before_message_delivery?.timeout_ms ??
+      DEFAULT_APP_HOOK_TIMEOUT_MS;
     const sessionId = ctx.sessionId;
 
     const raw: Effect.Effect<HookResult, Error> = remote
@@ -1677,7 +1719,9 @@ export class AppHost {
     const inProcess = this.hooks.get(appId)?.onSessionActive;
     if (!remote && !inProcess) return Effect.void;
     const manifest = this.manifests.get(appId);
-    const timeoutMs = manifest?.hooks?.on_session_active?.timeout_ms ?? 5000;
+    const timeoutMs =
+      manifest?.hooks?.on_session_active?.timeout_ms ??
+      DEFAULT_APP_HOOK_TIMEOUT_MS;
     const sessionId = ctx.sessionId;
 
     const raw: Effect.Effect<void, Error> = remote
@@ -1727,7 +1771,8 @@ export class AppHost {
     const inProcess = this.hooks.get(appId)?.onJoin;
     if (!remote && !inProcess) return Effect.void;
     const manifest = this.manifests.get(appId);
-    const timeoutMs = manifest?.hooks?.on_join?.timeout_ms ?? 5000;
+    const timeoutMs =
+      manifest?.hooks?.on_join?.timeout_ms ?? DEFAULT_APP_HOOK_TIMEOUT_MS;
     const sessionId = ctx.sessionId;
 
     const raw: Effect.Effect<void, Error> = remote
@@ -1779,7 +1824,8 @@ export class AppHost {
     const inProcess = this.hooks.get(appId)?.onClose;
     if (!remote && !inProcess) return Effect.void;
     const manifest = this.manifests.get(appId);
-    const timeoutMs = manifest?.hooks?.on_close?.timeout_ms ?? 5000;
+    const timeoutMs =
+      manifest?.hooks?.on_close?.timeout_ms ?? DEFAULT_APP_HOOK_TIMEOUT_MS;
     const sessionId = ctx.sessionId;
 
     const raw: Effect.Effect<void, Error> = remote
@@ -1896,7 +1942,7 @@ export class AppHost {
             }),
           ),
         ),
-        { concurrency: "unbounded" },
+        { concurrency: MAX_AGENT_ADMISSION_CONCURRENCY },
       );
 
       const allRejected = outcomes.every((o) => o.status === "rejected");
@@ -2069,13 +2115,17 @@ export class AppHost {
       }
 
       const results = yield* Effect.all(checks, {
-        concurrency: "unbounded",
+        concurrency: MAX_AGENT_ADMISSION_CHECK_CONCURRENCY,
         mode: "either",
       });
 
       for (const result of results) {
-        if (result._tag === "Left") {
-          return yield* Effect.fail(result.left);
+        const failure = Either.match(result, {
+          onLeft: (err) => err,
+          onRight: () => null,
+        });
+        if (failure !== null) {
+          return yield* Effect.fail(failure);
         }
       }
 
@@ -2160,7 +2210,8 @@ export class AppHost {
         ((info: RejectionInfo) => this.rejectAgent(session.id, agentId, info));
 
       const challengeId = crypto.randomUUID();
-      const timeoutMs = manifest.challengeTimeoutMs ?? 30000;
+      const timeoutMs =
+        manifest.challengeTimeoutMs ?? DEFAULT_CHALLENGE_TIMEOUT_MS;
 
       // Await external attestation only; the timeout is expressed as
       // Effect.timeoutFail below so it uses the Effect Clock (TestClock-
@@ -2205,25 +2256,39 @@ export class AppHost {
         ),
       );
 
-      if (attestation._tag === "Left") {
-        const err = attestation.left;
-        const isTimeout = err._tag === "AttestationTimeout";
-        const code: RejectionCode = isTimeout
-          ? "AttestationTimeout"
-          : "SkillMismatch";
-        const reason = isTimeout
-          ? "Skill attestation timed out"
-          : `Skill attestation failed: ${err.message}`;
-        yield* doReject({
-          stage: "capability",
-          reason,
-          suggestedAction: `Install the skill from ${manifest.skillUrl} and ensure version >= ${manifest.skillMinVersion ?? "any"}`,
-          code,
-        });
-        return yield* Effect.fail(forbidden(reason));
-      }
-
-      const result = attestation.right;
+      const result = yield* Either.match(attestation, {
+        onLeft: (err) => {
+          if (err instanceof AttestationTimeoutError) {
+            const failure: {
+              readonly code: RejectionCode;
+              readonly reason: string;
+            } = {
+              code: "AttestationTimeout",
+              reason: "Skill attestation timed out",
+            };
+            return doReject({
+              stage: "capability",
+              reason: failure.reason,
+              suggestedAction: `Install the skill from ${manifest.skillUrl} and ensure version >= ${manifest.skillMinVersion ?? "any"}`,
+              code: failure.code,
+            }).pipe(Effect.zipRight(Effect.fail(forbidden(failure.reason))));
+          }
+          const failure: {
+            readonly code: RejectionCode;
+            readonly reason: string;
+          } = {
+            code: "SkillMismatch",
+            reason: `Skill attestation failed: ${err.message}`,
+          };
+          return doReject({
+            stage: "capability",
+            reason: failure.reason,
+            suggestedAction: `Install the skill from ${manifest.skillUrl} and ensure version >= ${manifest.skillMinVersion ?? "any"}`,
+            code: failure.code,
+          }).pipe(Effect.zipRight(Effect.fail(forbidden(failure.reason))));
+        },
+        onRight: (attested) => Effect.succeed(attested),
+      });
 
       if (result.skillUrl !== manifest.skillUrl) {
         yield* doReject({
@@ -2349,9 +2414,9 @@ export class AppHost {
               agentId,
               ownerUserId,
               perm,
-              manifest.permissionTimeoutMs ?? 120000,
+              manifest.permissionTimeoutMs ?? DEFAULT_PERMISSION_TIMEOUT_MS,
             ),
-          { concurrency: "unbounded" },
+          { concurrency: MAX_PERMISSION_REQUEST_CONCURRENCY },
         );
         for (const resource of requested) {
           granted.push(resource);

--- a/packages/server/src/app/config.ts
+++ b/packages/server/src/app/config.ts
@@ -27,6 +27,9 @@ export interface LoadedConfig {
 /** Type alias so copied infrastructure files (e.g. db/client.ts) compile without changes. */
 export type ServerConfig = LoadedConfig;
 
+const CORS_REGEX_PREFIX = "regex:";
+const DEFAULT_SERVER_PORT = 3000;
+
 const parseCorsOrigins = (
   raw: string | undefined,
   devMode: boolean,
@@ -47,14 +50,15 @@ const parseCorsOrigins = (
       .split(",")
       .map((s) => s.trim())
       .filter(Boolean)) {
-      if (entry.startsWith("regex:")) {
+      if (entry.startsWith(CORS_REGEX_PREFIX)) {
+        const pattern = entry.slice(CORS_REGEX_PREFIX.length);
         try {
-          patterns.push(new RegExp(`^${entry.slice(6)}$`));
+          patterns.push(new RegExp(`^${pattern}$`));
         } catch (err) {
           return yield* Effect.fail(
             ConfigError.InvalidData(
               ["CORS_ORIGINS"],
-              `Invalid regex in CORS_ORIGINS: "${entry.slice(6)}" — ${err instanceof Error ? err.message : String(err)}`,
+              `Invalid regex in CORS_ORIGINS: "${pattern}" — ${err instanceof Error ? err.message : String(err)}`,
             ),
           );
         }
@@ -96,7 +100,9 @@ export const ServerConfigLoader: Effect.Effect<
     yield* Config.option(Config.string("ENCRYPTION_MASTER_SECRET")),
   );
 
-  const port = yield* Config.integer("PORT").pipe(Config.withDefault(3000));
+  const port = yield* Config.integer("PORT").pipe(
+    Config.withDefault(DEFAULT_SERVER_PORT),
+  );
   const corsRawOpt = yield* Config.option(Config.string("CORS_ORIGINS"));
   const corsOrigins = yield* parseCorsOrigins(
     Option.getOrUndefined(corsRawOpt),

--- a/packages/server/src/app/handlers/apps.handlers.ts
+++ b/packages/server/src/app/handlers/apps.handlers.ts
@@ -18,12 +18,14 @@ import { ConnIdTag } from "../layers.js";
 import { defineMethod } from "../../rpc/context.js";
 import { ParticipantService } from "../../services/participant.service.js";
 
+const DEFAULT_APP_SESSION_LIST_LIMIT = 50;
+
 export function createAppHandlers(deps: {
   appHost: AppHost;
   permissionService?: DefaultPermissionService;
 }): RpcMethodRegistry {
   return {
-    "apps/register": defineMethod(AppsRegister, {
+    [AppsRegister.name]: defineMethod(AppsRegister, {
       // A c2s `apps/register` call means the connected client wants to
       // serve the app's hook RPCs (`apps/onBeforeDispatch`, etc.). We
       // record the calling connection id so AppHost dispatches future
@@ -41,7 +43,7 @@ export function createAppHandlers(deps: {
         }),
     }),
 
-    "apps/create": defineMethod(AppsCreate, {
+    [AppsCreate.name]: defineMethod(AppsCreate, {
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const session = yield* deps.appHost.createSession(
@@ -53,7 +55,7 @@ export function createAppHandlers(deps: {
         }),
     }),
 
-    "apps/attestSkill": defineMethod(AppsAttestSkill, {
+    [AppsAttestSkill.name]: defineMethod(AppsAttestSkill, {
       handler: (params, ctx) =>
         Effect.sync(() => {
           deps.appHost.resolveChallenge(
@@ -66,7 +68,7 @@ export function createAppHandlers(deps: {
         }),
     }),
 
-    "permissions/grant": defineMethod(PermissionsGrant, {
+    [PermissionsGrant.name]: defineMethod(PermissionsGrant, {
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const ownerUserId = yield* ParticipantService.requireOwnerId(ctx);
@@ -81,7 +83,7 @@ export function createAppHandlers(deps: {
         }),
     }),
 
-    "permissions/list": defineMethod(PermissionsList, {
+    [PermissionsList.name]: defineMethod(PermissionsList, {
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const ownerUserId = yield* ParticipantService.requireOwnerId(ctx);
@@ -93,7 +95,7 @@ export function createAppHandlers(deps: {
         }),
     }),
 
-    "permissions/revoke": defineMethod(PermissionsRevoke, {
+    [PermissionsRevoke.name]: defineMethod(PermissionsRevoke, {
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const ownerUserId = yield* ParticipantService.requireOwnerId(ctx);
@@ -106,12 +108,12 @@ export function createAppHandlers(deps: {
         }),
     }),
 
-    "apps/closeSession": defineMethod(AppsCloseSession, {
+    [AppsCloseSession.name]: defineMethod(AppsCloseSession, {
       handler: (params, ctx) =>
         deps.appHost.closeSession(params.sessionId, ctx.agentId),
     }),
 
-    "apps/getSession": defineMethod(AppsGetSession, {
+    [AppsGetSession.name]: defineMethod(AppsGetSession, {
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const session = yield* deps.appHost.getSession(
@@ -122,13 +124,13 @@ export function createAppHandlers(deps: {
         }),
     }),
 
-    "apps/listSessions": defineMethod(AppsListSessions, {
+    [AppsListSessions.name]: defineMethod(AppsListSessions, {
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const sessions = yield* deps.appHost.listSessions(ctx.agentId, {
             appId: params.appId,
             status: params.status,
-            limit: params.limit ?? 50,
+            limit: params.limit ?? DEFAULT_APP_SESSION_LIST_LIMIT,
           });
           return { sessions };
         }),
@@ -165,7 +167,7 @@ export function createAppHandlers(deps: {
     // session ownership + conversation existence; tracking convId→appId
     // ownership is a schema change that has to come from architect, not
     // senior. Filed as a ratchet escalation in the PR comment.
-    "apps/attachConversation": defineMethod(AppsAttachConversation, {
+    [AppsAttachConversation.name]: defineMethod(AppsAttachConversation, {
       handler: (params) =>
         Effect.gen(function* () {
           // SessionNotFound (-32021) and Forbidden (-32001) round-trip to
@@ -185,7 +187,7 @@ export function createAppHandlers(deps: {
         }),
     }),
 
-    "apps/authorizeDispatch": defineMethod(AppsAuthorizeDispatch, {
+    [AppsAuthorizeDispatch.name]: defineMethod(AppsAuthorizeDispatch, {
       requiresActive: true,
       handler: (params, ctx) =>
         Effect.gen(function* () {

--- a/packages/server/src/app/handlers/auth.handlers.ts
+++ b/packages/server/src/app/handlers/auth.handlers.ts
@@ -56,7 +56,7 @@ export function createCoreAuthHandlers(deps: {
   userService: UserService | null;
 }): RpcMethodRegistry {
   return {
-    "auth/connect": defineMethod(Connect, {
+    [Connect.name]: defineMethod(Connect, {
       handler: (params) =>
         catchSqlErrorAsDefect(
           Effect.gen(function* () {
@@ -147,7 +147,7 @@ export function createCoreAuthHandlers(deps: {
         ),
     }),
 
-    "agents/list": defineMethod(AgentsList, {
+    [AgentsList.name]: defineMethod(AgentsList, {
       requiresActive: true,
       handler: (_params, ctx) =>
         catchSqlErrorAsDefect(

--- a/packages/server/src/app/handlers/conversations.handlers.ts
+++ b/packages/server/src/app/handlers/conversations.handlers.ts
@@ -27,7 +27,7 @@ export function createConversationHandlers(deps: {
   connections: ConnectionManager;
 }): RpcMethodRegistry {
   return {
-    "conversations/create": defineMethod(ConversationsCreate, {
+    [ConversationsCreate.name]: defineMethod(ConversationsCreate, {
       requiresActive: true,
       handler: (params, ctx) =>
         Effect.gen(function* () {
@@ -55,7 +55,7 @@ export function createConversationHandlers(deps: {
         }),
     }),
 
-    "conversations/list": defineMethod(ConversationsList, {
+    [ConversationsList.name]: defineMethod(ConversationsList, {
       requiresActive: true,
       handler: (params, ctx) =>
         deps.conversationService.list(
@@ -66,13 +66,13 @@ export function createConversationHandlers(deps: {
         ),
     }),
 
-    "conversations/get": defineMethod(ConversationsGet, {
+    [ConversationsGet.name]: defineMethod(ConversationsGet, {
       requiresActive: true,
       handler: (params, ctx) =>
         deps.conversationService.get(params.conversationId, ctx.agentId),
     }),
 
-    "conversations/update": defineMethod(ConversationsUpdate, {
+    [ConversationsUpdate.name]: defineMethod(ConversationsUpdate, {
       requiresActive: true,
       handler: (params, ctx) =>
         Effect.gen(function* () {
@@ -91,7 +91,7 @@ export function createConversationHandlers(deps: {
         }),
     }),
 
-    "conversations/leave": defineMethod(ConversationsLeave, {
+    [ConversationsLeave.name]: defineMethod(ConversationsLeave, {
       requiresActive: true,
       handler: (params, ctx) =>
         Effect.gen(function* () {
@@ -108,7 +108,7 @@ export function createConversationHandlers(deps: {
         }),
     }),
 
-    "conversations/archive": defineMethod(ConversationsArchive, {
+    [ConversationsArchive.name]: defineMethod(ConversationsArchive, {
       requiresActive: true,
       handler: (params, ctx) =>
         Effect.gen(function* () {
@@ -128,7 +128,7 @@ export function createConversationHandlers(deps: {
         }),
     }),
 
-    "conversations/unarchive": defineMethod(ConversationsUnarchive, {
+    [ConversationsUnarchive.name]: defineMethod(ConversationsUnarchive, {
       requiresActive: true,
       handler: (params, ctx) =>
         Effect.gen(function* () {
@@ -147,7 +147,7 @@ export function createConversationHandlers(deps: {
         }),
     }),
 
-    "conversations/mute": defineMethod(ConversationsMute, {
+    [ConversationsMute.name]: defineMethod(ConversationsMute, {
       requiresActive: true,
       handler: (params, ctx) =>
         Effect.gen(function* () {
@@ -165,7 +165,7 @@ export function createConversationHandlers(deps: {
         }),
     }),
 
-    "conversations/unmute": defineMethod(ConversationsUnmute, {
+    [ConversationsUnmute.name]: defineMethod(ConversationsUnmute, {
       requiresActive: true,
       handler: (params, ctx) =>
         Effect.gen(function* () {
@@ -182,25 +182,28 @@ export function createConversationHandlers(deps: {
         }),
     }),
 
-    "conversations/addParticipant": defineMethod(ConversationsAddParticipant, {
-      requiresActive: true,
-      handler: (params, ctx) =>
-        Effect.gen(function* () {
-          const participant = yield* deps.conversationService.addParticipant(
-            params.conversationId,
-            params.participant.id,
-            ctx.agentId,
-          );
-          for (const conn of deps.connections.getByAgent(
-            params.participant.id,
-          )) {
-            conn.conversationIds.add(params.conversationId);
-          }
-          return { participant };
-        }),
-    }),
+    [ConversationsAddParticipant.name]: defineMethod(
+      ConversationsAddParticipant,
+      {
+        requiresActive: true,
+        handler: (params, ctx) =>
+          Effect.gen(function* () {
+            const participant = yield* deps.conversationService.addParticipant(
+              params.conversationId,
+              params.participant.id,
+              ctx.agentId,
+            );
+            for (const conn of deps.connections.getByAgent(
+              params.participant.id,
+            )) {
+              conn.conversationIds.add(params.conversationId);
+            }
+            return { participant };
+          }),
+      },
+    ),
 
-    "conversations/removeParticipant": defineMethod(
+    [ConversationsRemoveParticipant.name]: defineMethod(
       ConversationsRemoveParticipant,
       {
         requiresActive: true,

--- a/packages/server/src/app/handlers/messages.handlers.ts
+++ b/packages/server/src/app/handlers/messages.handlers.ts
@@ -27,7 +27,7 @@ export function createMessageHandlers(deps: {
   db: Db;
 }): RpcMethodRegistry {
   return {
-    "messages/send": defineMethod(MessagesSend, {
+    [MessagesSend.name]: defineMethod(MessagesSend, {
       requiresActive: true,
       handler: (params, ctx) =>
         catchSqlErrorAsDefect(
@@ -83,7 +83,7 @@ export function createMessageHandlers(deps: {
         ),
     }),
 
-    "messages/list": defineMethod(MessagesList, {
+    [MessagesList.name]: defineMethod(MessagesList, {
       requiresActive: true,
       handler: (params, ctx) =>
         deps.messageService.list(params.conversationId, ctx.agentId, {

--- a/packages/server/src/app/handlers/presence.handlers.ts
+++ b/packages/server/src/app/handlers/presence.handlers.ts
@@ -9,7 +9,7 @@ export function createPresenceHandlers(deps: {
   presenceService: PresenceService;
 }): RpcMethodRegistry {
   return {
-    "presence/update": defineMethod(PresenceUpdate, {
+    [PresenceUpdate.name]: defineMethod(PresenceUpdate, {
       requiresActive: true,
       handler: (params, ctx) =>
         Effect.gen(function* () {
@@ -21,7 +21,7 @@ export function createPresenceHandlers(deps: {
         }),
     }),
 
-    "presence/subscribe": defineMethod(PresenceSubscribe, {
+    [PresenceSubscribe.name]: defineMethod(PresenceSubscribe, {
       requiresActive: true,
       handler: (params) =>
         Effect.gen(function* () {

--- a/packages/server/src/app/handlers/system.handlers.ts
+++ b/packages/server/src/app/handlers/system.handlers.ts
@@ -5,7 +5,7 @@ import { defineMethod } from "../../rpc/context.js";
 
 export function createSystemHandlers(): RpcMethodRegistry {
   return {
-    "system/ping": defineMethod(SystemPing, {
+    [SystemPing.name]: defineMethod(SystemPing, {
       handler: () => Effect.sync(() => ({ ts: new Date().toISOString() })),
     }),
   };

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -64,8 +64,16 @@ import {
   resolveServices,
 } from "./layers.js";
 
+import { Connect } from "@moltzap/protocol";
+
 /** Grace period after closing all WebSockets so in-flight sends can flush. */
 const SHUTDOWN_DRAIN_MS = 500;
+const HTTP_BAD_REQUEST = 400;
+const HTTP_OK = 200;
+const HTTP_CREATED = 201;
+const ERROR_INVALID_JSON = "Invalid JSON";
+const ERROR_INVALID_PARAMETERS = "Invalid parameters";
+const INVALID_JSON_BODY = Symbol("InvalidJsonBody");
 
 class ServerCloseError extends Data.TaggedError("ServerCloseError")<{
   readonly cause: unknown;
@@ -95,7 +103,7 @@ function isStringKeyedRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function runUserHook<TArgs>(
-  hook: (args: TArgs) => void | Promise<void>,
+  hook: (args: TArgs) => void | PromiseLike<void>,
   args: TArgs,
   label: string,
   logCtx: Record<string, unknown>,
@@ -225,19 +233,20 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     "/api/v1/auth/register",
     Effect.gen(function* () {
       const request = yield* HttpServerRequest.HttpServerRequest;
-      const bodyResult = yield* Effect.either(request.json);
-      if (bodyResult._tag === "Left") {
+      const body = yield* request.json.pipe(
+        Effect.catchAll(() => Effect.succeed(INVALID_JSON_BODY)),
+      );
+      if (body === INVALID_JSON_BODY) {
         return HttpServerResponse.unsafeJson(
-          { error: "Invalid JSON" },
-          { status: 400 },
+          { error: ERROR_INVALID_JSON },
+          { status: HTTP_BAD_REQUEST },
         );
       }
-      const body = bodyResult.right;
 
       if (!validators.registerParams(body)) {
         return HttpServerResponse.unsafeJson(
-          { error: "Invalid parameters" },
-          { status: 400 },
+          { error: ERROR_INVALID_PARAMETERS },
+          { status: HTTP_BAD_REQUEST },
         );
       }
 
@@ -289,32 +298,35 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       }
 
       const request = yield* HttpServerRequest.HttpServerRequest;
-      const bodyResult = yield* Effect.either(request.json);
-      if (bodyResult._tag === "Left") {
+      const body = yield* request.json.pipe(
+        Effect.catchAll(() => Effect.succeed(INVALID_JSON_BODY)),
+      );
+      if (body === INVALID_JSON_BODY) {
         return HttpServerResponse.unsafeJson(
-          { error: "Invalid JSON" },
-          { status: 400 },
+          { error: ERROR_INVALID_JSON },
+          { status: HTTP_BAD_REQUEST },
         );
       }
 
-      if (!isStringKeyedRecord(bodyResult.right)) {
+      if (!isStringKeyedRecord(body)) {
         return HttpServerResponse.unsafeJson(
-          { error: "Invalid parameters" },
-          { status: 400 },
+          { error: ERROR_INVALID_PARAMETERS },
+          { status: HTTP_BAD_REQUEST },
         );
       }
 
       // `validators.registerParams` is built from the protocol Register
       // schema with `additionalProperties: false`. Strip ownerUserId
       // before validating the rest of the body against that strict schema.
-      const fullBody = bodyResult.right;
+      const fullBody = body;
       const ownerUserIdRaw = fullBody["ownerUserId"];
-      const { ownerUserId: _stripped, ...registerBody } = fullBody;
+      const { ownerUserId, ...registerBody } = fullBody;
+      void ownerUserId;
 
       if (!validators.registerParams(registerBody)) {
         return HttpServerResponse.unsafeJson(
-          { error: "Invalid parameters" },
-          { status: 400 },
+          { error: ERROR_INVALID_PARAMETERS },
+          { status: HTTP_BAD_REQUEST },
         );
       }
 
@@ -334,7 +346,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
         ) {
           return HttpServerResponse.unsafeJson(
             { error: "ownerUserId must be a UUID" },
-            { status: 400 },
+            { status: HTTP_BAD_REQUEST },
           );
         }
         resolvedOwnerUserId = ownerUserIdRaw;
@@ -368,7 +380,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       // is the on-the-wire `rotated` signal; body shape stays unchanged.
       return HttpServerResponse.unsafeJson(
         { agentId: result.agentId, apiKey: result.apiKey },
-        { status: result.rotated ? 200 : 201 },
+        { status: result.rotated ? HTTP_OK : HTTP_CREATED },
       );
     }),
   );
@@ -399,21 +411,23 @@ export function createCoreApp(config: CoreConfig): CoreApp {
         );
       }
 
-      const bodyResult = yield* Effect.either(request.json);
-      if (bodyResult._tag === "Left") {
+      const rawBody = yield* request.json.pipe(
+        Effect.catchAll(() => Effect.succeed(INVALID_JSON_BODY)),
+      );
+      if (rawBody === INVALID_JSON_BODY) {
         return HttpServerResponse.unsafeJson(
-          { error: "Invalid JSON" },
-          { status: 400 },
+          { error: ERROR_INVALID_JSON },
+          { status: HTTP_BAD_REQUEST },
         );
       }
-      const body = bodyResult.right as {
+      const body = rawBody as {
         request_id?: string;
         access?: string[];
       };
       if (!body.request_id || !Array.isArray(body.access)) {
         return HttpServerResponse.unsafeJson(
           { error: "Invalid body: need request_id and access[]" },
-          { status: 400 },
+          { status: HTTP_BAD_REQUEST },
         );
       }
 
@@ -506,7 +520,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
                 id: null,
                 error: {
                   code: ErrorCodes.ParseError,
-                  message: "Invalid JSON",
+                  message: ERROR_INVALID_JSON,
                 },
               });
               return;
@@ -591,7 +605,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
               });
               return;
             }
-            if (frame.method !== "auth/connect" && !conn.auth) {
+            if (frame.method !== Connect.name && !conn.auth) {
               yield* sendFrame({
                 jsonrpc: "2.0",
                 type: "response",
@@ -626,7 +640,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
 
             // Fire connection hooks after a successful auth/connect — auth was
             // populated by the dispatch handler if the credentials were valid.
-            if (frame.method === "auth/connect") {
+            if (frame.method === Connect.name) {
               const authCtx = connections.get(connId)?.auth;
               if (!authCtx) return;
               const { agentId, ownerUserId } = authCtx;
@@ -704,7 +718,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     }).pipe(
       Effect.catchAll((err) => {
         logger.warn({ err }, "WS upgrade failed");
-        return HttpServerResponse.empty({ status: 400 });
+        return HttpServerResponse.empty({ status: HTTP_BAD_REQUEST });
       }),
     ),
   );

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -48,7 +48,7 @@ export const AppId = Brand.nominal<AppId>();
 
 export interface CoreConfig {
   db: Kysely<Database>;
-  dbCleanup?: () => Promise<void>;
+  dbCleanup?: () => PromiseLike<void>;
   encryptionMasterSecret?: string;
   port: number;
   corsOrigins: string[];
@@ -105,13 +105,13 @@ export type ConnectionHook = (params: {
   /** Owner user ID resolved at auth/connect time. Null for unclaimed agents. */
   ownerUserId: string | null;
   connId: string;
-}) => Promise<void> | void;
+}) => PromiseLike<void> | void;
 
 export type DisconnectionHook = (params: {
   agentId: string;
   ownerUserId: string | null;
   connId: string;
-}) => Promise<void> | void;
+}) => PromiseLike<void> | void;
 
 export interface CoreApp {
   readonly port: number;
@@ -206,5 +206,5 @@ export interface CoreApp {
     conversationId: string,
     key: string,
   ) => Effect.Effect<void, RpcFailure>;
-  close: () => Promise<void>;
+  close: () => PromiseLike<void>;
 }

--- a/packages/server/src/auth/agent-auth.ts
+++ b/packages/server/src/auth/agent-auth.ts
@@ -3,6 +3,9 @@ import { randomBytes, createHash } from "node:crypto";
 const API_KEY_PREFIX = "moltzap_agent_";
 const KEY_ID_BYTES = 8;
 const SECRET_BYTES = 24;
+const HEX_CHARS_PER_BYTE = 2;
+const CLAIM_TOKEN_BYTES = 16;
+const INVITE_TOKEN_BYTES = 32;
 
 /** Generate a Key ID + Secret API key with its derived storage values. */
 export function generateApiKey(): {
@@ -23,10 +26,10 @@ export function parseApiKey(
   if (!key.startsWith(API_KEY_PREFIX)) return null;
   const rest = key.slice(API_KEY_PREFIX.length);
   const sepIdx = rest.indexOf("_");
-  if (sepIdx !== KEY_ID_BYTES * 2) return null;
+  if (sepIdx !== KEY_ID_BYTES * HEX_CHARS_PER_BYTE) return null;
   const keyId = rest.slice(0, sepIdx);
   const secret = rest.slice(sepIdx + 1);
-  if (secret.length !== SECRET_BYTES * 2) return null;
+  if (secret.length !== SECRET_BYTES * HEX_CHARS_PER_BYTE) return null;
   return { keyId, secret };
 }
 
@@ -36,11 +39,11 @@ export function hashSecret(secret: string): string {
 }
 
 export function generateClaimToken(): string {
-  return "MZAP-" + randomBytes(16).toString("hex").toUpperCase();
+  return "MZAP-" + randomBytes(CLAIM_TOKEN_BYTES).toString("hex").toUpperCase();
 }
 
 export function generateInviteToken(): string {
-  return randomBytes(32).toString("base64url");
+  return randomBytes(INVITE_TOKEN_BYTES).toString("base64url");
 }
 
 export function isValidApiKeyFormat(key: string): boolean {

--- a/packages/server/src/config/effect-config.ts
+++ b/packages/server/src/config/effect-config.ts
@@ -13,6 +13,8 @@
 
 import { Config, Option } from "effect";
 
+const MAX_PORT_NUMBER = 65_535;
+
 // ── Reusable leaves ────────────────────────────────────────────────────
 
 const nonEmptyString = (name: string) =>
@@ -26,8 +28,8 @@ const nonEmptyString = (name: string) =>
 const portNumber = (name: string) =>
   Config.integer(name).pipe(
     Config.validate({
-      message: `${name} must be in range [1, 65535]`,
-      validation: (n: number) => n >= 1 && n <= 65535,
+      message: `${name} must be in range [1, ${MAX_PORT_NUMBER}]`,
+      validation: (n: number) => n >= 1 && n <= MAX_PORT_NUMBER,
     }),
   );
 

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -9,7 +9,16 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { dirname } from "node:path";
 import { parse as parseYaml } from "yaml";
-import { Data, Effect, ConfigProvider, Either, Match, Schema } from "effect";
+import {
+  Config,
+  ConfigProvider,
+  Data,
+  Effect,
+  Either,
+  Match,
+  Option,
+  Schema,
+} from "effect";
 import type { ConfigError } from "effect/ConfigError";
 import { MoltZapConfig, type MoltZapAppConfig } from "./effect-config.js";
 
@@ -38,17 +47,36 @@ export class ConfigLoadError extends Data.TaggedError("ConfigLoadError")<{
   readonly configError?: ConfigError;
 }> {}
 
+type ProcessEnvSnapshot = Readonly<Record<string, string | undefined>>;
+
+const readEnvValue = (
+  processEnv: ProcessEnvSnapshot | undefined,
+  key: string,
+): string | undefined => {
+  if (processEnv !== undefined) {
+    return processEnv[key];
+  }
+  return Option.getOrUndefined(
+    Effect.runSync(
+      Config.option(Config.string(key)).pipe(
+        Effect.withConfigProvider(ConfigProvider.fromEnv()),
+      ),
+    ),
+  );
+};
+
 /** Interpolate `${ENV_VAR}` references in string values throughout a parsed object. */
 function interpolateEnvVars(
   obj: unknown,
   path: string,
-): { ok: true; value: unknown } | { ok: false; error: ConfigLoadError } {
+  processEnv?: ProcessEnvSnapshot,
+): Effect.Effect<unknown, ConfigLoadError> {
   if (typeof obj === "string") {
     let missing: string | null = null;
     const replaced = obj.replace(
       /\$\{([^}]+)\}/g,
       (_match, varName: string) => {
-        const value = process.env[varName];
+        const value = readEnvValue(processEnv, varName);
         // Treat empty string the same as undefined: an accidentally empty
         // env var would otherwise silently interpolate into strings like
         // `https://${HOST}/callback` and produce a broken URL that still
@@ -61,36 +89,35 @@ function interpolateEnvVars(
       },
     );
     if (missing !== null) {
-      return {
-        ok: false,
-        error: new ConfigLoadError({
+      return Effect.fail(
+        new ConfigLoadError({
           kind: "env",
           path,
           message: `Missing env var "${missing}" referenced in "${path}"`,
         }),
-      };
+      );
     }
-    return { ok: true, value: replaced };
+    return Effect.succeed(replaced);
   }
   if (Array.isArray(obj)) {
-    const out: unknown[] = [];
-    for (const v of obj) {
-      const r = interpolateEnvVars(v, path);
-      if (!r.ok) return r;
-      out.push(r.value);
-    }
-    return { ok: true, value: out };
+    return Effect.gen(function* () {
+      const out: unknown[] = [];
+      for (const value of obj) {
+        out.push(yield* interpolateEnvVars(value, path, processEnv));
+      }
+      return out;
+    });
   }
   if (obj !== null && typeof obj === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(obj)) {
-      const r = interpolateEnvVars(val, path);
-      if (!r.ok) return r;
-      out[key] = r.value;
-    }
-    return { ok: true, value: out };
+    return Effect.gen(function* () {
+      const out: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(obj)) {
+        out[key] = yield* interpolateEnvVars(value, path, processEnv);
+      }
+      return out;
+    });
   }
-  return { ok: true, value: obj };
+  return Effect.succeed(obj);
 }
 
 /**
@@ -104,9 +131,11 @@ function interpolateEnvVars(
  */
 export const loadConfigFromFile = (
   path?: string,
+  processEnv?: ProcessEnvSnapshot,
 ): Effect.Effect<MoltZapAppConfig & { _configDir: string }, ConfigLoadError> =>
   Effect.gen(function* () {
-    const configPath = path ?? process.env["MOLTZAP_CONFIG"] ?? "moltzap.yaml";
+    const configPath =
+      path ?? readEnvValue(processEnv, "MOLTZAP_CONFIG") ?? "moltzap.yaml";
 
     const raw = yield* Effect.try({
       try: () => readFileSync(configPath, "utf-8"),
@@ -130,24 +159,24 @@ export const loadConfigFromFile = (
         }),
     });
 
-    const decoded = decodeYamlDocument(parsed);
-    if (Either.isLeft(decoded)) {
-      return yield* Effect.fail(
-        new ConfigLoadError({
-          kind: "yaml",
-          path: configPath,
-          message: `Invalid YAML in "${configPath}": top-level value must be a mapping (${decoded.left.message})`,
-          cause: decoded.left,
-        }),
-      );
-    }
+    const decoded = yield* Either.match(decodeYamlDocument(parsed), {
+      onLeft: (cause) =>
+        Effect.fail(
+          new ConfigLoadError({
+            kind: "yaml",
+            path: configPath,
+            message: `Invalid YAML in "${configPath}": top-level value must be a mapping (${cause.message})`,
+            cause,
+          }),
+        ),
+      onRight: (value) => Effect.succeed(value),
+    });
 
-    const interp = interpolateEnvVars(decoded.right, configPath);
-    if (!interp.ok) return yield* Effect.fail(interp.error);
+    const interp = yield* interpolateEnvVars(decoded, configPath, processEnv);
 
     // `fromJson` walks the nested object and produces flat paths that
     // `Config.all(...)` / `Config.nested(...)` / `Config.array(...)` consume.
-    const provider = ConfigProvider.fromJson(interp.value ?? {});
+    const provider = ConfigProvider.fromJson(interp ?? {});
 
     const value = yield* MoltZapConfig.pipe(
       Effect.withConfigProvider(provider),

--- a/packages/server/src/crypto/key-rotation.ts
+++ b/packages/server/src/crypto/key-rotation.ts
@@ -16,6 +16,8 @@ class KeyRotationError extends Data.TaggedError("KeyRotationError")<{
   }
 }
 
+const KEK_BYTES = 32;
+
 export function seedInitialKek(db: Db, envelope: EnvelopeEncryption) {
   return Effect.runPromise(seedInitialKekEffect(db, envelope));
 }
@@ -29,7 +31,7 @@ function seedInitialKekEffect(
   envelope: EnvelopeEncryption,
 ): Effect.Effect<void, SqlError, never> {
   return Effect.gen(function* () {
-    const kek = randomBytes(32);
+    const kek = randomBytes(KEK_BYTES);
     const encrypted = envelope.encryptKek(kek);
     const serialized = serializePayload(encrypted);
 
@@ -67,7 +69,7 @@ function rotateKekEffect(
     );
 
     const newVersion = currentVersion + 1;
-    const newKek = randomBytes(32);
+    const newKek = randomBytes(KEK_BYTES);
     const encryptedNewKek = envelope.encryptKek(newKek);
 
     const reWrappedCount = yield* transaction(db, (trx) =>

--- a/packages/server/src/db/effect-kysely-toolkit.ts
+++ b/packages/server/src/db/effect-kysely-toolkit.ts
@@ -46,7 +46,7 @@ const ATTR_DB_QUERY_TEXT = "db.query.text";
  * and `this.compile()` hit Kysely directly with no indirection.
  */
 function commitViaExecute(this: {
-  execute: () => Promise<ReadonlyArray<unknown>>;
+  execute: () => PromiseLike<ReadonlyArray<unknown>>;
   compile: () => { sql: string };
 }): Effect.Effect<ReadonlyArray<unknown>, SqlError> {
   return Effect.tryPromise({

--- a/packages/server/src/runtime-surface/config.ts
+++ b/packages/server/src/runtime-surface/config.ts
@@ -2,16 +2,23 @@
  * Shared runtime process config for server boot and eval orchestration.
  */
 
-import { ConfigProvider, Data, Effect, Match } from "effect";
+import {
+  Brand,
+  Config,
+  ConfigProvider,
+  Data,
+  Effect,
+  Match,
+  Option,
+} from "effect";
 import type { ConfigError } from "effect/ConfigError";
 import type { LoadedConfig } from "../app/config.js";
 import { ServerConfigLoader } from "../app/config.js";
 import type { MoltZapAppConfig } from "../config/effect-config.js";
 import { ConfigLoadError, loadConfigFromFile } from "../config/loader.js";
 
-export type RuntimeConfigPath = string & {
-  readonly __brand: "RuntimeConfigPath";
-};
+export type RuntimeConfigPath = string & Brand.Brand<"RuntimeConfigPath">;
+export const RuntimeConfigPath = Brand.nominal<RuntimeConfigPath>();
 
 export type RuntimeEnvironment = "development" | "test" | "production";
 
@@ -46,29 +53,95 @@ export interface RuntimeProcessConfig {
 export class RuntimeConfigSurfaceError extends Data.TaggedError(
   "RuntimeConfigSurfaceError",
 )<{
-  readonly cause:
-    | {
-        readonly _tag: "ConfigFileUnreadable";
-        readonly path: string;
-        readonly message: string;
-      }
-    | {
-        readonly _tag: "ConfigFileInvalid";
-        readonly path: string;
-        readonly message: string;
-      }
-    | {
-        readonly _tag: "EnvironmentInvalid";
-        readonly key: string;
-        readonly message: string;
-      };
+  readonly cause: RuntimeConfigSurfaceCause;
 }> {}
+
+export class ConfigFileUnreadable extends Data.TaggedError(
+  "ConfigFileUnreadable",
+)<{
+  readonly message: string;
+  readonly path: string;
+}> {}
+
+export class ConfigFileInvalid extends Data.TaggedError("ConfigFileInvalid")<{
+  readonly message: string;
+  readonly path: string;
+}> {}
+
+export class EnvironmentInvalid extends Data.TaggedError("EnvironmentInvalid")<{
+  readonly key: string;
+  readonly message: string;
+}> {}
+
+export type RuntimeConfigSurfaceCause =
+  | ConfigFileUnreadable
+  | ConfigFileInvalid
+  | EnvironmentInvalid;
 
 type ProcessEnvSnapshot = Readonly<Record<string, string | undefined>>;
 
 const DEFAULT_RUNTIME_ENVIRONMENT: RuntimeEnvironment = "development";
 const DEFAULT_LOG_LEVEL: RuntimeLogLevel = "info";
 const DEFAULT_SERVICE_NAME = "moltzap-server";
+const DECIMAL_RADIX = 10;
+
+const optionalEnv = (key: string) =>
+  Config.option(Config.string(key)).pipe(Config.map(Option.getOrUndefined));
+
+const RuntimeEnvSnapshotConfig = Config.all({
+  CORS_ORIGINS: optionalEnv("CORS_ORIGINS"),
+  DATABASE_URL: optionalEnv("DATABASE_URL"),
+  ENCRYPTION_MASTER_SECRET: optionalEnv("ENCRYPTION_MASTER_SECRET"),
+  LOG_LEVEL: optionalEnv("LOG_LEVEL"),
+  MOLTZAP_CONFIG: optionalEnv("MOLTZAP_CONFIG"),
+  MOLTZAP_DEV_MODE: optionalEnv("MOLTZAP_DEV_MODE"),
+  MOLTZAP_INCLUDE_FIBER_IDS: optionalEnv("MOLTZAP_INCLUDE_FIBER_IDS"),
+  MOLTZAP_INCLUDE_REQUEST_CONTEXT: optionalEnv(
+    "MOLTZAP_INCLUDE_REQUEST_CONTEXT",
+  ),
+  NODE_ENV: optionalEnv("NODE_ENV"),
+  OTEL_SERVICE_NAME: optionalEnv("OTEL_SERVICE_NAME"),
+  PORT: optionalEnv("PORT"),
+});
+
+const loadRuntimeEnvSnapshot: Effect.Effect<ProcessEnvSnapshot, never> =
+  RuntimeEnvSnapshotConfig.pipe(
+    Effect.withConfigProvider(ConfigProvider.fromEnv()),
+    Effect.orElseSucceed(() => ({})),
+  );
+
+const configFileUnreadable = (
+  path: RuntimeConfigPath,
+  message: string,
+): RuntimeConfigSurfaceError =>
+  new RuntimeConfigSurfaceError({
+    cause: new ConfigFileUnreadable({
+      path,
+      message,
+    }),
+  });
+
+const configFileInvalid = (
+  path: RuntimeConfigPath,
+  message: string,
+): RuntimeConfigSurfaceError =>
+  new RuntimeConfigSurfaceError({
+    cause: new ConfigFileInvalid({
+      path,
+      message,
+    }),
+  });
+
+const environmentInvalid = (
+  key: string,
+  message: string,
+): RuntimeConfigSurfaceError =>
+  new RuntimeConfigSurfaceError({
+    cause: new EnvironmentInvalid({
+      key,
+      message,
+    }),
+  });
 
 function resolveRuntimeConfigPath(
   input: LoadRuntimeConfigInput,
@@ -76,40 +149,7 @@ function resolveRuntimeConfigPath(
 ): RuntimeConfigPath {
   const selected =
     input.configPath ?? processEnv["MOLTZAP_CONFIG"] ?? "moltzap.yaml";
-  return selected as RuntimeConfigPath;
-}
-
-function replaceProcessEnv(next: ProcessEnvSnapshot): void {
-  // Snapshot before mutation: when `next === process.env`, deleting keys
-  // from process.env would also empty `next`, leaving the iteration over
-  // entries empty and process.env wiped. Copy first, then delete-and-replace.
-  const snapshot = { ...next };
-  for (const key of Object.keys(process.env)) {
-    delete process.env[key];
-  }
-  for (const [key, value] of Object.entries(snapshot)) {
-    if (value !== undefined) {
-      process.env[key] = value;
-    }
-  }
-}
-
-function withPatchedProcessEnv<A, E, R>(
-  processEnv: ProcessEnvSnapshot,
-  effect: Effect.Effect<A, E, R>,
-): Effect.Effect<A, E, R> {
-  return Effect.acquireUseRelease(
-    Effect.sync(() => {
-      const previous = { ...process.env };
-      replaceProcessEnv(processEnv);
-      return previous;
-    }),
-    () => effect,
-    (previous) =>
-      Effect.sync(() => {
-        replaceProcessEnv(previous);
-      }),
-  );
+  return RuntimeConfigPath(selected);
 }
 
 function mapConfigLoadError(
@@ -118,32 +158,14 @@ function mapConfigLoadError(
 ): RuntimeConfigSurfaceError {
   switch (error.kind) {
     case "read":
-      return new RuntimeConfigSurfaceError({
-        cause: {
-          _tag: "ConfigFileUnreadable",
-          path: configPath,
-          message: error.message,
-        },
-      });
+      return configFileUnreadable(configPath, error.message);
     case "env": {
       const missingKey = error.message.match(/"([^"]+)"/)?.[1] ?? "unknown";
-      return new RuntimeConfigSurfaceError({
-        cause: {
-          _tag: "EnvironmentInvalid",
-          key: missingKey,
-          message: error.message,
-        },
-      });
+      return environmentInvalid(missingKey, error.message);
     }
     case "yaml":
     case "validation":
-      return new RuntimeConfigSurfaceError({
-        cause: {
-          _tag: "ConfigFileInvalid",
-          path: configPath,
-          message: error.message,
-        },
-      });
+      return configFileInvalid(configPath, error.message);
   }
 }
 
@@ -194,13 +216,10 @@ function resolveRuntimeEnvironment(
       return Effect.succeed(raw);
     default:
       return Effect.fail(
-        new RuntimeConfigSurfaceError({
-          cause: {
-            _tag: "EnvironmentInvalid",
-            key: "NODE_ENV",
-            message: `NODE_ENV must be one of development, test, production; received "${raw}"`,
-          },
-        }),
+        environmentInvalid(
+          "NODE_ENV",
+          `NODE_ENV must be one of development, test, production; received "${raw}"`,
+        ),
       );
   }
 }
@@ -219,13 +238,10 @@ function resolveRuntimeLogLevel(
       return Effect.succeed(raw);
     default:
       return Effect.fail(
-        new RuntimeConfigSurfaceError({
-          cause: {
-            _tag: "EnvironmentInvalid",
-            key: "LOG_LEVEL",
-            message: `LOG_LEVEL must be one of debug, info, warn, error; received "${raw}"`,
-          },
-        }),
+        environmentInvalid(
+          "LOG_LEVEL",
+          `LOG_LEVEL must be one of debug, info, warn, error; received "${raw}"`,
+        ),
       );
   }
 }
@@ -256,13 +272,10 @@ function parseBooleanEnv(
     return Effect.succeed(false);
   }
   return Effect.fail(
-    new RuntimeConfigSurfaceError({
-      cause: {
-        _tag: "EnvironmentInvalid",
-        key,
-        message: `${key} must be a boolean-like value (true/false/1/0/yes/no/on/off); received "${raw}"`,
-      },
-    }),
+    environmentInvalid(
+      key,
+      `${key} must be a boolean-like value (true/false/1/0/yes/no/on/off); received "${raw}"`,
+    ),
   );
 }
 
@@ -275,16 +288,10 @@ function parseIntegerEnv(
   }
   if (!/^-?\d+$/.test(raw.trim())) {
     return Effect.fail(
-      new RuntimeConfigSurfaceError({
-        cause: {
-          _tag: "EnvironmentInvalid",
-          key,
-          message: `${key} must be an integer; received "${raw}"`,
-        },
-      }),
+      environmentInvalid(key, `${key} must be an integer; received "${raw}"`),
     );
   }
-  return Effect.succeed(Number.parseInt(raw, 10));
+  return Effect.succeed(Number.parseInt(raw, DECIMAL_RADIX));
 }
 
 function resolveTracingServiceName(
@@ -295,13 +302,10 @@ function resolveTracingServiceName(
   }
   if (raw.trim().length === 0) {
     return Effect.fail(
-      new RuntimeConfigSurfaceError({
-        cause: {
-          _tag: "EnvironmentInvalid",
-          key: "OTEL_SERVICE_NAME",
-          message: "OTEL_SERVICE_NAME must be a non-empty string when set",
-        },
-      }),
+      environmentInvalid(
+        "OTEL_SERVICE_NAME",
+        "OTEL_SERVICE_NAME must be a non-empty string when set",
+      ),
     );
   }
   return Effect.succeed(raw);
@@ -360,14 +364,14 @@ function buildServerConfigProviderInput(
 
 /** Empty app config used when no YAML file is found on the auto-discovery path. */
 const EMPTY_APP_CONFIG: MoltZapAppConfig & { _configDir: string } = {
-  _configDir: process.cwd(),
+  _configDir: globalThis.process.cwd(),
 };
 
 export function loadRuntimeProcessConfig(
   input: LoadRuntimeConfigInput,
 ): Effect.Effect<RuntimeProcessConfig, RuntimeConfigSurfaceError, never> {
   return Effect.gen(function* () {
-    const processEnv = input.processEnv ?? process.env;
+    const processEnv = input.processEnv ?? (yield* loadRuntimeEnvSnapshot);
     const configPath = resolveRuntimeConfigPath(input, processEnv);
 
     // Whether the operator explicitly asked for a config file (CLI arg or env
@@ -377,9 +381,9 @@ export function loadRuntimeProcessConfig(
       input.configPath !== undefined ||
       processEnv["MOLTZAP_CONFIG"] !== undefined;
 
-    const loadedAppConfig = yield* withPatchedProcessEnv(
+    const loadedAppConfig = yield* loadConfigFromFile(
+      configPath,
       processEnv,
-      loadConfigFromFile(configPath),
     ).pipe(
       Effect.catchIf(
         (error): error is ConfigLoadError =>
@@ -423,15 +427,11 @@ export function loadRuntimeProcessConfig(
     );
     const server = yield* ServerConfigLoader.pipe(
       Effect.withConfigProvider(ConfigProvider.fromJson(serverProviderInput)),
-      Effect.mapError(
-        (configError) =>
-          new RuntimeConfigSurfaceError({
-            cause: {
-              _tag: "ConfigFileInvalid",
-              path: configPath,
-              message: `Invalid runtime config in "${configPath}": ${formatConfigError(configError)}`,
-            },
-          }),
+      Effect.mapError((configError) =>
+        configFileInvalid(
+          configPath,
+          `Invalid runtime config in "${configPath}": ${formatConfigError(configError)}`,
+        ),
       ),
     );
 

--- a/packages/server/src/runtime-surface/logging.ts
+++ b/packages/server/src/runtime-surface/logging.ts
@@ -2,29 +2,24 @@
  * Shared runtime observability for server boot and eval orchestration.
  */
 
-import { Data, Effect } from "effect";
+import { Brand, Data, Effect } from "effect";
 import { getLogger, type Logger } from "../logger.js";
 import type { RuntimeProcessConfig } from "./config.js";
 
-export type RuntimeRequestId = string & {
-  readonly __brand: "RuntimeRequestId";
-};
+export type RuntimeRequestId = string & Brand.Brand<"RuntimeRequestId">;
+export const RuntimeRequestId = Brand.nominal<RuntimeRequestId>();
 
-export type RuntimeSessionId = string & {
-  readonly __brand: "RuntimeSessionId";
-};
+export type RuntimeSessionId = string & Brand.Brand<"RuntimeSessionId">;
+export const RuntimeSessionId = Brand.nominal<RuntimeSessionId>();
 
-export type RuntimeAgentId = string & {
-  readonly __brand: "RuntimeAgentId";
-};
+export type RuntimeAgentId = string & Brand.Brand<"RuntimeAgentId">;
+export const RuntimeAgentId = Brand.nominal<RuntimeAgentId>();
 
-export type RuntimeFiberId = string & {
-  readonly __brand: "RuntimeFiberId";
-};
+export type RuntimeFiberId = string & Brand.Brand<"RuntimeFiberId">;
+export const RuntimeFiberId = Brand.nominal<RuntimeFiberId>();
 
-export type RuntimeSpanName = string & {
-  readonly __brand: "RuntimeSpanName";
-};
+export type RuntimeSpanName = string & Brand.Brand<"RuntimeSpanName">;
+export const RuntimeSpanName = Brand.nominal<RuntimeSpanName>();
 
 export interface RuntimeLogContext {
   readonly requestId?: RuntimeRequestId;
@@ -56,16 +51,24 @@ export interface RuntimeObservability {
 export class RuntimeObservabilityError extends Data.TaggedError(
   "RuntimeObservabilityError",
 )<{
-  readonly cause:
-    | {
-        readonly _tag: "LoggerBootstrapFailed";
-        readonly message: string;
-      }
-    | {
-        readonly _tag: "FiberSupervisorUnavailable";
-        readonly message: string;
-      };
+  readonly cause: RuntimeObservabilityCause;
 }> {}
+
+export class LoggerBootstrapFailed extends Data.TaggedError(
+  "LoggerBootstrapFailed",
+)<{
+  readonly message: string;
+}> {}
+
+export class FiberSupervisorUnavailable extends Data.TaggedError(
+  "FiberSupervisorUnavailable",
+)<{
+  readonly message: string;
+}> {}
+
+export type RuntimeObservabilityCause =
+  | LoggerBootstrapFailed
+  | FiberSupervisorUnavailable;
 
 type LogFieldValue = string | number | boolean;
 
@@ -157,10 +160,9 @@ export function createRuntimeObservability(
     },
     catch: (cause) =>
       new RuntimeObservabilityError({
-        cause: {
-          _tag: "LoggerBootstrapFailed",
+        cause: new LoggerBootstrapFailed({
           message: cause instanceof Error ? cause.message : String(cause),
-        },
+        }),
       }),
   });
 }

--- a/packages/server/src/services/conversation.service.ts
+++ b/packages/server/src/services/conversation.service.ts
@@ -28,6 +28,10 @@ import {
 
 const MAX_GROUP_PARTICIPANTS = 256;
 const PREVIEW_CACHE_MAX = 2000;
+const PREVIEW_CACHE_TEXT_CHARS = 80;
+const DEFAULT_CONVERSATION_LIST_LIMIT = 50;
+const MSG_CONVERSATION_NOT_FOUND = "Conversation not found";
+const MSG_NOT_A_PARTICIPANT = "Not a participant";
 
 /**
  * Policy gate consulted before any conversation edge (DM target,
@@ -94,7 +98,10 @@ export class ConversationService {
   /** Write-through: called from MessageService.send() with plaintext parts before encryption */
   updatePreviewCache(conversationId: string, firstPartText: string): void {
     this.previewCache.delete(conversationId);
-    this.previewCache.set(conversationId, firstPartText.slice(0, 80));
+    this.previewCache.set(
+      conversationId,
+      firstPartText.slice(0, PREVIEW_CACHE_TEXT_CHARS),
+    );
     if (this.previewCache.size > PREVIEW_CACHE_MAX) {
       const oldest = this.previewCache.keys().next().value!;
       this.previewCache.delete(oldest);
@@ -278,7 +285,7 @@ export class ConversationService {
 
   list(
     agentId: string,
-    limit = 50,
+    limit = DEFAULT_CONVERSATION_LIST_LIMIT,
     cursor?: string,
     archived: "exclude" | "include" | "only" = "exclude",
   ): Effect.Effect<
@@ -405,7 +412,7 @@ export class ConversationService {
         );
 
         if (Option.isNone(convOpt)) {
-          return yield* Effect.fail(notFound("Conversation not found"));
+          return yield* Effect.fail(notFound(MSG_CONVERSATION_NOT_FOUND));
         }
         const conv = convOpt.value;
 
@@ -453,7 +460,7 @@ export class ConversationService {
         );
 
         if (Option.isNone(rowOpt)) {
-          return yield* Effect.fail(notFound("Conversation not found"));
+          return yield* Effect.fail(notFound(MSG_CONVERSATION_NOT_FOUND));
         }
 
         return this.mapConversation(rowOpt.value);
@@ -498,7 +505,7 @@ export class ConversationService {
             .where("id", "=", conversationId),
         );
         if (Option.isNone(currentOpt) || !currentOpt.value.archived_at) {
-          return yield* Effect.fail(notFound("Conversation not found"));
+          return yield* Effect.fail(notFound(MSG_CONVERSATION_NOT_FOUND));
         }
         return { archivedAt: currentOpt.value.archived_at.toISOString() };
       }),
@@ -536,7 +543,7 @@ export class ConversationService {
         );
 
         if (Option.isNone(convOpt)) {
-          return yield* Effect.fail(notFound("Conversation not found"));
+          return yield* Effect.fail(notFound(MSG_CONVERSATION_NOT_FOUND));
         }
         if (convOpt.value.type === "dm") {
           return yield* Effect.fail(invalidParams("Cannot leave a DM"));
@@ -549,7 +556,7 @@ export class ConversationService {
           .returning("conversation_id");
 
         if (deleted.length === 0) {
-          return yield* Effect.fail(notFound("Not a participant"));
+          return yield* Effect.fail(notFound(MSG_NOT_A_PARTICIPANT));
         }
       }),
     );
@@ -581,7 +588,7 @@ export class ConversationService {
             .where("id", "=", conversationId),
         );
         if (Option.isNone(convOpt)) {
-          return yield* Effect.fail(notFound("Conversation not found"));
+          return yield* Effect.fail(notFound(MSG_CONVERSATION_NOT_FOUND));
         }
         if (convOpt.value.type === "dm") {
           return yield* Effect.fail(
@@ -713,7 +720,7 @@ export class ConversationService {
           .returning("conversation_id");
 
         if (rows.length === 0) {
-          return yield* Effect.fail(notFound("Not a participant"));
+          return yield* Effect.fail(notFound(MSG_NOT_A_PARTICIPANT));
         }
       }),
     );
@@ -733,7 +740,7 @@ export class ConversationService {
           .returning("conversation_id");
 
         if (rows.length === 0) {
-          return yield* Effect.fail(notFound("Not a participant"));
+          return yield* Effect.fail(notFound(MSG_NOT_A_PARTICIPANT));
         }
       }),
     );
@@ -806,7 +813,7 @@ export class ConversationService {
         );
 
         if (Option.isNone(rowOpt)) {
-          return yield* Effect.fail(forbidden("Not a participant"));
+          return yield* Effect.fail(forbidden(MSG_NOT_A_PARTICIPANT));
         }
         if (!allowedRoles.includes(rowOpt.value.role)) {
           return yield* Effect.fail(forbidden("Insufficient permissions"));

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -41,6 +41,22 @@ function toBuf(v: Buffer | Uint8Array): Buffer {
  * on the presence signal alone.
  */
 const DELIVERY_TRACKING_MAX_PARTICIPANTS = 20;
+const PATCH_MIN_PARTS = 1;
+const PATCH_MAX_PARTS = 10;
+const DELIVERY_WEBHOOK_RETRY_BASE_SECONDS = 1;
+const DELIVERY_WEBHOOK_BACKOFF_FACTOR = 2;
+const DEFAULT_MESSAGE_HISTORY_LIMIT = 50;
+const MAX_MESSAGE_HISTORY_LIMIT = 100;
+const PLAINTEXT_IV_BYTES = 12;
+const PLAINTEXT_TAG_BYTES = 16;
+const CONVERSATION_KEYS_ALIAS = "conversation_keys as ck";
+const ENCRYPTION_KEYS_ALIAS = "encryption_keys as ek";
+const COL_EK_VERSION = "ek.version";
+const COL_CK_KEK_VERSION = "ck.kek_version";
+const COL_CK_WRAPPED_DEK = "ck.wrapped_dek";
+const COL_CK_DEK_VERSION = "ck.dek_version";
+const COL_EK_ENCRYPTED_KEY = "ek.encrypted_key";
+const COL_CK_CONVERSATION_ID = "ck.conversation_id";
 
 /** Config for the optional `deliveryWebhook` fire-and-forget fanout. */
 export interface DeliveryWebhookConfig {
@@ -163,7 +179,10 @@ export class MessageService {
           }
           if (hookResponse?.result.patch?.parts) {
             const patched = hookResponse.result.patch.parts;
-            if (patched.length >= 1 && patched.length <= 10) {
+            if (
+              patched.length >= PATCH_MIN_PARTS &&
+              patched.length <= PATCH_MAX_PARTS
+            ) {
               parts = patched;
               patchedBy = hookResponse.appId;
             } else {
@@ -320,7 +339,10 @@ export class MessageService {
     // 1s base, doubled per attempt, ±50% jitter. `intersect` with `recurs`
     // caps the retry count at `MAX_ATTEMPTS - 1` so total attempts = MAX.
     const retrySchedule = Schedule.intersect(
-      Schedule.exponential(Duration.seconds(1), 2).pipe(Schedule.jittered),
+      Schedule.exponential(
+        Duration.seconds(DELIVERY_WEBHOOK_RETRY_BASE_SECONDS),
+        DELIVERY_WEBHOOK_BACKOFF_FACTOR,
+      ).pipe(Schedule.jittered),
       Schedule.recurs(DELIVERY_WEBHOOK_MAX_ATTEMPTS - 1),
     );
 
@@ -365,7 +387,10 @@ export class MessageService {
           requesterAgentId,
         );
 
-        const limit = Math.min(options.limit ?? 50, 100);
+        const limit = Math.min(
+          options.limit ?? DEFAULT_MESSAGE_HISTORY_LIMIT,
+          MAX_MESSAGE_HISTORY_LIMIT,
+        );
 
         const rows = yield* this.db
           .selectFrom("messages")
@@ -413,8 +438,8 @@ export class MessageService {
           const plaintext = Buffer.from(JSON.stringify(parts), "utf-8");
           return {
             encrypted: plaintext,
-            iv: Buffer.alloc(12),
-            tag: Buffer.alloc(16),
+            iv: Buffer.alloc(PLAINTEXT_IV_BYTES),
+            tag: Buffer.alloc(PLAINTEXT_TAG_BYTES),
             dekVersion: 0,
             kekVersion: 0,
           };
@@ -423,16 +448,20 @@ export class MessageService {
         // Get or create conversation DEK (race-safe: ON CONFLICT + re-read)
         let keyRowOpt = yield* takeFirstOption(
           this.db
-            .selectFrom("conversation_keys as ck")
-            .innerJoin("encryption_keys as ek", "ek.version", "ck.kek_version")
+            .selectFrom(CONVERSATION_KEYS_ALIAS)
+            .innerJoin(
+              ENCRYPTION_KEYS_ALIAS,
+              COL_EK_VERSION,
+              COL_CK_KEK_VERSION,
+            )
             .select([
-              "ck.wrapped_dek",
-              "ck.dek_version",
-              "ck.kek_version",
-              "ek.encrypted_key",
+              COL_CK_WRAPPED_DEK,
+              COL_CK_DEK_VERSION,
+              COL_CK_KEK_VERSION,
+              COL_EK_ENCRYPTED_KEY,
             ])
-            .where("ck.conversation_id", "=", conversationId)
-            .orderBy("ck.dek_version", "desc")
+            .where(COL_CK_CONVERSATION_ID, "=", conversationId)
+            .orderBy(COL_CK_DEK_VERSION, "desc")
             .limit(1),
         );
 
@@ -483,20 +512,20 @@ export class MessageService {
             // Lost the race — another request created the DEK first, read theirs
             const winnerRow = yield* takeFirstOrFail(
               this.db
-                .selectFrom("conversation_keys as ck")
+                .selectFrom(CONVERSATION_KEYS_ALIAS)
                 .innerJoin(
-                  "encryption_keys as ek",
-                  "ek.version",
-                  "ck.kek_version",
+                  ENCRYPTION_KEYS_ALIAS,
+                  COL_EK_VERSION,
+                  COL_CK_KEK_VERSION,
                 )
                 .select([
-                  "ck.wrapped_dek",
-                  "ck.dek_version",
-                  "ck.kek_version",
-                  "ek.encrypted_key",
+                  COL_CK_WRAPPED_DEK,
+                  COL_CK_DEK_VERSION,
+                  COL_CK_KEK_VERSION,
+                  COL_EK_ENCRYPTED_KEY,
                 ])
-                .where("ck.conversation_id", "=", conversationId)
-                .orderBy("ck.dek_version", "desc")
+                .where(COL_CK_CONVERSATION_ID, "=", conversationId)
+                .orderBy(COL_CK_DEK_VERSION, "desc")
                 .limit(1),
               "winner DEK not found",
             );
@@ -592,15 +621,15 @@ export class MessageService {
         if (!dek) {
           const keyRowOpt = yield* takeFirstOption(
             this.db
-              .selectFrom("conversation_keys as ck")
+              .selectFrom(CONVERSATION_KEYS_ALIAS)
               .innerJoin(
-                "encryption_keys as ek",
-                "ek.version",
-                "ck.kek_version",
+                ENCRYPTION_KEYS_ALIAS,
+                COL_EK_VERSION,
+                COL_CK_KEK_VERSION,
               )
-              .select(["ck.wrapped_dek", "ek.encrypted_key"])
-              .where("ck.conversation_id", "=", row.conversation_id)
-              .where("ck.dek_version", "=", dekVersion),
+              .select([COL_CK_WRAPPED_DEK, COL_EK_ENCRYPTED_KEY])
+              .where(COL_CK_CONVERSATION_ID, "=", row.conversation_id)
+              .where(COL_CK_DEK_VERSION, "=", dekVersion),
           );
 
           if (Option.isNone(keyRowOpt)) {

--- a/packages/server/src/services/user.service.ts
+++ b/packages/server/src/services/user.service.ts
@@ -53,7 +53,8 @@ export interface UserService {
 }
 
 export class InProcessUserService implements UserService {
-  validateUser(_userId: UserId): Effect.Effect<{ valid: boolean }, never> {
+  validateUser(userId: UserId): Effect.Effect<{ valid: boolean }, never> {
+    void userId;
     return Effect.succeed({ valid: true });
   }
 }

--- a/packages/server/src/standalone.ts
+++ b/packages/server/src/standalone.ts
@@ -5,7 +5,7 @@ import { existsSync } from "node:fs";
 import { join, dirname, resolve, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Kysely, PostgresDialect, sql } from "kysely";
-import { Effect } from "effect";
+import { Data, Effect, Either } from "effect";
 import { FileSystem } from "@effect/platform";
 import { NodeFileSystem } from "@effect/platform-node";
 import type { MoltZapAppConfig as MoltZapConfig } from "./config/effect-config.js";
@@ -23,123 +23,158 @@ import { WebhookUserService } from "./services/user.service.js";
 import { logger } from "./logger.js";
 import type { CoreApp, CoreConfig } from "./app/types.js";
 import type { Database } from "./db/database.js";
-import { loadRuntimeProcessConfig } from "./runtime-surface/config.js";
-import type { RuntimeConfigPath } from "./runtime-surface/config.js";
-import { createRuntimeObservability } from "./runtime-surface/logging.js";
+import {
+  RuntimeConfigPath,
+  loadRuntimeProcessConfig,
+  type RuntimeConfigSurfaceError,
+} from "./runtime-surface/config.js";
+import {
+  createRuntimeObservability,
+  type RuntimeObservabilityError,
+} from "./runtime-surface/logging.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_WEBHOOK_TIMEOUT_MS = 10_000;
 
-function toError(err: unknown): Error {
-  return err instanceof Error ? err : new Error(String(err));
-}
+export class StandaloneOperationFailed extends Data.TaggedError(
+  "StandaloneOperationFailed",
+)<{
+  readonly cause: unknown;
+  readonly message: string;
+  readonly operation: string;
+}> {}
+
+export class SchemaFileNotFound extends Data.TaggedError("SchemaFileNotFound")<{
+  readonly message: string;
+}> {}
+
+type StandaloneServerError =
+  | RuntimeConfigSurfaceError
+  | RuntimeObservabilityError
+  | StandaloneOperationFailed
+  | SchemaFileNotFound;
+
+const operationFailed = (
+  operation: string,
+  cause: unknown,
+): StandaloneOperationFailed =>
+  new StandaloneOperationFailed({
+    cause,
+    message: cause instanceof Error ? cause.message : String(cause),
+    operation,
+  });
 
 // ── Database factory ────────────────────────────────────────────────
 
 interface DbHandle {
   db: Kysely<Database>;
-  cleanup: () => Promise<void>;
-  runMigrationSql: (sql: string) => Promise<void>;
+  cleanup: () => Effect.Effect<void, StandaloneOperationFailed, never>;
+  runMigrationSql: (
+    sql: string,
+  ) => Effect.Effect<void, StandaloneOperationFailed, never>;
 }
 
-function createPgLiteDb(dataDir?: string) {
-  return Effect.runPromise(
-    Effect.gen(function* () {
-      const { KyselyPGlite } = yield* Effect.tryPromise({
-        try: () => import("kysely-pglite"),
-        catch: toError,
-      });
+function createPgLiteDb(
+  dataDir?: string,
+): Effect.Effect<DbHandle, StandaloneOperationFailed, never> {
+  return Effect.gen(function* () {
+    const { KyselyPGlite } = yield* Effect.tryPromise({
+      try: () => import("kysely-pglite"),
+      catch: (cause) => operationFailed("load kysely-pglite", cause),
+    });
 
-      const kpg = yield* Effect.tryPromise({
-        try: () =>
-          dataDir ? KyselyPGlite.create(dataDir) : KyselyPGlite.create(),
-        catch: toError,
-      });
+    const kpg = yield* Effect.tryPromise({
+      try: () =>
+        dataDir ? KyselyPGlite.create(dataDir) : KyselyPGlite.create(),
+      catch: (cause) => operationFailed("create pglite database", cause),
+    });
 
-      // Effect-patched Kysely: builder chains can be used as `Effect`s inside
-      // services while the promise API (`.execute()`, `.transaction()`) still
-      // works for migration/seed code.
-      const db = makeEffectKysely<Database>({
-        dialect: kpg.dialect,
-      });
+    // Effect-patched Kysely: builder chains can be used as `Effect`s inside
+    // services while the promise API (`.execute()`, `.transaction()`) still
+    // works for migration/seed code.
+    const db = makeEffectKysely<Database>({
+      dialect: kpg.dialect,
+    });
 
-      return {
-        db,
-        cleanup: () =>
-          // Close the PGlite client after Kysely releases its connection. We use
-          // an Effect chain here rather than raw Promise composition to keep the
-          // sequencing guard-friendly.
-          Effect.runPromise(
+    return {
+      db,
+      cleanup: () =>
+        // Close the PGlite client after Kysely releases its connection. We use
+        // an Effect chain here rather than raw Promise composition to keep the
+        // sequencing guard-friendly.
+        Effect.tryPromise({
+          try: () => db.destroy(),
+          catch: (cause) => operationFailed("destroy pglite kysely", cause),
+        }).pipe(
+          Effect.flatMap(() =>
             Effect.tryPromise({
-              try: () => db.destroy(),
-              catch: toError,
-            }).pipe(
-              Effect.flatMap(() =>
-                Effect.tryPromise({
-                  try: () => kpg.client.close(),
-                  catch: toError,
-                }),
-              ),
-            ),
+              try: () => kpg.client.close(),
+              catch: (cause) => operationFailed("close pglite client", cause),
+            }),
           ),
-        runMigrationSql: (sqlText: string) =>
-          Effect.runPromise(
-            Effect.tryPromise({
-              try: () => kpg.client.exec(sqlText),
-              catch: toError,
-            }).pipe(Effect.asVoid),
-          ),
-      };
-    }),
-  );
+        ),
+      runMigrationSql: (sqlText: string) =>
+        Effect.tryPromise({
+          try: () => kpg.client.exec(sqlText),
+          catch: (cause) => operationFailed("run pglite migration sql", cause),
+        }).pipe(Effect.asVoid),
+    };
+  });
 }
 
-function createPostgresDb(url: string) {
-  return Effect.runPromise(
-    Effect.gen(function* () {
-      const pg = yield* Effect.tryPromise({
-        try: () => import("pg"),
-        catch: toError,
-      });
-      const pool = new pg.default.Pool({ connectionString: url, max: 20 });
-      // Effect-patched Kysely: builder chains can be used as `Effect`s inside
-      // services while the promise API (`.execute()`, `.transaction()`) still
-      // works for migration/seed code.
-      const db = makeEffectKysely<Database>({
-        dialect: new PostgresDialect({ pool }),
-      });
+function createPostgresDb(
+  url: string,
+): Effect.Effect<DbHandle, StandaloneOperationFailed, never> {
+  return Effect.gen(function* () {
+    const pg = yield* Effect.tryPromise({
+      try: () => import("pg"),
+      catch: (cause) => operationFailed("load pg", cause),
+    });
+    const pool = new pg.default.Pool({ connectionString: url, max: 20 });
+    // Effect-patched Kysely: builder chains can be used as `Effect`s inside
+    // services while the promise API (`.execute()`, `.transaction()`) still
+    // works for migration/seed code.
+    const db = makeEffectKysely<Database>({
+      dialect: new PostgresDialect({ pool }),
+    });
 
-      return {
-        db,
-        cleanup: () => db.destroy(),
-        runMigrationSql: (sqlText: string) => {
-          // Raw DDL — Kysely can't run before tables exist
-          const exec = pool.query.bind(pool);
-          return Effect.runPromise(
-            Effect.tryPromise({
-              try: () => exec(sqlText),
-              catch: toError,
-            }).pipe(Effect.asVoid),
-          );
-        },
-      };
-    }),
-  );
+    return {
+      db,
+      cleanup: () =>
+        Effect.tryPromise({
+          try: () => db.destroy(),
+          catch: (cause) => operationFailed("destroy postgres kysely", cause),
+        }),
+      runMigrationSql: (sqlText: string) => {
+        // Raw DDL — Kysely can't run before tables exist
+        const exec = pool.query.bind(pool);
+        return Effect.tryPromise({
+          try: () => exec(sqlText),
+          catch: (cause) =>
+            operationFailed("run postgres migration sql", cause),
+        }).pipe(Effect.asVoid);
+      },
+    };
+  });
 }
 
 // ── Migration ───────────────────────────────────────────────────────
 
-function findSchemaFile(): string {
+function findSchemaFile(): Effect.Effect<string, SchemaFileNotFound, never> {
   // Docker: copied to package root
   const dockerPath = join(__dirname, "..", "core-schema.sql");
-  if (existsSync(dockerPath)) return dockerPath;
+  if (existsSync(dockerPath)) return Effect.succeed(dockerPath);
   // Dev (tsx): running from src/, schema in src/app/
   const devPath = join(__dirname, "app", "core-schema.sql");
-  if (existsSync(devPath)) return devPath;
+  if (existsSync(devPath)) return Effect.succeed(devPath);
   // Compiled (node dist/): schema in ../src/app/
   const distPath = join(__dirname, "..", "src", "app", "core-schema.sql");
-  if (existsSync(distPath)) return distPath;
-  throw new Error(
-    "Cannot find core-schema.sql. Ensure it exists at the package root or in src/app/.",
+  if (existsSync(distPath)) return Effect.succeed(distPath);
+  return Effect.fail(
+    new SchemaFileNotFound({
+      message:
+        "Cannot find core-schema.sql. Ensure it exists at the package root or in src/app/.",
+    }),
   );
 }
 
@@ -152,7 +187,11 @@ function findSchemaFile(): string {
 function autoMigrateEffect(
   handle: DbHandle,
   encryptionSecret: string | undefined,
-): Effect.Effect<void, Error, FileSystem.FileSystem> {
+): Effect.Effect<
+  void,
+  SchemaFileNotFound | StandaloneOperationFailed,
+  FileSystem.FileSystem
+> {
   return Effect.gen(function* () {
     const result = yield* Effect.tryPromise({
       try: () =>
@@ -161,7 +200,7 @@ function autoMigrateEffect(
             SELECT FROM information_schema.tables WHERE table_name = 'agents'
           ) AS has_schema
         `.execute(handle.db),
-      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      catch: (cause) => operationFailed("check database schema", cause),
     });
 
     if (result.rows[0]?.has_schema) {
@@ -172,20 +211,18 @@ function autoMigrateEffect(
     logger.info("Applying database schema...");
 
     const fs = yield* FileSystem.FileSystem;
+    const schemaPath = yield* findSchemaFile();
     const schema = yield* fs
-      .readFileString(findSchemaFile(), "utf-8")
-      .pipe(Effect.mapError((e) => new Error(e.message)));
+      .readFileString(schemaPath, "utf-8")
+      .pipe(Effect.mapError((cause) => operationFailed("read schema", cause)));
 
-    yield* Effect.tryPromise({
-      try: () => handle.runMigrationSql(schema),
-      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-    });
+    yield* handle.runMigrationSql(schema);
 
     if (encryptionSecret) {
       const envelope = new EnvelopeEncryption(encryptionSecret);
       yield* Effect.tryPromise({
         try: () => seedInitialKek(handle.db, envelope),
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        catch: (cause) => operationFailed("seed encryption key", cause),
       });
     } else {
       logger.info(
@@ -203,39 +240,31 @@ export function startServer(configPath?: string) {
   return Effect.runPromise(startServerEffect(configPath));
 }
 
-function startServerEffect(configPath?: string): Effect.Effect<
-  {
-    app: CoreApp;
-    config: MoltZapConfig;
-    stop: () => Promise<void>;
-  },
-  Error,
-  never
-> {
+interface StandaloneServerHandle {
+  readonly app: CoreApp;
+  readonly config: MoltZapConfig;
+  readonly stop: CoreApp["close"];
+}
+
+function startServerEffect(
+  configPath?: string,
+): Effect.Effect<StandaloneServerHandle, StandaloneServerError, never> {
   return Effect.gen(function* () {
     const runtimeConfig = yield* loadRuntimeProcessConfig(
       configPath === undefined
         ? {}
-        : { configPath: configPath as RuntimeConfigPath },
+        : { configPath: RuntimeConfigPath(configPath) },
     );
     const observability = yield* createRuntimeObservability(runtimeConfig);
     const log = observability.logger;
-
-    process.env["LOG_LEVEL"] = runtimeConfig.logging.level;
-    process.env["NODE_ENV"] = runtimeConfig.environment;
-    process.env["OTEL_SERVICE_NAME"] = runtimeConfig.tracing.serviceName;
 
     // Create database (PGlite if no URL, Postgres otherwise)
     const appConfig = runtimeConfig.app;
     const databaseUrl = runtimeConfig.server.database.url;
     const usePgLite = databaseUrl.length === 0;
-    const handle = yield* Effect.tryPromise({
-      try: () =>
-        usePgLite
-          ? createPgLiteDb(appConfig.database?.data_dir)
-          : createPostgresDb(databaseUrl),
-      catch: toError,
-    });
+    const handle = yield* usePgLite
+      ? createPgLiteDb(appConfig.database?.data_dir)
+      : createPostgresDb(databaseUrl);
 
     if (usePgLite) {
       log.info("Using embedded PGlite database (no external Postgres needed)");
@@ -260,7 +289,7 @@ function startServerEffect(configPath?: string): Effect.Effect<
         ? new WebhookUserService(
             webhookClient,
             userServiceCfg.webhook_url,
-            userServiceCfg.timeout_ms ?? 10000,
+            userServiceCfg.timeout_ms ?? DEFAULT_WEBHOOK_TIMEOUT_MS,
             log,
           )
         : undefined;
@@ -282,7 +311,7 @@ function startServerEffect(configPath?: string): Effect.Effect<
 
     const coreConfig: CoreConfig = {
       db: handle.db,
-      dbCleanup: handle.cleanup,
+      dbCleanup: () => Effect.runPromise(handle.cleanup()),
       encryptionMasterSecret: runtimeConfig.server.encryption.masterSecret,
       port: runtimeConfig.server.server.port,
       corsOrigins: runtimeConfig.server.server.corsOrigins.exact,
@@ -303,7 +332,7 @@ function startServerEffect(configPath?: string): Effect.Effect<
         new WebhookContactService(
           webhookClient,
           appConfig.services.contacts.webhook_url,
-          appConfig.services.contacts.timeout_ms ?? 10000,
+          appConfig.services.contacts.timeout_ms ?? DEFAULT_WEBHOOK_TIMEOUT_MS,
           log,
         ),
       );
@@ -336,37 +365,47 @@ function startServerEffect(configPath?: string): Effect.Effect<
           const fs = yield* FileSystem.FileSystem;
           return yield* fs
             .readFileString(manifestPath, "utf-8")
-            .pipe(Effect.mapError((e) => new Error(e.message)));
+            .pipe(
+              Effect.mapError((cause) =>
+                operationFailed("read app manifest", cause),
+              ),
+            );
         }).pipe(Effect.provide(NodeFileSystem.layer));
 
       for (const appRef of appConfig.apps) {
         const manifestPath = isAbsolute(appRef.manifest)
           ? appRef.manifest
           : resolve(configDir, appRef.manifest);
-        const loadResult = yield* fsReadAppManifest(manifestPath).pipe(
-          Effect.map((json) => ({ ok: true as const, json })),
-          Effect.catchAll((err) => Effect.succeed({ ok: false as const, err })),
+        yield* fsReadAppManifest(manifestPath).pipe(
+          Effect.either,
+          Effect.flatMap(
+            Either.match({
+              onLeft: (err) =>
+                Effect.sync(() => {
+                  log.error(
+                    { err, path: appRef.manifest },
+                    "Failed to load app manifest",
+                  );
+                }),
+              onRight: (json) =>
+                Effect.sync(() => {
+                  try {
+                    const manifest = JSON.parse(json);
+                    app.registerApp(manifest);
+                    log.info(
+                      { appId: manifest.appId, path: appRef.manifest },
+                      "App manifest registered",
+                    );
+                  } catch (err) {
+                    log.error(
+                      { err, path: appRef.manifest },
+                      "Failed to load app manifest",
+                    );
+                  }
+                }),
+            }),
+          ),
         );
-        if (!loadResult.ok) {
-          log.error(
-            { err: loadResult.err, path: appRef.manifest },
-            "Failed to load app manifest",
-          );
-          continue;
-        }
-        try {
-          const manifest = JSON.parse(loadResult.json);
-          app.registerApp(manifest);
-          log.info(
-            { appId: manifest.appId, path: appRef.manifest },
-            "App manifest registered",
-          );
-        } catch (err) {
-          log.error(
-            { err, path: appRef.manifest },
-            "Failed to load app manifest",
-          );
-        }
       }
     }
 

--- a/packages/server/src/test-utils/fakes.ts
+++ b/packages/server/src/test-utils/fakes.ts
@@ -18,7 +18,7 @@
  *       slot into an Effect program via `Layer.provide(program, fakeLayer)`.
  */
 
-import { Layer } from "effect";
+import { Data, Layer, unsafeCoerce } from "effect";
 
 import type { WebhookClient } from "../adapters/webhook.js";
 import type { AppHost, DefaultPermissionService } from "../app/app-host.js";
@@ -46,6 +46,13 @@ import {
 
 // ── Generic typed fake factory ─────────────────────────────────────────────
 
+class FakeServiceMethodMissing extends Data.TaggedError(
+  "FakeServiceMethodMissing",
+)<{
+  readonly message: string;
+  readonly method: string;
+}> {}
+
 /**
  * Build a typed test double for an interface `S` from a partial implementation.
  * The cast is intentional: tests typically implement only the methods the
@@ -60,17 +67,22 @@ import {
  * existing field's signature does.
  */
 export const makeFakeService = <S extends object>(impl: Partial<S>): S =>
-  new Proxy(impl, {
-    get(target, prop, receiver) {
-      if (prop in target) return Reflect.get(target, prop, receiver);
-      // Symbol lookups (e.g. Symbol.toPrimitive) — let the default behavior run.
-      if (typeof prop === "symbol") return undefined;
-      throw new Error(
-        `FakeService: method '${String(prop)}' was called but not implemented. ` +
-          `Add it to the test double.`,
-      );
-    },
-  }) as S;
+  unsafeCoerce<Partial<S>, S>(
+    new Proxy(impl, {
+      get(target, prop, receiver) {
+        if (prop in target) return Reflect.get(target, prop, receiver);
+        // Symbol lookups (e.g. Symbol.toPrimitive) — let the default behavior run.
+        if (typeof prop === "symbol") return undefined;
+        const method = String(prop);
+        throw new FakeServiceMethodMissing({
+          message:
+            `FakeService: method '${method}' was called but not implemented. ` +
+            `Add it to the test double.`,
+          method,
+        });
+      },
+    }),
+  );
 
 // ── Webhook client — not behind a Tag, used via constructor injection ──────
 
@@ -88,7 +100,8 @@ export const makeFakeService = <S extends object>(impl: Partial<S>): S =>
  */
 export const makeFakeWebhookClient = (
   impl: Pick<WebhookClient, "call">,
-): WebhookClient => impl as WebhookClient;
+): WebhookClient =>
+  unsafeCoerce<Pick<WebhookClient, "call">, WebhookClient>(impl);
 
 // ── Layer-based fakes for tagged services ──────────────────────────────────
 //

--- a/packages/server/src/test-utils/helpers.ts
+++ b/packages/server/src/test-utils/helpers.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import type { EventFrame } from "@moltzap/protocol";
 import {
   makeCloseableTestClient,
@@ -7,6 +7,8 @@ import {
   type TestAgent,
 } from "@moltzap/protocol/testing";
 import { getBaseUrl, getWsUrl } from "./index.js";
+
+import { ConversationsCreate } from "@moltzap/protocol";
 
 export interface ServerTestClient
   extends Omit<CloseableTestClient, "close" | "drainEvents"> {
@@ -22,6 +24,11 @@ export interface ConnectedAgent {
 }
 
 const openClients: ServerTestClient[] = [];
+const MIN_AGENT_GROUP_SIZE = 2;
+
+class ServerTestHelperError extends Data.TaggedError("ServerTestHelperError")<{
+  readonly message: string;
+}> {}
 
 export function trackClient(client: ServerTestClient): void {
   openClients.push(client);
@@ -128,9 +135,11 @@ export function setupAgentGroup(
   opts?: { groupName?: string },
 ): Effect.Effect<{ agents: ConnectedAgent[]; conversationId?: string }, Error> {
   return Effect.gen(function* () {
-    if (count < 2) {
+    if (count < MIN_AGENT_GROUP_SIZE) {
       return yield* Effect.fail(
-        new Error("Agent group requires at least 2 agents"),
+        new ServerTestHelperError({
+          message: `Agent group requires at least ${MIN_AGENT_GROUP_SIZE} agents`,
+        }),
       );
     }
 
@@ -146,7 +155,7 @@ export function setupAgentGroup(
         type: "agent" as const,
         id: a.agentId,
       }));
-      const conv = (yield* creator.client.sendRpc("conversations/create", {
+      const conv = (yield* creator.client.sendRpc(ConversationsCreate.name, {
         type: "group",
         name: opts.groupName,
         participants: others,

--- a/packages/server/src/test-utils/server.ts
+++ b/packages/server/src/test-utils/server.ts
@@ -20,6 +20,20 @@ export type { CoreApp } from "../app/types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+class CoreTestServerError extends Error {
+  override readonly name = "CoreTestServerError";
+
+  constructor(
+    message: string,
+    override readonly cause?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+const ENCRYPTION_MASTER_SECRET_BYTES = 32;
+const PGLITE_BOOT_DELAY_MS = 200;
+
 // Minimal duplicate of `@moltzap/runtimes`'s `awaitAgentReadyByPolling` and
 // `RuntimeServerHandle`/`ReadyOutcome` shapes. We can't import from
 // `@moltzap/runtimes` here without flipping the workspace dep direction
@@ -80,8 +94,8 @@ function awaitAgentReadyByPolling(
 let coreApp: CoreApp | null = null;
 let appDb: Kysely<Database> | null = null;
 let pgliteClient: {
-  exec: (sql: string) => Promise<unknown>;
-  close: () => Promise<void>;
+  exec: (sql: string) => PromiseLike<unknown>;
+  close: () => PromiseLike<void>;
 } | null = null;
 let _masterSecret: string | null = null;
 let _baseUrl: string | null = null;
@@ -102,7 +116,7 @@ export interface CoreTestServer {
   runtimeServer: CoreTestRuntimeServerHandle;
 }
 
-export async function startCoreTestServer(_opts?: {
+type StartCoreTestServerOptions = {
   pgHost?: string;
   pgPort?: number;
   encryption?: boolean;
@@ -122,95 +136,165 @@ export async function startCoreTestServer(_opts?: {
   registrationSecret?: string;
   devModeUserId?: string;
   traceCaptureLayer?: Layer.Layer<TraceCaptureTag>;
-}): Promise<CoreTestServer> {
-  if (coreApp)
-    throw new Error(
-      "Test server already running. Call stopCoreTestServer() first.",
-    );
+};
 
-  const { KyselyPGlite } = await import("kysely-pglite");
-  const kpg = await KyselyPGlite.create();
-
-  pgliteClient = kpg.client;
-  appDb = makeEffectKysely<Database>({
-    dialect: kpg.dialect,
+function importPglite() {
+  return Effect.tryPromise({
+    try: () => import("kysely-pglite"),
+    catch: (cause) => new CoreTestServerError("PGlite import failed", cause),
   });
-
-  const srcPath = join(__dirname, "..", "app", "core-schema.sql");
-  const distPath = join(__dirname, "..", "..", "src", "app", "core-schema.sql");
-  const schemaPath = existsSync(srcPath) ? srcPath : distPath;
-  const schema = readFileSync(schemaPath, "utf-8");
-  await pgliteClient.exec(schema);
-
-  let masterSecret: string | undefined;
-  if (_opts?.encryption) {
-    masterSecret = randomBytes(32).toString("base64");
-    _masterSecret = masterSecret;
-    const envelope = new EnvelopeEncryption(masterSecret);
-    await seedInitialKek(appDb, envelope);
-  }
-
-  coreApp = createCoreApp({
-    db: appDb,
-    dbCleanup: async () => {
-      await appDb?.destroy();
-    },
-    encryptionMasterSecret: masterSecret,
-    port: 0,
-    corsOrigins: ["*"],
-    devMode: true,
-    devModeUserId: _opts?.devModeUserId,
-    userService: _opts?.userService,
-    registrationSecret: _opts?.registrationSecret,
-    traceCaptureLayer: _opts?.traceCaptureLayer,
-  });
-
-  await new Promise((r) => setTimeout(r, 200));
-
-  const assignedPort = coreApp.port;
-  _baseUrl = `http://localhost:${assignedPort}`;
-  _wsUrl = `ws://localhost:${assignedPort}/ws`;
-
-  const runtimeServer: CoreTestRuntimeServerHandle = {
-    awaitAgentReady: (agentId, timeoutMs) =>
-      awaitAgentReadyByPolling(coreApp!.connections, agentId, timeoutMs),
-  };
-
-  return {
-    baseUrl: _baseUrl,
-    wsUrl: _wsUrl,
-    db: appDb,
-    coreApp,
-    runtimeServer,
-  };
 }
 
-export async function stopCoreTestServer(): Promise<void> {
-  const app = coreApp;
+function execPglite(sql: string) {
   const client = pgliteClient;
-
-  coreApp = null;
-  appDb = null;
-  pgliteClient = null;
-  _masterSecret = null;
-  _baseUrl = null;
-  _wsUrl = null;
-
-  await app?.close();
-  try {
-    await client?.close();
-  } catch {
-    // PGlite already closed by dbCleanup
-  }
-}
-
-export async function resetCoreTestDb(): Promise<void> {
-  if (!pgliteClient || !appDb) {
-    throw new Error(
-      "Test server not running. Call startCoreTestServer() first.",
+  if (!client) {
+    return Effect.fail(
+      new CoreTestServerError("PGlite client not initialized."),
     );
   }
-  await pgliteClient.exec(`
+  return Effect.tryPromise({
+    try: () => client.exec(sql),
+    catch: (cause) => new CoreTestServerError("PGlite exec failed", cause),
+  });
+}
+
+function closePglite(client: NonNullable<typeof pgliteClient>) {
+  return Effect.tryPromise({
+    try: () => client.close(),
+    catch: (cause) => new CoreTestServerError("PGlite close failed", cause),
+  });
+}
+
+function seedEncryptionKey(db: Kysely<Database>, masterSecret: string) {
+  const envelope = new EnvelopeEncryption(masterSecret);
+  return Effect.tryPromise({
+    try: () => seedInitialKek(db, envelope),
+    catch: (cause) =>
+      new CoreTestServerError("Initial encryption key seed failed", cause),
+  });
+}
+
+function destroyDb() {
+  const db = appDb;
+  return db?.destroy() ?? Promise.resolve();
+}
+
+export function startCoreTestServer(_opts?: StartCoreTestServerOptions) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      if (coreApp) {
+        return yield* Effect.fail(
+          new CoreTestServerError(
+            "Test server already running. Call stopCoreTestServer() first.",
+          ),
+        );
+      }
+
+      const { KyselyPGlite } = yield* importPglite();
+      const kpg = yield* Effect.tryPromise({
+        try: () => KyselyPGlite.create(),
+        catch: (cause) =>
+          new CoreTestServerError("PGlite instance creation failed", cause),
+      });
+
+      pgliteClient = kpg.client;
+      appDb = makeEffectKysely<Database>({
+        dialect: kpg.dialect,
+      });
+
+      const srcPath = join(__dirname, "..", "app", "core-schema.sql");
+      const distPath = join(
+        __dirname,
+        "..",
+        "..",
+        "src",
+        "app",
+        "core-schema.sql",
+      );
+      const schemaPath = existsSync(srcPath) ? srcPath : distPath;
+      const schema = readFileSync(schemaPath, "utf-8");
+      yield* execPglite(schema);
+
+      let masterSecret: string | undefined;
+      if (_opts?.encryption) {
+        masterSecret = randomBytes(ENCRYPTION_MASTER_SECRET_BYTES).toString(
+          "base64",
+        );
+        _masterSecret = masterSecret;
+        yield* seedEncryptionKey(appDb, masterSecret);
+      }
+
+      coreApp = createCoreApp({
+        db: appDb,
+        dbCleanup: destroyDb,
+        encryptionMasterSecret: masterSecret,
+        port: 0,
+        corsOrigins: ["*"],
+        devMode: true,
+        devModeUserId: _opts?.devModeUserId,
+        userService: _opts?.userService,
+        registrationSecret: _opts?.registrationSecret,
+        traceCaptureLayer: _opts?.traceCaptureLayer,
+      });
+
+      yield* Effect.sleep(`${PGLITE_BOOT_DELAY_MS} millis`);
+
+      const assignedPort = coreApp.port;
+      _baseUrl = `http://localhost:${assignedPort}`;
+      _wsUrl = `ws://localhost:${assignedPort}/ws`;
+
+      const runtimeServer: CoreTestRuntimeServerHandle = {
+        awaitAgentReady: (agentId, timeoutMs) =>
+          awaitAgentReadyByPolling(coreApp!.connections, agentId, timeoutMs),
+      };
+
+      return {
+        baseUrl: _baseUrl,
+        wsUrl: _wsUrl,
+        db: appDb,
+        coreApp,
+        runtimeServer,
+      };
+    }),
+  );
+}
+
+export function stopCoreTestServer() {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const app = coreApp;
+      const client = pgliteClient;
+
+      coreApp = null;
+      appDb = null;
+      pgliteClient = null;
+      _masterSecret = null;
+      _baseUrl = null;
+      _wsUrl = null;
+
+      yield* Effect.tryPromise({
+        try: () => app?.close() ?? Promise.resolve(),
+        catch: (cause) =>
+          new CoreTestServerError("Core test app close failed", cause),
+      });
+      if (client) {
+        yield* closePglite(client).pipe(Effect.catchAll(() => Effect.void));
+      }
+    }),
+  );
+}
+
+export function resetCoreTestDb() {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      if (!pgliteClient || !appDb) {
+        return yield* Effect.fail(
+          new CoreTestServerError(
+            "Test server not running. Call startCoreTestServer() first.",
+          ),
+        );
+      }
+      yield* execPglite(`
     TRUNCATE TABLE
       app_permission_grants, app_session_conversations, app_session_participants, app_sessions,
       message_delivery, messages,
@@ -218,15 +302,16 @@ export async function resetCoreTestDb(): Promise<void> {
       agents, encryption_keys
     CASCADE;
   `);
-  if (_masterSecret && appDb) {
-    const envelope = new EnvelopeEncryption(_masterSecret);
-    await seedInitialKek(appDb, envelope);
-  }
+      if (_masterSecret && appDb) {
+        yield* seedEncryptionKey(appDb, _masterSecret);
+      }
+    }),
+  );
 }
 
 export function getCoreDb(): Kysely<Database> {
   if (!appDb)
-    throw new Error(
+    throw new CoreTestServerError(
       "Test server not running. Call startCoreTestServer() first.",
     );
   return appDb;
@@ -234,18 +319,18 @@ export function getCoreDb(): Kysely<Database> {
 
 export function getCoreApp(): CoreApp {
   if (!coreApp)
-    throw new Error(
+    throw new CoreTestServerError(
       "Test server not running. Call startCoreTestServer() first.",
     );
   return coreApp;
 }
 
 export function getBaseUrl(): string {
-  if (!_baseUrl) throw new Error("Test server not running.");
+  if (!_baseUrl) throw new CoreTestServerError("Test server not running.");
   return _baseUrl;
 }
 
 export function getWsUrl(): string {
-  if (!_wsUrl) throw new Error("Test server not running.");
+  if (!_wsUrl) throw new CoreTestServerError("Test server not running.");
   return _wsUrl;
 }

--- a/packages/server/src/ws/broadcaster.ts
+++ b/packages/server/src/ws/broadcaster.ts
@@ -1,12 +1,25 @@
-import { Effect } from "effect";
+import { Config, ConfigProvider, Effect, Option } from "effect";
 import type { EventFrame } from "@moltzap/protocol";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ConnectionManager } from "./connection.js";
 import { logger } from "../logger.js";
 
+const ServerBroadcastLogDir = Config.option(
+  Config.string("MOLTZAP_SERVER_BROADCAST_LOG_DIR"),
+);
+
+const getServerBroadcastLogDir = (): string | undefined =>
+  Option.getOrUndefined(
+    Effect.runSync(
+      ServerBroadcastLogDir.pipe(
+        Effect.withConfigProvider(ConfigProvider.fromEnv()),
+      ),
+    ),
+  );
+
 function appendBroadcastTrace(record: Record<string, unknown>): void {
-  const dir = process.env["MOLTZAP_SERVER_BROADCAST_LOG_DIR"];
+  const dir = getServerBroadcastLogDir();
   if (!dir) return;
   try {
     fs.mkdirSync(dir, { recursive: true });

--- a/packages/server/src/ws/connection.s2c.test.ts
+++ b/packages/server/src/ws/connection.s2c.test.ts
@@ -32,6 +32,14 @@ import {
   type MoltZapConnection,
 } from "./connection.js";
 
+import {
+  AppsOnBeforeDispatch,
+  AppsOnBeforeMessageDelivery,
+  AppsOnClose,
+  AppsOnJoin,
+  AppsOnSessionActive,
+} from "@moltzap/protocol";
+
 const noopShutdown: MoltZapConnection["shutdown"] = Effect.void;
 
 interface FakeConnSetup {
@@ -82,7 +90,7 @@ describe("sendRpcToClient — happy-path round-trip", () => {
       // `completeS2cResponse` settles it. Forking lets the test thread
       // synthesize the matching response.
       const fiber = yield* Effect.fork(
-        sendRpcToClient(conn, "apps/onJoin", { sessionId: "sess-1" }),
+        sendRpcToClient(conn, AppsOnJoin.name, { sessionId: "sess-1" }),
       );
 
       // Wait for the outbound frame to land in the Ref. `Effect.repeat`
@@ -106,7 +114,7 @@ describe("sendRpcToClient — happy-path round-trip", () => {
       };
       expect(frame.type).toBe("request");
       expect(frame.direction).toBe("s2c");
-      expect(frame.method).toBe("apps/onJoin");
+      expect(frame.method).toBe(AppsOnJoin.name);
       expect(frame.params.sessionId).toBe("sess-1");
       // `srv-<connId>-<seq>` namespace prefix — direction-namespacing keeps
       // c2s and s2c id pools disjoint per the architect plan.
@@ -146,7 +154,7 @@ describe("sendRpcToClient — happy-path round-trip", () => {
       );
 
       const fiber = yield* Effect.fork(
-        sendRpcToClient(conn, "apps/onClose", { sessionId: "sess-x" }),
+        sendRpcToClient(conn, AppsOnClose.name, { sessionId: "sess-x" }),
       );
 
       const captured = yield* Ref.get(outbound).pipe(
@@ -182,7 +190,7 @@ describe("sendRpcToClient — happy-path round-trip", () => {
         const e = err.value as S2cRpcResponseError;
         expect(e.code).toBe(-32000);
         expect(e.message).toBe("session-already-closed");
-        expect(e.method).toBe("apps/onClose");
+        expect(e.method).toBe(AppsOnClose.name);
       }
     }
   });
@@ -200,10 +208,10 @@ describe("sendRpcToClient — disconnect mid-request", () => {
       // Two concurrent in-flight s2c requests. Both must observe
       // `AppDisconnected` when the scope closes.
       const fiberA = yield* Effect.fork(
-        sendRpcToClient(conn, "apps/onBeforeDispatch", { tag: "A" }),
+        sendRpcToClient(conn, AppsOnBeforeDispatch.name, { tag: "A" }),
       );
       const fiberB = yield* Effect.fork(
-        sendRpcToClient(conn, "apps/onBeforeMessageDelivery", { tag: "B" }),
+        sendRpcToClient(conn, AppsOnBeforeMessageDelivery.name, { tag: "B" }),
       );
 
       // Wait until both requests have registered their pending entries
@@ -233,8 +241,8 @@ describe("sendRpcToClient — disconnect mid-request", () => {
     const [exitA, exitB] = await Effect.runPromise(program);
 
     for (const [exit, expectedMethod] of [
-      [exitA, "apps/onBeforeDispatch"],
-      [exitB, "apps/onBeforeMessageDelivery"],
+      [exitA, AppsOnBeforeDispatch.name],
+      [exitB, AppsOnBeforeMessageDelivery.name],
     ] as const) {
       expect(Exit.isFailure(exit)).toBe(true);
       if (Exit.isFailure(exit)) {
@@ -275,7 +283,7 @@ describe("sendRpcToClient — disconnect mid-request", () => {
         s2cRequestCounter: state.s2cRequestCounter,
       };
 
-      const exit = yield* sendRpcToClient(conn, "apps/onClose", {}).pipe(
+      const exit = yield* sendRpcToClient(conn, AppsOnClose.name, {}).pipe(
         Effect.exit,
       );
       const pendingSize = HashMap.size(yield* Ref.get(conn.s2cPending));
@@ -312,7 +320,7 @@ describe("sendRpcToClient — caller timeout", () => {
       // never reads a timeout; it just awaits a Deferred. If the response
       // never arrives, `Effect.timeout` fires.
       const start = Date.now();
-      const exit = yield* sendRpcToClient(conn, "apps/onJoin", {
+      const exit = yield* sendRpcToClient(conn, AppsOnJoin.name, {
         sessionId: "s",
       }).pipe(Effect.timeout(Duration.millis(100)), Effect.exit);
       const elapsed = Date.now() - start;
@@ -357,7 +365,7 @@ describe("sendRpcToClient — caller timeout", () => {
       );
 
       const fiber = yield* Effect.fork(
-        sendRpcToClient(conn, "apps/onSessionActive", {}),
+        sendRpcToClient(conn, AppsOnSessionActive.name, {}),
       );
       yield* Ref.get(conn.s2cPending).pipe(
         Effect.flatMap((m) =>
@@ -397,7 +405,7 @@ describe("sendRpcToClient — caller timeout", () => {
       );
 
       const fiber = yield* Effect.fork(
-        sendRpcToClient(conn, "apps/onJoin", { sessionId: "late" }),
+        sendRpcToClient(conn, AppsOnJoin.name, { sessionId: "late" }),
       );
 
       // Wait for the entry to be registered + the frame to be written.
@@ -457,7 +465,7 @@ describe("sendRpcToClient — caller timeout", () => {
       );
 
       const fiber = yield* Effect.fork(
-        sendRpcToClient(conn, "apps/onClose", {}),
+        sendRpcToClient(conn, AppsOnClose.name, {}),
       );
       yield* Ref.get(conn.s2cPending).pipe(
         Effect.flatMap((m) =>
@@ -508,7 +516,7 @@ describe("sendRpcToClient — caller timeout", () => {
         scope,
       );
 
-      const exit = yield* sendRpcToClient(conn, "apps/onJoin", {
+      const exit = yield* sendRpcToClient(conn, AppsOnJoin.name, {
         sessionId: "s",
       }).pipe(Effect.timeout(Duration.millis(50)), Effect.exit);
 

--- a/packages/server/src/ws/connection.ts
+++ b/packages/server/src/ws/connection.ts
@@ -233,17 +233,20 @@ export function sendRpcToClient(
       // both error tags are correct readings of the failure.
       () =>
         Effect.gen(function* () {
-          const writeOutcome = yield* Effect.either(connection.write(raw));
-          if (writeOutcome._tag === "Left") {
-            const err = new S2cRpcSocketError({
-              connectionId: connection.id,
-              method,
-              requestId,
-              cause: writeOutcome.left,
-            });
-            yield* Deferred.fail(deferred, err).pipe(Effect.ignore);
-            return yield* Effect.fail<S2cRpcError>(err);
-          }
+          yield* connection.write(raw).pipe(
+            Effect.catchAll((cause) => {
+              const err = new S2cRpcSocketError({
+                connectionId: connection.id,
+                method,
+                requestId,
+                cause,
+              });
+              return Deferred.fail(deferred, err).pipe(
+                Effect.ignore,
+                Effect.zipRight(Effect.fail<S2cRpcError>(err)),
+              );
+            }),
+          );
           return yield* Deferred.await(deferred);
         }),
       // release: remove the entry. Idempotent — `HashMap.remove` on an

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@moltzap/claude-code-channel':
         specifier: workspace:*
         version: link:../claude-code-channel
+      '@moltzap/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       effect:
         specifier: 3.21.0
         version: 3.21.0

--- a/scripts/sloppy-code-guard.sh
+++ b/scripts/sloppy-code-guard.sh
@@ -150,6 +150,110 @@ check legacy-define-method \
   'defineMethod<[^>]+>\(\{' \
   "Legacy defineMethod<T>({...}) — migrate to defineMethod(Manifest, { handler })"
 
+# RPC method names are defined once in packages/protocol/src/schema/methods/**.
+# All other code should reference the exported definition's `.name` so renames
+# and registry drift are caught by TypeScript instead of string search.
+matches=$(node <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const ts = require("typescript");
+
+const repo = process.cwd();
+const methodsDir = path.join(
+  repo,
+  "packages",
+  "protocol",
+  "src",
+  "schema",
+  "methods",
+);
+
+const methodByName = new Map();
+for (const entry of fs.readdirSync(methodsDir)) {
+  if (!entry.endsWith(".ts") || entry.endsWith(".test.ts")) continue;
+  const file = path.join(methodsDir, entry);
+  const text = fs.readFileSync(file, "utf8");
+  const pattern =
+    /export\s+const\s+([A-Za-z0-9_]+)\s*=\s*defineRpc\(\s*\{[\s\S]*?\bname:\s*"([^"]+)"/g;
+  for (const match of text.matchAll(pattern)) {
+    methodByName.set(match[2], match[1]);
+  }
+}
+
+function walk(dir, out) {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "dist" || entry.name === "node_modules") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+      out.push(full);
+    }
+  }
+}
+
+const files = [];
+walk(path.join(repo, "packages"), files);
+
+function isMethodDefinitionFile(file) {
+  return file.startsWith(methodsDir + path.sep);
+}
+
+for (const file of files) {
+  if (isMethodDefinitionFile(file)) continue;
+  const sourceText = fs.readFileSync(file, "utf8");
+  const source = ts.createSourceFile(
+    file,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const lineStarts = source.getLineStarts();
+  const lines = sourceText.split(/\r?\n/);
+
+  function report(node, methodName) {
+    const symbol = methodByName.get(methodName);
+    if (!symbol) return;
+    const pos = source.getLineAndCharacterOfPosition(node.getStart(source));
+    const lineNo = pos.line + 1;
+    const colNo = pos.character + 1;
+    const rel = path.relative(repo, file);
+    const lineText = lines[pos.line]?.trim() ?? "";
+    console.log(
+      `${rel}:${lineNo}:${colNo}: raw RPC method string ${JSON.stringify(
+        methodName,
+      )}; use ${symbol}.name :: ${lineText}`,
+    );
+  }
+
+  function visit(node) {
+    if (
+      ts.isStringLiteral(node) ||
+      ts.isNoSubstitutionTemplateLiteral(node)
+    ) {
+      report(node, node.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  void lineStarts;
+  visit(source);
+}
+NODE
+)
+matches=$(echo "$matches" | filter_pragma 'raw-rpc-method-string' | grep -v '^$' || true)
+if [ -n "$matches" ]; then
+  echo -e "${RED}[FAIL]${NC} [raw-rpc-method-string] Raw RPC method string detected — import the RpcDefinition from packages/protocol/src/schema/methods/** and use SomeRpc.name instead."
+  echo "$matches"
+  echo "    Opt out with: // $PRAGMA_TAG[raw-rpc-method-string]: <reason>"
+  echo ""
+  ERRORS=$((ERRORS + 1))
+fi
+
 # ============================================================
 # Effect Hygiene
 # ============================================================


### PR DESCRIPTION
## Summary
- enable the agent code guard backlog as a zero-warning ESLint pass and keep oxlint/format/typecheck clean
- replace broad ignored patterns with typed Effect/Data errors, constants, shared helpers, and protocol method constants
- add the sloppy-code guard for raw RPC method strings outside protocol method definitions
- fix a half-open WebSocket teardown path exposed by the full test run

Closes #403

## Verification
- pnpm format:check
- pnpm lint
- pnpm exec eslint packages/ --max-warnings 0
- pnpm typecheck
- pnpm -r test
- pnpm build (commit hook)
- bash scripts/sloppy-code-guard.sh