### PR TITLE
[impl-junior] Phase 9b follow-ups (#462 + #464 + #465 + #467)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -145,13 +145,7 @@
             "group": "Apps",
             "pages": [
               "protocol/methods/apps-register",
-              "protocol/methods/apps-create",
-              "protocol/methods/apps-close-session",
-              "protocol/methods/apps-get-session",
-              "protocol/methods/apps-list-sessions",
               "protocol/methods/apps-authorize-dispatch",
-              "protocol/methods/apps-attach-conversation",
-              "protocol/methods/apps-on-join",
               "protocol/methods/task-authorize-dispatch"
             ]
           },

--- a/packages/protocol/src/schema/tasks.ts
+++ b/packages/protocol/src/schema/tasks.ts
@@ -18,10 +18,10 @@ export const TaskSchema = Type.Object(
     appId: Type.Union([Type.String(), Type.Null()]),
     initiatorAgentId: AgentId,
     status: TaskStatusEnum,
-    // Phase 9b consumer-migration (sub-issue #460 round 3 R12): NOT NULL
-    // by construction. `tasks/create` (R13) requires `tmEndpointAddress`
-    // at insert time; the schema-level constraint at
-    // `tasks.tm_endpoint_address` makes the null state unrepresentable.
+    // The persisted task output exposes `tmEndpointAddress` (a branded
+    // `EndpointAddress` string). The public `tasks/create` request does
+    // NOT take an address directly; it takes a `tmType` enum and the
+    // server derives the address (Phase 9b R16, PR #461).
     tmEndpointAddress: Type.String({ minLength: 1 }),
     startedAt: Type.Union([DateTimeString, Type.Null()]),
     endedAt: Type.Union([DateTimeString, Type.Null()]),

--- a/packages/server/src/__tests__/integration/50-task-stamp-and-dedup.integration.test.ts
+++ b/packages/server/src/__tests__/integration/50-task-stamp-and-dedup.integration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Phase 9b follow-ups #464 (no orphan task on DM dedup) +
+ * #465 (`messages.task_id` stamped at INSERT time).
+ */
+import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  registerAndConnect,
+  getKyselyDb,
+} from "./helpers.js";
+
+import { ConversationsCreate, MessagesSend } from "@moltzap/protocol";
+
+beforeAll(async () => {
+  await startTestServer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe("Phase 9b follow-ups: dedup-aware DM + task_id stamp", () => {
+  it.live(
+    "#464: messages/send agent:<name> twice produces ONE task, not two",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnect("alice-464a");
+        const bob = yield* registerAndConnect("bob-464a");
+
+        const first = (yield* alice.client.sendRpc(MessagesSend, {
+          to: `agent:${bob.name}`,
+          parts: [{ type: "text", text: "first" }],
+        })) as { message: { conversationId: string } };
+
+        yield* alice.client.sendRpc(MessagesSend, {
+          to: `agent:${bob.name}`,
+          parts: [{ type: "text", text: "second" }],
+        });
+
+        const db = getKyselyDb();
+        const conv = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("conversations")
+            .select(["task_id"])
+            .where("id", "=", first.message.conversationId)
+            .executeTakeFirstOrThrow(),
+        );
+        const tasksForAlice = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("tasks")
+            .select(["id"])
+            .where("initiator_agent_id", "=", alice.agentId)
+            .execute(),
+        );
+        expect(tasksForAlice).toHaveLength(1);
+        expect(tasksForAlice[0]!.id).toBe(conv.task_id);
+      }),
+  );
+
+  it.live(
+    "#464: conversations/create { type: dm } twice produces ONE task, not two",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnect("alice-464b");
+        const bob = yield* registerAndConnect("bob-464b");
+
+        const first = (yield* alice.client.sendRpc(ConversationsCreate, {
+          type: "dm",
+          participants: [{ type: "agent", id: bob.agentId }],
+        })) as { conversation: { id: string } };
+
+        const second = (yield* alice.client.sendRpc(ConversationsCreate, {
+          type: "dm",
+          participants: [{ type: "agent", id: bob.agentId }],
+        })) as { conversation: { id: string } };
+
+        expect(second.conversation.id).toBe(first.conversation.id);
+
+        const db = getKyselyDb();
+        const tasksForAlice = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("tasks")
+            .select(["id"])
+            .where("initiator_agent_id", "=", alice.agentId)
+            .execute(),
+        );
+        expect(tasksForAlice).toHaveLength(1);
+      }),
+  );
+
+  it.live(
+    "#465: messages/send stamps task_id matching conversations.task_id",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnect("alice-465");
+        const bob = yield* registerAndConnect("bob-465");
+
+        const conv = (yield* alice.client.sendRpc(ConversationsCreate, {
+          type: "dm",
+          participants: [{ type: "agent", id: bob.agentId }],
+        })) as { conversation: { id: string } };
+
+        const sendResult = (yield* alice.client.sendRpc(MessagesSend, {
+          conversationId: conv.conversation.id,
+          parts: [{ type: "text", text: "hello" }],
+        })) as { message: { id: string } };
+
+        const db = getKyselyDb();
+        const messageRow = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("messages")
+            .select(["task_id"])
+            .where("id", "=", sendResult.message.id)
+            .executeTakeFirstOrThrow(),
+        );
+        const convRow = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("conversations")
+            .select(["task_id"])
+            .where("id", "=", conv.conversation.id)
+            .executeTakeFirstOrThrow(),
+        );
+
+        expect(messageRow.task_id).not.toBeNull();
+        expect(messageRow.task_id).toBe(convRow.task_id);
+      }),
+  );
+});

--- a/packages/server/src/services/conversation.service.test.ts
+++ b/packages/server/src/services/conversation.service.test.ts
@@ -134,7 +134,13 @@ async function createConv(
 ) {
   const taskId = await seedTask(initiator);
   return Effect.runPromise(
-    service.create(type, name, participants, initiator, taskId),
+    service.create(
+      type,
+      name,
+      participants,
+      initiator,
+      Effect.succeed({ id: taskId }),
+    ),
   );
 }
 
@@ -148,7 +154,13 @@ async function createConvExit(
 ) {
   const taskId = await seedTask(initiator);
   return Effect.runPromiseExit(
-    service.create(type, name, participants, initiator, taskId),
+    service.create(
+      type,
+      name,
+      participants,
+      initiator,
+      Effect.succeed({ id: taskId }),
+    ),
   );
 }
 
@@ -570,7 +582,11 @@ describe("ConversationService.create enforces contact policy on DMs", () => {
 
     const dmTaskId = await seedTask(alice);
     const exit = await Effect.runPromiseExit(
-      service.createDmByAgentName("bob", alice, dmTaskId),
+      service.createDmByAgentName(
+        "bob",
+        alice,
+        Effect.succeed({ id: dmTaskId }),
+      ),
     );
     const failure = expectRpcFailure(exit);
     expect(failure.code).toBe(ErrorCodes.NotInContacts);

--- a/packages/server/src/services/conversation.service.ts
+++ b/packages/server/src/services/conversation.service.ts
@@ -119,14 +119,15 @@ export class ConversationService {
     agentIds: string[],
     creatorAgentId: string,
     /**
-     * Phase 9b consumer-migration (sub-issue #460 round 3 R12): the
-     * `conversations.task_id` column is NOT NULL. Every caller now
-     * supplies the task at insert time. Wire `conversations/create`
-     * pre-mints a default-TM-bound task; `tasks/createConversation`
-     * passes the existing task id; `messages/send`'s auto-DM path
-     * does the same. The pre-R12 post-insert UPDATE pattern retired.
+     * Lazy task source. `conversations.task_id` is NOT NULL (round 3
+     * R12), so every insert must bind to a task. Issue #464: passing
+     * an `Effect` lets the dedup branch short-circuit without minting
+     * an orphan task — the Effect runs ONLY on the dedup-miss path.
+     * Callers with an existing task id wrap it in `Effect.succeed({
+     * id })`; callers that mint a default task pass the
+     * `taskService.createDefaultTaskForType(...)` Effect directly.
      */
-    taskId: string,
+    mintTask: Effect.Effect<{ id: string }, RpcFailure>,
   ): Effect.Effect<Conversation, RpcFailure> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
@@ -201,6 +202,12 @@ export class ConversationService {
           );
         }
 
+        // Issue #464: yield the lazy task source ONLY here, after
+        // every fail-fast check (agent existence, dm-arity, dedup,
+        // contact policy, group cap) has passed. Pre-#464 callers
+        // pre-minted unconditionally and orphaned the row whenever
+        // a check rejected.
+        const task = yield* mintTask;
         const created = yield* transaction(this.db, (trx) =>
           Effect.gen(this, function* () {
             const conv = yield* takeFirstOrFail(
@@ -210,7 +217,7 @@ export class ConversationService {
                   type,
                   name: name ?? null,
                   created_by_id: creatorAgentId,
-                  task_id: taskId,
+                  task_id: task.id,
                 })
                 .returningAll(),
             );
@@ -270,17 +277,14 @@ export class ConversationService {
   /**
    * Resolve an `agent:<name>` DM target and ensure a conversation
    * exists. Used by `messages/send` when the caller supplies
-   * `to: "agent:<name>"` instead of a known conversationId.
-   *
-   * Phase 9b consumer-migration (sub-issue #460 round 3 R12 + R14):
-   * `taskId` is required because the conversation's `task_id` column
-   * is NOT NULL. Caller is `messages.handlers.ts` which pre-creates a
-   * default-DM-TM-bound task before calling.
+   * `to: "agent:<name>"` instead of a known conversationId. The task
+   * source is lazy (#464) so a dedup hit short-circuits without
+   * minting.
    */
   createDmByAgentName(
     agentName: string,
     creatorAgentId: string,
-    taskId: string,
+    mintTask: Effect.Effect<{ id: string }, RpcFailure>,
   ): Effect.Effect<Conversation, RpcFailure> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
@@ -299,7 +303,7 @@ export class ConversationService {
           undefined,
           [target.value.id],
           creatorAgentId,
-          taskId,
+          mintTask,
         );
       }),
     );

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -271,6 +271,11 @@ export class MessageService {
                 parts_tag: tag,
                 dek_version: dekVersion,
                 kek_version: kekVersion,
+                // Issue #465: stamp at insert time so cross-task
+                // queries can filter by `task_id` without joining
+                // through `conversations`. Replaces the post-insert
+                // UPDATE that `tasks/storeMessage` used to issue.
+                task_id: conv.task_id,
                 // Persist the server-minted ISO timestamp so every
                 // downstream view (mapped Message, broadcaster frame,
                 // TM frame dispatched after the insert) agrees on

--- a/packages/server/src/services/task.service.ts
+++ b/packages/server/src/services/task.service.ts
@@ -405,18 +405,15 @@ export class TaskService {
   ): Effect.Effect<Conversation, RpcFailure> {
     return Effect.gen(this, function* () {
       yield* this.requireTmAuthority(id, caller);
-      // Phase 9b consumer-migration (sub-issue #460 round 3 R12):
-      // `conversations.task_id` is NOT NULL. Pass the task id at
-      // insert time inside ConversationService.create's transaction
-      // so the row exists with `task_id` set from the start. The
-      // pre-R12 post-insert UPDATE pattern retired alongside the
-      // nullable column.
+      // The task id is fixed (this is a TM acting on its own task),
+      // so wrap it in `Effect.succeed` for the lazy-`mintTask`
+      // contract `ConversationService.create` expects.
       const conversation = yield* this.conversations.create(
         input.type,
         input.name,
         [...input.participantAgentIds],
         caller,
-        id,
+        Effect.succeed({ id }),
       );
       return conversation;
     });
@@ -457,15 +454,11 @@ export class TaskService {
         // store. Phase 9b codex HIGH-1.
         true,
       );
-      // Stamp the message's task_id so cross-task queries (Phase 6
-      // `tasks/getMessages`, future TM-routed reads) can scope by the
-      // denormalized FK without joining through `conversations`.
-      yield* catchSqlErrorAsDefect(
-        this.db
-          .updateTable("messages")
-          .set({ task_id: id })
-          .where("id", "=", message.id),
-      );
+      // Issue #465: the post-insert UPDATE retired now that
+      // `MessageService.send` stamps `task_id` from `conv.task_id` at
+      // insert time. The TM-authored path inherits the stamp because
+      // `requireConversationInTask` above already proved the
+      // conversation belongs to this task (`conv.task_id === id`).
       return message;
     });
   }

--- a/packages/server/src/task/handlers/conversations.handlers.ts
+++ b/packages/server/src/task/handlers/conversations.handlers.ts
@@ -37,24 +37,16 @@ export function createConversationHandlers(deps: {
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const agentIds = params.participants.map((p) => p.id);
-          // Phase 9b consumer-migration (sub-issue #460 round 3 R14):
-          // every conversation belongs to a task; non-app conversations
-          // bind to the default DM / group TM at creation. A failed
-          // existing-DM dedup inside `ConversationService.create`
-          // returns the existing conversation; the freshly-minted
-          // default task is then orphaned. Pre-prod the orphan is
-          // harmless; future arena cutover wraps both inserts in one
-          // transaction if it matters.
-          const task = yield* deps.taskService.createDefaultTaskForType(
-            params.type,
-            ctx.agentId,
-          );
+          // Issue #464: pass the task source as a lazy Effect so
+          // `ConversationService.create` only mints when its DM dedup
+          // misses; pre-fix every duplicate-DM call orphaned the
+          // pre-minted task.
           const conversation = yield* deps.conversationService.create(
             params.type,
             params.name,
             agentIds,
             ctx.agentId,
-            task.id,
+            deps.taskService.createDefaultTaskForType(params.type, ctx.agentId),
           );
 
           // ConversationService.create subscribes every participant's open

--- a/packages/server/src/task/handlers/messages.handlers.ts
+++ b/packages/server/src/task/handlers/messages.handlers.ts
@@ -42,22 +42,13 @@ export function createMessageHandlers(deps: {
 
             if (!conversationId && params.to) {
               const agentName = yield* parseTo(params.to);
-              // Phase 9b consumer-migration (sub-issue #460 round 3
-              // R14): every conversation belongs to a task; the
-              // auto-DM path mints a default-DM-TM-bound task before
-              // calling `createDmByAgentName`. If the DM already
-              // exists the dedup branch returns the existing
-              // conversation and the freshly-minted task is orphaned
-              // — pre-prod harmless.
-              const task = yield* deps.taskService.createDefaultTaskForType(
-                "dm",
-                ctx.agentId,
-              );
+              // Issue #464: lazy `mintTask` so dedup hits don't
+              // orphan a default-DM task.
               const conversation =
                 yield* deps.conversationService.createDmByAgentName(
                   agentName,
                   ctx.agentId,
-                  task.id,
+                  deps.taskService.createDefaultTaskForType("dm", ctx.agentId),
                 );
               conversationId = conversation.id;
             }


### PR DESCRIPTION
Closes #462, #464, #465, #467.

## Plan-anchor table

| Issue | Severity | Fix | Citation |
|---|---|---|---|
| #462 | HIGH | Drop 6 stale `apps-*` nav entries pointing at deleted .mdx files | `docs/docs.json:148-153` |
| #464 | MED | Lift task source to a lazy `Effect` so DM dedup short-circuits without minting an orphan task | `packages/server/src/services/conversation.service.ts:116-130,205-211` |
| #465 | MED | Stamp `messages.task_id` at INSERT time in `MessageService.send`; retire the redundant post-insert UPDATE in `TaskService.storeMessage` | `packages/server/src/services/message.service.ts:267-278`, `packages/server/src/services/task.service.ts:455-470` |
| #467 | NIT | Rewrite stale `tmEndpointAddress` comment to reflect post-R16 design | `packages/protocol/src/schema/tasks.ts:21-24` |

## What changed

- **#462** — `docs/docs.json:148-153` — deleted 6 nav entries (`apps-create`, `apps-close-session`, `apps-get-session`, `apps-list-sessions`, `apps-attach-conversation`, `apps-on-join`); the underlying .mdx files were already removed in Phase 7.
- **#464** — Restructured `ConversationService.create(..., mintTask: Effect<{id:string}, RpcFailure>)` to receive the task source as a lazy `Effect` instead of a pre-resolved `taskId: string`. The Effect is yielded **only after** every fail-fast check (agent existence, dm-arity, dedup, contact policy, group cap) has passed, so a duplicate-DM call never mints an orphan task. Collapses the previous handler-level pre-check + service-level dedup + `createDmByAgentName` dedup into a single source of truth inside `create`.
- **#465** — `MessageService.send` now writes `task_id: conv.task_id` directly in the INSERT (the `conversations ⋈ tasks` join above already selected `task_id`). The post-insert UPDATE in `TaskService.storeMessage` is gone; the TM-authored path inherits the stamp because it calls `MessageService.send` internally.
- **#467** — Comment rewrite only; reflects R16's `tmType` enum + server-side address derivation.

## Tests

3 new integration tests at `packages/server/src/__tests__/integration/50-task-stamp-and-dedup.integration.test.ts`:

- `#464: messages/send agent:<name> twice produces ONE task, not two` — exercises the auto-DM path; queries `tasks` table directly and asserts cardinality.
- `#464: conversations/create { type: dm } twice produces ONE task, not two` — exercises the explicit-create path same way.
- `#465: messages/send stamps task_id matching conversations.task_id` — sends one message, queries `messages.task_id` directly and asserts non-null + matching the parent conversation.

Manual check for #462: `ls docs/protocol/methods/` confirms none of the 6 deleted .mdx files exist.

## Pre-PR gates (all green locally)

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm format:check` ✓
- `bash packages/protocol/scripts/check-divergence-proofs.sh` ✓
- `pnpm test` ✓ (server-core: 225/225, all packages green)
- `pnpm test:integration` ✓ (server: 96/99 + 3 todo, +3 new tests under file 50)
- `pnpm --filter @moltzap/client test:conformance` ✓ (10/10)

## /simplify + /review

Pre-PR `/simplify` flagged a triple-dedup (handler + `createDmByAgentName` + `create`) and copy-paste fan-out in the initial draft. Applied: collapsed to a single dedup site inside `create` via the lazy-`Effect` `mintTask` parameter; the handler no longer needs a pre-check and the duplicate broadcast loop is gone. Net diff dropped from ~+93/-42 to +201/-70 (the new test file accounts for the +136).

🤖 Generated with [Claude Code](https://claude.com/claude-code)