### PR TITLE
[impl-junior] env: bin/setup-worktree.sh + pnpm.onlyBuiltDependencies (#439)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ pnpm typecheck                # tsc across all packages
 pnpm dev                      # dev server (packages/server)
 ```
 
+### Fresh `git worktree add` checkout
+
+A new worktree starts with no `node_modules/` and no built `dist/`, and pnpm 10 blocks the `@anthropic-ai/claude-code` postinstall by default. Run the bootstrap once:
+
+```bash
+bin/setup-worktree.sh
+```
+
+This wraps `pnpm install` + `pnpm -r build` and is idempotent. The root `package.json` `pnpm.onlyBuiltDependencies` field whitelists `@anthropic-ai/claude-code` so its `install.cjs` runs during install — `packages/runtimes` integration tests need the resolved native binary.
+
 ## Documentation
 
 [docs.moltzap.xyz](https://docs.moltzap.xyz) or `pnpm docs` for local preview.

--- a/bin/setup-worktree.sh
+++ b/bin/setup-worktree.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# bin/setup-worktree.sh — bootstrap a fresh `git worktree add` checkout
+#
+# Why this exists:
+#   `git worktree add` produces a clean filesystem checkout with no
+#   `node_modules/` and no built `dist/`. Every dispatched teammate working in
+#   a fresh worktree needs the same three steps before any `pnpm` command
+#   resolves: install, build, native postinstall. Per-dispatch handling
+#   recurred ~5x during epic #415; this script collapses it to one line.
+#
+# What it does (idempotent — safe to re-run):
+#   1. `pnpm install`
+#        Populates per-package `node_modules/` from the shared pnpm store.
+#        With root `package.json` -> `pnpm.onlyBuiltDependencies`, this also
+#        runs `@anthropic-ai/claude-code`'s postinstall (`install.cjs`),
+#        which downloads the platform-native `bin/claude.exe` (~245MB) used
+#        by `packages/runtimes` integration tests.
+#   2. `pnpm -r build`
+#        Builds every workspace package's `dist/`. Required because:
+#          - `@moltzap/protocol`'s `exports` map points at `./dist/...` —
+#            consumers cannot resolve subpaths (`/schemas`, `/testing`,
+#            `/schemas/primitives`) until the dist tree exists.
+#          - `@moltzap/client`'s `bin` entry points at
+#            `dist/cli/index.js` — pnpm warns at install time when this is
+#            missing.
+#
+# Usage:
+#   git worktree add ../moltzap-feature -b feature origin/main
+#   cd ../moltzap-feature
+#   bin/setup-worktree.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "==> pnpm install (root: $ROOT)"
+pnpm install
+
+echo "==> pnpm -r build"
+pnpm -r build
+
+echo
+echo "Worktree ready. node_modules populated, dist/ built, claude-code binary resolved."

--- a/package.json
+++ b/package.json
@@ -34,5 +34,10 @@
     "oxfmt": "^0.7.0",
     "oxlint": "^0.16.0",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@anthropic-ai/claude-code"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Closes #439. Mechanical fix for three recurring env-friction issues that hit ~5 dispatched teammates in fresh `git worktree add` checkouts during epic #415.

- Root `package.json` adds `pnpm.onlyBuiltDependencies: ["@anthropic-ai/claude-code"]`. pnpm 10's default blocks postinstall scripts; this whitelist lets `install.cjs` run during `pnpm install`, replacing the placeholder `bin/claude.exe` (~5KB) with the resolved native binary (~245MB) that `packages/runtimes` integration tests need.
- New `bin/setup-worktree.sh` runs `pnpm install && pnpm -r build`. Idempotent. Replaces the three-step manual workaround dispatched teammates kept reinventing.
- README.md "Development" section names the script and explains why a fresh worktree needs it.

## Root cause (per #439 investigation)

| # | Root cause | File:line |
|---|---|---|
| 1 | `@moltzap/protocol`'s `exports` map points at `./dist/*` (`packages/protocol/package.json:14-32`); fresh worktrees have no `dist/` until `pnpm -r build` runs. Consumers fail with `Cannot find module '@moltzap/protocol/{testing,schemas,schemas/primitives}'`. | `packages/protocol/package.json:14-32` |
| 2 | `git worktree add` produces a clean checkout with no `node_modules/`. Confirmed: `ls node_modules/` returns ENOENT before `pnpm install`. | n/a (git worktree behavior) |
| 3 | pnpm 10 defaults to `onlyBuiltDependencies=[]` (security hardening: PR pnpm/pnpm#7953), blocking postinstall scripts unless explicitly whitelisted. `pnpm install` warns: `Ignored build scripts: @anthropic-ai/claude-code, …`. The package's `postinstall: "node install.cjs"` (`node_modules/@anthropic-ai/claude-code/package.json` ships a placeholder `bin/claude.exe`) never runs. | root `package.json` (no `pnpm.onlyBuiltDependencies` field) |

## Verified

```
rm -rf node_modules packages/*/node_modules packages/*/dist
bin/setup-worktree.sh
# → pnpm install (no @anthropic-ai/claude-code in "Ignored" warning)
# → pnpm -r build (all 9 workspaces green)
# → bin/claude.exe resolved to 245MB native binary
pnpm typecheck   # clean exit 0
```

## Test plan

- [ ] Reviewer: `git worktree add /tmp/moltzap-verify junior/439-env-hardening && cd /tmp/moltzap-verify && bin/setup-worktree.sh && pnpm typecheck`
- [ ] Confirm `node_modules/<pkg>/node_modules/@anthropic-ai/claude-code/bin/claude.exe` is ~245MB (not 5KB placeholder)
- [ ] Future dispatch prompts (epic #415 phases 3–11) can reference `bin/setup-worktree.sh` as the single setup step

## Out of scope

- Refactoring pnpm workspace structure
- Building protocol via a `prepare` script (would slow every install; the wrapper approach is cheaper and explicit)
- CI changes (CI already runs `pnpm install` + `pnpm -r build`; this fix targets local worktree dispatches only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)