### PR TITLE
[impl-senior] Phase 2: drop legacy flat-barrel UserId/AgentId/MessageId/ConversationId schema-values (#420)

### DIFF
--- a/packages/claude-code-channel/src/types.ts
+++ b/packages/claude-code-channel/src/types.ts
@@ -11,14 +11,16 @@
 import { Brand, type Effect } from "effect";
 import type { EnrichedInboundMessage, WsClientLogger } from "@moltzap/client";
 import {
-  AgentId as AgentIdSchema,
-  ConversationId as ConversationIdSchema,
-  MessageId as MessageIdSchema,
   agentId,
   conversationId,
   messageId,
   type Static,
 } from "@moltzap/protocol";
+import {
+  AgentId as AgentIdSchema,
+  ConversationId as ConversationIdSchema,
+  MessageId as MessageIdSchema,
+} from "@moltzap/protocol/schemas/primitives";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { AllowlistError, PushError } from "./errors.js";
 

--- a/packages/client/src/test-utils/ids.ts
+++ b/packages/client/src/test-utils/ids.ts
@@ -1,12 +1,14 @@
 import {
-  AgentId as AgentIdSchema,
-  ConversationId as ConversationIdSchema,
-  MessageId as MessageIdSchema,
   agentId,
   conversationId,
   messageId,
   type Static,
 } from "@moltzap/protocol";
+import {
+  AgentId as AgentIdSchema,
+  ConversationId as ConversationIdSchema,
+  MessageId as MessageIdSchema,
+} from "@moltzap/protocol/schemas/primitives";
 
 type AgentId = Static<typeof AgentIdSchema>;
 type ConversationId = Static<typeof ConversationIdSchema>;

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -22,6 +22,10 @@
       "types": "./dist/schema/index.d.ts",
       "import": "./dist/schema/index.js"
     },
+    "./schemas/primitives": {
+      "types": "./dist/schema/primitives.d.ts",
+      "import": "./dist/schema/primitives.js"
+    },
     "./testing": {
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js"

--- a/packages/protocol/src/schema/index.ts
+++ b/packages/protocol/src/schema/index.ts
@@ -1,8 +1,9 @@
+// `UserId`, `AgentId`, `ConversationId`, `MessageId` are intentionally NOT
+// re-exported here. The flat barrel and the `./schemas` subpath would shadow
+// the actor-model brand types (Phase 3 Slice F) that own those names.
+// Consumers needing the TypeBox schema values import directly from
+// `@moltzap/protocol/schemas/primitives`. See plan §2.10 / #420.
 export {
-  UserId,
-  AgentId,
-  ConversationId,
-  MessageId,
   ContactId,
   userId,
   agentId,

--- a/packages/server/src/app/hooks.ts
+++ b/packages/server/src/app/hooks.ts
@@ -1,5 +1,5 @@
 import type { LogicalClock, Part, Static } from "@moltzap/protocol";
-import { MessageId } from "@moltzap/protocol";
+import { MessageId } from "@moltzap/protocol/schemas/primitives";
 import { Schema } from "effect";
 
 type MessageIdValue = Static<typeof MessageId>;

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -2,10 +2,7 @@ import type { Kysely } from "kysely";
 import { Brand, type Effect, type Layer } from "effect";
 import type { RpcMethodBinding } from "../rpc/context.js";
 import {
-  AgentId as AgentIdSchema,
   AppSessionId as AppSessionIdSchema,
-  ConversationId as ConversationIdSchema,
-  UserId as UserIdSchema,
   agentId as makeAgentId,
   appSessionId as makeAppSessionId,
   conversationId as makeConversationId,
@@ -14,6 +11,11 @@ import {
   type AppSession,
   type Static,
 } from "@moltzap/protocol";
+import {
+  AgentId as AgentIdSchema,
+  ConversationId as ConversationIdSchema,
+  UserId as UserIdSchema,
+} from "@moltzap/protocol/schemas/primitives";
 import type { Database } from "../db/database.js";
 import type { ContactService } from "./app-host.js";
 import type { RpcFailure } from "../runtime/index.js";


### PR DESCRIPTION
Closes #420
Parent epic: #415
Plan: [layered-network-refactor-2026-05.md](https://github.com/chughtapan/moltzap/blob/main/docs/plans/layered-network-refactor-2026-05.md) — §2.10 Slice F gate, §3 Phase 2

## What changed

Phase 2 of the layered network refactor (#161 cleanup). The protocol's flat barrel and `./schemas` subpath stop re-exporting four legacy TypeBox schema-values (`UserId`, `AgentId`, `ConversationId`, `MessageId`) so Phase 3's actor-model brand types own those names cleanly. A new `./schemas/primitives` subpath becomes the canonical home for TypeBox schema-value imports. Four internal consumers migrate to the subpath.

Arena is **not** modified — that's Phase 11.

## Plan anchors

| Change | Plan anchor |
|---|---|
| `packages/protocol/package.json` — add `./schemas/primitives` exports entry | §3 Phase 2 "migrate consumers to subpath imports"; #420 acceptance: "import from subpath e.g. `@moltzap/protocol/schemas/primitives`" |
| `packages/protocol/src/schema/index.ts` — drop the four schema-values from the explicit re-export; add load-bearing comment | §2.10 Slice F gate ("Drop legacy TypeBox UserId/AgentId/MessageId/ConversationId schema-value exports from flat barrel and `./schemas` subpath"); #420 |
| `packages/server/src/app/types.ts` — three schema imports → subpath | §3 Phase 2 |
| `packages/server/src/app/hooks.ts` — `MessageId` import → subpath | §3 Phase 2 |
| `packages/claude-code-channel/src/types.ts` — three schema imports → subpath | §3 Phase 2 |
| `packages/client/src/test-utils/ids.ts` — three schema imports → subpath | §3 Phase 2 |

## Consumers migrated (4 files across 3 packages)

- **`@moltzap/protocol`** — schema/index.ts re-export pruned; package.json subpath added
- **`@moltzap/server-core`** — `src/app/types.ts`, `src/app/hooks.ts`
- **`@moltzap/claude-code-channel`** — `src/types.ts`
- **`@moltzap/client`** — `src/test-utils/ids.ts`

The lowercase factories (`userId`, `agentId`, `conversationId`, `messageId`) and `ContactId`/`InviteToken` remain on the flat barrel + `./schemas` per the plan — only the four uppercase TypeBox schema-values move, since those are the ones that collide with Phase 3 Slice F's brand types.

## Acceptance verification (per #420 + #161)

```
$ rg "(UserId|AgentId|MessageId|ConversationId)" packages/protocol/src/index.ts packages/protocol/src/schema/index.ts
packages/protocol/src/schema/index.ts:1:// `UserId`, `AgentId`, `ConversationId`, `MessageId` are intentionally NOT
# (only the load-bearing comment remains; no exports leak)

$ rg -U '\{[^}]*(\bUserId\b|\bAgentId\b|\bMessageId\b|\bConversationId\b)[^}]*\}\s*from\s*"@moltzap/protocol"' packages/ --type ts
# (zero hits — no consumer imports these names from the bare flat barrel)

$ rg -U '\{[^}]*(\bUserId\b|\bAgentId\b|\bMessageId\b|\bConversationId\b)[^}]*\}\s*from\s*"@moltzap/protocol/schemas"' packages/ --type ts
# (zero hits — no consumer imports from the ./schemas subpath either)
```

Slice F (Phase 3) negative-canary safety net is preserved: those four names are unreachable from `@moltzap/protocol` and `@moltzap/protocol/schemas` after this PR.

## Scope

- Modules touched: `@moltzap/protocol`, `@moltzap/server-core`, `@moltzap/client`, `@moltzap/claude-code-channel`
- Tier (`safer-diff-scope --base origin/main`): **senior** (6 files / 4 modules / 0 new public surface in code; one new package.json subpath authorized by plan §3 Phase 2)
- New modules: 0
- New public signatures outside the plan: 0 (the `./schemas/primitives` subpath is named in #420 acceptance)
- New deps: 0
- LOC: 25 insertions / 14 deletions

## Tests

- `pnpm typecheck` — clean
- `pnpm lint` — `Found 0 warnings and 0 errors.` (eslint) + `Finished in 52ms on 369 files with 101 rules using 8 threads.` (oxlint)
- `pnpm format:check` — clean (after `pnpm format`)
- `bash packages/protocol/scripts/check-divergence-proofs.sh` — `OK (26 suite registrars proof-required, 28 legacy exemptions, no skipped placeholders)`
- `pnpm test` — all packages green:
  - `protocol: 11 files / 141 tests`
  - `server: 23 files / 177 tests`
  - `client: 21 files / 250 passed (+ 6 todo)`
  - `app-sdk: 5 files / 72 tests`
  - `claude-code-channel: 2 files / 47 tests`
  - `nanoclaw-channel: 1 file / 19 tests`
  - `openclaw-channel: 7 files / 73 tests`
  - `runtimes: 3 files / 37 tests`
- `pnpm -r --filter @moltzap/server-core --filter @moltzap/client --filter @moltzap/openclaw-channel --filter @moltzap/claude-code-channel run test:integration` — green:
  - `server: 32 files / 141 tests`
  - `client: 1 file / 40 tests`
  - `claude-code-channel: 1 file / 5 tests`
  - `openclaw-channel: 1 file / 5 tests (2 skipped)`
- `pnpm --filter @moltzap/runtimes run test:integration` — `claude-code-adapter.integration.test.ts` fails with `Error: claude native binary not installed.` This is a **pre-existing environmental failure** (verified by `git stash`-and-rerun on the unmodified main); unrelated to this diff.

## Pre-PR hygiene

- **`/simplify`** — applied. Three findings, all skipped with rationale:
  - F1 "collapse split imports" — skip: `Static` lives in `rpc.ts`, not `primitives.ts`, so each consumer still needs two import sources. No actual reduction.
  - F2 "`./schemas` (plural) vs `./schema/...` (singular) source-path asymmetry" — skip: pre-existing convention on main; renaming the existing `./schemas` subpath is architect-tier scope expansion. New entry follows the existing pattern.
  - F3 "5-line comment in `schema/index.ts`" — confirmed load-bearing (warns the next contributor against re-introducing the four exports and re-creating the Phase 3 Slice F shadow collision). Keep.
- **`/review`** — clean. 0 critical findings, 0 informational findings. PR Quality Score: **10/10**. Specialists auto-gated (39-line diff < 50). Inline adversarial pass clean (Codex structured-review threshold is 200 LOC).

## Confidence

**HIGH** — Acceptance grep returns zero hits on both surfaces. Typecheck/lint/format/test gates all green across every internal package. The `./schemas/primitives` subpath wiring is verified by the consumers' typecheck (resolution must work for `tsc --noEmit` to pass). Phase 3's negative-canary safety net is intact.

`/safer:review-senior` is mandatory before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)