### PR TITLE
[impl-staff] Phase 8 G1: network.send + AgentEndpointResolver multimap (#426)

### DIFF
--- a/packages/protocol/src/network/actor-model.test.ts
+++ b/packages/protocol/src/network/actor-model.test.ts
@@ -17,6 +17,8 @@ import {
 import {
   agentId,
   endpointAddress,
+  endpointAddressKind,
+  makeEndpointAddress,
   userId,
   type AgentId,
   type AuthenticatedIdentity,
@@ -49,6 +51,36 @@ describe("actor-model brand factories", () => {
     expect(() => endpointAddress("")).toThrow();
     expect(() => endpointAddress("tm:agent:not-a-uuid")).toThrow();
     expect(() => endpointAddress("tm:unknown:uuid-here")).toThrow();
+  });
+
+  it("makeEndpointAddress mints `tm:<kind>:<uuid>` for each declared kind", () => {
+    const a = makeEndpointAddress(
+      "agent",
+      "00000000-0000-4000-8000-000000000001",
+    );
+    expect(a).toBe("tm:agent:00000000-0000-4000-8000-000000000001");
+    const b = makeEndpointAddress(
+      "app",
+      "00000000-0000-4000-8000-000000000002",
+    );
+    expect(b).toBe("tm:app:00000000-0000-4000-8000-000000000002");
+  });
+
+  it("makeEndpointAddress rejects non-UUID inputs (brand predicate fires)", () => {
+    expect(() => makeEndpointAddress("agent", "not-a-uuid")).toThrow();
+  });
+
+  it("endpointAddressKind reads back the kind for each declared kind", () => {
+    expect(
+      endpointAddressKind(
+        endpointAddress("tm:agent:00000000-0000-4000-8000-000000000001"),
+      ),
+    ).toBe("agent");
+    expect(
+      endpointAddressKind(
+        endpointAddress("tm:app:00000000-0000-4000-8000-000000000002"),
+      ),
+    ).toBe("app");
   });
 });
 
@@ -127,6 +159,16 @@ describe("flat-barrel runtime negative canary", () => {
   const flatBarrelKeys = Object.keys(flatBarrel);
 
   for (const name of FORBIDDEN_RUNTIME_NAMES) {
+    it(`@moltzap/protocol does not re-export "${name}" as a runtime value`, () => {
+      expect(flatBarrelKeys).not.toContain(name);
+    });
+  }
+
+  // Phase 8 Slice G1 introduced two new helper exports — they must also stay
+  // scoped to the `./actor-model` import path. The brand-shape (`tm:<kind>:<uuid>`)
+  // is plan-§2.11 contract; a flat-barrel re-export would expand the public
+  // wire-format surface beyond what the plan authorized.
+  for (const name of ["endpointAddressKind", "makeEndpointAddress"] as const) {
     it(`@moltzap/protocol does not re-export "${name}" as a runtime value`, () => {
       expect(flatBarrelKeys).not.toContain(name);
     });

--- a/packages/protocol/src/network/actor-model.ts
+++ b/packages/protocol/src/network/actor-model.ts
@@ -52,7 +52,12 @@ export type EndpointAddress = BrandedString<"EndpointAddress">;
 export const ENDPOINT_ADDRESS_KINDS = ["agent", "app"] as const;
 export type EndpointAddressKind = (typeof ENDPOINT_ADDRESS_KINDS)[number];
 
-const ENDPOINT_ADDRESS_PREFIX = "tm:";
+/**
+ * Common prefix for every {@link EndpointAddress} on the wire — `tm:`.
+ * Exported so server-side code that mints addresses or routes by kind
+ * does not re-declare the same string and silently fork.
+ */
+export const ENDPOINT_ADDRESS_PREFIX = "tm:";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -82,6 +87,47 @@ const EndpointAddressBrand = Brand.refined<EndpointAddress>(
  *  fails {@link isEndpointAddress}. */
 export const endpointAddress = (value: string): EndpointAddress =>
   EndpointAddressBrand(value);
+
+/**
+ * Read the `kind` segment out of a branded {@link EndpointAddress}.
+ *
+ * The brand predicate at {@link isEndpointAddress} already proves the
+ * shape `tm:<kind>:<uuid>` with `kind ∈ {@link ENDPOINT_ADDRESS_KINDS}`.
+ * This helper checks the kinds in declaration order and returns the
+ * first match. Adding a new kind to the const tuple automatically
+ * extends this dispatch as long as the brand predicate is updated in
+ * lockstep — the {@link ENDPOINT_ADDRESS_KINDS}-driven loop owns the
+ * exhaustiveness story.
+ *
+ * The trailing `return ENDPOINT_ADDRESS_KINDS[0]` is unreachable for any
+ * well-formed branded value (the brand guarantees at least one match)
+ * but appears for the type checker — `for...of` does not narrow to a
+ * non-empty result. The brand's own tests cover the malformed case.
+ */
+export const endpointAddressKind = (
+  address: EndpointAddress,
+): EndpointAddressKind => {
+  const raw = address as string;
+  const rest = raw.slice(ENDPOINT_ADDRESS_PREFIX.length);
+  for (const kind of ENDPOINT_ADDRESS_KINDS) {
+    if (rest.startsWith(`${kind}:`)) return kind;
+  }
+  return ENDPOINT_ADDRESS_KINDS[0];
+};
+
+/**
+ * Mint an `EndpointAddress` from a kind and a UUID. The single
+ * construction site for `tm:<kind>:<uuid>` strings — every other
+ * caller routes through here so the wire format does not fork.
+ *
+ * Throws if the resulting string fails {@link isEndpointAddress} (e.g.,
+ * `uuid` is not a UUID).
+ */
+export const makeEndpointAddress = (
+  kind: EndpointAddressKind,
+  uuid: string,
+): EndpointAddress =>
+  endpointAddress(`${ENDPOINT_ADDRESS_PREFIX}${kind}:${uuid}`);
 
 // ---------------------------------------------------------------------------
 // Endpoint kind / registration

--- a/packages/server/src/__tests__/integration/49-network-send-resolver.integration.test.ts
+++ b/packages/server/src/__tests__/integration/49-network-send-resolver.integration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Phase 8 Slice G1 integration test: AgentEndpointResolver lifecycle +
+ * NetworkSendService delivery against the real WS server, observed
+ * through the public CoreApp surface.
+ *
+ * Plan: `docs/plans/layered-network-refactor-2026-05.md` §2.10/§2.11.
+ * Issue #426 acceptance.
+ *
+ * Coverage:
+ *   - `auth/connect` populates the resolver: `network.send` to the
+ *     freshly-connected agent's address returns {@link DeliveryAck} and
+ *     the recipient client decodes the typed notification on the wire.
+ *   - Disconnect drains the resolver: `network.send` to the same address
+ *     after close fails with {@link RecipientNotResolved}.
+ *   - Multimap semantics: two simultaneous connections of the same agent
+ *     each receive the payload through their own address.
+ *
+ * The resolver itself is not exposed on `CoreApp`; the test reaches the
+ * `connId` it routes by via `coreApp.connections.all()`, which is the
+ * existing public surface.
+ */
+import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { it } from "@effect/vitest";
+import { Cause, Effect, Exit, Option } from "effect";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  getCoreApp,
+} from "./helpers.js";
+import {
+  registerAgent,
+  connectTestClient,
+  registerAndConnect,
+} from "./helpers.js";
+import { getBaseUrl } from "../../test-utils/index.js";
+import {
+  notificationFrame,
+  PresenceChangedNotificationDefinition,
+  agentId as protocolAgentId,
+} from "@moltzap/protocol";
+import { agentConnectionEndpointAddress } from "../../network/agent-endpoint-resolver.js";
+import {
+  opaquePayload,
+  RecipientNotResolved,
+} from "../../network/network-send.js";
+
+beforeAll(async () => {
+  await startTestServer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+/**
+ * Look up the connection id for an authenticated agent by walking the
+ * `ConnectionManager`. Replaces direct resolver access — the resolver
+ * is server-internal in Phase 8 G1 (issue #426 dual-DI does not
+ * authorize raw resolver exposure on `CoreApp`).
+ */
+function connIdsForAgent(agentIdString: string): readonly string[] {
+  const branded = protocolAgentId(agentIdString);
+  return getCoreApp()
+    .connections.all()
+    .filter((conn) => conn.auth?.agentId === branded)
+    .map((conn) => conn.id);
+}
+
+describe("AgentEndpointResolver + network.send lifecycle (Phase 8 G1)", () => {
+  it.live(
+    "network.send delivers a real notification to a connected agent",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnect("alice-resolver");
+        const [connId] = connIdsForAgent(alice.agentId);
+        if (!connId) throw new Error("expected one live connection");
+        const address = agentConnectionEndpointAddress(connId);
+
+        // Real notification frame so the client's typed-bridge accepts it.
+        // Asserts end-to-end wire delivery, not just the server-side write
+        // ack — `waitForNotification` only fires after the frame decodes
+        // through the validation pipeline at the client edge.
+        const frame = notificationFrame(PresenceChangedNotificationDefinition, {
+          agentId: protocolAgentId(alice.agentId),
+          status: "online",
+        });
+
+        const ack = yield* getCoreApp().networkSendService.send(
+          address,
+          opaquePayload(JSON.stringify(frame)),
+        );
+        expect(ack._tag).toBe("DeliveryAck");
+        expect(ack.to).toEqual(address);
+
+        const received = yield* alice.client.waitForNotification(
+          PresenceChangedNotificationDefinition,
+        );
+        expect((received.params as { agentId: string }).agentId).toBe(
+          alice.agentId,
+        );
+      }),
+  );
+
+  it.live(
+    "disconnect drains the resolver: subsequent send fails with RecipientNotResolved",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnect("alice-drain");
+        const [connId] = connIdsForAgent(alice.agentId);
+        if (!connId) throw new Error("expected one live connection");
+        const address = agentConnectionEndpointAddress(connId);
+
+        yield* alice.client.close();
+        // The WS finalizer that calls `agentEndpointResolver.remove`
+        // runs asynchronously after `close`; small sleep lets it settle
+        // before the assertion.
+        yield* Effect.sleep("100 millis");
+
+        const exit = yield* Effect.exit(
+          getCoreApp().networkSendService.send(
+            address,
+            opaquePayload(JSON.stringify({ noop: true })),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const failure = Cause.failureOption(exit.cause);
+          expect(Option.isSome(failure)).toBe(true);
+          if (Option.isSome(failure)) {
+            expect(failure.value).toBeInstanceOf(RecipientNotResolved);
+          }
+        }
+      }),
+  );
+
+  it.live(
+    "multimap: two connections of the same agent each receive their own send",
+    () =>
+      Effect.gen(function* () {
+        const { agentId: aId, apiKey } = yield* registerAgent(
+          getBaseUrl(),
+          "alice-multi",
+        );
+        const c1 = yield* connectTestClient({ agentId: aId, apiKey });
+        const c2 = yield* connectTestClient({ agentId: aId, apiKey });
+
+        const ids = connIdsForAgent(aId);
+        expect(ids).toHaveLength(2);
+        const [id1, id2] = ids as readonly [string, string];
+
+        const addr1 = agentConnectionEndpointAddress(id1);
+        const addr2 = agentConnectionEndpointAddress(id2);
+        const frame = notificationFrame(PresenceChangedNotificationDefinition, {
+          agentId: protocolAgentId(aId),
+          status: "online",
+        });
+        const payload = opaquePayload(JSON.stringify(frame));
+
+        const ack1 = yield* getCoreApp().networkSendService.send(
+          addr1,
+          payload,
+        );
+        expect(ack1._tag).toBe("DeliveryAck");
+        const ack2 = yield* getCoreApp().networkSendService.send(
+          addr2,
+          payload,
+        );
+        expect(ack2._tag).toBe("DeliveryAck");
+
+        const r1 = yield* c1.waitForNotification(
+          PresenceChangedNotificationDefinition,
+        );
+        const r2 = yield* c2.waitForNotification(
+          PresenceChangedNotificationDefinition,
+        );
+        expect((r1.params as { agentId: string }).agentId).toBe(aId);
+        expect((r2.params as { agentId: string }).agentId).toBe(aId);
+
+        yield* c1.close();
+        yield* c2.close();
+      }),
+  );
+});

--- a/packages/server/src/app/layers.test.ts
+++ b/packages/server/src/app/layers.test.ts
@@ -8,6 +8,8 @@ import { NoopTraceCaptureLive } from "../runtime-surface/trace-capture.js";
 import { LoggerLive, getLogger } from "../logger.js";
 import { Broadcaster } from "../ws/broadcaster.js";
 import { ConnectionManager } from "../ws/connection.js";
+import { AgentEndpointResolver } from "../network/agent-endpoint-resolver.js";
+import { NetworkSendService } from "../network/network-send.js";
 import { AuthService } from "../services/auth.service.js";
 import { ContactsService } from "../services/contact.service.js";
 import { ConversationService } from "../services/conversation.service.js";
@@ -65,6 +67,10 @@ it.effect("ServicesLive resolves every service via resolveServices", () =>
     // fail to compile the graph or produce `undefined` at a tag.
     expect(services.connections).toBeInstanceOf(ConnectionManager);
     expect(services.broadcaster).toBeInstanceOf(Broadcaster);
+    expect(services.agentEndpointResolver).toBeInstanceOf(
+      AgentEndpointResolver,
+    );
+    expect(services.networkSendService).toBeInstanceOf(NetworkSendService);
     expect(services.authService).toBeInstanceOf(AuthService);
     expect(services.participantService).toBeInstanceOf(ParticipantService);
     expect(services.conversationService).toBeInstanceOf(ConversationService);

--- a/packages/server/src/app/layers.ts
+++ b/packages/server/src/app/layers.ts
@@ -15,6 +15,8 @@ import {
 } from "../runtime-surface/trace-capture.js";
 import { ConnectionManager } from "../ws/connection.js";
 import { Broadcaster } from "../ws/broadcaster.js";
+import { AgentEndpointResolver } from "../network/agent-endpoint-resolver.js";
+import { NetworkSendService } from "../network/network-send.js";
 import { AuthService } from "../services/auth.service.js";
 import { ParticipantService } from "../services/participant.service.js";
 import { ContactsService } from "../services/contact.service.js";
@@ -66,6 +68,29 @@ export class BroadcasterTag extends Context.Tag("moltzap/Broadcaster")<
   BroadcasterTag,
   Broadcaster
 >() {}
+
+/**
+ * `AgentId → Set<EndpointAddress>` multimap maintained by the `auth/connect`
+ * success path and the WS disconnect finalizer. Read by
+ * {@link NetworkSendServiceTag} for O(1) outbound routing.
+ *
+ * Coexists with {@link ConnectionManagerTag} during Phase 8 (Slice G1).
+ * Phase 10 (Slice G2) deletes {@link BroadcasterTag} once consumers
+ * migrate to {@link NetworkSendServiceTag}.
+ */
+export class AgentEndpointResolverTag extends Context.Tag(
+  "moltzap/AgentEndpointResolver",
+)<AgentEndpointResolverTag, AgentEndpointResolver>() {}
+
+/**
+ * The `network.send(to, payload)` outbound-routing primitive. New in
+ * Slice G1; lives alongside {@link BroadcasterTag} during Phase 8.
+ * Consumer migration is Phase 9 (Slice C); Broadcaster deletion is
+ * Phase 10 (Slice G2).
+ */
+export class NetworkSendServiceTag extends Context.Tag(
+  "moltzap/NetworkSendService",
+)<NetworkSendServiceTag, NetworkSendService>() {}
 
 export class AuthServiceTag extends Context.Tag("moltzap/AuthService")<
   AuthServiceTag,
@@ -143,6 +168,31 @@ export const BroadcasterLive = Layer.effect(
   Effect.gen(function* () {
     const connections = yield* ConnectionManagerTag;
     return new Broadcaster(connections);
+  }),
+);
+
+/**
+ * Build the resolver from its `Effect.make` constructor. The resolver is
+ * a `Ref`-backed in-memory data structure with no upstream deps; the
+ * Layer exists to register it under {@link AgentEndpointResolverTag} so
+ * downstream layers (and `network.send`) can pick it up via Context.
+ */
+export const AgentEndpointResolverLive = Layer.effect(
+  AgentEndpointResolverTag,
+  AgentEndpointResolver.make,
+);
+
+/**
+ * `network.send` Layer. Composes the resolver and the connection manager
+ * into the {@link NetworkSendService} instance the rest of the server
+ * holds via {@link NetworkSendServiceTag}.
+ */
+export const NetworkSendServiceLive = Layer.effect(
+  NetworkSendServiceTag,
+  Effect.gen(function* () {
+    const resolver = yield* AgentEndpointResolverTag;
+    const connections = yield* ConnectionManagerTag;
+    return new NetworkSendService(resolver, connections);
   }),
 );
 
@@ -267,17 +317,32 @@ const Tier1 = Layer.mergeAll(
   ContactsServiceLive,
 );
 
-/** Tier 2 — Broadcaster + Presence both need Tier 1's ConnectionManager.
- * Presence is here (not Tier 1) because it broadcasts `presence/changed`
- * directly to subscriber sockets via ConnectionManager — same wiring shape
- * as Broadcaster. */
+/** Tier 2 — Broadcaster + Presence + AgentEndpointResolver all sit
+ * directly above Tier 1's ConnectionManager. The resolver has no
+ * upstream deps (in-memory `Ref`); it joins this tier so
+ * NetworkSendServiceLive can pick it up at Tier 2.5 below.
+ *
+ * Slice G1 (Phase 8) introduces AgentEndpointResolverLive alongside
+ * the existing layers. */
 const Tier2 = Layer.provideMerge(
-  Layer.mergeAll(BroadcasterLive, PresenceServiceLive),
+  Layer.mergeAll(
+    BroadcasterLive,
+    PresenceServiceLive,
+    AgentEndpointResolverLive,
+  ),
   Tier1,
 );
 
+/** Tier 2.5 — NetworkSendServiceLive depends on the AgentEndpointResolver
+ * exposed by Tier 2 plus the ConnectionManager from Tier 1. `provideMerge`
+ * wires them in and keeps NetworkSendServiceTag visible to higher tiers.
+ *
+ * Coexists with BroadcasterTag during Phase 8; consumer migration to
+ * NetworkSendServiceTag lands in Phase 9 (Slice C). */
+const Tier2NetworkSend = Layer.provideMerge(NetworkSendServiceLive, Tier2);
+
 /** Tier 3 — AppHost needs Broadcaster/Connections. */
-const Tier3 = Layer.provideMerge(AppHostLive, Tier2);
+const Tier3 = Layer.provideMerge(AppHostLive, Tier2NetworkSend);
 
 /** Tier 4 — ConversationService needs AppHost for the session-attach check. */
 const Tier4 = Layer.provideMerge(ConversationServiceLive, Tier3);
@@ -311,6 +376,8 @@ export interface ResolvedServices {
   readonly logger: Logger;
   readonly connections: ConnectionManager;
   readonly broadcaster: Broadcaster;
+  readonly agentEndpointResolver: AgentEndpointResolver;
+  readonly networkSendService: NetworkSendService;
   readonly authService: AuthService;
   readonly participantService: ParticipantService;
   readonly conversationService: ConversationService;
@@ -334,6 +401,8 @@ export const resolveServices = Effect.all({
   encryption: EncryptionTag,
   connections: ConnectionManagerTag,
   broadcaster: BroadcasterTag,
+  agentEndpointResolver: AgentEndpointResolverTag,
+  networkSendService: NetworkSendServiceTag,
   authService: AuthServiceTag,
   participantService: ParticipantServiceTag,
   conversationService: ConversationServiceTag,

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -49,6 +49,7 @@ import { EnvelopeEncryption } from "../crypto/envelope.js";
 import { createCoreAuthHandlers } from "../network/handlers/auth.handlers.js";
 import { createSystemHandlers } from "../network/handlers/system.handlers.js";
 import { createEndpointHandlers } from "../network/handlers/endpoints.handlers.js";
+import { agentConnectionEndpointAddress } from "../network/agent-endpoint-resolver.js";
 import { createConversationHandlers } from "../task/handlers/conversations.handlers.js";
 import { createMessageHandlers } from "../task/handlers/messages.handlers.js";
 import { createPresenceHandlers } from "../task/handlers/presence.handlers.js";
@@ -176,6 +177,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
   const {
     connections,
     broadcaster,
+    agentEndpointResolver,
     authService,
     conversationService,
     contactService,
@@ -197,6 +199,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       conversationService,
       presenceService,
       connections,
+      agentEndpointResolver,
       db,
       userService: config.userService ?? null,
     }),
@@ -611,6 +614,17 @@ export function createCoreApp(config: CoreConfig): CoreApp {
                   );
                 }
               }
+              // Slice G1 (plan §2.11): remove the connection's endpoint
+              // address from the resolver. Skipped for never-authed
+              // connections — `auth/connect` is the single registration
+              // site, so an unauthed disconnect has nothing to clean up
+              // and would not have an `agentId` to address the entry by.
+              if (authCtx) {
+                yield* agentEndpointResolver.remove(
+                  authCtx.agentId,
+                  agentConnectionEndpointAddress(connId),
+                );
+              }
               presenceService.removeConnection(connId);
               connections.remove(connId);
               if (Exit.isFailure(exit)) {
@@ -704,6 +718,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       disconnectionHooks.push(hook);
     },
     broadcaster,
+    networkSendService: services.networkSendService,
     traceCapture,
     connections,
     registerApp(manifest) {

--- a/packages/server/src/app/types.ts
+++ b/packages/server/src/app/types.ts
@@ -19,6 +19,7 @@ import type { UserService } from "../services/user.service.js";
 import type { WebhookClient } from "../adapters/webhook.js";
 import type { Broadcaster } from "../ws/broadcaster.js";
 import type { ConnectionManager } from "../ws/connection.js";
+import type { NetworkSendService } from "../network/network-send.js";
 import type {
   BeforeMessageDeliveryHook,
   BeforeDispatchHook,
@@ -124,8 +125,26 @@ export interface CoreApp {
    * emit events out-of-band (not via `broadcastToConversation`) use this to
    * `sendToAgent(agentId, event)`. Stable identity — same ref across the
    * server lifetime.
+   *
+   * Coexists with {@link networkSendService} during Phase 8 (Slice G1).
+   * Phase 10 (Slice G2) deletes this field once consumers migrate.
    */
   readonly broadcaster: Broadcaster;
+  /**
+   * The new outbound-routing primitive introduced in Slice G1
+   * (Phase 8). Use `networkSendService.send(to, payload)` for new code;
+   * existing call sites continue to use {@link broadcaster} until
+   * Phase 9 (Slice C) migrates them.
+   *
+   * The backing `AgentEndpointResolver` is intentionally NOT exposed
+   * here — its mutable add/remove surface is server-internal lifecycle,
+   * not a CoreApp consumer concern (issue #426 authorizes the dual-DI
+   * pair, not raw resolver access). Tests that need to assert resolver
+   * state observe it indirectly via `networkSendService.send` outcomes.
+   *
+   * Plan: `docs/plans/layered-network-refactor-2026-05.md` §2.10.
+   */
+  readonly networkSendService: NetworkSendService;
   readonly traceCapture: TraceCapture;
   /**
    * Live ConnectionManager instance. Apps can query `getByParticipant` to

--- a/packages/server/src/network/agent-endpoint-resolver.test.ts
+++ b/packages/server/src/network/agent-endpoint-resolver.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for {@link AgentEndpointResolver}.
+ *
+ * Each test covers exactly one behavior named in plan §2.11 or issue #426
+ * acceptance: multimap semantics, atomic add/remove, idempotence, fan-out
+ * snapshot, reverse-index lookup. Tests run synchronously via
+ * `Effect.runSync` because the resolver is a pure in-memory `Ref`.
+ */
+import { describe, expect, it } from "vitest";
+import { Effect, HashSet, Option } from "effect";
+import { agentId } from "@moltzap/protocol/network";
+import {
+  AgentEndpointResolver,
+  agentConnectionEndpointAddress,
+} from "./agent-endpoint-resolver.js";
+
+// Test agent ids — UUIDs that pass the `agentId` brand predicate.
+const ALICE = agentId("00000000-0000-4000-8000-00000000a11c");
+const BOB = agentId("00000000-0000-4000-8000-00000000b0b0");
+
+// Test connection ids — UUIDs so the derived address satisfies the
+// EndpointAddress brand predicate (`tm:<kind>:<uuid>`).
+const CONN_A = "00000000-0000-4000-8000-00000000c001";
+const CONN_B = "00000000-0000-4000-8000-00000000c002";
+const CONN_C = "00000000-0000-4000-8000-00000000c003";
+
+const makeResolver = (): AgentEndpointResolver =>
+  Effect.runSync(AgentEndpointResolver.make);
+
+describe("AgentEndpointResolver", () => {
+  it("starts empty: resolveAll returns the empty set for any agent", () => {
+    const resolver = makeResolver();
+    const set = Effect.runSync(resolver.resolveAll(ALICE));
+    expect(HashSet.size(set)).toBe(0);
+  });
+
+  it("starts empty: connectionForAddress returns Option.none()", () => {
+    const resolver = makeResolver();
+    const out = Effect.runSync(
+      resolver.connectionForAddress(agentConnectionEndpointAddress(CONN_A)),
+    );
+    expect(Option.isNone(out)).toBe(true);
+  });
+
+  it("add: a single (agent, address, conn) tuple is queryable both ways", () => {
+    const resolver = makeResolver();
+    const addr = agentConnectionEndpointAddress(CONN_A);
+
+    Effect.runSync(resolver.add(ALICE, addr, CONN_A));
+
+    const fan = Effect.runSync(resolver.resolveAll(ALICE));
+    expect(HashSet.size(fan)).toBe(1);
+    expect(HashSet.has(fan, addr)).toBe(true);
+
+    const conn = Effect.runSync(resolver.connectionForAddress(addr));
+    expect(conn).toEqual(Option.some(CONN_A));
+  });
+
+  it("add: multimap holds multiple connections for the same agent", () => {
+    const resolver = makeResolver();
+    const addrA = agentConnectionEndpointAddress(CONN_A);
+    const addrB = agentConnectionEndpointAddress(CONN_B);
+
+    Effect.runSync(resolver.add(ALICE, addrA, CONN_A));
+    Effect.runSync(resolver.add(ALICE, addrB, CONN_B));
+
+    const fan = Effect.runSync(resolver.resolveAll(ALICE));
+    expect(HashSet.size(fan)).toBe(2);
+    expect(HashSet.has(fan, addrA)).toBe(true);
+    expect(HashSet.has(fan, addrB)).toBe(true);
+
+    expect(Effect.runSync(resolver.connectionForAddress(addrA))).toEqual(
+      Option.some(CONN_A),
+    );
+    expect(Effect.runSync(resolver.connectionForAddress(addrB))).toEqual(
+      Option.some(CONN_B),
+    );
+  });
+
+  it("add: same address twice is idempotent on the forward set", () => {
+    const resolver = makeResolver();
+    const addr = agentConnectionEndpointAddress(CONN_A);
+
+    Effect.runSync(resolver.add(ALICE, addr, CONN_A));
+    Effect.runSync(resolver.add(ALICE, addr, CONN_A));
+
+    const fan = Effect.runSync(resolver.resolveAll(ALICE));
+    expect(HashSet.size(fan)).toBe(1);
+  });
+
+  it("add: distinct agents do not see each other's entries", () => {
+    const resolver = makeResolver();
+    const addrA = agentConnectionEndpointAddress(CONN_A);
+    const addrB = agentConnectionEndpointAddress(CONN_B);
+
+    Effect.runSync(resolver.add(ALICE, addrA, CONN_A));
+    Effect.runSync(resolver.add(BOB, addrB, CONN_B));
+
+    expect(HashSet.size(Effect.runSync(resolver.resolveAll(ALICE)))).toBe(1);
+    expect(HashSet.size(Effect.runSync(resolver.resolveAll(BOB)))).toBe(1);
+  });
+
+  it("remove: drops the entry from both indices", () => {
+    const resolver = makeResolver();
+    const addr = agentConnectionEndpointAddress(CONN_A);
+
+    Effect.runSync(resolver.add(ALICE, addr, CONN_A));
+    Effect.runSync(resolver.remove(ALICE, addr));
+
+    expect(HashSet.size(Effect.runSync(resolver.resolveAll(ALICE)))).toBe(0);
+    expect(
+      Option.isNone(Effect.runSync(resolver.connectionForAddress(addr))),
+    ).toBe(true);
+  });
+
+  it("remove: leaves sibling entries intact for the same agent", () => {
+    const resolver = makeResolver();
+    const addrA = agentConnectionEndpointAddress(CONN_A);
+    const addrB = agentConnectionEndpointAddress(CONN_B);
+
+    Effect.runSync(resolver.add(ALICE, addrA, CONN_A));
+    Effect.runSync(resolver.add(ALICE, addrB, CONN_B));
+    Effect.runSync(resolver.remove(ALICE, addrA));
+
+    const fan = Effect.runSync(resolver.resolveAll(ALICE));
+    expect(HashSet.size(fan)).toBe(1);
+    expect(HashSet.has(fan, addrB)).toBe(true);
+    expect(Effect.runSync(resolver.connectionForAddress(addrB))).toEqual(
+      Option.some(CONN_B),
+    );
+  });
+
+  it("remove: dropping the last entry clears the agent key entirely", () => {
+    // Emptying the bucket should not leave a phantom key behind that would
+    // make `resolveAll` produce an empty `HashSet` in a way that surprises
+    // a caller doing `HashSet.size === 0` checks.
+    const resolver = makeResolver();
+    const addr = agentConnectionEndpointAddress(CONN_A);
+
+    Effect.runSync(resolver.add(ALICE, addr, CONN_A));
+    Effect.runSync(resolver.remove(ALICE, addr));
+
+    const fan = Effect.runSync(resolver.resolveAll(ALICE));
+    expect(HashSet.size(fan)).toBe(0);
+  });
+
+  it("remove: mis-targeted remove cannot evict a sibling's reverse entry", () => {
+    // Regression guard for the resolver-tear bug: BOB owns `addr`, but a
+    // mis-targeted `remove(ALICE, addr)` (programmer error or a re-issued
+    // lifecycle hook on the wrong agent id) must not silently drop
+    // `byAddress[addr]`. Otherwise a subsequent `network.send(addr)` would
+    // see an inconsistent state — `resolveAll(BOB)` still returns `addr`
+    // but `connectionForAddress(addr)` is gone.
+    const resolver = makeResolver();
+    const addr = agentConnectionEndpointAddress(CONN_A);
+
+    Effect.runSync(resolver.add(BOB, addr, CONN_A));
+    Effect.runSync(resolver.remove(ALICE, addr));
+
+    const fan = Effect.runSync(resolver.resolveAll(BOB));
+    expect(HashSet.size(fan)).toBe(1);
+    expect(HashSet.has(fan, addr)).toBe(true);
+    expect(Effect.runSync(resolver.connectionForAddress(addr))).toEqual(
+      Option.some(CONN_A),
+    );
+  });
+
+  it("remove: idempotent on never-added pairs (defensive disconnect path)", () => {
+    const resolver = makeResolver();
+    const addr = agentConnectionEndpointAddress(CONN_A);
+
+    // No prior add; mirrors a never-authed disconnect that still calls
+    // remove. Resolver state must stay consistent.
+    Effect.runSync(resolver.remove(ALICE, addr));
+
+    expect(HashSet.size(Effect.runSync(resolver.resolveAll(ALICE)))).toBe(0);
+    expect(
+      Option.isNone(Effect.runSync(resolver.connectionForAddress(addr))),
+    ).toBe(true);
+  });
+
+  it("connectionForAddress: each address resolves to its own connection id", () => {
+    // Reverse-index correctness: a single agent with multiple connections
+    // must produce distinct lookups. Regression guard for "same agent
+    // overwrites the reverse index" bug.
+    const resolver = makeResolver();
+    const addrA = agentConnectionEndpointAddress(CONN_A);
+    const addrB = agentConnectionEndpointAddress(CONN_B);
+    const addrC = agentConnectionEndpointAddress(CONN_C);
+
+    Effect.runSync(resolver.add(ALICE, addrA, CONN_A));
+    Effect.runSync(resolver.add(ALICE, addrB, CONN_B));
+    Effect.runSync(resolver.add(BOB, addrC, CONN_C));
+
+    expect(Effect.runSync(resolver.connectionForAddress(addrA))).toEqual(
+      Option.some(CONN_A),
+    );
+    expect(Effect.runSync(resolver.connectionForAddress(addrB))).toEqual(
+      Option.some(CONN_B),
+    );
+    expect(Effect.runSync(resolver.connectionForAddress(addrC))).toEqual(
+      Option.some(CONN_C),
+    );
+  });
+});
+
+describe("agentConnectionEndpointAddress", () => {
+  it("produces a tm:agent:<connId> address satisfying the EndpointAddress brand", () => {
+    const addr = agentConnectionEndpointAddress(CONN_A);
+    expect(String(addr)).toBe(`tm:agent:${CONN_A}`);
+  });
+
+  it("rejects a non-UUID connection id at construction", () => {
+    expect(() => agentConnectionEndpointAddress("not-a-uuid")).toThrow();
+  });
+});

--- a/packages/server/src/network/agent-endpoint-resolver.ts
+++ b/packages/server/src/network/agent-endpoint-resolver.ts
@@ -1,0 +1,202 @@
+/**
+ * In-memory `AgentId → Set<EndpointAddress>` multimap with a paired
+ * `EndpointAddress → ConnectionId` reverse index.
+ *
+ * Plan: `docs/plans/layered-network-refactor-2026-05.md` §2.10 (Slice G1
+ * scope), §2.11 (resolver constraint). Issue #426 acceptance.
+ *
+ * Why a multimap. An authenticated agent can hold multiple WebSocket
+ * connections (web tab + CLI + mobile). Fan-out has to address every live
+ * connection of that agent without re-scanning `ConnectionManager`. The
+ * forward map (`HashMap<AgentId, HashSet<EndpointAddress>>`) gives O(1)
+ * fan-out via {@link AgentEndpointResolver.resolveAll}.
+ *
+ * Why a paired reverse index. {@link NetworkSendService.send} routes by an
+ * already-resolved `EndpointAddress` (the network's stable wire identity
+ * for a recipient), not by `AgentId`. Without the reverse index, the send
+ * path would either O(N) scan the forward map or do a DB lookup — both
+ * violate the §2.11 perf assertion ("O(1) hot path. No DB lookup."). The
+ * reverse index is invariant: every entry in the forward map's union of
+ * sets has exactly one matching reverse-index entry. Both updates happen
+ * inside a single {@link Ref.update} so the invariant cannot tear.
+ *
+ * Why the connection id is the routing target. The address format
+ * `tm:agent:<connId>` is stable for the lifetime of the WS connection
+ * and unique across connections (connId is a UUID minted at socket
+ * accept). The reverse index stores `connId` directly so a send-time
+ * lookup goes resolver → connId → `ConnectionManager.get(connId)` with
+ * no parsing of the address string at the hot path.
+ *
+ * Auth-lifecycle (per §2.11):
+ * - Socket connect: NOT yet added to the resolver (no `agentId` known).
+ * - `auth/connect` success: {@link add} writes the entry atomically.
+ * - Disconnect: {@link remove} removes the entry whether the connection
+ *   was authed or not (idempotent on never-authed connections).
+ *
+ * Out of scope for G1:
+ * - Cross-process / multi-server scaling. Resolver state is process-local.
+ * - TM (`tm:app:`) endpoint registration. {@link NetworkSendService.send}
+ *   handles `tm:app:` separately (Phase 9 territory).
+ */
+import { Effect, HashMap, HashSet, Option, Ref } from "effect";
+import {
+  makeEndpointAddress,
+  type AgentId,
+  type EndpointAddress,
+} from "@moltzap/protocol/network";
+
+/**
+ * Mint the `EndpointAddress` for an agent's WebSocket connection.
+ *
+ * Format: `tm:agent:<connId>`. The connection id is a UUID (see
+ * `app/server.ts:418` — `crypto.randomUUID()`), so the result satisfies
+ * the `tm:<kind>:<uuid>` brand predicate at
+ * `packages/protocol/src/network/actor-model.ts:61`.
+ *
+ * Distinct namespace from `endpointAddressForAgent` in
+ * `services/task.service.ts`, which mints `tm:agent:<agentId>` for durable
+ * task-manager registration. Both share the `tm:agent:` prefix because the
+ * brand only checks `kind ∈ {agent, app}` and that the trailing token is a
+ * UUID — the brand is intentionally agnostic about which UUID it carries.
+ * The two namespaces never collide in a single map: the resolver is keyed
+ * by per-connection addresses; the durable TM column lives on
+ * `tasks.tm_endpoint_address`. {@link NetworkSendService.send} also routes
+ * the two kinds through different code paths.
+ */
+export const agentConnectionEndpointAddress = (
+  connectionId: string,
+): EndpointAddress => makeEndpointAddress("agent", connectionId);
+
+/**
+ * Snapshot of the resolver's combined state. Held in a single {@link Ref}
+ * so atomic updates touch both halves at once. Forward and reverse must
+ * stay invariant; see module doc.
+ */
+interface ResolverState {
+  readonly byAgent: HashMap.HashMap<AgentId, HashSet.HashSet<EndpointAddress>>;
+  readonly byAddress: HashMap.HashMap<EndpointAddress, string>;
+}
+
+const emptyState: ResolverState = {
+  byAgent: HashMap.empty<AgentId, HashSet.HashSet<EndpointAddress>>(),
+  byAddress: HashMap.empty<EndpointAddress, string>(),
+};
+
+/**
+ * Multimap of agent → endpoint addresses, plus a reverse index from
+ * address → connection id.
+ *
+ * All mutators run inside a single {@link Ref.update} so the forward and
+ * reverse views never disagree, even under concurrent {@link add} /
+ * {@link remove} calls from independent `auth/connect` and disconnect
+ * fibers.
+ */
+export class AgentEndpointResolver {
+  static make: Effect.Effect<AgentEndpointResolver> = Effect.map(
+    Ref.make<ResolverState>(emptyState),
+    (state) => new AgentEndpointResolver(state),
+  );
+
+  private constructor(private readonly state: Ref.Ref<ResolverState>) {}
+
+  /**
+   * Atomically associate `(agentId, address)` and `(address, connectionId)`.
+   *
+   * Idempotent on the forward set: re-adding the same address to the same
+   * agent leaves the set unchanged ({@link HashSet.add} is set-union
+   * semantics). The reverse index overwrites — a subsequent `add` for the
+   * same address with a different connection id wins. In practice the
+   * caller mints `address` from `connectionId` via
+   * {@link agentConnectionEndpointAddress}, so the address is unique per
+   * connection and the reverse-overwrite path only fires on programmer
+   * error.
+   */
+  add(
+    agentId: AgentId,
+    address: EndpointAddress,
+    connectionId: string,
+  ): Effect.Effect<void> {
+    return Ref.update(this.state, (s) => ({
+      byAgent: HashMap.modifyAt(s.byAgent, agentId, (existing) =>
+        Option.some(
+          Option.match(existing, {
+            onNone: () => HashSet.make(address),
+            onSome: (set) => HashSet.add(set, address),
+          }),
+        ),
+      ),
+      byAddress: HashMap.set(s.byAddress, address, connectionId),
+    }));
+  }
+
+  /**
+   * Atomically drop `(agentId, address)` from the forward multimap and,
+   * if the pair was actually present in the agent's set, drop `address`
+   * from the reverse index too.
+   *
+   * Idempotent. Calling `remove` for a `(agentId, address)` pair that was
+   * never added is a no-op — the disconnect path can fire it
+   * unconditionally when the connection authed. For never-authed
+   * connections, the disconnect path simply skips the call (no agentId
+   * to address it with) and the resolver state is unchanged.
+   *
+   * Tearing the invariant matters when `address` is genuinely owned by
+   * a *different* agent than the caller asserts. The reverse index is
+   * only cleared when `byAgent[agentId]` actually held `address`; a
+   * stray `remove(WRONG_AGENT, address)` therefore cannot evict
+   * `byAddress[address]` from under the rightful owner. This guarantees
+   * the two maps stay consistent under any sequence of mis-targeted
+   * removes (programmer error or a re-issued lifecycle hook).
+   *
+   * If removing `address` empties the agent's set, the agent key itself
+   * is dropped from the forward map so {@link resolveAll} returns the
+   * empty set rather than hitting an empty bucket.
+   */
+  remove(agentId: AgentId, address: EndpointAddress): Effect.Effect<void> {
+    return Ref.update(this.state, (s) => {
+      const existed = Option.match(HashMap.get(s.byAgent, agentId), {
+        onNone: () => false,
+        onSome: (set) => HashSet.has(set, address),
+      });
+      if (!existed) return s;
+      return {
+        byAgent: HashMap.modifyAt(s.byAgent, agentId, (existing) =>
+          Option.flatMap(existing, (set) => {
+            const next = HashSet.remove(set, address);
+            return HashSet.size(next) === 0 ? Option.none() : Option.some(next);
+          }),
+        ),
+        byAddress: HashMap.remove(s.byAddress, address),
+      };
+    });
+  }
+
+  /**
+   * Hot-path fan-out lookup. Returns every endpoint address currently
+   * associated with `agentId`. Read-only snapshot — the `HashSet` is
+   * immutable and the caller cannot mutate the resolver through it.
+   */
+  resolveAll(
+    agentId: AgentId,
+  ): Effect.Effect<HashSet.HashSet<EndpointAddress>> {
+    return Effect.map(Ref.get(this.state), (s) =>
+      Option.getOrElse(HashMap.get(s.byAgent, agentId), () =>
+        HashSet.empty<EndpointAddress>(),
+      ),
+    );
+  }
+
+  /**
+   * Hot-path send-routing lookup. Returns the connection id bound to
+   * `address`, or `Option.none()` if no live connection holds that
+   * address. {@link NetworkSendService.send} composes this with
+   * `ConnectionManager.get` to produce the writable connection.
+   */
+  connectionForAddress(
+    address: EndpointAddress,
+  ): Effect.Effect<Option.Option<string>> {
+    return Effect.map(Ref.get(this.state), (s) =>
+      HashMap.get(s.byAddress, address),
+    );
+  }
+}

--- a/packages/server/src/network/handlers/auth.handlers.ts
+++ b/packages/server/src/network/handlers/auth.handlers.ts
@@ -13,6 +13,8 @@ import type {
 import type { HelloOk, AgentCard } from "@moltzap/protocol";
 import type { ConnectionManager } from "../../ws/connection.js";
 import type { Db } from "../../db/client.js";
+import type { AgentEndpointResolver } from "../agent-endpoint-resolver.js";
+import { agentConnectionEndpointAddress } from "../agent-endpoint-resolver.js";
 import {
   PROTOCOL_VERSION,
   Connect,
@@ -59,6 +61,14 @@ export function createCoreAuthHandlers(deps: {
   conversationService: ConversationService;
   presenceService: PresenceService;
   connections: ConnectionManager;
+  /**
+   * Slice G1 multimap of `AgentId → Set<EndpointAddress>`. Populated on
+   * successful `auth/connect` (this handler), cleared on socket close
+   * (the WS finalizer in `app/server.ts`). The new `network.send`
+   * outbound primitive routes through this resolver — see
+   * `network/network-send.ts` and plan §2.10/§2.11.
+   */
+  agentEndpointResolver: AgentEndpointResolver;
   db: Db;
   /** Optional app-minted session resolver. When null, auth/connect rejects
    * `sessionToken` requests with Unauthorized. */
@@ -93,6 +103,22 @@ export function createCoreAuthHandlers(deps: {
                   );
 
             conn.auth = auth;
+
+            // Slice G1 (plan §2.11): once `auth/connect` resolves an
+            // identity, register the connection's endpoint address with
+            // the resolver. The disconnect finalizer in `app/server.ts`
+            // mirrors this with `agentEndpointResolver.remove`.
+            //
+            // Atomic relative to other resolver operations — `add` is a
+            // single `Ref.update`. Idempotent on the forward set, so a
+            // re-issued `auth/connect` (already-authed branch above
+            // short-circuits, but defense-in-depth) cannot duplicate
+            // entries.
+            yield* deps.agentEndpointResolver.add(
+              auth.agentId,
+              agentConnectionEndpointAddress(connId),
+              connId,
+            );
 
             const convIds = yield* deps.conversationService.getConversationIds(
               auth.agentId,

--- a/packages/server/src/network/network-send.test.ts
+++ b/packages/server/src/network/network-send.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for {@link NetworkSendService}.
+ *
+ * Each test covers exactly one branch of the send path:
+ *   - happy path: agent address resolves and write succeeds.
+ *   - {@link RecipientNotResolved}: resolver miss; connection-manager miss
+ *     (race where the resolver retains a stale entry).
+ *   - {@link EndpointKindNotImplemented}: app-kind addresses fail with the
+ *     placeholder tag (Phase 9 territory).
+ *   - {@link WriteFailed}: connection.write rejects.
+ *
+ * The service is exercised directly (no Layer composition) so each test
+ * has full control over the resolver and connection manager state.
+ */
+import { describe, expect, it } from "vitest";
+import { Cause, Effect, Exit, HashMap, Option, Ref } from "effect";
+import * as Socket from "@effect/platform/Socket";
+import { agentId, endpointAddress } from "@moltzap/protocol/network";
+import { ConnectionManager } from "../ws/connection.js";
+import {
+  AgentEndpointResolver,
+  agentConnectionEndpointAddress,
+} from "./agent-endpoint-resolver.js";
+import {
+  DeliveryAck,
+  EndpointKindNotImplemented,
+  NetworkSendService,
+  RecipientNotResolved,
+  WriteFailed,
+  opaquePayload,
+} from "./network-send.js";
+
+const ALICE = agentId("00000000-0000-4000-8000-00000000a11c");
+const CONN_A = "00000000-0000-4000-8000-00000000c001";
+
+const APP_ADDR = endpointAddress(`tm:app:00000000-0000-4000-8000-0000000a9990`);
+
+const makeResolver = (): AgentEndpointResolver =>
+  Effect.runSync(AgentEndpointResolver.make);
+
+/**
+ * Build a minimal MoltZapConnection record that satisfies the parts of
+ * the interface the send path actually reads:
+ *   - `id`
+ *   - `write(raw)`: Effect succeeding or failing per `writeBehavior`
+ *
+ * Other fields are present as placeholders to satisfy the structural type
+ * but are not exercised by the send path.
+ */
+function fakeConnection(
+  id: string,
+  writeBehavior: "ok" | { fail: Socket.SocketError },
+  capture: { raw: string | null },
+): import("../ws/connection.js").MoltZapConnection {
+  return {
+    id,
+    write: (raw: string) => {
+      capture.raw = raw;
+      if (writeBehavior === "ok") return Effect.void;
+      return Effect.fail(writeBehavior.fail);
+    },
+    shutdown: Effect.void,
+    auth: null,
+    lastPong: 0,
+    conversationIds: new Set<string>(),
+    mutedConversations: new Set<string>(),
+    appCallbackPending: Effect.runSync(
+      Ref.make(
+        HashMap.empty<
+          import("@moltzap/protocol").JsonRpcStringId,
+          {
+            readonly method: import("@moltzap/protocol").JsonRpcMethod;
+            readonly deferred: never;
+          }
+        >() as import("../ws/connection.js").AppCallbackPendingMap,
+      ),
+    ),
+    appCallbackRequestCounter: Effect.runSync(Ref.make(0)),
+  };
+}
+
+describe("NetworkSendService.send", () => {
+  it("agent address: resolves via resolver, writes payload, returns DeliveryAck", () => {
+    const resolver = makeResolver();
+    const connections = new ConnectionManager();
+    const capture = { raw: null as string | null };
+    const conn = fakeConnection(CONN_A, "ok", capture);
+    connections.add(conn);
+
+    const addr = agentConnectionEndpointAddress(CONN_A);
+    Effect.runSync(resolver.add(ALICE, addr, CONN_A));
+
+    const service = new NetworkSendService(resolver, connections);
+    const payload = opaquePayload(`{"jsonrpc":"2.0","method":"x","params":{}}`);
+
+    const exit = Effect.runSyncExit(service.send(addr, payload));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value).toBeInstanceOf(DeliveryAck);
+      expect(exit.value.to).toEqual(addr);
+    }
+    expect(capture.raw).toBe(payload);
+  });
+
+  it("agent address: resolver miss → RecipientNotResolved", () => {
+    const resolver = makeResolver();
+    const connections = new ConnectionManager();
+    const service = new NetworkSendService(resolver, connections);
+    const addr = agentConnectionEndpointAddress(CONN_A);
+    const payload = opaquePayload("{}");
+
+    const exit = Effect.runSyncExit(service.send(addr, payload));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure)).toBe(true);
+      if (Option.isSome(failure)) {
+        expect(failure.value).toBeInstanceOf(RecipientNotResolved);
+        expect(failure.value._tag).toBe("RecipientNotResolved");
+      }
+    }
+  });
+
+  it("agent address: resolver hit but connection gone → RecipientNotResolved", () => {
+    // Race: resolver still holds the entry but the connection closed
+    // between the WS finalizer and the send call.
+    const resolver = makeResolver();
+    const connections = new ConnectionManager(); // empty
+    const addr = agentConnectionEndpointAddress(CONN_A);
+    Effect.runSync(resolver.add(ALICE, addr, CONN_A));
+    const service = new NetworkSendService(resolver, connections);
+    const payload = opaquePayload("{}");
+
+    const exit = Effect.runSyncExit(service.send(addr, payload));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      if (Option.isSome(failure)) {
+        expect(failure.value).toBeInstanceOf(RecipientNotResolved);
+      }
+    }
+  });
+
+  it("app address: returns EndpointKindNotImplemented (Phase 9 deferral)", () => {
+    const resolver = makeResolver();
+    const connections = new ConnectionManager();
+    const service = new NetworkSendService(resolver, connections);
+    const payload = opaquePayload("{}");
+
+    const exit = Effect.runSyncExit(service.send(APP_ADDR, payload));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure)).toBe(true);
+      if (Option.isSome(failure)) {
+        expect(failure.value).toBeInstanceOf(EndpointKindNotImplemented);
+        expect((failure.value as EndpointKindNotImplemented).kind).toBe("app");
+      }
+    }
+  });
+
+  it("agent address: socket write rejects → WriteFailed wraps the cause", async () => {
+    const resolver = makeResolver();
+    const connections = new ConnectionManager();
+    const capture = { raw: null as string | null };
+    // Build a SocketError. The constructor accepts `reason`-style payloads;
+    // any well-formed instance suffices here because the test inspects
+    // identity via `instanceof`.
+    const cause = new Socket.SocketGenericError({
+      reason: "Write",
+      cause: new Error("EPIPE"),
+    });
+    const conn = fakeConnection(CONN_A, { fail: cause }, capture);
+    connections.add(conn);
+    const addr = agentConnectionEndpointAddress(CONN_A);
+    Effect.runSync(resolver.add(ALICE, addr, CONN_A));
+    const service = new NetworkSendService(resolver, connections);
+    const payload = opaquePayload("{}");
+
+    const exit = await Effect.runPromiseExit(service.send(addr, payload));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure)).toBe(true);
+      if (Option.isSome(failure)) {
+        expect(failure.value).toBeInstanceOf(WriteFailed);
+        expect((failure.value as WriteFailed).cause).toBe(cause);
+      }
+    }
+  });
+});
+
+describe("opaquePayload", () => {
+  it("brands a string and round-trips bytes unchanged", () => {
+    const raw = `{"jsonrpc":"2.0","method":"task/ready","params":{}}`;
+    const branded = opaquePayload(raw);
+    expect(String(branded)).toBe(raw);
+  });
+});

--- a/packages/server/src/network/network-send.ts
+++ b/packages/server/src/network/network-send.ts
@@ -1,0 +1,211 @@
+/**
+ * `network.send(to: EndpointAddress, payload: OpaquePayload)
+ *   → Effect<DeliveryAck, DeliveryError, never>`
+ *
+ * The new outbound-routing primitive introduced in Slice G1. Coexists with
+ * the legacy {@link Broadcaster} during Phase 8; consumer migration to
+ * `network.send` lands in Phase 9 (Slice C). {@link Broadcaster} deletion
+ * lands in Phase 10 (Slice G2).
+ *
+ * Plan: `docs/plans/layered-network-refactor-2026-05.md` §2.4.a, §2.10
+ * (Slice G1), §2.11 (resolver constraint). Issue #426 acceptance.
+ *
+ * Why a tagged service rather than a free function. The send path needs
+ * exactly two collaborators — the {@link AgentEndpointResolver} for the
+ * agent-kind lookup and the {@link ConnectionManager} for the writable
+ * socket — and the dual-DI requirement (issue #426: "New tags introduced
+ * alongside") asks for a Tag the rest of the server's `Layer` graph can
+ * provide. A class with a single method composed from the two
+ * collaborators is the smallest shape that satisfies both.
+ *
+ * Why the error channel is `never` for the Context parameter. Per Issue
+ * #426 acceptance: `Effect<DeliveryAck, DeliveryError, never>`. The
+ * service holds its collaborators by direct reference, not Context, so
+ * callers do not have to provide additional services to invoke `send`.
+ *
+ * Endpoint kind handling:
+ * - `tm:agent:<connId>` — resolves via the {@link AgentEndpointResolver}'s
+ *   reverse index, then writes to the matching connection. O(1) hot path,
+ *   no DB lookup (per §2.11). Returns
+ *   {@link RecipientNotResolved} if the address is unknown to the
+ *   resolver (typical: the recipient connection closed between fan-out
+ *   computation and `send` invocation).
+ * - `tm:app:<id>` — Phase 9 territory. Returns
+ *   {@link EndpointKindNotImplemented}. Slice G1 deliberately does not
+ *   ship app-kind delivery to avoid coupling with the TM topology
+ *   refactor; that lands as part of Slice C.
+ *
+ * The brand at `packages/protocol/src/network/actor-model.ts:48` already
+ * encodes the kind in the prefix. The send path parses the prefix once
+ * and switches; the switch is exhaustive over `EndpointAddressKind`
+ * (Phase 6 R3 pattern).
+ */
+import { Brand, Data, Effect, Match, Option } from "effect";
+import {
+  endpointAddressKind,
+  type EndpointAddress,
+  type EndpointAddressKind,
+} from "@moltzap/protocol/network";
+import type * as Socket from "@effect/platform/Socket";
+import { ConnectionManager } from "../ws/connection.js";
+import { AgentEndpointResolver } from "./agent-endpoint-resolver.js";
+
+/**
+ * Branded raw-string payload. Opaque to the network: `network.send`
+ * does not parse, transform, or validate the payload — it writes the
+ * exact bytes to the recipient socket.
+ *
+ * Why opaque. The send primitive sits below the typed-RPC layer (which
+ * encodes/decodes JSON-RPC frames). Callers serialize a frame to a string
+ * (or any wire-encodable bytes-as-string) before crossing the boundary.
+ * The brand prevents an unwitting caller from passing an arbitrary
+ * `string` (e.g., a plain message body) where a wire frame is expected.
+ *
+ * Construction site: {@link opaquePayload}. The brand is nominal — there
+ * is no shape predicate — because the only invariant `network.send` cares
+ * about is "the caller intends this to be a wire-ready payload."
+ */
+export type OpaquePayload = string & Brand.Brand<"OpaquePayload">;
+const OpaquePayloadBrand = Brand.nominal<OpaquePayload>();
+
+/** Brand a raw string as an {@link OpaquePayload}. */
+export const opaquePayload = (raw: string): OpaquePayload =>
+  OpaquePayloadBrand(raw);
+
+// ---------------------------------------------------------------------------
+// Result + error channel
+// ---------------------------------------------------------------------------
+
+/**
+ * Acknowledges a successful write to the underlying socket.
+ *
+ * Carries the recipient address; no count field — Slice G1 only routes
+ * single-recipient agent addresses, so a count would always be 1. When
+ * Slice G2 (Phase 10) introduces multi-recipient sends, the right shape
+ * is a list of delivered addresses, not a counter — added then with the
+ * concrete need.
+ */
+export class DeliveryAck extends Data.TaggedClass("DeliveryAck")<{
+  readonly to: EndpointAddress;
+}> {}
+
+/**
+ * The recipient address has no live connection. Typical cause: the
+ * recipient socket closed between resolver lookup and the `send` call.
+ * Caller-recoverable — the right response is usually to drop or queue,
+ * not retry.
+ */
+export class RecipientNotResolved extends Data.TaggedError(
+  "RecipientNotResolved",
+)<{
+  readonly to: EndpointAddress;
+}> {}
+
+/**
+ * The address is well-formed but its kind is not yet wired in this slice.
+ * Specifically: `tm:app:` addresses are reserved for Phase 9 (Slice C).
+ *
+ * Distinguished from {@link RecipientNotResolved} because the failure is
+ * a build-time gap (this slice does not ship the implementation), not a
+ * runtime liveness gap (the recipient is gone). Caller observability
+ * benefits from the distinction; once Phase 9 lands, this tag is removed
+ * from the channel.
+ */
+export class EndpointKindNotImplemented extends Data.TaggedError(
+  "EndpointKindNotImplemented",
+)<{
+  readonly to: EndpointAddress;
+  readonly kind: EndpointAddressKind;
+}> {}
+
+/**
+ * The underlying socket write failed. Wraps the inner
+ * {@link Socket.SocketError} so the caller can distinguish a write
+ * failure from a resolution failure without re-running the lookup.
+ *
+ * Per the Phase 1B platform decision, the wire is `@effect/platform`
+ * Socket; the cause type comes from there.
+ */
+export class WriteFailed extends Data.TaggedError("WriteFailed")<{
+  readonly to: EndpointAddress;
+  readonly cause: Socket.SocketError;
+}> {}
+
+/**
+ * Discriminated union of every failure mode `network.send` can produce.
+ * Exhaustive at the call site via `_tag` matching (Phase 6 R3 pattern).
+ */
+export type DeliveryError =
+  | RecipientNotResolved
+  | EndpointKindNotImplemented
+  | WriteFailed;
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * The outbound-routing primitive. Use the constructor directly in code;
+ * route through `NetworkSendServiceTag` in DI-aware code.
+ */
+export class NetworkSendService {
+  constructor(
+    private readonly resolver: AgentEndpointResolver,
+    private readonly connections: ConnectionManager,
+  ) {}
+
+  /**
+   * Route `payload` to the connection bound to `to`. Resolves the address
+   * kind once, dispatches per kind, and returns a {@link DeliveryAck} on
+   * success or a {@link DeliveryError} member on failure.
+   *
+   * The Effect's R parameter is `never`: the service holds its
+   * collaborators directly, so callers do not have to provide a
+   * {@link AgentEndpointResolver} / {@link ConnectionManager} via Context
+   * to invoke `send`.
+   */
+  send(
+    to: EndpointAddress,
+    payload: OpaquePayload,
+  ): Effect.Effect<DeliveryAck, DeliveryError, never> {
+    const kind: EndpointAddressKind = endpointAddressKind(to);
+    return Match.value(kind).pipe(
+      Match.when("agent", () => this.sendToAgentEndpoint(to, payload)),
+      Match.when("app", () =>
+        Effect.fail(new EndpointKindNotImplemented({ to, kind: "app" })),
+      ),
+      Match.exhaustive,
+    );
+  }
+
+  /**
+   * Agent-kind delivery. Resolves the address to a live connection via
+   * the resolver's reverse index + the connection manager, writes the
+   * payload, and tags the outcome.
+   *
+   * Failure cases:
+   * - resolver miss OR resolver hit + closed connection (race):
+   *   {@link RecipientNotResolved} — both shapes mean "no live recipient
+   *   for this address," and callers cannot tell which without poking
+   *   internal state. Folded into one branch.
+   * - socket write fails → {@link WriteFailed}.
+   */
+  private sendToAgentEndpoint(
+    to: EndpointAddress,
+    payload: OpaquePayload,
+  ): Effect.Effect<DeliveryAck, DeliveryError, never> {
+    return Effect.gen(this, function* () {
+      const connOpt = Option.flatMap(
+        yield* this.resolver.connectionForAddress(to),
+        (id) => Option.fromNullable(this.connections.get(id)),
+      );
+      if (Option.isNone(connOpt)) {
+        return yield* Effect.fail(new RecipientNotResolved({ to }));
+      }
+      yield* connOpt.value
+        .write(payload)
+        .pipe(Effect.mapError((cause) => new WriteFailed({ to, cause })));
+      return new DeliveryAck({ to });
+    });
+  }
+}

--- a/packages/server/src/services/task.service.ts
+++ b/packages/server/src/services/task.service.ts
@@ -1,6 +1,7 @@
 import { Effect, Option } from "effect";
 import {
   endpointAddress as brandEndpointAddress,
+  makeEndpointAddress,
   type EndpointAddress,
   type AgentId as ActorAgentId,
 } from "@moltzap/protocol/network";
@@ -58,12 +59,17 @@ interface TaskRow {
   readonly created_at: Date;
 }
 
-const TM_AGENT_PREFIX = "tm:agent:";
-
+/**
+ * Stable TM-endpoint address for a registering agent: `tm:agent:<agentId>`.
+ * Distinct from `agentConnectionEndpointAddress(connId)` in
+ * `network/agent-endpoint-resolver.ts`, which mints `tm:agent:<connId>`
+ * for the resolver multimap. Both reuse the protocol-side
+ * {@link makeEndpointAddress} primitive, so the wire prefix never forks.
+ */
 export function endpointAddressForAgent(
   agent: ActorAgentId | BrandedAgentId,
 ): EndpointAddress {
-  return brandEndpointAddress(`${TM_AGENT_PREFIX}${agent}`);
+  return makeEndpointAddress("agent", agent);
 }
 
 function rowToTask(row: TaskRow): Task {


### PR DESCRIPTION
Closes #426
Parent epic: #415
Plan: [docs/plans/layered-network-refactor-2026-05.md](https://github.com/chughtapan/moltzap/blob/main/docs/plans/layered-network-refactor-2026-05.md) §2.10 (Slice G1 split), §2.11 (resolver constraint)

## What changed

Slice G1 introduces the new outbound-routing primitive `network.send(to: EndpointAddress, payload: OpaquePayload) → Effect<DeliveryAck, DeliveryError, never>` plus the `AgentEndpointResolver` HashMap multimap that backs O(1) agent-kind delivery. Coexists with the legacy `Broadcaster` (dual-DI). No consumer migration in this PR — that is Phase 9 (Slice C). Broadcaster deletion is Phase 10 (Slice G2).

## Traceability

| New artifact | Kind | Plan / issue anchor |
|---|---|---|
| `packages/server/src/network/agent-endpoint-resolver.ts` | new module | Plan §2.10/§2.11; Issue #426 |
| `AgentEndpointResolver` class (`add`, `remove`, `resolveAll`, `connectionForAddress`) | public class | Plan §2.11; Issue #426 acceptance |
| `agentConnectionEndpointAddress(connId)` helper | public fn | Plan §2.11 |
| `AgentEndpointResolverTag` + `AgentEndpointResolverLive` | new DI tag + layer | Issue #426 dual-DI |
| `packages/server/src/network/network-send.ts` | new module | Plan §2.4.a, §2.10; Issue #426 |
| `NetworkSendService` class with `.send(to, payload)` | public class | Plan §2.10; Issue #426 |
| `OpaquePayload` brand + `opaquePayload(raw)` factory | public type | Issue #426 acceptance |
| `DeliveryAck` tagged class | public type | Issue #426 acceptance |
| `DeliveryError` (`RecipientNotResolved` ∣ `EndpointKindNotImplemented` ∣ `WriteFailed`) | public union | Issue #426 acceptance |
| `NetworkSendServiceTag` + `NetworkSendServiceLive` | new DI tag + layer | Issue #426 dual-DI |
| `ENDPOINT_ADDRESS_PREFIX` (now exported), `endpointAddressKind`, `makeEndpointAddress` | protocol helpers | Phase 6 brand-pattern reuse |
| Hook in `network/handlers/auth.handlers.ts` post-`conn.auth = auth` | wire-up | Plan §2.11 auth-lifecycle |
| Hook in `app/server.ts` onExit (resolver.remove if authed) | wire-up | Plan §2.11 auth-lifecycle |
| `CoreApp.networkSendService` exposure | public surface | Issue #426 dual-DI |

## Scope

- New modules: `network/agent-endpoint-resolver.ts`, `network/network-send.ts`
- New public exports: 9 (`AgentEndpointResolver`, `agentConnectionEndpointAddress`, `NetworkSendService`, `OpaquePayload`, `opaquePayload`, `DeliveryAck`, `DeliveryError`, `RecipientNotResolved`, `EndpointKindNotImplemented`, `WriteFailed`) plus 4 DI tags/layers (`AgentEndpointResolverTag`, `AgentEndpointResolverLive`, `NetworkSendServiceTag`, `NetworkSendServiceLive`) plus 3 protocol helpers (`ENDPOINT_ADDRESS_PREFIX`, `endpointAddressKind`, `makeEndpointAddress`)
- New deps: 0
- Tier (target): staff

## Resolver contract (plan §2.11)

- `HashMap<AgentId, HashSet<EndpointAddress>>` forward multimap + paired `HashMap<EndpointAddress, ConnectionId>` reverse index, both updated under a single `Ref.update` so the invariant cannot tear.
- Atomic add on `auth/connect` success (post-`conn.auth = auth`).
- Atomic remove on disconnect (when `conn.auth` was set).
- `resolveAll(agentId): HashSet<EndpointAddress>` for fan-out.
- `connectionForAddress(address): Option<string>` for send routing.
- O(1) hot path. No DB lookup.
- Mis-targeted `remove(WRONG_AGENT, addr)` cannot evict the rightful owner's reverse-index entry — guarded by `existed` check, regression-tested.

## Auth-lifecycle wiring

- `auth.handlers.ts:117`: post-`conn.auth = auth`, calls `agentEndpointResolver.add(agentId, agentConnectionEndpointAddress(connId), connId)`.
- `app/server.ts` WS `onExit`: if connection was authed, calls `agentEndpointResolver.remove(authCtx.agentId, agentConnectionEndpointAddress(connId))`.
- Address format: `tm:agent:<connId>` (connId is a UUID minted at socket accept; satisfies the `tm:<kind>:<uuid>` brand).

## Dual-DI evidence

- `BroadcasterTag` + `BroadcasterLive` unchanged (existing call sites untouched).
- `AgentEndpointResolverTag` + `AgentEndpointResolverLive` introduced at `app/layers.ts`.
- `NetworkSendServiceTag` + `NetworkSendServiceLive` introduced at `app/layers.ts`.
- `ResolvedServices` and `resolveServices` extended with `agentEndpointResolver` + `networkSendService` (server-internal handler graph).
- `CoreApp` exposes `networkSendService` only — the resolver stays server-internal per issue #426 dual-DI scope.

## Tests

- `packages/server/src/network/agent-endpoint-resolver.test.ts` — 14 unit tests covering multimap semantics, atomic add/remove, idempotence, mis-targeted-remove invariant, multi-connection multimap, distinct-agents isolation.
- `packages/server/src/network/network-send.test.ts` — 6 unit tests: happy path, `RecipientNotResolved` (resolver miss + closed-connection race), `EndpointKindNotImplemented` (app-kind), `WriteFailed` (socket write rejection), `OpaquePayload` brand round-trip.
- `packages/server/src/__tests__/integration/49-network-send-resolver.integration.test.ts` — 3 end-to-end tests: real WS auth/connect populates the resolver and `network.send` delivers a `presence/changed` notification (asserted via `client.waitForNotification`), disconnect drains the resolver (subsequent send returns `RecipientNotResolved`), multimap semantics for two simultaneous connections of the same agent.
- `packages/protocol/src/network/actor-model.test.ts` — 5 tests added for `makeEndpointAddress` + `endpointAddressKind` + flat-barrel negative canary for the new helpers.
- `packages/server/src/app/layers.test.ts` — extended to assert the resolver and send service are wired into the Layer graph.

## Simplify skips

None — every `/simplify` finding applied. Notable applied fixes:

- Reused brand prefix: extracted `ENDPOINT_ADDRESS_PREFIX` + `makeEndpointAddress` + `endpointAddressKind` into the protocol; `task.service.ts:endpointAddressForAgent` now routes through the same primitive.
- Dropped speculative `recipientCount` field on `DeliveryAck` (always 1 in G1; correct fan-out shape lands in G2 with the actual need).
- Folded the two `RecipientNotResolved` branches in `sendToAgentEndpoint` into one composed `Option.flatMap`.

## Codex diff review

- Round 1: 4 issues found.
  - P1 resolver-remove invariant tear: `remove(WRONG_AGENT, addr)` could evict `byAddress[addr]` from under the rightful owner. **FIXED** with an `existed` guard + regression test (`agent-endpoint-resolver.test.ts:148`).
  - P2 CoreApp exposure of `agentEndpointResolver`: not authorized by issue #426 dual-DI. **FIXED** — the resolver is server-internal; `CoreApp` exposes only `networkSendService`.
  - P3 integration-test depth: only asserted `DeliveryAck`. **FIXED** — now asserts wire receipt via `client.waitForNotification(PresenceChangedNotificationDefinition)`.
  - P1 resolver-add ordering before fallible work in `auth/connect`: deferred — pre-existing `conn.auth = auth` already had this shape; refactoring it is beyond the dispatch's "single hook to populate the resolver" stop rule. The resolver state mirrors `conn.auth` state; both clear together on disconnect.
- Round 2: PASS (re-verified all P1/P2/P3 fixes; no new issues).

## CI status

Pending after push. Pre-PR gates passed locally:
- `pnpm typecheck` ✓
- `pnpm lint` ✓ (eslint + oxlint, 0 warnings)
- `pnpm format:check` ✓
- `bash packages/protocol/scripts/check-divergence-proofs.sh` ✓ (26 proof-required suites OK)
- `pnpm test` ✓ (server-core: 238 pass; protocol new tests: 22 pass; client/channels/runtimes all pass)
- `pnpm test:integration` ✓ (49-network-send-resolver: 3 pass)
- `pnpm --filter @moltzap/client test:conformance` ✓ (10 pass)
- `/codex` review ✓ (PASS round 2)

## Confidence

HIGH — every artifact traces to plan §2.10/§2.11 or issue #426 acceptance; new modules are spec-authorized architectural surface; both unit and integration coverage of resolver + send paths; codex independent review PASS round 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)