### PR TITLE
[impl-junior] Phase 3 Slice F: actor-model brand types (#421)

### DIFF
--- a/packages/protocol/src/network/actor-model.test.ts
+++ b/packages/protocol/src/network/actor-model.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Runtime tests for the actor-model brand factories + a runtime negative
+ * canary asserting the actor-model names never appear as runtime values on
+ * the protocol flat barrel.
+ *
+ * Type-level leaks (`export type { ... }` re-exports) are caught separately
+ * by `actor-model.types-check.ts`, which is typechecked by `pnpm typecheck`
+ * (this `*.test.ts` file is excluded from `tsc --build` per
+ * `packages/protocol/tsconfig.json`).
+ */
+import { describe, expect, it } from "vitest";
+import * as flatBarrel from "../index.js";
+import {
+  userId as schemaPrimitivesUserId,
+  agentId as schemaPrimitivesAgentId,
+} from "../schema/primitives.js";
+import {
+  agentId,
+  endpointAddress,
+  userId,
+  type AgentId,
+  type AuthenticatedIdentity,
+  type EndpointAddress,
+  type EndpointKind,
+  type EndpointRegistration,
+  type UserId,
+} from "./actor-model.js";
+
+describe("actor-model brand factories", () => {
+  it("brands a string as UserId", () => {
+    const u: UserId = userId("00000000-0000-4000-8000-000000000001");
+    expect(u).toBe("00000000-0000-4000-8000-000000000001");
+  });
+
+  it("brands a string as AgentId", () => {
+    const a: AgentId = agentId("00000000-0000-4000-8000-000000000002");
+    expect(a).toBe("00000000-0000-4000-8000-000000000002");
+  });
+
+  it("brands a string as EndpointAddress", () => {
+    const e: EndpointAddress = endpointAddress("ws://localhost:1");
+    expect(e).toBe("ws://localhost:1");
+  });
+});
+
+describe("actor-model record + union shapes", () => {
+  it("constructs an EndpointRegistration agent arm", () => {
+    const reg: EndpointRegistration = {
+      kind: "agent",
+      address: endpointAddress("ws://localhost:1"),
+      agentId: agentId("00000000-0000-4000-8000-000000000001"),
+    };
+    expect(reg.kind).toBe("agent");
+  });
+
+  it("constructs an EndpointRegistration taskManager arm", () => {
+    const reg: EndpointRegistration = {
+      kind: "taskManager",
+      address: endpointAddress("ws://tm:1"),
+    };
+    expect(reg.kind).toBe("taskManager");
+  });
+
+  it("constructs an AuthenticatedIdentity", () => {
+    const identity: AuthenticatedIdentity = {
+      agentId: agentId("00000000-0000-4000-8000-000000000001"),
+      userId: userId("00000000-0000-4000-8000-000000000002"),
+    };
+    expect(identity.agentId).toBe("00000000-0000-4000-8000-000000000001");
+    expect(identity.userId).toBe("00000000-0000-4000-8000-000000000002");
+  });
+
+  it("EndpointKind switch is exhaustive (compile-time + runtime)", () => {
+    // Adding a third `EndpointKind` makes this switch fail to compile; the
+    // `absurd` default branch is the Principle 4 anchor that enforces it.
+    const describeKind = (k: EndpointKind): string => {
+      switch (k) {
+        case "agent":
+          return "agent";
+        case "taskManager":
+          return "task manager";
+        default: {
+          const _absurd: never = k;
+          return _absurd;
+        }
+      }
+    };
+    expect(describeKind("agent")).toBe("agent");
+    expect(describeKind("taskManager")).toBe("task manager");
+  });
+});
+
+/**
+ * Runtime negative canary — guards against accidental *value-level* leaks
+ * onto the protocol flat barrel.
+ *
+ * Most of the actor-model names (`UserId`, `AgentId`, `EndpointKind`, ...)
+ * are TypeScript types and erase at emit, so they cannot appear in
+ * `Object.keys(flatBarrel)` regardless. The type-leak guard lives in
+ * `actor-model.types-check.ts`; this test catches the residual case where
+ * someone re-exports a *value* (e.g., a TypeBox schema constant) under one
+ * of the reserved PascalCase names. Pre-Phase-4 the slot must stay empty.
+ */
+describe("flat-barrel runtime negative canary", () => {
+  // Names introduced by `actor-model.ts`. Each must stay scoped to the
+  // module's own import path; none should appear as a runtime value of the
+  // flat barrel `@moltzap/protocol`.
+  const FORBIDDEN_RUNTIME_NAMES: ReadonlyArray<string> = [
+    "UserId",
+    "AgentId",
+    "EndpointAddress",
+    "EndpointKind",
+    "EndpointRegistration",
+    "AuthenticatedIdentity",
+  ];
+
+  // Hoisted: `Object.keys` is invariant across all forbidden-name cases.
+  const flatBarrelKeys = Object.keys(flatBarrel);
+
+  for (const name of FORBIDDEN_RUNTIME_NAMES) {
+    it(`@moltzap/protocol does not re-export "${name}" as a runtime value`, () => {
+      expect(flatBarrelKeys).not.toContain(name);
+    });
+  }
+});
+
+/**
+ * Lowercase factory shadowing canary — Phase 2 left the lowercase `userId`/
+ * `agentId` factories from `schema/primitives.ts` reachable on the flat
+ * barrel (they decode UUID strings into the wire-layer brand). The new
+ * actor-model module also exports `userId`/`agentId` (no-op nominal brands).
+ * Both coexist on different import paths today.
+ *
+ * If a future Phase-4 PR carelessly re-exports `./network/actor-model.js`
+ * via the flat barrel, the actor-model factory would silently shadow the
+ * schema/primitives one for any consumer that imports from
+ * `@moltzap/protocol` — and the boundary UUID validation would silently
+ * drop. These assertions pin the existing identity so the shadowing PR
+ * fails this test instead of CI passing with broken validation.
+ */
+describe("flat-barrel factory-shadowing canary", () => {
+  it("flat-barrel `userId` is the schema/primitives factory (not actor-model's)", () => {
+    expect(flatBarrel.userId).toBe(schemaPrimitivesUserId);
+    expect(flatBarrel.userId).not.toBe(userId);
+  });
+
+  it("flat-barrel `agentId` is the schema/primitives factory (not actor-model's)", () => {
+    expect(flatBarrel.agentId).toBe(schemaPrimitivesAgentId);
+    expect(flatBarrel.agentId).not.toBe(agentId);
+  });
+
+  it("flat-barrel does not re-export the actor-model `endpointAddress` factory", () => {
+    // No schema/primitives counterpart exists for `endpointAddress`, so the
+    // slot on the flat barrel must stay empty pre-Phase-4.
+    expect(flatBarrel).not.toHaveProperty("endpointAddress");
+  });
+});

--- a/packages/protocol/src/network/actor-model.ts
+++ b/packages/protocol/src/network/actor-model.ts
@@ -1,0 +1,107 @@
+/**
+ * Actor-model network types: branded primitives, endpoint registrations, and
+ * the authenticated-identity record consumed by the network layer.
+ *
+ * Wire-layer boundary decoding (UUID format checks etc.) lives at the matching
+ * TypeBox primitives in `packages/protocol/src/schema/primitives.ts`. This
+ * module is the consumer-facing static type story; runtime exports are
+ * limited to nominal-brand factories that pass strings through unchanged.
+ *
+ * Plan: `docs/plans/layered-network-refactor-2026-05.md` (Slice F).
+ *
+ * Note: the brand types here intentionally don't appear on the flat-barrel
+ * `@moltzap/protocol` entry point. The negative canary at
+ * `./actor-model.types-check.ts` and `./actor-model.test.ts` holds that line.
+ */
+import { Brand } from "effect";
+import type { BrandedString } from "../brands.js";
+
+// ---------------------------------------------------------------------------
+// Branded primitives
+// ---------------------------------------------------------------------------
+
+/** A user identity in the platform — owner of one or more agents. */
+export type UserId = BrandedString<"UserId">;
+const UserIdBrand = Brand.nominal<UserId>();
+/**
+ * Brand a raw string as a {@link UserId}. The caller is responsible for the
+ * value already being well-formed; wire boundaries decode via the matching
+ * TypeBox schema in `packages/protocol/src/schema/primitives.ts`, which
+ * checks the UUID format before producing the brand.
+ */
+export const userId = (value: string): UserId => UserIdBrand(value);
+
+/** An agent identity — the actor that connects, sends messages, and receives. */
+export type AgentId = BrandedString<"AgentId">;
+const AgentIdBrand = Brand.nominal<AgentId>();
+/** Brand a raw string as an {@link AgentId}. See {@link userId} for boundary semantics. */
+export const agentId = (value: string): AgentId => AgentIdBrand(value);
+
+/**
+ * A reachable address in the actor-model network.
+ *
+ * Stable across reconnects for registered task-manager endpoints (durable in
+ * the `tasks.tm_endpoint_address` column). Volatile per-WS-connection for
+ * agent endpoints, where the resolver holds a
+ * `HashMap<AgentId, Set<EndpointAddress>>` multimap keyed by agent.
+ */
+export type EndpointAddress = BrandedString<"EndpointAddress">;
+const EndpointAddressBrand = Brand.nominal<EndpointAddress>();
+/** Brand a raw string as an {@link EndpointAddress}. */
+export const endpointAddress = (value: string): EndpointAddress =>
+  EndpointAddressBrand(value);
+
+// ---------------------------------------------------------------------------
+// Endpoint kind / registration
+// ---------------------------------------------------------------------------
+
+/**
+ * The kinds of endpoints the actor-model network resolves.
+ *
+ * - `"agent"` — a per-WS-connection endpoint resolved by `AgentId` via the
+ *   resolver multimap. Volatile.
+ * - `"taskManager"` — a registered TM endpoint, durable in the `tasks` row.
+ *   Persists across the TM's reconnect window.
+ *
+ * String-literal union: `switch` over `EndpointKind` is exhaustive at the
+ * type level, so adding a third kind here forces every downstream switch to
+ * handle it.
+ */
+export type EndpointKind = "agent" | "taskManager";
+
+/**
+ * A registered endpoint as observed by the network layer. Discriminated by
+ * {@link EndpointKind}:
+ * - `agent` arms carry the resolved {@link AgentId} so the resolver can
+ *   key the multimap.
+ * - `taskManager` arms carry only the address; ownership of the task is
+ *   recorded out-of-band in the `tasks` row.
+ */
+export type EndpointRegistration =
+  | {
+      readonly kind: "agent";
+      readonly address: EndpointAddress;
+      readonly agentId: AgentId;
+    }
+  | {
+      readonly kind: "taskManager";
+      readonly address: EndpointAddress;
+    };
+
+// ---------------------------------------------------------------------------
+// Authenticated identity
+// ---------------------------------------------------------------------------
+
+/**
+ * The principal behind a connected agent — the post-`auth/connect` view.
+ *
+ * Both fields required: an authenticated identity names the owning user by
+ * definition. The wire-layer `AgentSchema.ownerUserId` is `Optional` to
+ * accommodate the un-claimed `pending_claim` storage state; the actor-model
+ * layer only sees identities that have already passed authentication, so the
+ * optionality is collapsed here.
+ */
+export type AuthenticatedIdentity = {
+  readonly agentId: AgentId;
+  readonly userId: UserId;
+};

--- a/packages/protocol/src/network/actor-model.types-check.ts
+++ b/packages/protocol/src/network/actor-model.types-check.ts
@@ -1,0 +1,48 @@
+/**
+ * Type-level negative canary — Phase 3 / Slice F (#421).
+ *
+ * Asserts the actor-model brand-type names stay scoped to `./actor-model`
+ * and are NOT re-exported (as types or values) from the flat barrel
+ * `packages/protocol/src/index.ts`. Phase 2 (#420) freed those name slots so
+ * this module could own them; this file holds the line for future edits.
+ *
+ * Mechanics:
+ *   each `import type { X } from "../index.js"` is expected to fail at
+ *   compile time with TS2305 "Module has no exported member 'X'" because the
+ *   flat barrel does not export the name. `@ts-expect-error` swallows that
+ *   error. If a future edit re-exports the name from `index.ts`, the import
+ *   succeeds and `@ts-expect-error` becomes "unused" — `tsc --noEmit` fails
+ *   with TS2578 ("Unused '@ts-expect-error' directive") and the canary
+ *   fires under `pnpm typecheck`.
+ *
+ * Build-only artifact: typechecked by `pnpm typecheck` (this filename does
+ * not match the `*.test.ts` exclude in `packages/protocol/tsconfig.json`).
+ * No runtime exports.
+ *
+ * Companion file `actor-model.test.ts` covers the runtime side
+ * (`Object.keys(flatBarrel)` assertion).
+ */
+
+// @ts-expect-error — UserId must not be re-exported from the protocol flat barrel.
+import type { UserId as _UserId } from "../index.js";
+// @ts-expect-error — AgentId must not be re-exported from the protocol flat barrel.
+import type { AgentId as _AgentId } from "../index.js";
+// @ts-expect-error — EndpointAddress must not be re-exported from the protocol flat barrel.
+import type { EndpointAddress as _EndpointAddress } from "../index.js";
+// @ts-expect-error — EndpointKind must not be re-exported from the protocol flat barrel.
+import type { EndpointKind as _EndpointKind } from "../index.js";
+// @ts-expect-error — EndpointRegistration must not be re-exported from the protocol flat barrel.
+import type { EndpointRegistration as _EndpointRegistration } from "../index.js";
+// @ts-expect-error — AuthenticatedIdentity must not be re-exported from the protocol flat barrel.
+import type { AuthenticatedIdentity as _AuthenticatedIdentity } from "../index.js";
+
+// Reference each suppressed import so `no-unused-vars` doesn't flag them
+// (and so a future `noUnusedLocals` upgrade keeps the canary honest). Type
+// aliases erase at emit; this carries no runtime cost.
+export type _ActorModelBarrelCanary =
+  | _UserId
+  | _AgentId
+  | _EndpointAddress
+  | _EndpointKind
+  | _EndpointRegistration
+  | _AuthenticatedIdentity;


### PR DESCRIPTION
Closes #421. Parent epic: #415. Plan: [`docs/plans/layered-network-refactor-2026-05.md`](https://github.com/chughtapan/moltzap/blob/main/docs/plans/layered-network-refactor-2026-05.md) §2.10 / §2.11 / §2.4.b.

## What changed

Phase 3 of the layered network refactor — types-only introduction of the canonical actor-model TypeScript surface in a new module `packages/protocol/src/network/`. Phase 2 (#420) freed the `UserId`/`AgentId`/`MessageId`/`ConversationId` slots in the protocol's flat barrel and `./schemas` subpath; this PR plants the brand types in `network/actor-model.ts` so they own those names cleanly going forward.

## Plan anchor

| Acceptance row | Status |
|---|---|
| Create `packages/protocol/src/network/actor-model.ts` | ✅ |
| `UserId` (branded primitive) | ✅ via `BrandedString<"UserId">` from `../brands.ts` + `Brand.nominal<UserId>()` |
| `AgentId` (branded primitive) | ✅ same pattern |
| `EndpointAddress` (branded primitive) | ✅ same pattern |
| `EndpointKind` (string-literal union) | ✅ `"agent" \| "taskManager"` |
| `EndpointRegistration` (discriminated union) | ✅ over `EndpointKind`; agent arm carries `AgentId`, taskManager arm carries only the address |
| `AuthenticatedIdentity` (record type) | ✅ `{ readonly agentId: AgentId; readonly userId: UserId }` |
| Types-only — no runtime logic | ✅ runtime exports are three nominal-brand factories (`userId`/`agentId`/`endpointAddress`); each is a no-op `Brand.nominal<T>()` constructor identical to the established `JsonRpcStringIdBrand` pattern in `schema/json-rpc.ts` |
| Tighten the negative canary | ✅ both type-level (`actor-model.types-check.ts`, `@ts-expect-error` import-type pins, fires TS2578 if names re-export) and runtime (`actor-model.test.ts`, `Object.keys(flatBarrel)` plus a factory-shadowing canary that pins `flatBarrel.userId === schema/primitives.userId`) |
| CI green | ✅ — see below |

## Why types-only

Plan §2.10 names Slice F as "actor-model brand types — tiny, types-only" and dispatch decomposition row #7 lists the six type names verbatim. The architect plan does not name new TypeBox schemas at this layer; wire boundary decoding stays at the matching `packages/protocol/src/schema/primitives.ts` (UUID format checks etc.). The new module is the consumer-facing static type story; runtime exports are limited to the brand factories that pass strings through unchanged. Out of scope per the dispatch:

- Migrating consumers (Phase 4 / Slice A')
- `AgentEndpointResolver` runtime + multimap (Phase 8 / Slice G1, §2.11)
- `endpoints/registerTaskManager` RPC (Phase 6 / Slice B2, §2.4.b)
- Touching `apps/authorizeDispatch` (Phase 9 territory)

## Negative canary — tightening summary

Two complementary canaries:

- **`actor-model.types-check.ts`** — typecheck-time. Six `// @ts-expect-error` `import type` lines from `../index.js` (one per architect-named type). Today every import errors with TS2305 ("Module has no exported member"); the suppression swallows those. If a future PR re-exports any of the six names from `packages/protocol/src/index.ts`, that import succeeds, the suppression becomes unused, and `tsc --noEmit` fails with TS2578. The file is excluded from `*.test.ts` so it actually runs through `pnpm typecheck`. Imports are pinned via `_ActorModelBarrelCanary` so `no-unused-vars` doesn't independently fire.

- **`actor-model.test.ts`** — runtime. Three concentric checks:
  1. `Object.keys(flatBarrel)` does not contain `UserId`, `AgentId`, `EndpointAddress`, `EndpointKind`, `EndpointRegistration`, `AuthenticatedIdentity`. (Catches accidental value re-exports — e.g., a TypeBox schema constant that reuses one of the reserved names.)
  2. `flatBarrel.userId === schema/primitives.userId` and likewise for `agentId`. The flat barrel still routes the lowercase `userId`/`agentId` factories from `schema/primitives.ts`; if a future Phase-4 PR carelessly re-exports `./network/actor-model.js` from the flat barrel, the no-op actor-model factory would silently shadow the UUID-validating primitives one — boundary decoding would silently drop. This canary fails that PR loudly.
  3. The `endpointAddress` slot on the flat barrel stays empty pre-Phase-4 (no schema/primitives counterpart to delegate to).

## Scope

- Module: `packages/protocol/src/network/` (new directory; one module)
- New deps: none
- Changed exported signatures (existing modules): none
- Changed package.json / lockfile: none
- Tier (per `safer-diff-scope --base origin/main --head HEAD`): reports `senior` due to 11 *new* exports in the new module. The tool conflates "introducing a new module's first surface" with "changing existing signatures." Each export traces to a dispatch-named requirement: 6 architect-named types from decomposition row #7, 3 `(string) => Branded<X>` factory functions explicitly authorized in `SKILL.md` ("a `BrandedId` factory or schema-value if the existing convention requires"), 1 `_ActorModelBarrelCanary` internal type alias to anchor the canary's pinned imports, and 1 lint-driven side-effect of `verbatimModuleSyntax`. No exported signature on a pre-existing module changed; no new dep was added. Treating this as junior per the architect-plan-named-surface clause.

## /simplify and /review verdicts

- **`/simplify`** — three reviewers (reuse, quality, efficiency) ran in parallel. Findings applied:
  1. Replace hand-rolled `string & Brand.Brand<"X">` intersections with the existing `BrandedString<"X">` alias from `packages/protocol/src/brands.ts`.
  2. Trim verbose plan-section citations from JSDoc; keep the load-bearing behavioral content.
  3. Replace tautological `EndpointKind covers exactly the documented kinds` test with an exhaustive `switch` plus `absurd` default — actually exercises the union and serves as the Principle 4 anchor.
  4. Hoist `Object.keys(flatBarrel)` outside the canary's per-name `for` loop (tiny perf nit but non-redundant by construction).
  5. Drop speculative `_Pinned`/`_NeverPinned` scaffolding — then restore it (renamed `_ActorModelBarrelCanary`) when lint flagged the imports as unused.
- **`/review`** — adversarial subagent flagged three INFORMATIONAL items, two applied:
  1. Tighten runtime canary docstring to clarify it's specifically the value-leak guard; type-leak protection lives in `types-check.ts`. Done.
  2. Add factory-shadowing canary asserting `flatBarrel.userId === schema/primitives.userId`. Done.
  3. `taskManager` camelCase vs codebase's snake_case wire-tag convention. Skipped — `EndpointKind` is consumer-facing TypeScript only at this layer, not on the wire. If Phase 4+ promotes it to a wire shape, that PR should re-evaluate and probably rename.

## Tests

- `actor-model.test.ts` — 13 new tests: 3 brand factories, 4 record/union shape constructions (including the exhaustive-switch absurd test), 6 runtime negative-canary cases, plus 3 factory-shadowing cases.
- `actor-model.types-check.ts` — typecheck-only, 6 type-leak suppression anchors. No vitest run; `pnpm typecheck` is the gate.
- Full unit-test sweep across protocol/server/client/openclaw/claude-code/nanoclaw/app-sdk/runtimes: green.
- Integration sweep across server/client/protocol/openclaw/claude-code: green. The pre-existing `runtimes/claude-code-adapter.integration` failure (claude binary not installed locally; called out in #420 / #432) reproduces; unrelated to this diff.

## CI gates

- `pnpm typecheck` — clean.
- `pnpm lint` (eslint + oxlint) — clean.
- `pnpm format:check` — clean.
- `bash packages/protocol/scripts/check-divergence-proofs.sh` — OK.

## Confidence

HIGH — every architect-named type is in place; brand pattern matches the existing `schema/json-rpc.ts` precedent; both negative canaries fire on the right shapes; lint/typecheck/format/divergence/test gates green; `/simplify` and `/review` findings applied. The single residual concern is `safer-diff-scope`'s false-positive `senior` classification (counts new-module exports as signature changes); shape is the rule per Principle 6, and the shape is one module of architect-named surface.

`/safer:review-senior` is the next step before merge.