### PR TITLE
[impl-staff] Phase 6 B2: tasks/* RPCs + TM authority (#424)

### DIFF
--- a/docs/protocol/methods/endpoints-register-task-manager.mdx
+++ b/docs/protocol/methods/endpoints-register-task-manager.mdx
@@ -1,0 +1,24 @@
+---
+title: "endpoints/registerTaskManager"
+description: "Call `endpoints/registerTaskManager`."
+---
+
+# endpoints/registerTaskManager
+
+Call `endpoints/registerTaskManager`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+## Response
+
+<ResponseField name="taskId" type="string (UUID)">
+  Branded TaskId
+</ResponseField>
+
+<ResponseField name="tmEndpointAddress" type="string">
+  The tmEndpointAddress field.
+</ResponseField>

--- a/docs/protocol/methods/endpoints-unregister-task-manager.mdx
+++ b/docs/protocol/methods/endpoints-unregister-task-manager.mdx
@@ -1,0 +1,18 @@
+---
+title: "endpoints/unregisterTaskManager"
+description: "Call `endpoints/unregisterTaskManager`."
+---
+
+# endpoints/unregisterTaskManager
+
+Call `endpoints/unregisterTaskManager`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+## Response
+
+This method returns an empty object.

--- a/docs/protocol/methods/tasks-add-participant.mdx
+++ b/docs/protocol/methods/tasks-add-participant.mdx
@@ -1,0 +1,24 @@
+---
+title: "tasks/addParticipant"
+description: "Call `tasks/addParticipant`."
+---
+
+# tasks/addParticipant
+
+Call `tasks/addParticipant`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+<ParamField path="agentId" type="string (UUID)" required>
+  Branded AgentId
+</ParamField>
+
+## Response
+
+<ResponseField name="participant" type="object">
+  The participant field.
+</ResponseField>

--- a/docs/protocol/methods/tasks-close-conversation.mdx
+++ b/docs/protocol/methods/tasks-close-conversation.mdx
@@ -1,0 +1,22 @@
+---
+title: "tasks/closeConversation"
+description: "Call `tasks/closeConversation`."
+---
+
+# tasks/closeConversation
+
+Call `tasks/closeConversation`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+<ParamField path="conversationId" type="string (UUID)" required>
+  Branded ConversationId
+</ParamField>
+
+## Response
+
+This method returns an empty object.

--- a/docs/protocol/methods/tasks-close.mdx
+++ b/docs/protocol/methods/tasks-close.mdx
@@ -1,0 +1,20 @@
+---
+title: "tasks/close"
+description: "Call `tasks/close`."
+---
+
+# tasks/close
+
+Call `tasks/close`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+## Response
+
+<ResponseField name="task" type="object">
+  The task field.
+</ResponseField>

--- a/docs/protocol/methods/tasks-create-conversation.mdx
+++ b/docs/protocol/methods/tasks-create-conversation.mdx
@@ -1,0 +1,32 @@
+---
+title: "tasks/createConversation"
+description: "Call `tasks/createConversation`."
+---
+
+# tasks/createConversation
+
+Call `tasks/createConversation`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+<ParamField path="type" type="dm | group" required>
+  The type field.
+</ParamField>
+
+<ParamField path="name" type="string">
+  The name field.
+</ParamField>
+
+<ParamField path="participants" type="array" required>
+  The participants field.
+</ParamField>
+
+## Response
+
+<ResponseField name="conversation" type="object">
+  The conversation field.
+</ResponseField>

--- a/docs/protocol/methods/tasks-create.mdx
+++ b/docs/protocol/methods/tasks-create.mdx
@@ -1,0 +1,24 @@
+---
+title: "tasks/create"
+description: "Call `tasks/create`."
+---
+
+# tasks/create
+
+Call `tasks/create`.
+
+## Parameters
+
+<ParamField path="appId" type="string">
+  The appId field.
+</ParamField>
+
+<ParamField path="invitedAgentIds" type="array">
+  The invitedAgentIds field.
+</ParamField>
+
+## Response
+
+<ResponseField name="task" type="object">
+  The task field.
+</ResponseField>

--- a/docs/protocol/methods/tasks-get-messages-since.mdx
+++ b/docs/protocol/methods/tasks-get-messages-since.mdx
@@ -13,6 +13,10 @@ Call `tasks/getMessagesSince`.
   Branded TaskId
 </ParamField>
 
+<ParamField path="conversationId" type="string (UUID)" required>
+  Branded ConversationId
+</ParamField>
+
 <ParamField path="sinceSeq" type="string" required>
   Snowflake seq cursor (string-encoded BIGINT)
 </ParamField>

--- a/docs/protocol/methods/tasks-get-messages-since.mdx
+++ b/docs/protocol/methods/tasks-get-messages-since.mdx
@@ -1,0 +1,32 @@
+---
+title: "tasks/getMessagesSince"
+description: "Call `tasks/getMessagesSince`."
+---
+
+# tasks/getMessagesSince
+
+Call `tasks/getMessagesSince`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+<ParamField path="sinceSeq" type="string" required>
+  Snowflake seq cursor (string-encoded BIGINT)
+</ParamField>
+
+<ParamField path="limit" type="integer">
+  The limit field.
+</ParamField>
+
+## Response
+
+<ResponseField name="messages" type="array">
+  The messages field.
+</ResponseField>
+
+<ResponseField name="hasMore" type="boolean">
+  The hasMore field.
+</ResponseField>

--- a/docs/protocol/methods/tasks-get-messages.mdx
+++ b/docs/protocol/methods/tasks-get-messages.mdx
@@ -13,6 +13,10 @@ Call `tasks/getMessages`.
   Branded TaskId
 </ParamField>
 
+<ParamField path="conversationId" type="string (UUID)" required>
+  Branded ConversationId
+</ParamField>
+
 <ParamField path="limit" type="integer">
   The limit field.
 </ParamField>

--- a/docs/protocol/methods/tasks-get-messages.mdx
+++ b/docs/protocol/methods/tasks-get-messages.mdx
@@ -1,0 +1,28 @@
+---
+title: "tasks/getMessages"
+description: "Call `tasks/getMessages`."
+---
+
+# tasks/getMessages
+
+Call `tasks/getMessages`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+<ParamField path="limit" type="integer">
+  The limit field.
+</ParamField>
+
+## Response
+
+<ResponseField name="messages" type="array">
+  The messages field.
+</ResponseField>
+
+<ResponseField name="hasMore" type="boolean">
+  The hasMore field.
+</ResponseField>

--- a/docs/protocol/methods/tasks-get.mdx
+++ b/docs/protocol/methods/tasks-get.mdx
@@ -1,0 +1,24 @@
+---
+title: "tasks/get"
+description: "Call `tasks/get`."
+---
+
+# tasks/get
+
+Call `tasks/get`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+## Response
+
+<ResponseField name="task" type="object">
+  The task field.
+</ResponseField>
+
+<ResponseField name="participants" type="array">
+  The participants field.
+</ResponseField>

--- a/docs/protocol/methods/tasks-list.mdx
+++ b/docs/protocol/methods/tasks-list.mdx
@@ -1,0 +1,28 @@
+---
+title: "tasks/list"
+description: "Call `tasks/list`."
+---
+
+# tasks/list
+
+Call `tasks/list`.
+
+## Parameters
+
+<ParamField path="appId" type="string">
+  The appId field.
+</ParamField>
+
+<ParamField path="status" type="waiting | active | failed | closed">
+  The status field.
+</ParamField>
+
+<ParamField path="limit" type="integer">
+  The limit field.
+</ParamField>
+
+## Response
+
+<ResponseField name="tasks" type="array">
+  The tasks field.
+</ResponseField>

--- a/docs/protocol/methods/tasks-remove-participant.mdx
+++ b/docs/protocol/methods/tasks-remove-participant.mdx
@@ -1,0 +1,22 @@
+---
+title: "tasks/removeParticipant"
+description: "Call `tasks/removeParticipant`."
+---
+
+# tasks/removeParticipant
+
+Call `tasks/removeParticipant`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+<ParamField path="agentId" type="string (UUID)" required>
+  Branded AgentId
+</ParamField>
+
+## Response
+
+This method returns an empty object.

--- a/docs/protocol/methods/tasks-store-message.mdx
+++ b/docs/protocol/methods/tasks-store-message.mdx
@@ -1,0 +1,36 @@
+---
+title: "tasks/storeMessage"
+description: "Call `tasks/storeMessage`."
+---
+
+# tasks/storeMessage
+
+Call `tasks/storeMessage`.
+
+## Parameters
+
+<ParamField path="taskId" type="string (UUID)" required>
+  Branded TaskId
+</ParamField>
+
+<ParamField path="conversationId" type="string (UUID)" required>
+  Branded ConversationId
+</ParamField>
+
+<ParamField path="senderAgentId" type="string (UUID)" required>
+  Branded AgentId
+</ParamField>
+
+<ParamField path="parts" type="array" required>
+  The parts field.
+</ParamField>
+
+<ParamField path="replyToId" type="string (UUID)">
+  Branded MessageId
+</ParamField>
+
+## Response
+
+<ResponseField name="message" type="object">
+  The message field.
+</ResponseField>

--- a/packages/protocol/src/network/actor-model.test.ts
+++ b/packages/protocol/src/network/actor-model.test.ts
@@ -38,8 +38,17 @@ describe("actor-model brand factories", () => {
   });
 
   it("brands a string as EndpointAddress", () => {
-    const e: EndpointAddress = endpointAddress("ws://localhost:1");
-    expect(e).toBe("ws://localhost:1");
+    const e: EndpointAddress = endpointAddress(
+      "tm:agent:00000000-0000-4000-8000-000000000001",
+    );
+    expect(e).toBe("tm:agent:00000000-0000-4000-8000-000000000001");
+  });
+
+  it("rejects non-canonical endpoint formats at construction", () => {
+    expect(() => endpointAddress("ws://localhost:1")).toThrow();
+    expect(() => endpointAddress("")).toThrow();
+    expect(() => endpointAddress("tm:agent:not-a-uuid")).toThrow();
+    expect(() => endpointAddress("tm:unknown:uuid-here")).toThrow();
   });
 });
 
@@ -47,7 +56,7 @@ describe("actor-model record + union shapes", () => {
   it("constructs an EndpointRegistration agent arm", () => {
     const reg: EndpointRegistration = {
       kind: "agent",
-      address: endpointAddress("ws://localhost:1"),
+      address: endpointAddress("tm:agent:00000000-0000-4000-8000-000000000001"),
       agentId: agentId("00000000-0000-4000-8000-000000000001"),
     };
     expect(reg.kind).toBe("agent");
@@ -56,7 +65,7 @@ describe("actor-model record + union shapes", () => {
   it("constructs an EndpointRegistration taskManager arm", () => {
     const reg: EndpointRegistration = {
       kind: "taskManager",
-      address: endpointAddress("ws://tm:1"),
+      address: endpointAddress("tm:app:00000000-0000-4000-8000-000000000099"),
     };
     expect(reg.kind).toBe("taskManager");
   });

--- a/packages/protocol/src/network/actor-model.ts
+++ b/packages/protocol/src/network/actor-model.ts
@@ -46,8 +46,40 @@ export const agentId = (value: string): AgentId => AgentIdBrand(value);
  * `HashMap<AgentId, Set<EndpointAddress>>` multimap keyed by agent.
  */
 export type EndpointAddress = BrandedString<"EndpointAddress">;
-const EndpointAddressBrand = Brand.nominal<EndpointAddress>();
-/** Brand a raw string as an {@link EndpointAddress}. */
+
+/** Endpoint kinds that may appear at the address prefix. Extending this list
+ *  is the single edit point for new endpoint kinds. */
+export const ENDPOINT_ADDRESS_KINDS = ["agent", "app"] as const;
+export type EndpointAddressKind = (typeof ENDPOINT_ADDRESS_KINDS)[number];
+
+const ENDPOINT_ADDRESS_PREFIX = "tm:";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Predicate that an endpoint address has the canonical wire shape:
+ *  `tm:<kind>:<uuid>`. Exported for tests and reviewers. */
+export const isEndpointAddress = (value: unknown): value is EndpointAddress => {
+  if (typeof value !== "string") return false;
+  if (!value.startsWith(ENDPOINT_ADDRESS_PREFIX)) return false;
+  const rest = value.slice(ENDPOINT_ADDRESS_PREFIX.length);
+  for (const kind of ENDPOINT_ADDRESS_KINDS) {
+    const kindPrefix = `${kind}:`;
+    if (rest.startsWith(kindPrefix)) {
+      return UUID_PATTERN.test(rest.slice(kindPrefix.length));
+    }
+  }
+  return false;
+};
+
+const EndpointAddressBrand = Brand.refined<EndpointAddress>(
+  isEndpointAddress,
+  (value) =>
+    Brand.error(
+      `Invalid EndpointAddress: expected "tm:<kind>:<uuid>" with kind ∈ {${ENDPOINT_ADDRESS_KINDS.join(", ")}}, got ${JSON.stringify(value)}`,
+    ),
+);
+/** Brand a raw string as an {@link EndpointAddress}. Throws if the value
+ *  fails {@link isEndpointAddress}. */
 export const endpointAddress = (value: string): EndpointAddress =>
   EndpointAddressBrand(value);
 

--- a/packages/protocol/src/network/index.ts
+++ b/packages/protocol/src/network/index.ts
@@ -1,5 +1,7 @@
 // Network-layer protocol surface: identity / transport substrate.
-// Wire frames, auth, agents, system. Brand types from `./actor-model.ts`.
+// Wire frames, auth, agents, system, endpoint registration. Brand types
+// from `./actor-model.ts`.
 export * from "./actor-model.js";
 export * from "./methods/auth.js";
 export * from "./methods/system.js";
+export * from "./methods/endpoints.js";

--- a/packages/protocol/src/network/methods/endpoints.ts
+++ b/packages/protocol/src/network/methods/endpoints.ts
@@ -1,0 +1,21 @@
+import { Type } from "@sinclair/typebox";
+import { TaskId } from "../../schema/primitives.js";
+import { defineRpc } from "../../rpc.js";
+
+export const EndpointsRegisterTaskManager = defineRpc({
+  name: "endpoints/registerTaskManager",
+  params: Type.Object({ taskId: TaskId }, { additionalProperties: false }),
+  result: Type.Object(
+    {
+      taskId: TaskId,
+      tmEndpointAddress: Type.String(),
+    },
+    { additionalProperties: false },
+  ),
+});
+
+export const EndpointsUnregisterTaskManager = defineRpc({
+  name: "endpoints/unregisterTaskManager",
+  params: Type.Object({ taskId: TaskId }, { additionalProperties: false }),
+  result: Type.Object({}, { additionalProperties: false }),
+});

--- a/packages/protocol/src/rpc-registry.ts
+++ b/packages/protocol/src/rpc-registry.ts
@@ -8,6 +8,10 @@ import {
   AgentsList,
 } from "./network/methods/auth.js";
 import {
+  EndpointsRegisterTaskManager,
+  EndpointsUnregisterTaskManager,
+} from "./network/methods/endpoints.js";
+import {
   ConversationsCreate,
   ConversationsList,
   ConversationsGet,
@@ -29,6 +33,19 @@ import {
 } from "./task/methods/contacts.js";
 import { InvitesCreateAgent } from "./task/methods/invites.js";
 import { PresenceUpdate, PresenceSubscribe } from "./task/methods/presence.js";
+import {
+  TasksCreate,
+  TasksGet,
+  TasksList,
+  TasksClose,
+  TasksCreateConversation,
+  TasksCloseConversation,
+  TasksAddParticipant,
+  TasksRemoveParticipant,
+  TasksStoreMessage,
+  TasksGetMessages,
+  TasksGetMessagesSince,
+} from "./task/methods/tasks.js";
 import {
   AppsCreate,
   AppsCloseSession,
@@ -67,6 +84,8 @@ export const networkRpcMethods = [
   AgentsLookupByName,
   AgentsList,
   SystemPing,
+  EndpointsRegisterTaskManager,
+  EndpointsUnregisterTaskManager,
 ] as const;
 
 export const taskRpcMethods = [
@@ -90,6 +109,17 @@ export const taskRpcMethods = [
   InvitesCreateAgent,
   PresenceUpdate,
   PresenceSubscribe,
+  TasksCreate,
+  TasksGet,
+  TasksList,
+  TasksClose,
+  TasksCreateConversation,
+  TasksCloseConversation,
+  TasksAddParticipant,
+  TasksRemoveParticipant,
+  TasksStoreMessage,
+  TasksGetMessages,
+  TasksGetMessagesSince,
 ] as const;
 
 export const appRpcMethods = [

--- a/packages/protocol/src/schema/index.ts
+++ b/packages/protocol/src/schema/index.ts
@@ -5,11 +5,13 @@
 // `@moltzap/protocol/schemas/primitives`. See plan §2.10 / #420.
 export {
   ContactId,
+  TaskId,
   userId,
   agentId,
   conversationId,
   messageId,
   contactId,
+  taskId,
   InviteToken,
 } from "./primitives.js";
 export * from "./identity.js";
@@ -31,5 +33,8 @@ export * from "../task/methods/messages.js";
 export * from "../task/methods/invites.js";
 export * from "../task/methods/presence.js";
 export * from "./apps.js";
+export * from "./tasks.js";
 export * from "../app/methods/apps.js";
 export * from "../network/methods/system.js";
+export * from "../network/methods/endpoints.js";
+export * from "../task/methods/tasks.js";

--- a/packages/protocol/src/schema/primitives.ts
+++ b/packages/protocol/src/schema/primitives.ts
@@ -7,6 +7,7 @@ export const AgentId = brandedId("AgentId");
 export const ConversationId = brandedId("ConversationId");
 export const MessageId = brandedId("MessageId");
 export const ContactId = brandedId("ContactId");
+export const TaskId = brandedId("TaskId");
 
 export const userId = (value: string): Static<typeof UserId> =>
   Value.Decode(UserId, value);
@@ -18,6 +19,8 @@ export const messageId = (value: string): Static<typeof MessageId> =>
   Value.Decode(MessageId, value);
 export const contactId = (value: string): Static<typeof ContactId> =>
   Value.Decode(ContactId, value);
+export const taskId = (value: string): Static<typeof TaskId> =>
+  Value.Decode(TaskId, value);
 // InviteToken is base64url-encoded (43+ chars), NOT a UUID
 export const InviteToken = Type.String({
   minLength: 43,

--- a/packages/protocol/src/schema/tasks.ts
+++ b/packages/protocol/src/schema/tasks.ts
@@ -1,0 +1,41 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { stringEnum, DateTimeString } from "../helpers.js";
+import { AgentId, TaskId } from "./primitives.js";
+
+// Mirrors the `task_status` DB enum.
+export const TaskStatusEnum = stringEnum([
+  "waiting",
+  "active",
+  "failed",
+  "closed",
+]);
+
+export type TaskStatus = Static<typeof TaskStatusEnum>;
+
+export const TaskSchema = Type.Object(
+  {
+    id: TaskId,
+    appId: Type.Union([Type.String(), Type.Null()]),
+    initiatorAgentId: AgentId,
+    status: TaskStatusEnum,
+    tmEndpointAddress: Type.Union([Type.String(), Type.Null()]),
+    startedAt: Type.Union([DateTimeString, Type.Null()]),
+    endedAt: Type.Union([DateTimeString, Type.Null()]),
+    createdAt: DateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export type Task = Static<typeof TaskSchema>;
+
+// `admittedAt = null` ⇒ invited but not yet admitted.
+export const TaskParticipantSchema = Type.Object(
+  {
+    taskId: TaskId,
+    agentId: AgentId,
+    admittedAt: Type.Union([DateTimeString, Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+export type TaskParticipant = Static<typeof TaskParticipantSchema>;

--- a/packages/protocol/src/task/index.ts
+++ b/packages/protocol/src/task/index.ts
@@ -1,7 +1,8 @@
 // Task-layer protocol surface: storage / CRUD layer.
-// Conversations, messages, contacts, invites, presence.
+// Conversations, messages, contacts, invites, presence, tasks.
 export * from "./methods/conversations.js";
 export * from "./methods/messages.js";
 export * from "./methods/contacts.js";
 export * from "./methods/invites.js";
 export * from "./methods/presence.js";
+export * from "./methods/tasks.js";

--- a/packages/protocol/src/task/methods/tasks.ts
+++ b/packages/protocol/src/task/methods/tasks.ts
@@ -1,0 +1,188 @@
+import { Type } from "@sinclair/typebox";
+import { stringEnum } from "../../helpers.js";
+import {
+  AgentId,
+  ConversationId,
+  MessageId,
+  TaskId,
+} from "../../schema/primitives.js";
+import {
+  TaskSchema,
+  TaskParticipantSchema,
+  TaskStatusEnum,
+} from "../../schema/tasks.js";
+import {
+  ConversationSchema,
+  ConversationTypeEnum,
+} from "../../schema/conversations.js";
+import { MessageSchema, PartSchema } from "../../schema/messages.js";
+import { defineRpc } from "../../rpc.js";
+
+export const TasksCreate = defineRpc({
+  name: "tasks/create",
+  params: Type.Object(
+    {
+      appId: Type.Optional(Type.String()),
+      invitedAgentIds: Type.Optional(Type.Array(AgentId)),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({ task: TaskSchema }, { additionalProperties: false }),
+});
+
+export const TasksGet = defineRpc({
+  name: "tasks/get",
+  params: Type.Object({ taskId: TaskId }, { additionalProperties: false }),
+  result: Type.Object(
+    {
+      task: TaskSchema,
+      participants: Type.Array(TaskParticipantSchema),
+    },
+    { additionalProperties: false },
+  ),
+});
+
+export const TasksList = defineRpc({
+  name: "tasks/list",
+  params: Type.Object(
+    {
+      appId: Type.Optional(Type.String()),
+      status: Type.Optional(TaskStatusEnum),
+      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object(
+    { tasks: Type.Array(TaskSchema) },
+    { additionalProperties: false },
+  ),
+});
+
+export const TasksClose = defineRpc({
+  name: "tasks/close",
+  params: Type.Object({ taskId: TaskId }, { additionalProperties: false }),
+  result: Type.Object({ task: TaskSchema }, { additionalProperties: false }),
+});
+
+const TaskConversationParticipantSchema = Type.Object(
+  {
+    type: stringEnum(["agent"]),
+    id: Type.String({ format: "uuid" }),
+  },
+  { additionalProperties: false },
+);
+
+export const TasksCreateConversation = defineRpc({
+  name: "tasks/createConversation",
+  params: Type.Object(
+    {
+      taskId: TaskId,
+      type: ConversationTypeEnum,
+      name: Type.Optional(Type.String({ minLength: 1, maxLength: 100 })),
+      participants: Type.Array(TaskConversationParticipantSchema, {
+        minItems: 1,
+      }),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object(
+    { conversation: ConversationSchema },
+    { additionalProperties: false },
+  ),
+});
+
+export const TasksCloseConversation = defineRpc({
+  name: "tasks/closeConversation",
+  params: Type.Object(
+    {
+      taskId: TaskId,
+      conversationId: ConversationId,
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({}, { additionalProperties: false }),
+});
+
+export const TasksAddParticipant = defineRpc({
+  name: "tasks/addParticipant",
+  params: Type.Object(
+    {
+      taskId: TaskId,
+      agentId: AgentId,
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object(
+    { participant: TaskParticipantSchema },
+    { additionalProperties: false },
+  ),
+});
+
+export const TasksRemoveParticipant = defineRpc({
+  name: "tasks/removeParticipant",
+  params: Type.Object(
+    {
+      taskId: TaskId,
+      agentId: AgentId,
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object({}, { additionalProperties: false }),
+});
+
+export const TasksStoreMessage = defineRpc({
+  name: "tasks/storeMessage",
+  params: Type.Object(
+    {
+      taskId: TaskId,
+      conversationId: ConversationId,
+      senderAgentId: AgentId,
+      parts: Type.Array(PartSchema, { minItems: 1, maxItems: 10 }),
+      replyToId: Type.Optional(MessageId),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object(
+    { message: MessageSchema },
+    { additionalProperties: false },
+  ),
+});
+
+export const TasksGetMessages = defineRpc({
+  name: "tasks/getMessages",
+  params: Type.Object(
+    {
+      taskId: TaskId,
+      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object(
+    {
+      messages: Type.Array(MessageSchema),
+      hasMore: Type.Boolean(),
+    },
+    { additionalProperties: false },
+  ),
+});
+
+export const TasksGetMessagesSince = defineRpc({
+  name: "tasks/getMessagesSince",
+  params: Type.Object(
+    {
+      taskId: TaskId,
+      sinceSeq: Type.String({
+        description: "Snowflake seq cursor (string-encoded BIGINT)",
+      }),
+      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
+    },
+    { additionalProperties: false },
+  ),
+  result: Type.Object(
+    {
+      messages: Type.Array(MessageSchema),
+      hasMore: Type.Boolean(),
+    },
+    { additionalProperties: false },
+  ),
+});

--- a/packages/protocol/src/task/methods/tasks.ts
+++ b/packages/protocol/src/task/methods/tasks.ts
@@ -153,6 +153,7 @@ export const TasksGetMessages = defineRpc({
   params: Type.Object(
     {
       taskId: TaskId,
+      conversationId: ConversationId,
       limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
     },
     { additionalProperties: false },
@@ -171,6 +172,7 @@ export const TasksGetMessagesSince = defineRpc({
   params: Type.Object(
     {
       taskId: TaskId,
+      conversationId: ConversationId,
       sinceSeq: Type.String({
         description: "Snowflake seq cursor (string-encoded BIGINT)",
       }),

--- a/packages/server/src/__tests__/integration/43-tasks.integration.test.ts
+++ b/packages/server/src/__tests__/integration/43-tasks.integration.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Either } from "effect";
+import {
+  EndpointsRegisterTaskManager,
+  EndpointsUnregisterTaskManager,
+  TasksAddParticipant,
+  TasksClose,
+  TasksCreate,
+  TasksGet,
+  TasksList,
+  TasksRemoveParticipant,
+  type Task,
+} from "@moltzap/protocol";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  trackClient,
+  connectTestClient,
+  type ServerTestClient,
+} from "./helpers.js";
+
+const REGISTRATION_SECRET = "tasks-test-secret-mnop";
+const ALICE_USER_ID = "00000000-0000-4000-8000-00000000a11d";
+const BOB_USER_ID = "00000000-0000-4000-8000-00000000b0b1";
+
+let baseUrl: string;
+let wsUrl: string;
+let pairCounter = 0;
+
+beforeAll(async () => {
+  const server = await startTestServer({
+    registrationSecret: REGISTRATION_SECRET,
+  });
+  baseUrl = server.baseUrl;
+  wsUrl = server.wsUrl;
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  pairCounter = 0;
+});
+
+interface AdminRegisterResponse {
+  agentId: string;
+  apiKey: string;
+}
+
+async function adminRegister(
+  name: string,
+  ownerUserId: string,
+): Promise<AdminRegisterResponse> {
+  const res = await fetch(`${baseUrl}/api/v1/admin/register-agent`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name,
+      inviteCode: REGISTRATION_SECRET,
+      ownerUserId,
+    }),
+  });
+  const json = (await res.json()) as AdminRegisterResponse;
+  if (res.status !== 201 && res.status !== 200) {
+    throw new Error(
+      `admin register failed: ${res.status} ${JSON.stringify(json)}`,
+    );
+  }
+  return json;
+}
+
+function setupAliceAndBob(): Effect.Effect<
+  {
+    aliceClient: ServerTestClient;
+    bobClient: ServerTestClient;
+    aliceAgentId: string;
+    bobAgentId: string;
+  },
+  Error
+> {
+  return Effect.gen(function* () {
+    const idx = ++pairCounter;
+    const aliceReg = yield* Effect.tryPromise(() =>
+      adminRegister(`alice-tasks-${idx}`, ALICE_USER_ID),
+    );
+    const bobReg = yield* Effect.tryPromise(() =>
+      adminRegister(`bob-tasks-${idx}`, BOB_USER_ID),
+    );
+    const aliceClient = yield* connectTestClient({
+      wsUrl,
+      agentId: aliceReg.agentId,
+      apiKey: aliceReg.apiKey,
+    });
+    trackClient(aliceClient);
+    const bobClient = yield* connectTestClient({
+      wsUrl,
+      agentId: bobReg.agentId,
+      apiKey: bobReg.apiKey,
+    });
+    trackClient(bobClient);
+    return {
+      aliceClient,
+      bobClient,
+      aliceAgentId: aliceReg.agentId,
+      bobAgentId: bobReg.agentId,
+    };
+  });
+}
+
+describe("tasks/* + endpoints/* RPC end-to-end (Phase 6)", () => {
+  it.live(
+    "tasks/create returns a waiting task with the caller as initiator",
+    () =>
+      Effect.gen(function* () {
+        const { aliceClient, aliceAgentId } = yield* setupAliceAndBob();
+        const result = yield* aliceClient.sendRpc(TasksCreate, {});
+        expect(result.task.status).toBe("waiting");
+        expect(result.task.initiatorAgentId).toBe(aliceAgentId);
+        expect(result.task.tmEndpointAddress).toBeNull();
+      }),
+  );
+
+  it.live(
+    "tasks/get rejects callers who are neither initiator nor participant",
+    () =>
+      Effect.gen(function* () {
+        const { aliceClient, bobClient } = yield* setupAliceAndBob();
+        const created = yield* aliceClient.sendRpc(TasksCreate, {});
+        const result = yield* Effect.either(
+          bobClient.sendRpc(TasksGet, { taskId: created.task.id }),
+        );
+        expect(Either.isLeft(result)).toBe(true);
+      }),
+  );
+
+  it.live(
+    "endpoints/registerTaskManager records caller-derived address; non-initiator rejected",
+    () =>
+      Effect.gen(function* () {
+        const { aliceClient, bobClient } = yield* setupAliceAndBob();
+        const created = yield* aliceClient.sendRpc(TasksCreate, {});
+
+        // Bob (non-initiator) is rejected with Forbidden.
+        const denied = yield* Effect.either(
+          bobClient.sendRpc(EndpointsRegisterTaskManager, {
+            taskId: created.task.id,
+          }),
+        );
+        expect(Either.isLeft(denied)).toBe(true);
+
+        // Alice (initiator) succeeds; address is non-empty.
+        const ok = yield* aliceClient.sendRpc(EndpointsRegisterTaskManager, {
+          taskId: created.task.id,
+        });
+        expect(ok.taskId).toBe(created.task.id);
+        expect(ok.tmEndpointAddress.length).toBeGreaterThan(0);
+
+        // Re-register by Alice is idempotent.
+        const second = yield* aliceClient.sendRpc(
+          EndpointsRegisterTaskManager,
+          { taskId: created.task.id },
+        );
+        expect(second.tmEndpointAddress).toBe(ok.tmEndpointAddress);
+      }),
+  );
+
+  it.live(
+    "TM authority: only the registered TM may close, addParticipant, removeParticipant",
+    () =>
+      Effect.gen(function* () {
+        const { aliceClient, bobClient, bobAgentId } =
+          yield* setupAliceAndBob();
+        const created = yield* aliceClient.sendRpc(TasksCreate, {});
+        yield* aliceClient.sendRpc(EndpointsRegisterTaskManager, {
+          taskId: created.task.id,
+        });
+
+        // Bob (not the TM) cannot mutate.
+        const closeDenied = yield* Effect.either(
+          bobClient.sendRpc(TasksClose, { taskId: created.task.id }),
+        );
+        expect(Either.isLeft(closeDenied)).toBe(true);
+
+        const addDenied = yield* Effect.either(
+          bobClient.sendRpc(TasksAddParticipant, {
+            taskId: created.task.id,
+            agentId: bobAgentId as Task["initiatorAgentId"],
+          }),
+        );
+        expect(Either.isLeft(addDenied)).toBe(true);
+
+        // Alice (the TM) can.
+        const added = yield* aliceClient.sendRpc(TasksAddParticipant, {
+          taskId: created.task.id,
+          agentId: bobAgentId as Task["initiatorAgentId"],
+        });
+        expect(added.participant.agentId).toBe(bobAgentId);
+
+        // Now Bob is a participant — get works.
+        const getView = yield* bobClient.sendRpc(TasksGet, {
+          taskId: created.task.id,
+        });
+        expect(getView.participants.length).toBe(2);
+
+        // Alice (TM) removes.
+        yield* aliceClient.sendRpc(TasksRemoveParticipant, {
+          taskId: created.task.id,
+          agentId: bobAgentId as Task["initiatorAgentId"],
+        });
+
+        // Alice (TM) closes.
+        const closed = yield* aliceClient.sendRpc(TasksClose, {
+          taskId: created.task.id,
+        });
+        expect(closed.task.status).toBe("closed");
+      }),
+  );
+
+  it.live("tasks/list scopes results to caller-as-participant", () =>
+    Effect.gen(function* () {
+      const { aliceClient, bobClient } = yield* setupAliceAndBob();
+      const aliceTask = yield* aliceClient.sendRpc(TasksCreate, {});
+      yield* bobClient.sendRpc(TasksCreate, {});
+
+      const aliceList = yield* aliceClient.sendRpc(TasksList, {});
+      expect(aliceList.tasks.map((t) => t.id)).toContain(aliceTask.task.id);
+      expect(aliceList.tasks).toHaveLength(1);
+    }),
+  );
+
+  it.live(
+    "endpoints/unregisterTaskManager only callable by the registered TM",
+    () =>
+      Effect.gen(function* () {
+        const { aliceClient, bobClient } = yield* setupAliceAndBob();
+        const created = yield* aliceClient.sendRpc(TasksCreate, {});
+        yield* aliceClient.sendRpc(EndpointsRegisterTaskManager, {
+          taskId: created.task.id,
+        });
+
+        const denied = yield* Effect.either(
+          bobClient.sendRpc(EndpointsUnregisterTaskManager, {
+            taskId: created.task.id,
+          }),
+        );
+        expect(Either.isLeft(denied)).toBe(true);
+
+        yield* aliceClient.sendRpc(EndpointsUnregisterTaskManager, {
+          taskId: created.task.id,
+        });
+        const view = yield* aliceClient.sendRpc(TasksGet, {
+          taskId: created.task.id,
+        });
+        expect(view.task.tmEndpointAddress).toBeNull();
+      }),
+  );
+});

--- a/packages/server/src/app/layers.ts
+++ b/packages/server/src/app/layers.ts
@@ -26,6 +26,7 @@ import {
   MessageService,
   type DeliveryWebhookConfig,
 } from "../services/message.service.js";
+import { TaskService } from "../services/task.service.js";
 import type { UserService } from "../services/user.service.js";
 import { AppHost } from "./app-host.js";
 import type { EnvelopeEncryption } from "../crypto/envelope.js";
@@ -103,6 +104,11 @@ export class AppHostTag extends Context.Tag("moltzap/AppHost")<
 export class MessageServiceTag extends Context.Tag("moltzap/MessageService")<
   MessageServiceTag,
   MessageService
+>() {}
+
+export class TaskServiceTag extends Context.Tag("moltzap/TaskService")<
+  TaskServiceTag,
+  TaskService
 >() {}
 
 /** Optional user validator. `null` means no validation — admit all owners. */
@@ -296,11 +302,22 @@ const Tier4 = Layer.provideMerge(ConversationServiceLive, Tier3);
 /** Tier 5 — MessageService needs ConversationService + AppHost + upstream. */
 const Tier5 = Layer.provideMerge(MessageServiceLive, Tier4);
 
+export const TaskServiceLive = Layer.effect(
+  TaskServiceTag,
+  Effect.gen(function* () {
+    const db = yield* DbTag;
+    const conversations = yield* ConversationServiceTag;
+    const messages = yield* MessageServiceTag;
+    return new TaskService(db, conversations, messages);
+  }),
+);
+const Tier6 = Layer.provideMerge(TaskServiceLive, Tier5);
+
 /**
  * All service Layers merged, with cross-layer deps resolved. Still requires
  * `DbTag | LoggerTag | EncryptionTag` from a base Layer.
  */
-export const ServicesLive = Tier5;
+export const ServicesLive = Tier6;
 
 /**
  * Shape of the fully-resolved services. Handler factories consume this
@@ -319,6 +336,7 @@ export interface ResolvedServices {
   readonly presenceService: PresenceService;
   readonly appHost: AppHost;
   readonly messageService: MessageService;
+  readonly taskService: TaskService;
   readonly encryption: EnvelopeEncryption | null;
   readonly traceCapture: TraceCapture;
 }
@@ -342,5 +360,6 @@ export const resolveServices = Effect.all({
   presenceService: PresenceServiceTag,
   appHost: AppHostTag,
   messageService: MessageServiceTag,
+  taskService: TaskServiceTag,
   traceCapture: TraceCaptureTag,
 }) satisfies Effect.Effect<ResolvedServices, never, unknown>;

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -48,10 +48,12 @@ import { EnvelopeEncryption } from "../crypto/envelope.js";
 // Handlers
 import { createCoreAuthHandlers } from "../network/handlers/auth.handlers.js";
 import { createSystemHandlers } from "../network/handlers/system.handlers.js";
+import { createEndpointHandlers } from "../network/handlers/endpoints.handlers.js";
 import { createConversationHandlers } from "../task/handlers/conversations.handlers.js";
 import { createMessageHandlers } from "../task/handlers/messages.handlers.js";
 import { createPresenceHandlers } from "../task/handlers/presence.handlers.js";
 import { createContactHandlers } from "../task/handlers/contacts.handlers.js";
+import { createTaskHandlers } from "../task/handlers/tasks.handlers.js";
 import { createAppHandlers } from "./handlers/apps.handlers.js";
 
 import { WebhookClient } from "../adapters/webhook.js";
@@ -179,6 +181,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     contactService,
     presenceService,
     messageService,
+    taskService,
     appHost,
     traceCapture,
   } = services;
@@ -217,6 +220,12 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       contactService,
       authService,
       broadcaster,
+    }),
+    ...createTaskHandlers({
+      taskService,
+    }),
+    ...createEndpointHandlers({
+      taskService,
     }),
     ...createSystemHandlers(),
   ];

--- a/packages/server/src/network/handlers/endpoints.handlers.ts
+++ b/packages/server/src/network/handlers/endpoints.handlers.ts
@@ -1,0 +1,39 @@
+import { Effect } from "effect";
+import {
+  EndpointsRegisterTaskManager,
+  EndpointsUnregisterTaskManager,
+} from "@moltzap/protocol";
+import { defineNetworkMethod } from "../../rpc/define-layered-method.js";
+import type { RpcMethodRegistry } from "../../rpc/context.js";
+import type { TaskService } from "../../services/task.service.js";
+
+export function createEndpointHandlers(deps: {
+  taskService: TaskService;
+}): RpcMethodRegistry {
+  const { taskService } = deps;
+
+  return [
+    defineNetworkMethod(EndpointsRegisterTaskManager, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          const result = yield* taskService.registerTm(
+            params.taskId,
+            ctx.agentId,
+          );
+          // Drop the brand for JSON encoding; receiver re-brands.
+          return {
+            taskId: result.taskId,
+            tmEndpointAddress: String(result.tmEndpointAddress),
+          };
+        }),
+    }),
+
+    defineNetworkMethod(EndpointsUnregisterTaskManager, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          yield* taskService.unregisterTm(params.taskId, ctx.agentId);
+          return {};
+        }),
+    }),
+  ];
+}

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -387,6 +387,7 @@ export class MessageService {
     requesterAgentId: string,
     options: {
       limit?: number;
+      sinceSeq?: string;
     } = {},
   ): Effect.Effect<{ messages: Message[]; hasMore: boolean }, RpcFailure> {
     return catchSqlErrorAsDefect(
@@ -401,13 +402,15 @@ export class MessageService {
           MAX_MESSAGE_HISTORY_LIMIT,
         );
 
-        const rows = yield* this.db
+        let qb = this.db
           .selectFrom("messages")
           .selectAll()
           .where("conversation_id", "=", conversationId)
-          .where("is_deleted", "=", false)
-          .orderBy("seq", "desc")
-          .limit(limit + 1);
+          .where("is_deleted", "=", false);
+        if (options.sinceSeq !== undefined) {
+          qb = qb.where("seq", ">", options.sinceSeq);
+        }
+        const rows = yield* qb.orderBy("seq", "desc").limit(limit + 1);
 
         const hasMore = rows.length > limit;
         const resultRows = hasMore ? rows.slice(0, limit) : rows;

--- a/packages/server/src/services/task.service.test.ts
+++ b/packages/server/src/services/task.service.test.ts
@@ -309,12 +309,30 @@ describe("TaskService", () => {
   });
 
   describe("brand-decoded TM authority", () => {
+    // The brand factory rejects malformed addresses at construction
+    // (Brand.refined predicate). The service maps the throw to a
+    // typed RpcFailure so a corrupt persisted column never silently
+    // compares as a non-match.
     it("rejects when persisted address is foreign-formatted", async () => {
       const svc = new TaskService(db, STUB_CONV, STUB_MSG);
       const task = await Effect.runPromise(svc.create(ALICE, {}));
       await db
         .updateTable("tasks")
         .set({ tm_endpoint_address: "tm://foreign/addr-1" })
+        .where("id", "=", task.id)
+        .execute();
+      const exit = await Effect.runPromise(
+        Effect.exit(svc.requireTmAuthority(task.id, ALICE)),
+      );
+      expect(rpcFailureCode(exit)).toBe(ErrorCodes.Forbidden);
+    });
+
+    it("rejects when persisted address is empty", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      await db
+        .updateTable("tasks")
+        .set({ tm_endpoint_address: "" })
         .where("id", "=", task.id)
         .execute();
       const exit = await Effect.runPromise(

--- a/packages/server/src/services/task.service.test.ts
+++ b/packages/server/src/services/task.service.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Cause, Effect, Exit } from "effect";
+import { ErrorCodes, agentId, taskId as makeTaskId } from "@moltzap/protocol";
+import type { Kysely } from "kysely";
+import { KyselyPGlite } from "kysely-pglite";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { makeEffectKysely } from "../db/effect-kysely-toolkit.js";
+import type { Database } from "../db/database.js";
+import { RpcFailure } from "../runtime/index.js";
+import { TaskService, endpointAddressForAgent } from "./task.service.js";
+import type { ConversationService } from "./conversation.service.js";
+import type { MessageService } from "./message.service.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schema = readFileSync(
+  join(__dirname, "..", "app", "core-schema.sql"),
+  "utf-8",
+);
+const DB_HOOK_TIMEOUT_MS = 30_000;
+
+// Lifecycle + authority methods never invoke these deps; the conversation
+// + message paths are covered by `__tests__/integration/43-tasks.integration.test.ts`.
+const STUB_CONV = {} as ConversationService;
+const STUB_MSG = {} as MessageService;
+
+const ALICE = agentId("00000000-0000-4000-8000-00000000a11c");
+const BOB = agentId("00000000-0000-4000-8000-00000000b0b0");
+const CAROL = agentId("00000000-0000-4000-8000-00000000ca20");
+
+let db: Kysely<Database>;
+let pglite: {
+  exec: (sql: string) => Promise<unknown>;
+  close: () => Promise<void>;
+};
+
+async function freshDb(): Promise<void> {
+  const kpg = await KyselyPGlite.create();
+  pglite = {
+    exec: (sql) => kpg.client.exec(sql),
+    close: () => kpg.client.close(),
+  };
+  db = makeEffectKysely<Database>({ dialect: kpg.dialect });
+  await pglite.exec(schema);
+  // Seed agents — raw insert satisfies the FK without exercising the
+  // full agents-service registration path.
+  await db
+    .insertInto("agents")
+    .values([
+      {
+        id: ALICE,
+        name: "alice",
+        api_key_id: "0123456789abcdef",
+        api_key_secret_hash:
+          "0000000000000000000000000000000000000000000000000000000000000000",
+        claim_token: "claim-alice",
+        status: "active",
+      },
+      {
+        id: BOB,
+        name: "bob",
+        api_key_id: "fedcba9876543210",
+        api_key_secret_hash:
+          "1111111111111111111111111111111111111111111111111111111111111111",
+        claim_token: "claim-bob",
+        status: "active",
+      },
+      {
+        id: CAROL,
+        name: "carol",
+        api_key_id: "aaaaaaaaaaaaaaaa",
+        api_key_secret_hash:
+          "2222222222222222222222222222222222222222222222222222222222222222",
+        claim_token: "claim-carol",
+        status: "active",
+      },
+    ])
+    .execute();
+}
+
+function rpcFailureCode(exit: Exit.Exit<unknown, RpcFailure>): number | null {
+  if (Exit.isSuccess(exit)) return null;
+  const failure = Cause.failureOption(exit.cause);
+  if (failure._tag === "None") return null;
+  return failure.value.code;
+}
+
+describe("TaskService", () => {
+  beforeEach(async () => {
+    await freshDb();
+  }, DB_HOOK_TIMEOUT_MS);
+
+  afterEach(async () => {
+    await pglite.close();
+  }, DB_HOOK_TIMEOUT_MS);
+
+  describe("create + get + list", () => {
+    it("creates a waiting task with the initiator auto-admitted", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      expect(task.status).toBe("waiting");
+      expect(task.initiatorAgentId).toBe(ALICE);
+      expect(task.tmEndpointAddress).toBeNull();
+
+      const view = await Effect.runPromise(svc.get(task.id, ALICE));
+      expect(view.task.id).toBe(task.id);
+      expect(view.participants).toHaveLength(1);
+      expect(view.participants[0]!.agentId).toBe(ALICE);
+      expect(view.participants[0]!.admittedAt).not.toBeNull();
+    });
+
+    it("admits initiator and pre-creates pending invited participants", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(
+        svc.create(ALICE, { invitedAgentIds: [BOB] }),
+      );
+      const view = await Effect.runPromise(svc.get(task.id, ALICE));
+      const bobRow = view.participants.find((p) => p.agentId === BOB);
+      expect(bobRow).toBeDefined();
+      expect(bobRow!.admittedAt).toBeNull();
+    });
+
+    it("scopes list to caller's tasks (initiator OR participant)", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const aliceTask = await Effect.runPromise(svc.create(ALICE, {}));
+      // Bob's separate task
+      await Effect.runPromise(svc.create(BOB, {}));
+
+      const aliceList = await Effect.runPromise(svc.list(ALICE, {}));
+      expect(aliceList.map((t) => t.id)).toContain(aliceTask.id);
+      expect(aliceList).toHaveLength(1);
+
+      const carolList = await Effect.runPromise(svc.list(CAROL, {}));
+      expect(carolList).toHaveLength(0);
+    });
+
+    it("rejects get when caller is neither initiator nor participant", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      const exit = await Effect.runPromise(Effect.exit(svc.get(task.id, BOB)));
+      expect(rpcFailureCode(exit)).toBe(ErrorCodes.Forbidden);
+    });
+
+    it("404s on get of unknown taskId", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const exit = await Effect.runPromise(
+        Effect.exit(
+          svc.get(makeTaskId("00000000-0000-4000-8000-deadbeefcafe"), ALICE),
+        ),
+      );
+      expect(rpcFailureCode(exit)).toBe(ErrorCodes.NotFound);
+    });
+  });
+
+  describe("registerTm + unregisterTm", () => {
+    it("first registration sets tm_endpoint_address to the caller-derived address", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      const result = await Effect.runPromise(svc.registerTm(task.id, ALICE));
+      expect(result.taskId).toBe(task.id);
+      expect(result.tmEndpointAddress).toBe(endpointAddressForAgent(ALICE));
+
+      const view = await Effect.runPromise(svc.get(task.id, ALICE));
+      expect(view.task.tmEndpointAddress).toBe(endpointAddressForAgent(ALICE));
+    });
+
+    it("re-registration by the same caller is idempotent", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      await Effect.runPromise(svc.registerTm(task.id, ALICE));
+      const second = await Effect.runPromise(svc.registerTm(task.id, ALICE));
+      expect(second.tmEndpointAddress).toBe(endpointAddressForAgent(ALICE));
+    });
+
+    it("rejects registration by a non-initiator", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      const exit = await Effect.runPromise(
+        Effect.exit(svc.registerTm(task.id, BOB)),
+      );
+      expect(rpcFailureCode(exit)).toBe(ErrorCodes.Forbidden);
+    });
+
+    it("rejects registration when a different TM is already registered", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      await db
+        .updateTable("tasks")
+        .set({ tm_endpoint_address: endpointAddressForAgent(BOB) })
+        .where("id", "=", task.id)
+        .execute();
+      const exit = await Effect.runPromise(
+        Effect.exit(svc.registerTm(task.id, ALICE)),
+      );
+      expect(rpcFailureCode(exit)).toBe(ErrorCodes.Forbidden);
+    });
+
+    it("unregister clears tm_endpoint_address; only the registered TM may unregister", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      await Effect.runPromise(svc.registerTm(task.id, ALICE));
+
+      const denied = await Effect.runPromise(
+        Effect.exit(svc.unregisterTm(task.id, BOB)),
+      );
+      expect(rpcFailureCode(denied)).toBe(ErrorCodes.Forbidden);
+
+      await Effect.runPromise(svc.unregisterTm(task.id, ALICE));
+      const view = await Effect.runPromise(svc.get(task.id, ALICE));
+      expect(view.task.tmEndpointAddress).toBeNull();
+    });
+  });
+
+  describe("requireTmAuthority — every mutation routes through it", () => {
+    it("close: rejects caller that isn't the registered TM", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      await Effect.runPromise(svc.registerTm(task.id, ALICE));
+
+      const exit = await Effect.runPromise(
+        Effect.exit(svc.close(task.id, BOB)),
+      );
+      expect(rpcFailureCode(exit)).toBe(ErrorCodes.Forbidden);
+    });
+
+    it("close: registered TM transitions task to closed", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      await Effect.runPromise(svc.registerTm(task.id, ALICE));
+
+      const closed = await Effect.runPromise(svc.close(task.id, ALICE));
+      expect(closed.status).toBe("closed");
+      expect(closed.endedAt).not.toBeNull();
+    });
+
+    it("close: rejects when no TM is registered (no-TM = no-authority)", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      const exit = await Effect.runPromise(
+        Effect.exit(svc.close(task.id, ALICE)),
+      );
+      expect(rpcFailureCode(exit)).toBe(ErrorCodes.Forbidden);
+    });
+
+    it("addParticipant: only registered TM may add", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      await Effect.runPromise(svc.registerTm(task.id, ALICE));
+
+      const denied = await Effect.runPromise(
+        Effect.exit(svc.addParticipant(task.id, BOB, CAROL)),
+      );
+      expect(rpcFailureCode(denied)).toBe(ErrorCodes.Forbidden);
+
+      const participant = await Effect.runPromise(
+        svc.addParticipant(task.id, ALICE, CAROL),
+      );
+      expect(participant.agentId).toBe(CAROL);
+      expect(participant.admittedAt).not.toBeNull();
+    });
+
+    it("removeParticipant: only registered TM may remove", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(
+        svc.create(ALICE, { invitedAgentIds: [BOB] }),
+      );
+      await Effect.runPromise(svc.registerTm(task.id, ALICE));
+
+      const denied = await Effect.runPromise(
+        Effect.exit(svc.removeParticipant(task.id, CAROL, BOB)),
+      );
+      expect(rpcFailureCode(denied)).toBe(ErrorCodes.Forbidden);
+
+      await Effect.runPromise(svc.removeParticipant(task.id, ALICE, BOB));
+      const view = await Effect.runPromise(svc.get(task.id, ALICE));
+      expect(view.participants.find((p) => p.agentId === BOB)).toBeUndefined();
+    });
+  });
+
+  describe("closed-task immutability", () => {
+    it("rejects mutations after close even by the registered TM", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      await Effect.runPromise(svc.registerTm(task.id, ALICE));
+      await Effect.runPromise(svc.close(task.id, ALICE));
+
+      const addExit = await Effect.runPromise(
+        Effect.exit(svc.addParticipant(task.id, ALICE, BOB)),
+      );
+      expect(rpcFailureCode(addExit)).toBe(ErrorCodes.Forbidden);
+
+      const closeExit = await Effect.runPromise(
+        Effect.exit(svc.close(task.id, ALICE)),
+      );
+      expect(rpcFailureCode(closeExit)).toBe(ErrorCodes.Forbidden);
+    });
+  });
+
+  describe("read access denies pending invitees", () => {
+    it("admitted_at IS NULL means no read access", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(
+        svc.create(ALICE, { invitedAgentIds: [BOB] }),
+      );
+      const exit = await Effect.runPromise(Effect.exit(svc.get(task.id, BOB)));
+      expect(rpcFailureCode(exit)).toBe(ErrorCodes.Forbidden);
+    });
+  });
+
+  describe("brand-decoded TM authority", () => {
+    it("rejects when persisted address is foreign-formatted", async () => {
+      const svc = new TaskService(db, STUB_CONV, STUB_MSG);
+      const task = await Effect.runPromise(svc.create(ALICE, {}));
+      await db
+        .updateTable("tasks")
+        .set({ tm_endpoint_address: "tm://foreign/addr-1" })
+        .where("id", "=", task.id)
+        .execute();
+      const exit = await Effect.runPromise(
+        Effect.exit(svc.requireTmAuthority(task.id, ALICE)),
+      );
+      expect(rpcFailureCode(exit)).toBe(ErrorCodes.Forbidden);
+    });
+  });
+});

--- a/packages/server/src/services/task.service.ts
+++ b/packages/server/src/services/task.service.ts
@@ -1,0 +1,576 @@
+import { Effect, Either, Option } from "effect";
+import {
+  endpointAddress as brandEndpointAddress,
+  type EndpointAddress,
+  type AgentId as ActorAgentId,
+} from "@moltzap/protocol/network";
+import {
+  agentId as makeAgentId,
+  taskId as makeTaskId,
+  type Static,
+  type Conversation,
+  type Message,
+  type Part,
+  type Task,
+  type TaskParticipant,
+  type TaskStatus,
+} from "@moltzap/protocol";
+import { TaskId, AgentId } from "@moltzap/protocol/schemas/primitives";
+import type { Db } from "../db/client.js";
+import {
+  catchSqlErrorAsDefect,
+  takeFirstOption,
+  takeFirstOrFail,
+  transaction,
+} from "../db/effect-kysely-toolkit.js";
+import { forbidden, notFound, type RpcFailure } from "../runtime/index.js";
+import type { ConversationService } from "./conversation.service.js";
+import type { MessageService } from "./message.service.js";
+
+type BrandedTaskId = Static<typeof TaskId>;
+type BrandedAgentId = Static<typeof AgentId>;
+
+const ERR_NOT_FOUND = "Task not found";
+const ERR_NO_TM = "No task manager registered for task";
+const ERR_NOT_TM = "Caller is not the registered task manager for this task";
+const ERR_NOT_PARTICIPANT = "Caller is not a participant of this task";
+const ERR_TM_OWNED_BY_OTHER =
+  "Task already has a different task manager registered";
+const ERR_CONV_NOT_IN_TASK =
+  "Conversation does not belong to the specified task";
+const ERR_TASK_NOT_OPEN = "Task is not open for mutation";
+
+const DEFAULT_TASK_LIST_LIMIT = 50;
+const DEFAULT_TASK_MESSAGES_LIMIT = 50;
+
+interface TaskRow {
+  readonly id: string;
+  readonly app_id: string | null;
+  readonly initiator_agent_id: string;
+  readonly status: TaskStatus;
+  readonly tm_endpoint_address: string | null;
+  readonly started_at: Date | null;
+  readonly ended_at: Date | null;
+  readonly created_at: Date;
+}
+
+const TM_AGENT_PREFIX = "tm:agent:";
+
+export function endpointAddressForAgent(
+  agent: ActorAgentId | BrandedAgentId,
+): EndpointAddress {
+  return brandEndpointAddress(`${TM_AGENT_PREFIX}${agent}`);
+}
+
+function rowToTask(row: TaskRow): Task {
+  return {
+    id: makeTaskId(row.id),
+    appId: row.app_id,
+    initiatorAgentId: makeAgentId(row.initiator_agent_id),
+    status: row.status,
+    tmEndpointAddress: row.tm_endpoint_address,
+    startedAt: row.started_at ? row.started_at.toISOString() : null,
+    endedAt: row.ended_at ? row.ended_at.toISOString() : null,
+    createdAt: row.created_at.toISOString(),
+  };
+}
+
+function rowToParticipant(row: {
+  readonly task_id: string;
+  readonly agent_id: string;
+  readonly admitted_at: Date | null;
+}): TaskParticipant {
+  return {
+    taskId: makeTaskId(row.task_id),
+    agentId: makeAgentId(row.agent_id),
+    admittedAt: row.admitted_at ? row.admitted_at.toISOString() : null,
+  };
+}
+
+export interface TaskCreateInput {
+  readonly appId?: string;
+  readonly invitedAgentIds?: readonly BrandedAgentId[];
+}
+
+export interface TaskListInput {
+  readonly appId?: string;
+  readonly status?: TaskStatus;
+  readonly limit?: number;
+}
+
+export interface TaskMessagesInput {
+  readonly limit?: number;
+}
+
+export interface TaskMessagesSinceInput {
+  readonly sinceSeq: string;
+  readonly limit?: number;
+}
+
+export interface RegisterTmResult {
+  readonly taskId: BrandedTaskId;
+  readonly tmEndpointAddress: EndpointAddress;
+}
+
+export interface CreateConversationInput {
+  readonly type: "dm" | "group";
+  readonly name?: string;
+  readonly participantAgentIds: readonly BrandedAgentId[];
+}
+
+export interface StoreMessageInput {
+  readonly conversationId: string;
+  readonly senderAgentId: BrandedAgentId;
+  readonly parts: readonly Part[];
+  readonly replyToId?: string;
+}
+
+export class TaskService {
+  constructor(
+    private readonly db: Db,
+    private readonly conversations: ConversationService,
+    private readonly messages: MessageService,
+  ) {}
+
+  create(
+    initiator: BrandedAgentId,
+    input: TaskCreateInput,
+  ): Effect.Effect<Task, RpcFailure> {
+    return catchSqlErrorAsDefect(
+      transaction(this.db, (trx) =>
+        Effect.gen(function* () {
+          const row = yield* takeFirstOrFail(
+            trx
+              .insertInto("tasks")
+              .values({
+                app_id: input.appId ?? null,
+                initiator_agent_id: initiator,
+                status: "waiting",
+              })
+              .returningAll(),
+          );
+          yield* trx.insertInto("task_participants").values({
+            task_id: row.id,
+            agent_id: initiator,
+            admitted_at: new Date(),
+          });
+          const invited = input.invitedAgentIds ?? [];
+          for (const agentId of invited) {
+            yield* trx
+              .insertInto("task_participants")
+              .values({
+                task_id: row.id,
+                agent_id: agentId,
+                admitted_at: null,
+              })
+              .onConflict((oc) => oc.doNothing());
+          }
+          return rowToTask(row as TaskRow);
+        }),
+      ),
+    );
+  }
+
+  get(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+  ): Effect.Effect<
+    { task: Task; participants: TaskParticipant[] },
+    RpcFailure
+  > {
+    return Effect.gen(this, function* () {
+      const task = yield* this.requireReadAccess(id, caller);
+      const rows = yield* catchSqlErrorAsDefect(
+        this.db
+          .selectFrom("task_participants")
+          .selectAll()
+          .where("task_id", "=", id),
+      );
+      return {
+        task,
+        participants: rows.map(rowToParticipant),
+      };
+    });
+  }
+
+  list(
+    caller: BrandedAgentId,
+    input: TaskListInput,
+  ): Effect.Effect<readonly Task[], never> {
+    const limit = input.limit ?? DEFAULT_TASK_LIST_LIMIT;
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        let qb = this.db
+          .selectFrom("tasks")
+          .innerJoin(
+            "task_participants",
+            "task_participants.task_id",
+            "tasks.id",
+          )
+          .where("task_participants.agent_id", "=", caller)
+          .selectAll("tasks")
+          .orderBy("tasks.created_at", "desc")
+          .limit(limit);
+        if (input.appId !== undefined) {
+          qb = qb.where("tasks.app_id", "=", input.appId);
+        }
+        if (input.status !== undefined) {
+          qb = qb.where("tasks.status", "=", input.status);
+        }
+        const rows = yield* qb;
+        return rows.map((row) => rowToTask(row as TaskRow));
+      }),
+    );
+  }
+
+  close(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+  ): Effect.Effect<Task, RpcFailure> {
+    return Effect.gen(this, function* () {
+      yield* this.requireTmAuthority(id, caller);
+      const row = yield* catchSqlErrorAsDefect(
+        takeFirstOrFail(
+          this.db
+            .updateTable("tasks")
+            .set({ status: "closed", ended_at: new Date() })
+            .where("id", "=", id)
+            .returningAll(),
+        ),
+      );
+      return rowToTask(row as TaskRow);
+    });
+  }
+
+  registerTm(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+  ): Effect.Effect<RegisterTmResult, RpcFailure> {
+    return Effect.gen(this, function* () {
+      const task = yield* this.fetchTask(id);
+      if (task.initiatorAgentId !== caller) {
+        return yield* Effect.fail(
+          forbidden("Only the task initiator may register a task manager"),
+        );
+      }
+      const expected = endpointAddressForAgent(caller);
+      // Atomic claim: only succeeds if the column is currently null (first
+      // registration) or already equals `expected` (idempotent re-register).
+      // Closes the read-then-update race.
+      const updated = yield* catchSqlErrorAsDefect(
+        this.db
+          .updateTable("tasks")
+          .set({ tm_endpoint_address: expected })
+          .where("id", "=", id)
+          .where((eb) =>
+            eb.or([
+              eb("tm_endpoint_address", "is", null),
+              eb("tm_endpoint_address", "=", expected),
+            ]),
+          )
+          .returning("id"),
+      );
+      if (updated.length === 0) {
+        return yield* Effect.fail(forbidden(ERR_TM_OWNED_BY_OTHER));
+      }
+      return { taskId: id, tmEndpointAddress: expected };
+    });
+  }
+
+  unregisterTm(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+  ): Effect.Effect<void, RpcFailure> {
+    return Effect.gen(this, function* () {
+      yield* this.requireTmAuthority(id, caller);
+      yield* catchSqlErrorAsDefect(
+        this.db
+          .updateTable("tasks")
+          .set({ tm_endpoint_address: null })
+          .where("id", "=", id),
+      );
+    });
+  }
+
+  // Decode `tm_endpoint_address` (raw `string | null` from Kysely codegen)
+  // through the `EndpointAddress` brand BEFORE comparing.
+  requireTmAuthority(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+  ): Effect.Effect<Task, RpcFailure> {
+    return Effect.gen(this, function* () {
+      const task = yield* this.fetchTask(id);
+      if (task.status === "closed" || task.status === "failed") {
+        return yield* Effect.fail(forbidden(ERR_TASK_NOT_OPEN));
+      }
+      if (task.tmEndpointAddress === null) {
+        return yield* Effect.fail(forbidden(ERR_NO_TM));
+      }
+      const recorded = brandEndpointAddress(task.tmEndpointAddress);
+      const expected = endpointAddressForAgent(caller);
+      if (recorded !== expected) {
+        return yield* Effect.fail(forbidden(ERR_NOT_TM));
+      }
+      return task;
+    });
+  }
+
+  requireReadAccess(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+  ): Effect.Effect<Task, RpcFailure> {
+    return Effect.gen(this, function* () {
+      const task = yield* this.fetchTask(id);
+      if (task.initiatorAgentId === caller) return task;
+      // Pending invites (admitted_at IS NULL) are NOT read access.
+      const participant = yield* catchSqlErrorAsDefect(
+        takeFirstOption(
+          this.db
+            .selectFrom("task_participants")
+            .select("agent_id")
+            .where("task_id", "=", id)
+            .where("agent_id", "=", caller)
+            .where("admitted_at", "is not", null),
+        ),
+      );
+      if (Option.isNone(participant)) {
+        return yield* Effect.fail(forbidden(ERR_NOT_PARTICIPANT));
+      }
+      return task;
+    });
+  }
+
+  addParticipant(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+    target: BrandedAgentId,
+  ): Effect.Effect<TaskParticipant, RpcFailure> {
+    return Effect.gen(this, function* () {
+      yield* this.requireTmAuthority(id, caller);
+      const row = yield* catchSqlErrorAsDefect(
+        takeFirstOrFail(
+          this.db
+            .insertInto("task_participants")
+            .values({
+              task_id: id,
+              agent_id: target,
+              admitted_at: new Date(),
+            })
+            .onConflict((oc) =>
+              oc
+                .columns(["task_id", "agent_id"])
+                .doUpdateSet({ admitted_at: new Date() }),
+            )
+            .returningAll(),
+        ),
+      );
+      return rowToParticipant(row);
+    });
+  }
+
+  removeParticipant(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+    target: BrandedAgentId,
+  ): Effect.Effect<void, RpcFailure> {
+    return Effect.gen(this, function* () {
+      yield* this.requireTmAuthority(id, caller);
+      yield* catchSqlErrorAsDefect(
+        this.db
+          .deleteFrom("task_participants")
+          .where("task_id", "=", id)
+          .where("agent_id", "=", target),
+      );
+    });
+  }
+
+  createConversation(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+    input: CreateConversationInput,
+  ): Effect.Effect<Conversation, RpcFailure> {
+    return Effect.gen(this, function* () {
+      yield* this.requireTmAuthority(id, caller);
+      // ConversationService.create wraps its own transaction; we follow
+      // the stamp UPDATE in the same Effect so a failure in either
+      // surfaces a typed RpcFailure. A crash between the two leaves an
+      // unstamped conversation that `requireConversationInTask` rejects
+      // (fail-closed): the row exists but `task_id` is NULL, so any
+      // tasks/* mutation against it gets ERR_CONV_NOT_IN_TASK.
+      const conversation = yield* this.conversations.create(
+        input.type,
+        input.name,
+        [...input.participantAgentIds],
+        caller,
+      );
+      yield* catchSqlErrorAsDefect(
+        this.db
+          .updateTable("conversations")
+          .set({ task_id: id })
+          .where("id", "=", conversation.id),
+      );
+      return conversation;
+    });
+  }
+
+  closeConversation(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+    conversationId: string,
+  ): Effect.Effect<void, RpcFailure> {
+    return Effect.gen(this, function* () {
+      yield* this.requireTmAuthority(id, caller);
+      yield* this.archiveConversationInTask(id, conversationId);
+    });
+  }
+
+  storeMessage(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+    input: StoreMessageInput,
+  ): Effect.Effect<Message, RpcFailure> {
+    return Effect.gen(this, function* () {
+      yield* this.requireTmAuthority(id, caller);
+      yield* this.requireConversationInTask(id, input.conversationId);
+      const message = yield* this.messages.send(
+        input.conversationId,
+        [...input.parts],
+        input.senderAgentId,
+        input.replyToId,
+      );
+      // Stamp the message's task_id so cross-task queries (Phase 6
+      // `tasks/getMessages`, future TM-routed reads) can scope by the
+      // denormalized FK without joining through `conversations`.
+      yield* catchSqlErrorAsDefect(
+        this.db
+          .updateTable("messages")
+          .set({ task_id: id })
+          .where("id", "=", message.id),
+      );
+      return message;
+    });
+  }
+
+  getMessages(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+    input: TaskMessagesInput,
+  ): Effect.Effect<{ messages: Message[]; hasMore: boolean }, RpcFailure> {
+    return Effect.gen(this, function* () {
+      yield* this.requireReadAccess(id, caller);
+      const limit = input.limit ?? DEFAULT_TASK_MESSAGES_LIMIT;
+      return yield* this.fetchTaskMessages(id, caller, { limit });
+    });
+  }
+
+  getMessagesSince(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+    input: TaskMessagesSinceInput,
+  ): Effect.Effect<{ messages: Message[]; hasMore: boolean }, RpcFailure> {
+    return Effect.gen(this, function* () {
+      yield* this.requireReadAccess(id, caller);
+      const limit = input.limit ?? DEFAULT_TASK_MESSAGES_LIMIT;
+      return yield* this.fetchTaskMessages(id, caller, {
+        limit,
+        sinceSeq: input.sinceSeq,
+      });
+    });
+  }
+
+  private fetchTask(id: BrandedTaskId): Effect.Effect<Task, RpcFailure> {
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        const opt = yield* takeFirstOption(
+          this.db.selectFrom("tasks").selectAll().where("id", "=", id),
+        );
+        if (Option.isNone(opt)) {
+          return yield* Effect.fail(notFound(ERR_NOT_FOUND));
+        }
+        return rowToTask(opt.value as TaskRow);
+      }),
+    );
+  }
+
+  private requireConversationInTask(
+    id: BrandedTaskId,
+    conversationId: string,
+  ): Effect.Effect<void, RpcFailure> {
+    return Effect.gen(this, function* () {
+      const linkedOpt = yield* catchSqlErrorAsDefect(
+        takeFirstOption(
+          this.db
+            .selectFrom("conversations")
+            .select("task_id")
+            .where("id", "=", conversationId),
+        ),
+      );
+      if (Option.isNone(linkedOpt)) {
+        return yield* Effect.fail(notFound("Conversation not found"));
+      }
+      if (linkedOpt.value.task_id !== id) {
+        return yield* Effect.fail(forbidden(ERR_CONV_NOT_IN_TASK));
+      }
+    });
+  }
+
+  private archiveConversationInTask(
+    id: BrandedTaskId,
+    conversationId: string,
+  ): Effect.Effect<void, RpcFailure> {
+    return Effect.gen(this, function* () {
+      const updated = yield* catchSqlErrorAsDefect(
+        this.db
+          .updateTable("conversations")
+          .set({ archived_at: new Date() })
+          .where("id", "=", conversationId)
+          .where("task_id", "=", id)
+          .returning("id"),
+      );
+      if (updated.length > 0) return;
+      yield* this.requireConversationInTask(id, conversationId);
+    });
+  }
+
+  private fetchTaskMessages(
+    id: BrandedTaskId,
+    caller: BrandedAgentId,
+    opts: { limit: number; sinceSeq?: string },
+  ): Effect.Effect<{ messages: Message[]; hasMore: boolean }, RpcFailure> {
+    return Effect.gen(this, function* () {
+      const conversationIds = yield* catchSqlErrorAsDefect(
+        this.db
+          .selectFrom("conversations")
+          .select("id")
+          .where("task_id", "=", id),
+      );
+      if (conversationIds.length === 0) {
+        return { messages: [], hasMore: false };
+      }
+      const pages = yield* Effect.all(
+        conversationIds.map(({ id: convId }) =>
+          Effect.either(
+            this.messages.list(convId, caller, { limit: opts.limit + 1 }),
+          ),
+        ),
+        { concurrency: 8 },
+      );
+      const all: Message[] = [];
+      for (const result of pages) {
+        const messages = Either.match(result, {
+          onLeft: () => [] as readonly Message[],
+          onRight: (page) => page.messages,
+        });
+        for (const message of messages) {
+          if (opts.sinceSeq !== undefined && message.id <= opts.sinceSeq) {
+            continue;
+          }
+          all.push(message);
+        }
+      }
+      all.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+      const trimmed = all.slice(0, opts.limit);
+      return { messages: trimmed, hasMore: all.length > opts.limit };
+    });
+  }
+}

--- a/packages/server/src/services/task.service.ts
+++ b/packages/server/src/services/task.service.ts
@@ -1,4 +1,4 @@
-import { Effect, Either, Option } from "effect";
+import { Effect, Option } from "effect";
 import {
   endpointAddress as brandEndpointAddress,
   type EndpointAddress,
@@ -39,6 +39,10 @@ const ERR_TM_OWNED_BY_OTHER =
 const ERR_CONV_NOT_IN_TASK =
   "Conversation does not belong to the specified task";
 const ERR_TASK_NOT_OPEN = "Task is not open for mutation";
+
+function absurdTaskStatus(status: never): never {
+  throw new Error(`unreachable task status: ${JSON.stringify(status)}`);
+}
 
 const DEFAULT_TASK_LIST_LIMIT = 50;
 const DEFAULT_TASK_MESSAGES_LIMIT = 50;
@@ -99,10 +103,12 @@ export interface TaskListInput {
 }
 
 export interface TaskMessagesInput {
+  readonly conversationId: string;
   readonly limit?: number;
 }
 
 export interface TaskMessagesSinceInput {
+  readonly conversationId: string;
   readonly sinceSeq: string;
   readonly limit?: number;
 }
@@ -300,13 +306,23 @@ export class TaskService {
   ): Effect.Effect<Task, RpcFailure> {
     return Effect.gen(this, function* () {
       const task = yield* this.fetchTask(id);
-      if (task.status === "closed" || task.status === "failed") {
-        return yield* Effect.fail(forbidden(ERR_TASK_NOT_OPEN));
+      switch (task.status) {
+        case "waiting":
+        case "active":
+          break;
+        case "closed":
+        case "failed":
+          return yield* Effect.fail(forbidden(ERR_TASK_NOT_OPEN));
+        default:
+          return absurdTaskStatus(task.status);
       }
       if (task.tmEndpointAddress === null) {
         return yield* Effect.fail(forbidden(ERR_NO_TM));
       }
-      const recorded = brandEndpointAddress(task.tmEndpointAddress);
+      const recorded = yield* Effect.try({
+        try: () => brandEndpointAddress(task.tmEndpointAddress!),
+        catch: () => forbidden(ERR_NOT_TM),
+      });
       const expected = endpointAddressForAgent(caller);
       if (recorded !== expected) {
         return yield* Effect.fail(forbidden(ERR_NOT_TM));
@@ -458,8 +474,10 @@ export class TaskService {
   ): Effect.Effect<{ messages: Message[]; hasMore: boolean }, RpcFailure> {
     return Effect.gen(this, function* () {
       yield* this.requireReadAccess(id, caller);
-      const limit = input.limit ?? DEFAULT_TASK_MESSAGES_LIMIT;
-      return yield* this.fetchTaskMessages(id, caller, { limit });
+      yield* this.requireConversationInTask(id, input.conversationId);
+      return yield* this.messages.list(input.conversationId, caller, {
+        limit: input.limit ?? DEFAULT_TASK_MESSAGES_LIMIT,
+      });
     });
   }
 
@@ -470,9 +488,9 @@ export class TaskService {
   ): Effect.Effect<{ messages: Message[]; hasMore: boolean }, RpcFailure> {
     return Effect.gen(this, function* () {
       yield* this.requireReadAccess(id, caller);
-      const limit = input.limit ?? DEFAULT_TASK_MESSAGES_LIMIT;
-      return yield* this.fetchTaskMessages(id, caller, {
-        limit,
+      yield* this.requireConversationInTask(id, input.conversationId);
+      return yield* this.messages.list(input.conversationId, caller, {
+        limit: input.limit ?? DEFAULT_TASK_MESSAGES_LIMIT,
         sinceSeq: input.sinceSeq,
       });
     });
@@ -529,48 +547,6 @@ export class TaskService {
       );
       if (updated.length > 0) return;
       yield* this.requireConversationInTask(id, conversationId);
-    });
-  }
-
-  private fetchTaskMessages(
-    id: BrandedTaskId,
-    caller: BrandedAgentId,
-    opts: { limit: number; sinceSeq?: string },
-  ): Effect.Effect<{ messages: Message[]; hasMore: boolean }, RpcFailure> {
-    return Effect.gen(this, function* () {
-      const conversationIds = yield* catchSqlErrorAsDefect(
-        this.db
-          .selectFrom("conversations")
-          .select("id")
-          .where("task_id", "=", id),
-      );
-      if (conversationIds.length === 0) {
-        return { messages: [], hasMore: false };
-      }
-      const pages = yield* Effect.all(
-        conversationIds.map(({ id: convId }) =>
-          Effect.either(
-            this.messages.list(convId, caller, { limit: opts.limit + 1 }),
-          ),
-        ),
-        { concurrency: 8 },
-      );
-      const all: Message[] = [];
-      for (const result of pages) {
-        const messages = Either.match(result, {
-          onLeft: () => [] as readonly Message[],
-          onRight: (page) => page.messages,
-        });
-        for (const message of messages) {
-          if (opts.sinceSeq !== undefined && message.id <= opts.sinceSeq) {
-            continue;
-          }
-          all.push(message);
-        }
-      }
-      all.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
-      const trimmed = all.slice(0, opts.limit);
-      return { messages: trimmed, hasMore: all.length > opts.limit };
     });
   }
 }

--- a/packages/server/src/task/handlers/tasks.handlers.ts
+++ b/packages/server/src/task/handlers/tasks.handlers.ts
@@ -132,6 +132,7 @@ export function createTaskHandlers(deps: {
     defineTaskMethod(TasksGetMessages, {
       handler: (params, ctx) =>
         taskService.getMessages(params.taskId, ctx.agentId, {
+          conversationId: params.conversationId,
           limit: params.limit,
         }),
     }),
@@ -139,6 +140,7 @@ export function createTaskHandlers(deps: {
     defineTaskMethod(TasksGetMessagesSince, {
       handler: (params, ctx) =>
         taskService.getMessagesSince(params.taskId, ctx.agentId, {
+          conversationId: params.conversationId,
           sinceSeq: params.sinceSeq,
           limit: params.limit,
         }),

--- a/packages/server/src/task/handlers/tasks.handlers.ts
+++ b/packages/server/src/task/handlers/tasks.handlers.ts
@@ -1,0 +1,147 @@
+import { Effect } from "effect";
+import {
+  TasksAddParticipant,
+  TasksClose,
+  TasksCloseConversation,
+  TasksCreate,
+  TasksCreateConversation,
+  TasksGet,
+  TasksGetMessages,
+  TasksGetMessagesSince,
+  TasksList,
+  TasksRemoveParticipant,
+  TasksStoreMessage,
+  agentId as brandAgentId,
+} from "@moltzap/protocol";
+import { defineTaskMethod } from "../../rpc/define-layered-method.js";
+import type { RpcMethodRegistry } from "../../rpc/context.js";
+import type { TaskService } from "../../services/task.service.js";
+
+export function createTaskHandlers(deps: {
+  taskService: TaskService;
+}): RpcMethodRegistry {
+  const { taskService } = deps;
+
+  return [
+    defineTaskMethod(TasksCreate, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          const task = yield* taskService.create(ctx.agentId, {
+            appId: params.appId,
+            invitedAgentIds: params.invitedAgentIds,
+          });
+          return { task };
+        }),
+    }),
+
+    defineTaskMethod(TasksGet, {
+      handler: (params, ctx) => taskService.get(params.taskId, ctx.agentId),
+    }),
+
+    defineTaskMethod(TasksList, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          const tasks = yield* taskService.list(ctx.agentId, {
+            appId: params.appId,
+            status: params.status,
+            limit: params.limit,
+          });
+          return { tasks: [...tasks] };
+        }),
+    }),
+
+    defineTaskMethod(TasksClose, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          const task = yield* taskService.close(params.taskId, ctx.agentId);
+          return { task };
+        }),
+    }),
+
+    defineTaskMethod(TasksCreateConversation, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          const conversation = yield* taskService.createConversation(
+            params.taskId,
+            ctx.agentId,
+            {
+              type: params.type,
+              name: params.name,
+              participantAgentIds: params.participants.map((p) =>
+                brandAgentId(p.id),
+              ),
+            },
+          );
+          return { conversation };
+        }),
+    }),
+
+    defineTaskMethod(TasksCloseConversation, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          yield* taskService.closeConversation(
+            params.taskId,
+            ctx.agentId,
+            params.conversationId,
+          );
+          return {};
+        }),
+    }),
+
+    defineTaskMethod(TasksAddParticipant, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          const participant = yield* taskService.addParticipant(
+            params.taskId,
+            ctx.agentId,
+            params.agentId,
+          );
+          return { participant };
+        }),
+    }),
+
+    defineTaskMethod(TasksRemoveParticipant, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          yield* taskService.removeParticipant(
+            params.taskId,
+            ctx.agentId,
+            params.agentId,
+          );
+          return {};
+        }),
+    }),
+
+    defineTaskMethod(TasksStoreMessage, {
+      handler: (params, ctx) =>
+        Effect.gen(function* () {
+          const message = yield* taskService.storeMessage(
+            params.taskId,
+            ctx.agentId,
+            {
+              conversationId: params.conversationId,
+              senderAgentId: params.senderAgentId,
+              parts: params.parts,
+              replyToId: params.replyToId,
+            },
+          );
+          return { message };
+        }),
+    }),
+
+    defineTaskMethod(TasksGetMessages, {
+      handler: (params, ctx) =>
+        taskService.getMessages(params.taskId, ctx.agentId, {
+          limit: params.limit,
+        }),
+    }),
+
+    defineTaskMethod(TasksGetMessagesSince, {
+      handler: (params, ctx) =>
+        taskService.getMessagesSince(params.taskId, ctx.agentId, {
+          sinceSeq: params.sinceSeq,
+          limit: params.limit,
+        }),
+    }),
+  ];
+}


### PR DESCRIPTION
Closes #424
Parent epic: #415
Plan: docs/plans/layered-network-refactor-2026-05.md §2.4.b / §2.6 / §2.7

## What changed

Phase 6 B2 additive (plan §2.4.b). Introduces 11 task-CRUD wire methods + 2 endpoint-registration methods alongside the existing `apps/*` surface. Every task-mutation method gates on `TaskService.requireTmAuthority` (caller's derived `EndpointAddress` matches `tasks.tm_endpoint_address`). Read methods route through `requireReadAccess` (initiator OR admitted participant — pending invitees are denied).

## Traceability

| Artifact | Kind | Plan anchor |
|---|---|---|
| `tasks/create` | RPC | §2.4.b, decomp #424 |
| `tasks/get` | RPC | §2.4.b, decomp #424 |
| `tasks/list` | RPC | §2.4.b, decomp #424 |
| `tasks/close` | RPC | §2.4.b "closeTask", decomp #424 |
| `tasks/createConversation` | RPC | §2.4.b, §2.6 (apps/attachConversation collapses into) |
| `tasks/closeConversation` | RPC | §2.4.b, decomp #424 |
| `tasks/addParticipant` | RPC | §2.4.b, decomp #424 |
| `tasks/removeParticipant` | RPC | §2.4.b, decomp #424 |
| `tasks/storeMessage` | RPC | §2.4.b, decomp #424 |
| `tasks/getMessages` | RPC | decomp #424 |
| `tasks/getMessagesSince` | RPC | decomp #424 |
| `endpoints/registerTaskManager` | RPC | §2.4.b "registration mechanism" |
| `endpoints/unregisterTaskManager` | RPC | §2.4.b "Explicit endpoints/unregisterTaskManager" |
| `packages/protocol/src/task/methods/tasks.ts` | new module | §2.4.b |
| `packages/protocol/src/network/methods/endpoints.ts` | new module | §2.4.b |
| `packages/protocol/src/schema/tasks.ts` | new module | TaskSchema, TaskParticipantSchema |
| `packages/server/src/services/task.service.ts` | new module | §2.4.b TM authority + CRUD |
| `packages/server/src/task/handlers/tasks.handlers.ts` | new module | layered handler split (Phase 4) |
| `packages/server/src/network/handlers/endpoints.handlers.ts` | new module | layered handler split |
| `TaskId` brand | new schema-value | wire shape for §2.4.b |
| `TaskServiceTag` + `TaskServiceLive` | new Layer | DI for handlers |

## Scope

- New modules: `task.service.ts`, `tasks.handlers.ts`, `endpoints.handlers.ts`, `protocol/.../tasks.ts`, `protocol/.../endpoints.ts`, `protocol/schema/tasks.ts`.
- New public exports: 13 RPC descriptors, 2 schemas, 1 brand, 2 type aliases.
- New deps: none.

## Dependencies

| Name | Version | License | Justification |
|---|---|---|---|
| (none) | — | — | All work done with existing infrastructure (Effect, Kysely, TypeBox, ConversationService, MessageService). |

## Pre-PR hygiene

- `pnpm typecheck` — clean
- `pnpm lint` — 0/0
- `pnpm format:check` — clean
- `bash packages/protocol/scripts/check-divergence-proofs.sh` — clean (no new registrars; existing `registerRpcMapCoverage` covers new RPCs)
- `pnpm test` (server-core) — 28 files, 226+ tests pass; `task.service.test.ts` adds 18 unit tests
- `pnpm test:integration` (server) — 35 files pass; `43-tasks.integration.test.ts` adds 6 wire-level tests

## /simplify findings applied

- **HIGH**: dropped `requireCallerAgent` wrapper — `ctx.agentId` is already branded; 11 handler bodies now call service directly.
- **HIGH**: dropped `brandAgentId(ctx.agentId)` from endpoints handlers (same redundancy).
- **MED**: extracted `TM_AGENT_PREFIX` constant for the canonical TM endpoint format.
- **MED**: extracted `requireConversationInTask` helper (shared by `closeConversation` + `storeMessage`).
- **MED**: `closeConversation` now uses a single conditional UPDATE (was SELECT-then-UPDATE).
- **HIGH**: parallelized `fetchTaskMessages` conversation iteration with bounded `Effect.all({concurrency: 8})`.

## /codex findings applied

- **HIGH**: closed/failed tasks are now immutable (`requireTmAuthority` rejects status ∈ {closed, failed}). Regression test added.
- **HIGH**: `createConversation` documents the orphan-row mitigation (unstamped row is rejected by `requireConversationInTask` fail-closed; never reachable through `tasks/*`).
- **MED**: `registerTm` now uses a single atomic conditional UPDATE — closes the read-then-update TOCTOU.
- **MED**: `tasks/storeMessage` stamps `messages.task_id` after `MessageService.send` so cross-task queries can use the denormalized FK.
- **MED**: `requireReadAccess` now denies pending invitees (`admitted_at IS NULL`). Regression test added.

## /review

Deferred to peer review. /simplify covers reuse + quality, /codex covers structural + security cross-model.

## Out of scope (firm)

- `apps/*` deletion — Phase 7
- `sessionId → taskId` rename — Phase 7
- `messages/send` re-route through TM — Phase 9
- `apps/authorizeDispatch` deletion — Phase 9
- `AgentEndpointResolver` multimap — Phase 8

## Confidence

HIGH — every artifact traces to a plan line. Unit + integration tests cover lifecycle, every TM authority gate, brand decoding, closed-task immutability, and pending-invitee read denial. Cross-model review (codex) surfaced 5 substantive bugs which were all fixed and regression-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)