### PR TITLE
[impl-junior] Cleanup trio: stale test comment shipped; #434/#435 obsolete (#433)

### DIFF
--- a/packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts
+++ b/packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts
@@ -28,8 +28,6 @@ const OTHER_USER_ID = "00000000-0000-4000-8000-000000000002";
 const ADMIN_TEST_MANIFEST: AppManifest = {
   appId: "admin-register-test-app",
   name: "Admin Register Test App",
-  // Empty permissions — admission auto-completes without prompting,
-  // keeping this test focused on the owner-id check at app-host.ts:753.
   conversations: [{ key: "main", name: "Main", participantFilter: "all" }],
 };
 


### PR DESCRIPTION
## What this PR does

Closes **#433** with a 2-line comment removal. The other two trio sub-issues (#434, #435) are already fixed by prior work and will be closed as obsolete after this lands.

## Per-issue summary

### #433 — stale test comment (fixed here)

`packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts` had a 2-line comment in `ADMIN_TEST_MANIFEST` referencing an empty `permissions` field. The `AppManifest.permissions` field was deleted in #430 (Phase 1B), so the comment no longer parses against the schema.

Strip the 2 comment lines. No code logic changed; the test's coverage of the owner-id check at `app-host.ts` is preserved.

### #435 — addParticipant schema mismatch (already fixed)

The schema-vs-handler mismatch was fixed in commit [`3126f771`](https://github.com/chughtapan/moltzap/commit/3126f771) ("fix(ci): restore conformance + protocol + integration test green for #414"). The commit message explicitly names this fix:

> ConversationsAddParticipant and ConversationsUpdate result schemas declared `{}` while the handlers return `{participant}` and `{conversation}`; strict response validation rejected the response. Declare the actual fields.

Current state on `main`:
- Schema at `packages/protocol/src/task/methods/conversations.ts:119-122` declares `result: Type.Object({ participant: ConversationParticipantSchema }, { additionalProperties: false })` ✓
- Handler at `packages/server/src/task/handlers/conversations.handlers.ts:198` returns `{ participant }` ✓
- Wire-validating regression test exists at `packages/server/src/__tests__/integration/04-group-chat.integration.test.ts:90-97` (alice adds bob via `ConversationsAddParticipant`, asserts `result.participant.conversationId` and `result.participant.role`)

No additional change needed. Will close #435 as obsolete with a comment citing the resolution.

### #434 — plan-doc framing (already addressed)

The framing concern was addressed by commit [`d0d8a33`](https://github.com/chughtapan/moltzap/commit/d0d8a33) ("docs(plan): consolidate corrections, remove self-inconsistency"). The doc rewrite folded all corrections into §2 body, restructured the doc as a clear "Landing Plan" with §1 explicitly noting what's already done in PR #414, listed phases sequentially in §3, and added an explicit "Decision evolution" archeological footer.

The original concern — that the doc was ambiguous between "historical deletion record" vs. "live design narrative" — is resolved by the rewrite: the doc is now structurally and explicitly a forward-looking landing plan. Will close #434 as obsolete with a comment citing the rewrite.

## Scope

- Module: `packages/server/src/__tests__/integration/41-admin-register-agent.integration.test.ts`
- Tier: junior (1 file, 2 lines deleted, no code logic changed)
- New exported signatures: none
- New deps: none

## Pre-PR gates

| Gate | Result |
|---|---|
| `pnpm typecheck` | clean |
| `pnpm lint` | 0 warnings, 0 errors |
| `pnpm format:check` | clean |
| `pnpm test:integration` (server) | 146 passed (33 files) |
| `/simplify` on diff | no findings (2-line comment delete, no new code) |
| `/review` on diff | no findings (no logic change, no security/SQL/LLM trust boundary) |

## Confidence

HIGH — diff is 2 deleted comment lines; full test suite green; #435 + #434 verified as already-resolved via commit-history evidence cited above.