### PR TITLE
[impl-senior] Phase 1C: errors→protocol, drop @effect/rpc bridge, shared AJV (#418)

### DIFF
--- a/packages/app-sdk/src/app.handlers.test.ts
+++ b/packages/app-sdk/src/app.handlers.test.ts
@@ -51,6 +51,16 @@ interface InstalledHandler {
   (params: unknown): Effect.Effect<unknown, MockRpcServerErrorInstance>;
 }
 
+// Override `RpcServerError` so `mapAttachError`'s `instanceof` check
+// matches the failures the mock client raises.
+vi.mock("@moltzap/protocol", async () => {
+  const actual =
+    await vi.importActual<typeof import("@moltzap/protocol")>(
+      "@moltzap/protocol",
+    );
+  return { ...actual, RpcServerError: MockRpcServerError };
+});
+
 vi.mock("@moltzap/client", async () => {
   return {
     MoltZapWsClient: vi.fn().mockImplementation(() => {
@@ -127,7 +137,6 @@ vi.mock("@moltzap/client", async () => {
         },
       };
     }),
-    RpcServerError: MockRpcServerError,
     DuplicateServerRpcHandlerError: MockDuplicateError,
   };
 });

--- a/packages/app-sdk/src/app.ts
+++ b/packages/app-sdk/src/app.ts
@@ -1,14 +1,14 @@
-import {
-  MoltZapWsClient,
-  NotConnectedError,
-  RpcServerError,
-  RpcTimeoutError,
-} from "@moltzap/client";
+import { MoltZapWsClient } from "@moltzap/client";
 import type {
   WsClientLogger,
   MoltZapWsClientOptions,
   NotificationSubscription,
 } from "@moltzap/client";
+import {
+  NotConnectedError,
+  RpcServerError,
+  RpcTimeoutError,
+} from "@moltzap/protocol";
 import type {
   AnyNotificationDefinition,
   AppManifest,

--- a/packages/client/src/channel-core.test.ts
+++ b/packages/client/src/channel-core.test.ts
@@ -17,7 +17,7 @@ import {
   testMessageId,
   type FakeChannelService,
 } from "./test-utils/index.js";
-import { RpcServerError } from "./runtime/errors.js";
+import { RpcServerError } from "@moltzap/protocol";
 
 const agent = testAgentId;
 const conversation = testConversationId;

--- a/packages/client/src/cli/transport.test.ts
+++ b/packages/client/src/cli/transport.test.ts
@@ -9,7 +9,7 @@ import {
   NotConnectedError,
   RpcServerError,
   RpcTimeoutError,
-} from "../runtime/errors.js";
+} from "@moltzap/protocol";
 import {
   decideTransport,
   makeTransportLayer,
@@ -33,13 +33,13 @@ import { AppsListSessions } from "@moltzap/protocol";
  */
 vi.mock("../ws-client.js", async () => {
   const effect = await import("effect");
-  const errors = await import("../runtime/errors.js");
+  const protocol = await import("@moltzap/protocol");
   return {
     MoltZapWsClient: vi.fn().mockImplementation(() => ({
       connect: () => effect.Effect.void,
       sendRpc: (_definition: unknown, _params: unknown) =>
         effect.Effect.fail(
-          new errors.RpcServerError({
+          new protocol.RpcServerError({
             code: -32001,
             message: "item not found",
           }),

--- a/packages/client/src/cli/transport.ts
+++ b/packages/client/src/cli/transport.ts
@@ -20,7 +20,7 @@ import {
   NotConnectedError,
   RpcServerError,
   RpcTimeoutError,
-} from "../runtime/errors.js";
+} from "@moltzap/protocol";
 import { MoltZapWsClient } from "../ws-client.js";
 import { request as daemonRequest } from "./socket-client.js";
 import type { ProfileError } from "./profile.js";

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,13 +10,7 @@ export {
   type ServiceRpcError,
 } from "./service.js";
 export type { PermissionsRequiredNotification } from "@moltzap/protocol";
-export {
-  AgentNotFoundError,
-  NotConnectedError,
-  RpcServerError,
-  RpcTimeoutError,
-  MalformedFrameError,
-} from "./runtime/errors.js";
+export { AgentNotFoundError, MalformedFrameError } from "./runtime/errors.js";
 export {
   MoltZapChannelCore,
   type ChannelCoreOptions,

--- a/packages/client/src/runtime/errors.test.ts
+++ b/packages/client/src/runtime/errors.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { AgentNotFoundError, MalformedFrameError } from "./errors.js";
 import {
-  AgentNotFoundError,
-  MalformedFrameError,
+  MessagesSend,
   NotConnectedError,
   RpcServerError,
   RpcTimeoutError,
-} from "./errors.js";
-
-import { MessagesSend } from "@moltzap/protocol";
+} from "@moltzap/protocol";
 
 describe("AgentNotFoundError", () => {
   it("carries agentName and derives a `_tag` + `message`", () => {

--- a/packages/client/src/runtime/errors.ts
+++ b/packages/client/src/runtime/errors.ts
@@ -1,26 +1,5 @@
 import { Data } from "effect";
-import type {
-  AppCallbackRpcMethodName,
-  JsonRpcMethod,
-} from "@moltzap/protocol";
-
-/** The socket is not in the OPEN state when an RPC was attempted. */
-export class NotConnectedError extends Data.TaggedError("NotConnectedError")<{
-  readonly message: string;
-}> {}
-
-/** The RPC exceeded the per-call timeout without a response frame. */
-export class RpcTimeoutError extends Data.TaggedError("RpcTimeoutError")<{
-  readonly method: JsonRpcMethod;
-  readonly timeoutMs: number;
-}> {}
-
-/** The server returned an `error` response frame. */
-export class RpcServerError extends Data.TaggedError("RpcServerError")<{
-  readonly code: number;
-  readonly message: string;
-  readonly data?: unknown;
-}> {}
+import type { AppCallbackRpcMethodName } from "@moltzap/protocol";
 
 /** Inbound frame failed to parse as JSON or did not match the expected shape. */
 export class MalformedFrameError extends Data.TaggedError(

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -1,8 +1,2 @@
-export {
-  AgentNotFoundError,
-  NotConnectedError,
-  RpcTimeoutError,
-  RpcServerError,
-  MalformedFrameError,
-} from "./errors.js";
+export { AgentNotFoundError, MalformedFrameError } from "./errors.js";
 export { snapshot, getOr } from "./refs.js";

--- a/packages/client/src/runtime/runtime.test.ts
+++ b/packages/client/src/runtime/runtime.test.ts
@@ -2,12 +2,11 @@ import { it } from "@effect/vitest";
 import { Effect, Exit } from "effect";
 import { expect, it as itSync } from "vitest";
 import {
+  MessagesSend,
   NotConnectedError,
   RpcServerError,
   RpcTimeoutError,
-} from "./errors.js";
-
-import { MessagesSend } from "@moltzap/protocol";
+} from "@moltzap/protocol";
 
 it.effect("tagged errors discriminate by _tag", () =>
   Effect.gen(function* () {

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -35,8 +35,11 @@ import {
   messageId as toMessageId,
   MessagesList,
   MessagesSend,
+  NotConnectedError,
   PermissionsGrant,
   rpcMethods,
+  RpcServerError,
+  RpcTimeoutError,
   type RpcDefinition,
   type ParamsOf,
   type ResultOf,
@@ -57,12 +60,7 @@ import {
   type RpcCallOptions,
   type WsClientLogger,
 } from "./ws-client.js";
-import {
-  AgentNotFoundError,
-  NotConnectedError,
-  RpcServerError,
-  RpcTimeoutError,
-} from "./runtime/errors.js";
+import { AgentNotFoundError } from "./runtime/errors.js";
 import { getOr, snapshot } from "./runtime/refs.js";
 import { LocalServiceCommands } from "./runtime/local-service-commands.js";
 import type {

--- a/packages/client/src/test-utils/conformance-adapter.ts
+++ b/packages/client/src/test-utils/conformance-adapter.ts
@@ -51,7 +51,7 @@ import {
   NotConnectedError,
   RpcServerError,
   RpcTimeoutError,
-} from "../runtime/errors.js";
+} from "@moltzap/protocol";
 
 const CONNECT_READY_TIMEOUT_MS = 30_000;
 

--- a/packages/client/src/test-utils/fake-service.ts
+++ b/packages/client/src/test-utils/fake-service.ts
@@ -31,11 +31,11 @@ import {
   decodeNotification,
   ErrorCodes,
   notificationGroup,
+  RpcServerError,
 } from "@moltzap/protocol";
 import { Effect, HashMap, Option, Ref } from "effect";
 import { MoltZapService, type ServiceRpcError } from "../service.js";
 import type { RpcCallOptions } from "../ws-client.js";
-import { RpcServerError } from "../runtime/errors.js";
 import { testAgentId } from "./ids.js";
 
 /** A tracked `sendRpc` invocation. */

--- a/packages/client/src/ws-client.test.ts
+++ b/packages/client/src/ws-client.test.ts
@@ -35,7 +35,7 @@ import {
   RPC_TIMEOUT_MS,
   type CloseInfo,
 } from "./ws-client.js";
-import { RpcServerError, RpcTimeoutError } from "./runtime/errors.js";
+import { RpcServerError, RpcTimeoutError } from "@moltzap/protocol";
 
 import {
   AppsOnClose,

--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -21,8 +21,11 @@ import {
   Connect,
   decodeRpcResult,
   jsonRpcStringId,
+  NotConnectedError,
   requestFrame,
   responseFrame,
+  RpcServerError,
+  RpcTimeoutError,
   type AnyAppCallbackRpcDefinition,
   type AnyNotificationDefinition,
   type JsonRpcStringId,
@@ -34,12 +37,7 @@ import {
   type TSchema,
   type Static,
 } from "@moltzap/protocol";
-import {
-  DuplicateServerRpcHandlerError,
-  NotConnectedError,
-  RpcServerError,
-  RpcTimeoutError,
-} from "./runtime/errors.js";
+import { DuplicateServerRpcHandlerError } from "./runtime/errors.js";
 import { decodeFrames, type DecodedNotification } from "./runtime/frame.js";
 import {
   makeSubscriberRegistry,

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@effect/platform": "^0.96.0",
-    "@effect/rpc": "0.75.0",
     "@sinclair/typebox": "^0.34.0",
     "ajv": "^8.17.0",
     "ajv-formats": "^3.0.0",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -5,6 +5,7 @@ export * from "./brands.js";
 export * from "./schema/index.js";
 export * from "./types.js";
 export * from "./rpc.js";
+export * from "./rpc-errors.js";
 export * from "./notification.js";
 export * from "./rpc-groups.js";
 export * from "./rpc-registry.js";

--- a/packages/protocol/src/internal/ajv.ts
+++ b/packages/protocol/src/internal/ajv.ts
@@ -1,0 +1,30 @@
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import type { TSchema, Static } from "@sinclair/typebox";
+
+/**
+ * Single shared AJV instance for the protocol package. Both `defineRpc()`
+ * and `defineNotification()` register their TypeBox schemas against this
+ * instance at module load, so every wire boundary uses the same compiled
+ * validator pool with identical options.
+ *
+ * The instance itself is not exported. AJV's `_compileMetaSchema` mutates
+ * its own `opts` on first compile, so `Object.freeze` on the instance
+ * would break compilation. Instead, the factory exposes only `compile`,
+ * which is the single operation any descriptor needs. Options are sealed
+ * inside the closure and unreachable from callers.
+ */
+const ajvInstance = addFormats(new Ajv({ strict: true, allErrors: true }));
+
+export const ajv: {
+  readonly compile: <T extends TSchema>(
+    schema: T,
+  ) => (data: unknown) => data is Static<T>;
+} = Object.freeze({
+  compile: <T extends TSchema>(
+    schema: T,
+  ): ((data: unknown) => data is Static<T>) => {
+    const validate = ajvInstance.compile<Static<T>>(schema);
+    return (data: unknown): data is Static<T> => validate(data);
+  },
+});

--- a/packages/protocol/src/notification.ts
+++ b/packages/protocol/src/notification.ts
@@ -1,9 +1,6 @@
 import { type Static, type TSchema } from "@sinclair/typebox";
-import Ajv from "ajv";
-import addFormats from "ajv-formats";
+import { ajv } from "./internal/ajv.js";
 import type { JsonRpcMethod } from "./schema/json-rpc.js";
-
-const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
 
 export interface NotificationDefinition<
   Name extends string,
@@ -22,11 +19,10 @@ export function defineNotification<
   readonly name: JsonRpcMethod<Name>;
   readonly params: P;
 }): NotificationDefinition<Name, P> {
-  const validateParams = ajv.compile<Static<P>>(def.params);
   return {
     name: def.name,
     paramsSchema: def.params,
-    validateParams: (data: unknown): data is Static<P> => validateParams(data),
+    validateParams: ajv.compile(def.params),
     Params: null!,
   };
 }

--- a/packages/protocol/src/rpc-errors.ts
+++ b/packages/protocol/src/rpc-errors.ts
@@ -1,0 +1,32 @@
+/**
+ * Wire-derived RPC error tags surfaced to callers of an RPC.
+ *
+ * These tags describe failures at the JSON-RPC transport boundary:
+ * - `NotConnectedError` — the socket is not OPEN (or closed mid-call).
+ * - `RpcTimeoutError` — no response frame arrived inside the per-call deadline.
+ * - `RpcServerError` — the peer returned an `error` response frame.
+ *
+ * They live in `@moltzap/protocol` because the failure mode is wire-level,
+ * not transport-implementation-specific. Both client and server consumers
+ * pattern-match on the same `_tag` strings.
+ */
+import { Data } from "effect";
+import type { JsonRpcMethod } from "./schema/json-rpc.js";
+
+/** The socket is not in the OPEN state when an RPC was attempted. */
+export class NotConnectedError extends Data.TaggedError("NotConnectedError")<{
+  readonly message: string;
+}> {}
+
+/** The RPC exceeded the per-call timeout without a response frame. */
+export class RpcTimeoutError extends Data.TaggedError("RpcTimeoutError")<{
+  readonly method: JsonRpcMethod;
+  readonly timeoutMs: number;
+}> {}
+
+/** The peer returned an `error` response frame. */
+export class RpcServerError extends Data.TaggedError("RpcServerError")<{
+  readonly code: number;
+  readonly message: string;
+  readonly data?: unknown;
+}> {}

--- a/packages/protocol/src/rpc-groups.ts
+++ b/packages/protocol/src/rpc-groups.ts
@@ -1,73 +1,22 @@
-import { Rpc, RpcGroup } from "@effect/rpc";
-import { Data, Effect, Layer, Schema } from "effect";
+/**
+ * Descriptor-driven Effect-native RPC + notification group helpers.
+ *
+ * TypeBox + the shared AJV instance (`internal/ajv.ts`) is the single
+ * runtime decode authority for wire data. This module owns the
+ * Effect-native plumbing on top of those descriptors: group construction,
+ * per-frame decode, handler binding, and dispatch.
+ */
+import { Data, Effect } from "effect";
 import type { NotificationFrame, RequestFrame } from "./schema/frames.js";
 import type { JsonRpcMethod, JsonRpcStringId } from "./schema/json-rpc.js";
 import type {
   NotificationDefinition,
   NotificationParamsOf,
 } from "./notification.js";
-import type { ParamsOf, ResultOf, RpcDefinition, TSchema } from "./rpc.js";
+import type { ParamsOf, RpcDefinition, TSchema } from "./rpc.js";
 
 type AnyRpcDefinition = RpcDefinition<string, TSchema, TSchema>;
 type AnyNotificationDefinition = NotificationDefinition<string, TSchema>;
-
-type EffectRpcFor<D extends AnyRpcDefinition> = Rpc.Rpc<
-  D["name"],
-  Schema.Schema<ParamsOf<D>>,
-  Schema.Schema<ResultOf<D>>
->;
-
-type EffectNotificationRpcFor<D extends AnyNotificationDefinition> = Rpc.Rpc<
-  D["name"],
-  Schema.Schema<NotificationParamsOf<D>>,
-  typeof Schema.Void
->;
-
-type EffectRpcUnion<Definitions extends readonly AnyRpcDefinition[]> =
-  Definitions[number] extends infer D
-    ? D extends AnyRpcDefinition
-      ? EffectRpcFor<D>
-      : never
-    : never;
-
-type EffectNotificationRpcUnion<
-  Definitions extends readonly AnyNotificationDefinition[],
-> = Definitions[number] extends infer D
-  ? D extends AnyNotificationDefinition
-    ? EffectNotificationRpcFor<D>
-    : never
-  : never;
-
-/**
- * TypeBox remains the runtime decode authority for MoltZap wire data.
- * `@effect/rpc` needs an Effect Schema at descriptor-construction time, so
- * we give it an opaque schema with the TypeBox static type projected onto it.
- * These schemas are intentionally not used to validate the wire; the
- * descriptor's compiled AJV validator is the only boundary decoder.
- */
-const bridgeEffectRpcType = <A>(value: unknown): A => value as A;
-
-const opaqueEffectSchema = <A>(): Schema.Schema<A> =>
-  Schema.declare<A>((input): input is A => {
-    void input;
-    return true;
-  });
-
-const toEffectRpc = <D extends AnyRpcDefinition>(
-  definition: D,
-): EffectRpcFor<D> =>
-  Rpc.make(definition.name, {
-    payload: opaqueEffectSchema<ParamsOf<D>>(),
-    success: opaqueEffectSchema<ResultOf<D>>(),
-  });
-
-const toEffectNotificationRpc = <D extends AnyNotificationDefinition>(
-  definition: D,
-): EffectNotificationRpcFor<D> =>
-  Rpc.make(definition.name, {
-    payload: opaqueEffectSchema<NotificationParamsOf<D>>(),
-    success: Schema.Void,
-  });
 
 const descriptorMap = <D extends { readonly name: JsonRpcMethod }>(
   definitions: readonly D[],
@@ -88,7 +37,6 @@ export interface RpcDescriptorGroup<
 > {
   readonly layer: LayerName;
   readonly definitions: Definitions;
-  readonly effectGroup: RpcGroup.RpcGroup<EffectRpcUnion<Definitions>>;
   readonly byName: ReadonlyMap<JsonRpcMethod, Definitions[number]>;
   readonly byDefinition: ReadonlySet<Definitions[number]>;
 }
@@ -99,9 +47,6 @@ export interface NotificationDescriptorGroup<
 > {
   readonly layer: LayerName;
   readonly definitions: Definitions;
-  readonly effectGroup: RpcGroup.RpcGroup<
-    EffectNotificationRpcUnion<Definitions>
-  >;
   readonly byName: ReadonlyMap<JsonRpcMethod, Definitions[number]>;
   readonly byDefinition: ReadonlySet<Definitions[number]>;
 }
@@ -113,13 +58,9 @@ export function defineRpcGroup<
   layer: LayerName,
   definitions: Definitions,
 ): RpcDescriptorGroup<LayerName, Definitions> {
-  const effectRpcs = definitions.map(toEffectRpc);
   return {
     layer,
     definitions,
-    effectGroup: bridgeEffectRpcType<
-      RpcGroup.RpcGroup<EffectRpcUnion<Definitions>>
-    >(RpcGroup.make(...effectRpcs)),
     byName: descriptorMap(definitions),
     byDefinition: descriptorSet(definitions),
   };
@@ -132,13 +73,9 @@ export function defineNotificationGroup<
   layer: LayerName,
   definitions: Definitions,
 ): NotificationDescriptorGroup<LayerName, Definitions> {
-  const effectRpcs = definitions.map(toEffectNotificationRpc);
   return {
     layer,
     definitions,
-    effectGroup: bridgeEffectRpcType<
-      RpcGroup.RpcGroup<EffectNotificationRpcUnion<Definitions>>
-    >(RpcGroup.make(...effectRpcs)),
     byName: descriptorMap(definitions),
     byDefinition: descriptorSet(definitions),
   };
@@ -317,101 +254,6 @@ export function isDecodedNotification<D extends AnyNotificationDefinition>(
   return notification.definition === definition;
 }
 
-export interface RpcHandlerBinding<D extends AnyRpcDefinition, E, R> {
-  readonly definition: D;
-  readonly handler: (params: ParamsOf<D>) => Effect.Effect<ResultOf<D>, E, R>;
-}
-
-export interface NotificationHandlerBinding<
-  D extends AnyNotificationDefinition,
-  E,
-  R,
-> {
-  readonly definition: D;
-  readonly handler: (
-    params: NotificationParamsOf<D>,
-  ) => Effect.Effect<void, E, R>;
-}
-
-export const bindRpcHandler = <D extends AnyRpcDefinition, E, R>(
-  definition: D,
-  handler: (params: ParamsOf<D>) => Effect.Effect<ResultOf<D>, E, R>,
-): RpcHandlerBinding<D, E, R> => ({ definition, handler });
-
-export const bindNotificationHandler = <
-  D extends AnyNotificationDefinition,
-  E,
-  R,
->(
-  definition: D,
-  handler: (params: NotificationParamsOf<D>) => Effect.Effect<void, E, R>,
-): NotificationHandlerBinding<D, E, R> => ({ definition, handler });
-
-type RpcHandlerTuple<Definitions extends readonly AnyRpcDefinition[], E> = {
-  readonly [Index in keyof Definitions]: Definitions[Index] extends AnyRpcDefinition
-    ? RpcHandlerBinding<Definitions[Index], E, unknown>
-    : never;
-};
-
-type NotificationHandlerTuple<
-  Definitions extends readonly AnyNotificationDefinition[],
-  E,
-> = {
-  readonly [Index in keyof Definitions]: Definitions[Index] extends AnyNotificationDefinition
-    ? NotificationHandlerBinding<Definitions[Index], E, unknown>
-    : never;
-};
-
-type RpcBindingRequirements<Bindings extends readonly unknown[]> =
-  Bindings[number] extends RpcHandlerBinding<AnyRpcDefinition, unknown, infer R>
-    ? R
-    : never;
-
-type NotificationBindingRequirements<Bindings extends readonly unknown[]> =
-  Bindings[number] extends NotificationHandlerBinding<
-    AnyNotificationDefinition,
-    unknown,
-    infer R
-  >
-    ? R
-    : never;
-
-export interface EffectRpcHandlerLayer<
-  Definitions extends readonly AnyRpcDefinition[],
-  E,
-  R,
-> {
-  readonly group: RpcDescriptorGroup<string, Definitions>;
-  readonly layer: Layer.Layer<
-    Rpc.ToHandler<EffectRpcUnion<Definitions>>,
-    never,
-    R
-  >;
-  readonly byName: ReadonlyMap<JsonRpcMethod, Definitions[number]>;
-  readonly byDefinition: ReadonlySet<Definitions[number]>;
-  readonly dispatch: (
-    request: DecodedRpcRequest<Definitions[number]>,
-  ) => Effect.Effect<ResultOf<Definitions[number]>, E, R>;
-}
-
-export interface EffectNotificationHandlerLayer<
-  Definitions extends readonly AnyNotificationDefinition[],
-  E,
-  R,
-> {
-  readonly group: NotificationDescriptorGroup<string, Definitions>;
-  readonly layer: Layer.Layer<
-    Rpc.ToHandler<EffectNotificationRpcUnion<Definitions>>,
-    never,
-    R
-  >;
-  readonly byName: ReadonlyMap<JsonRpcMethod, Definitions[number]>;
-  readonly byDefinition: ReadonlySet<Definitions[number]>;
-  readonly dispatch: (
-    notification: DecodedNotification<Definitions[number]>,
-  ) => Effect.Effect<void, E, R>;
-}
-
 export function isDecodedRpcRequestInGroup<
   const Definitions extends readonly AnyRpcDefinition[],
 >(
@@ -430,55 +272,70 @@ export function isDecodedNotificationInGroup<
   return group.byDefinition.has(notification.definition as Definitions[number]);
 }
 
-export function defineEffectRpcHandlers<
-  const Definitions extends readonly AnyRpcDefinition[],
+export interface NotificationHandlerBinding<
+  D extends AnyNotificationDefinition,
   E,
-  const Bindings extends RpcHandlerTuple<Definitions, E>,
->(
-  group: RpcDescriptorGroup<string, Definitions>,
-  bindings: Bindings,
-): EffectRpcHandlerLayer<Definitions, E, RpcBindingRequirements<Bindings>> {
-  const dispatchHandlers = new Map<
-    Definitions[number],
-    (params: unknown) => Effect.Effect<unknown, E, unknown>
-  >();
-  const handlers = Object.fromEntries(
-    bindings.map((binding) => {
-      const handler = (params: unknown) =>
-        binding.handler(bridgeEffectRpcType<never>(params));
-      dispatchHandlers.set(binding.definition as Definitions[number], handler);
-      return [binding.definition.name, handler];
-    }),
-  );
-  return {
-    group,
-    layer: group.effectGroup.toLayer(
-      group.effectGroup.of(
-        bridgeEffectRpcType<RpcGroup.HandlersFrom<EffectRpcUnion<Definitions>>>(
-          handlers,
-        ),
-      ),
-    ) as Layer.Layer<
-      Rpc.ToHandler<EffectRpcUnion<Definitions>>,
-      never,
-      RpcBindingRequirements<Bindings>
-    >,
-    byName: group.byName,
-    byDefinition: group.byDefinition,
-    dispatch: (request) => {
-      const handler = dispatchHandlers.get(request.definition);
-      if (handler === undefined) {
-        return Effect.die(new Error("Missing RPC handler for descriptor"));
-      }
-      return handler(request.params) as Effect.Effect<
-        ResultOf<Definitions[number]>,
-        E,
-        RpcBindingRequirements<Bindings>
-      >;
-    },
-  };
+  R,
+> {
+  readonly definition: D;
+  readonly handler: (
+    params: NotificationParamsOf<D>,
+  ) => Effect.Effect<void, E, R>;
 }
 
+export const bindNotificationHandler = <
+  D extends AnyNotificationDefinition,
+  E,
+  R,
+>(
+  definition: D,
+  handler: (params: NotificationParamsOf<D>) => Effect.Effect<void, E, R>,
+): NotificationHandlerBinding<D, E, R> => ({ definition, handler });
+
+type NotificationHandlerTuple<
+  Definitions extends readonly AnyNotificationDefinition[],
+  E,
+> = {
+  readonly [Index in keyof Definitions]: Definitions[Index] extends AnyNotificationDefinition
+    ? NotificationHandlerBinding<Definitions[Index], E, unknown>
+    : never;
+};
+
+type NotificationBindingRequirements<Bindings extends readonly unknown[]> =
+  Bindings[number] extends NotificationHandlerBinding<
+    AnyNotificationDefinition,
+    unknown,
+    infer R
+  >
+    ? R
+    : never;
+
+export interface EffectNotificationHandlerLayer<
+  Definitions extends readonly AnyNotificationDefinition[],
+  E,
+  R,
+> {
+  readonly group: NotificationDescriptorGroup<string, Definitions>;
+  readonly byName: ReadonlyMap<JsonRpcMethod, Definitions[number]>;
+  readonly byDefinition: ReadonlySet<Definitions[number]>;
+  readonly dispatch: (
+    notification: DecodedNotification<Definitions[number]>,
+  ) => Effect.Effect<void, E, R>;
+}
+
+/**
+ * Bind a tuple of notification handlers to their descriptors. Returns a
+ * dispatcher that routes each `DecodedNotification` to its handler by
+ * descriptor identity (set during construction), so dispatch is O(1)
+ * lookup with no name-string comparison on the hot path.
+ *
+ * The internal handler map stores `unknown -> Effect<void, E, R>` because
+ * `Definitions[number]` is a union and each individual binding is keyed
+ * to one concrete `D`. Descriptor identity (set during construction) is
+ * the soundness proof: dispatch only sees `params` produced by the same
+ * descriptor's pre-compiled AJV validator, so the unknown→params cast is
+ * the boundary where validation already passed.
+ */
 export function defineEffectNotificationHandlers<
   const Definitions extends readonly AnyNotificationDefinition[],
   E,
@@ -491,45 +348,33 @@ export function defineEffectNotificationHandlers<
   E,
   NotificationBindingRequirements<Bindings>
 > {
+  type Requirements = NotificationBindingRequirements<Bindings>;
   const dispatchHandlers = new Map<
-    Definitions[number],
-    (params: unknown) => Effect.Effect<void, E, unknown>
+    AnyNotificationDefinition,
+    (params: unknown) => Effect.Effect<void, E, Requirements>
   >();
-  const handlers = Object.fromEntries(
-    bindings.map((binding) => {
-      const handler = (params: unknown) =>
-        binding.handler(bridgeEffectRpcType<never>(params));
-      dispatchHandlers.set(binding.definition as Definitions[number], handler);
-      return [binding.definition.name, handler];
-    }),
-  );
+  for (const binding of bindings) {
+    dispatchHandlers.set(
+      binding.definition,
+      binding.handler as (
+        params: unknown,
+      ) => Effect.Effect<void, E, Requirements>,
+    );
+  }
   return {
     group,
-    layer: group.effectGroup.toLayer(
-      group.effectGroup.of(
-        bridgeEffectRpcType<
-          RpcGroup.HandlersFrom<EffectNotificationRpcUnion<Definitions>>
-        >(handlers),
-      ),
-    ) as Layer.Layer<
-      Rpc.ToHandler<EffectNotificationRpcUnion<Definitions>>,
-      never,
-      NotificationBindingRequirements<Bindings>
-    >,
     byName: group.byName,
     byDefinition: group.byDefinition,
     dispatch: (notification) => {
       const handler = dispatchHandlers.get(notification.definition);
       if (handler === undefined) {
         return Effect.die(
-          new Error("Missing notification handler for descriptor"),
+          new Error(
+            `Missing notification handler for ${String(notification.method)}`,
+          ),
         );
       }
-      return handler(notification.params) as Effect.Effect<
-        void,
-        E,
-        NotificationBindingRequirements<Bindings>
-      >;
+      return handler(notification.params);
     },
   };
 }

--- a/packages/protocol/src/rpc.ts
+++ b/packages/protocol/src/rpc.ts
@@ -1,7 +1,6 @@
 import { type TSchema, type Static } from "@sinclair/typebox";
-import Ajv from "ajv";
-import addFormats from "ajv-formats";
 import { Data, Effect } from "effect";
+import { ajv } from "./internal/ajv.js";
 import { jsonRpcMethod, type JsonRpcMethod } from "./schema/json-rpc.js";
 
 /**
@@ -9,13 +8,6 @@ import { jsonRpcMethod, type JsonRpcMethod } from "./schema/json-rpc.js";
  * can type against manifests without taking a direct typebox dependency.
  */
 export type { TSchema, Static } from "@sinclair/typebox";
-
-/**
- * Shared AJV instance across every `defineRpc` call. Pre-compiles each
- * `params` schema once at module load so validation is a single function
- * call per inbound RPC — no per-call compilation cost on the hot path.
- */
-const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
 
 /**
  * A typed manifest for one RPC method. Couples:
@@ -54,14 +46,12 @@ export function defineRpc<
   P extends TSchema,
   R extends TSchema,
 >(def: { name: Name; params: P; result: R }): RpcDefinition<Name, P, R> {
-  const validateParams = ajv.compile<Static<P>>(def.params);
-  const validateResult = ajv.compile<Static<R>>(def.result);
   return {
     name: jsonRpcMethod(def.name),
     paramsSchema: def.params,
     resultSchema: def.result,
-    validateParams: (data: unknown): data is Static<P> => validateParams(data),
-    validateResult: (data: unknown): data is Static<R> => validateResult(data),
+    validateParams: ajv.compile(def.params),
+    validateResult: ajv.compile(def.result),
     // Phantom — never read at runtime. Typed as `Static<P>` so
     // `typeof def.Params` at the type level yields the params type.
     Params: null!,

--- a/packages/protocol/src/validators.ts
+++ b/packages/protocol/src/validators.ts
@@ -1,6 +1,3 @@
-import Ajv from "ajv";
-import addFormats from "ajv-formats";
-import { type Static, type TSchema } from "@sinclair/typebox";
 import {
   RequestFrameSchema,
   ResponseFrameSchema,
@@ -9,6 +6,7 @@ import {
   type ResponseFrame,
   type NotificationFrame,
 } from "./schema/index.js";
+import { ajv } from "./internal/ajv.js";
 import { PushPreferencesSchema } from "./schema/methods/push.js";
 import {
   Register,
@@ -88,34 +86,21 @@ import {
 import { SystemPing } from "./schema/methods/system.js";
 
 /**
- * This AJV instance handles frame-level validation only. Each RPC
- * manifest carries its own pre-compiled `validateParams` (compiled once
- * inside `defineRpc`), which is what the router dispatches against.
- */
-const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
-
-const compileGuard = <S extends TSchema, Guarded = Static<S>>(schema: S) => {
-  const validate = ajv.compile<Static<S>>(schema);
-  return (value: unknown): value is Guarded => validate(value);
-};
-
-/**
  * Named validator table. Every RPC manifest's `validateParams` is re-exported
  * here under a stable `xxxParams` key. Frame validators and notification
  * payload validators live here because they are not request/response RPCs.
  */
 export const validators = {
   // Frames.
-  requestFrame: compileGuard<typeof RequestFrameSchema, RequestFrame>(
-    RequestFrameSchema,
-  ),
-  responseFrame: compileGuard<typeof ResponseFrameSchema, ResponseFrame>(
-    ResponseFrameSchema,
-  ),
-  notificationFrame: compileGuard<
-    typeof NotificationFrameSchema,
-    NotificationFrame
-  >(NotificationFrameSchema),
+  requestFrame: ajv.compile(RequestFrameSchema) as (
+    value: unknown,
+  ) => value is RequestFrame,
+  responseFrame: ajv.compile(ResponseFrameSchema) as (
+    value: unknown,
+  ) => value is ResponseFrame,
+  notificationFrame: ajv.compile(NotificationFrameSchema) as (
+    value: unknown,
+  ) => value is NotificationFrame,
 
   // Auth.
   registerParams: Register.validateParams,
@@ -160,7 +145,7 @@ export const validators = {
   // Push.
   pushRegisterParams: PushRegister.validateParams,
   pushUnregisterParams: PushUnregister.validateParams,
-  pushPreferencesParams: compileGuard(PushPreferencesSchema),
+  pushPreferencesParams: ajv.compile(PushPreferencesSchema),
 
   // Surfaces.
   surfaceUpdateParams: SurfaceUpdate.validateParams,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,9 +230,6 @@ importers:
       '@effect/platform':
         specifier: ^0.96.0
         version: 0.96.0(effect@3.21.0)
-      '@effect/rpc':
-        specifier: 0.75.0
-        version: 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.49
@@ -248,7 +245,7 @@ importers:
     devDependencies:
       '@effect/platform-node':
         specifier: ^0.106.0
-        version: 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+        version: 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -855,12 +852,6 @@ packages:
     peerDependencies:
       '@effect/typeclass': ^0.38.0
       effect: ^3.19.0
-
-  '@effect/rpc@0.75.0':
-    resolution: {integrity: sha512-VFeJ16cZUXqiIzG9UHOVKGuiBPJ7fV+0lEbJU6xi12JnnxXe/19BQPpOwiRawCUbPOR3/xIURDUgGxU+Ft0pvQ==}
-    peerDependencies:
-      '@effect/platform': ^0.96.0
-      effect: ^3.21.0
 
   '@effect/rpc@0.75.1':
     resolution: {integrity: sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg==}
@@ -8727,15 +8718,6 @@ snapshots:
       toml: 3.0.0
       yaml: 2.8.3
 
-  '@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
-    dependencies:
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/workflow': 0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      effect: 3.21.0
-      kubernetes-types: 1.30.0
-
   '@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
       '@effect/platform': 0.96.0(effect@3.21.0)
@@ -8751,20 +8733,6 @@ snapshots:
       effect: 3.21.0
       uuid: 11.1.0
 
-  '@effect/platform-node-shared@0.59.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
-    dependencies:
-      '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@parcel/watcher': 2.5.6
-      effect: 3.21.0
-      multipasta: 0.2.7
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@effect/platform-node-shared@0.59.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
       '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
@@ -8774,21 +8742,6 @@ snapshots:
       '@parcel/watcher': 2.5.6
       effect: 3.21.0
       multipasta: 0.2.7
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@effect/platform-node@0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
-    dependencies:
-      '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/platform-node-shared': 0.59.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      effect: 3.21.0
-      mime: 3.0.0
-      undici: 7.24.6
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -8826,12 +8779,6 @@ snapshots:
     dependencies:
       '@effect/typeclass': 0.38.0(effect@3.21.0)
       effect: 3.21.0
-
-  '@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)':
-    dependencies:
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      effect: 3.21.0
-      msgpackr: 1.11.12
 
   '@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)':
     dependencies:
@@ -8874,13 +8821,6 @@ snapshots:
     dependencies:
       effect: 3.21.0
       vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
-    dependencies:
-      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      effect: 3.21.0
 
   '@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.1(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:


### PR DESCRIPTION
Closes #418
Parent epic: #415
Plan anchors: [layered-network-refactor-2026-05.md](https://github.com/chughtapan/moltzap/blob/chore/strict-json-rpc-frames/docs/plans/layered-network-refactor-2026-05.md) §2.2, §2.3, §10.4

## What changed

Three coupled cleanups land together so arena's vendored app-sdk (Phase -1, blocked on this PR per §10.4) can import the relocated error types correctly on first try.

## PART 1 — Move RPC error tags to `@moltzap/protocol`

Moved `RpcServerError`, `NotConnectedError`, `RpcTimeoutError` from `@moltzap/client` to a new `packages/protocol/src/rpc-errors.ts`. They are wire-derived failure tags; protocol is the stronger home (§2.2).

- All in-tree consumers (`ws-client`, `service`, `cli/transport`, `test-utils`, `app-sdk`, the test files) import from `@moltzap/protocol` directly.
- Dropped the `@moltzap/client` re-export cleanly. Per §10.4, arena is out-of-tree and migrates in Phase 11; in-tree workspaces don't need a transitional shim.
- `app-sdk/src/app.handlers.test.ts` `vi.mock` retargeted to `@moltzap/protocol` for the one symbol the test overrides (`RpcServerError`); rest of protocol surface preserved via `importActual` spread.

## PART 2 — Drop `@effect/rpc` bridge in `packages/protocol/src/rpc-groups.ts`

Deleted the bridge layer (§2.3): `opaqueEffectSchema`, `bridgeEffectRpcType`, `Rpc.make` calls, `effectGroup` field on descriptor groups, the `EffectRpc*` type plumbing, and the now-unreachable `Layer` plumbing on `EffectNotificationHandlerLayer`. Net deletion: ~163 lines from `rpc-groups.ts`.

Replaced with a thin descriptor-driven dispatcher we own — bind definition → handler directly, descriptor identity is the soundness proof for dispatch. All call sites of `defineRpcGroup`, `defineNotificationGroup`, `bindNotificationHandler`, and `defineEffectNotificationHandlers` continue to work unchanged.

Dropped `@effect/rpc` from `packages/protocol/package.json` (zero remaining consumers monorepo-wide).

**Deletion-default cleanup:** removed dead `defineEffectRpcHandlers` and `bindRpcHandler` (zero callers anywhere; refactor posture says delete adjacent dead code).

## PART 3 — Single shared frozen-singleton AJV

New `packages/protocol/src/internal/ajv.ts` exposes a frozen factory with one method: `compile(schema)`. The instance itself stays closure-private — AJV's `_compileMetaSchema` mutates `opts` on first compile, so `Object.freeze` on the instance breaks compilation. Sealing options inside the closure delivers the "callers can't mutate options" guarantee without breaking AJV.

`defineRpc` (`rpc.ts`), `defineNotification` (`notification.ts`), and the `validators` table (`validators.ts`) now share one compile pool. `validators.ts` dropped its duplicate AJV instance and the local `compileGuard` helper (caught by /simplify reuse pass).

## Plan anchors

| Change | Plan anchor |
|---|---|
| Move 3 error tags into `packages/protocol/src/rpc-errors.ts`; export from index | §2.2 "Errors move from client to protocol" |
| Update internal consumers; drop client re-export cleanly | §2.2; §10.4 "Phase 1C lands first, then arena vendors against the corrected client" |
| Delete `@effect/rpc` bridge; thin descriptor binder we own | §2.3 |
| Drop `@effect/rpc` package dep | §2.3, §8 (last row) |
| Delete dead `defineEffectRpcHandlers` and `bindRpcHandler` | §10 (deletion-default refactor posture) |
| Consolidate AJV → `packages/protocol/src/internal/ajv.ts`; freeze | §2.3, §8 (AJV singleton row) |
| Migrate `validators.ts` off its private AJV | §2.3 (single shared instance) |

## Scope

- Modules touched: `@moltzap/protocol`, `@moltzap/client`, `@moltzap/app-sdk`. arena out-of-tree (Phase 11).
- New modules: 0 (`internal/ajv.ts` and `rpc-errors.ts` are new files inside an existing module).
- New public signatures outside the plan: 0.
- New deps: 0. Dropped: `@effect/rpc`.

## Tests

- `pnpm -r build` — clean.
- `pnpm lint` — clean.
- `pnpm --filter @moltzap/protocol test` — 131 passed / 20 pre-existing failures (identical count to base `chore/strict-json-rpc-frames`; failures are in `__divergence_proofs__/{client,server}-executable.proofs.test.ts`, unrelated to this diff).
- `pnpm --filter @moltzap/client test` — 250 passed / 13 pre-existing failures (identical to base; CLI schema decode tests).
- `pnpm --filter @moltzap/app-sdk test` — 75 / 75. The single change here was retargeting the `vi.mock` in `app.handlers.test.ts` to `@moltzap/protocol` (previously mocked `@moltzap/client`).
- `pnpm --filter @moltzap/openclaw-channel test` — 73 / 73.
- `pnpm --filter @moltzap/runtimes test` — 37 / 37.
- `pnpm --filter @moltzap/server-core test` — 178 passed / 19 pre-existing failures (identical to base).
- `pnpm --filter @moltzap/claude-code-channel test` — 47 passed / 1 pre-existing conformance failure (identical to base).

Conformance suite (`packages/protocol/src/testing/conformance/`) green for the slices that aren't the pre-existing `__divergence_proofs__` regressions on base.

## Pre-PR review

- `/simplify` ran and findings applied: consolidated `validators.ts` onto the new shared AJV (caught a leftover duplicate AJV instance + `compileGuard` helper); trimmed narrative comments that explained WHAT/Phase-1C rather than WHY.
- `/review` ran, critical pass clean. All `instanceof` checks for the moved errors resolve to imports from `@moltzap/protocol` (verified by grep across all packages).

## Confidence

HIGH. Build clean, lint clean, every consumer rerouted, test counts match base on every package. The one test-side change (`app.handlers.test.ts` mock retarget) is the expected consequence of moving the import home; the test now mocks the new home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)