### PR TITLE
[impl-junior] Phase 10 follow-ups (#469 + #472 + #479 + #480 + #477 cleanup verify)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -160,7 +160,6 @@
             "pages": [
               "protocol/notifications/overview",
               "protocol/notifications/messages-received",
-              "protocol/notifications/messages-delivered",
               "protocol/notifications/conversations-created",
               "protocol/notifications/conversations-updated",
               "protocol/notifications/conversations-archived",

--- a/packages/server/src/network/agent-endpoint-resolver.test.ts
+++ b/packages/server/src/network/agent-endpoint-resolver.test.ts
@@ -214,14 +214,15 @@ describe("AgentEndpointResolver — Phase 8 codex deferrals", () => {
     expect(HashSet.size(Effect.runSync(resolver.resolveAll(ALICE)))).toBe(0);
   });
 
-  it("idempotent remove on never-added pairs (defensive precondition for close-during-auth in auth handler; full race test in Phase 9b)", () => {
+  it("idempotent remove on never-added pairs (defensive precondition for close-during-auth in auth handler; full race test in Phase 9b's 40-task-manager-routing.integration.test.ts)", () => {
     // Resolver-contract guard: the auth handler's transactional flow
     // skips `add` when `connections.get(connId)` returns undefined at
     // re-check time (close-during-auth). The WS scope's onExit
     // finalizer cannot tell whether `add` fired, and it does not need
     // to — `remove` on a never-added pair is documented idempotent.
     // This test verifies that resolver precondition; the full auth-
-    // handler race test (real WS close timing) lives in Phase 9b.
+    // handler race test (real WS close timing) lives in Phase 9b's
+    // packages/server/src/__tests__/integration/40-task-manager-routing.integration.test.ts.
     const resolver = makeResolver();
 
     // The handler set conn.auth but the connection closed before the

--- a/packages/server/src/network/network-send.ts
+++ b/packages/server/src/network/network-send.ts
@@ -33,11 +33,21 @@ import {
   type EndpointAddress,
   type EndpointAddressKind,
 } from "@moltzap/protocol/network";
+import type { Static } from "@moltzap/protocol";
+import type { ConversationId as ConversationIdSchema } from "@moltzap/protocol/schemas/primitives";
 import type * as Socket from "@effect/platform/Socket";
 import { ConnectionManager } from "../ws/connection.js";
 import { AgentEndpointResolver } from "./agent-endpoint-resolver.js";
 import type { AppTmRegistry } from "./app-tm-registry.js";
 import { logger } from "../logger.js";
+
+/**
+ * `ConversationId` is intentionally NOT re-exported from the
+ * `@moltzap/protocol` flat barrel (the actor-model brand types own
+ * those identifiers). The schema lives at `schemas/primitives` and we
+ * lift it to a static type via TypeBox's `Static`.
+ */
+type ConversationId = Static<typeof ConversationIdSchema>;
 
 /**
  * Branded raw-string payload. The send primitive writes the exact
@@ -135,7 +145,7 @@ export class NetworkSendService {
     agentIds: readonly AgentId[],
     payload: OpaquePayload,
     opts?: {
-      readonly forConversation?: string;
+      readonly forConversation?: ConversationId;
       readonly excludeConnectionId?: string;
     },
   ): Effect.Effect<{ readonly delivered: readonly AgentId[] }, never, never> {

--- a/packages/server/src/services/conversation.service.ts
+++ b/packages/server/src/services/conversation.service.ts
@@ -5,6 +5,7 @@ import type {
   ConversationParticipant,
   ConversationSummary,
 } from "@moltzap/protocol";
+import type { AgentId } from "../app/types.js";
 import { Effect, Option } from "effect";
 import {
   RpcFailure,
@@ -774,7 +775,7 @@ export class ConversationService {
 
   getParticipantAgentIds(
     conversationId: string,
-  ): Effect.Effect<string[], RpcFailure> {
+  ): Effect.Effect<readonly AgentId[], RpcFailure> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
         const rows = yield* this.db
@@ -782,7 +783,7 @@ export class ConversationService {
           .select("agent_id")
           .where("conversation_id", "=", conversationId);
 
-        return rows.map((r) => r.agent_id);
+        return rows.map((r) => protocolAgentId(r.agent_id));
       }),
     );
   }

--- a/packages/server/src/services/message.service.ts
+++ b/packages/server/src/services/message.service.ts
@@ -9,7 +9,6 @@ import {
   notificationFrame,
 } from "@moltzap/protocol";
 import {
-  agentId as makeAgentId,
   isEndpointAddress,
   type EndpointAddress,
 } from "@moltzap/protocol/network";
@@ -290,9 +289,12 @@ export class MessageService {
         });
         const eventPayload = opaquePayload(JSON.stringify(event));
         const broadcastResult = yield* this.networkSendService.broadcast(
-          participants.map((id) => makeAgentId(id)),
+          participants,
           eventPayload,
-          { forConversation: conversationId, excludeConnectionId },
+          {
+            forConversation: protocolConversationId(conversationId),
+            excludeConnectionId,
+          },
         );
         const delivered: readonly string[] = broadcastResult.delivered;
 

--- a/packages/server/src/task/handlers/contacts.handlers.ts
+++ b/packages/server/src/task/handlers/contacts.handlers.ts
@@ -13,7 +13,6 @@ import {
   type Static,
   type TSchema,
 } from "@moltzap/protocol";
-import { agentId as makeAgentId } from "@moltzap/protocol/network";
 import { UserId } from "@moltzap/protocol/schemas/primitives";
 import type { ContactsService } from "../../services/contact.service.js";
 import type { AuthService } from "../../services/auth.service.js";
@@ -47,10 +46,7 @@ export function createContactHandlers(deps: {
       if (agentIds.length === 0) return;
       const frame = notificationFrame(definition, params);
       const payload = opaquePayload(JSON.stringify(frame));
-      yield* networkSendService.broadcast(
-        agentIds.map((id) => makeAgentId(id)),
-        payload,
-      );
+      yield* networkSendService.broadcast(agentIds, payload);
     });
 
   const requireOwner = (

--- a/packages/server/src/task/handlers/conversations.handlers.ts
+++ b/packages/server/src/task/handlers/conversations.handlers.ts
@@ -25,10 +25,17 @@ import {
   type NotificationParamsOf,
   type TSchema,
 } from "@moltzap/protocol";
-import { agentId as makeAgentId } from "@moltzap/protocol/network";
+import {
+  agentId as makeAgentId,
+  type AgentId,
+} from "@moltzap/protocol/network";
+import type { Static } from "@moltzap/protocol";
+import type { ConversationId as ConversationIdSchema } from "@moltzap/protocol/schemas/primitives";
 import { Effect } from "effect";
 import { defineTaskMethod } from "../../rpc/define-layered-method.js";
 import { ConnIdTag } from "../../app/layers.js";
+
+type ConversationId = Static<typeof ConversationIdSchema>;
 
 export function createConversationHandlers(deps: {
   conversationService: ConversationService;
@@ -39,22 +46,20 @@ export function createConversationHandlers(deps: {
   const broadcastToConversation = <
     D extends NotificationDefinition<string, TSchema>,
   >(
-    conversationId: string,
+    conversationId: ConversationId,
     definition: D,
     params: NotificationParamsOf<D>,
   ): Effect.Effect<void, never> =>
     Effect.gen(function* () {
       const participants = yield* deps.conversationService
         .getParticipantAgentIds(conversationId)
-        .pipe(Effect.orElseSucceed(() => [] as readonly string[]));
+        .pipe(Effect.orElseSucceed(() => [] as readonly AgentId[]));
       if (participants.length === 0) return;
       const frame = notificationFrame(definition, params);
       const payload = opaquePayload(JSON.stringify(frame));
-      yield* deps.networkSendService.broadcast(
-        participants.map((id) => makeAgentId(id)),
-        payload,
-        { forConversation: conversationId },
-      );
+      yield* deps.networkSendService.broadcast(participants, payload, {
+        forConversation: conversationId,
+      });
     });
 
   return [


### PR DESCRIPTION
Closes #469
Closes #472
Closes #479
Closes #480

Phase 10 follow-up cleanup batch covering 4 active issues plus a
verification of #477 (already-resolved by Phase 10's `b8bcabc` merge).

## Plan-anchor table

| Issue | Severity | File:line@b560d28 | Verdict |
|---|---|---|---|
| #469 | HIGH | `docs/docs.json:160-177@b560d28` | ✓ orphan nav entry dropped |
| #472 | MED | `packages/server/src/network/agent-endpoint-resolver.test.ts:217-235@b560d28` | ✓ test 4 honest-named to match test 3 (test 3 already done in c874dca) |
| #477 | LOW | n/a | ✓ verified clean — no Broadcaster references in conversation.service.ts / its test / 40-task-manager-routing.integration.test.ts post-merge |
| #479 | LOW | `packages/server/src/network/network-send.ts:148@b560d28` | ✓ `forConversation?: ConversationId` |
| #480 | LOW | `packages/server/src/services/conversation.service.ts:776-790@b560d28`, `packages/server/src/services/auth.service.ts:138-151@b560d28` | ✓ `getParticipantAgentIds` returns `readonly AgentId[]`; `agentsForOwner` already returned `ReadonlyArray<AgentId>`; 3 redundant `.map((id) => makeAgentId(id))` re-brands dropped |

## Issue-by-issue

### #469 — orphan messages-delivered nav entry
The `messages-delivered.mdx` file was deleted in Phase 7.5 but
`docs/docs.json` still listed it. Drop the line at `docs/docs.json:163`
(was line 172 pre-edit). Verified the on-disk file does not exist
and no other reference points at it.

### #472 — Phase 8 deferral test honest-naming
Test #3 (`agent-endpoint-resolver.test.ts:196-215`) was already
renamed in c874dca ("review: C1-C4 review fixes"). It now correctly
names resolver-contract behavior and points at
`40-task-manager-routing.integration.test.ts`.

Test #4 (`agent-endpoint-resolver.test.ts:217-235`) had been renamed
in the same commit BUT only said "Phase 9b" without naming the
integration test file. This commit amends the title and comment to
explicitly point at
`packages/server/src/__tests__/integration/40-task-manager-routing.integration.test.ts`,
matching the parity test #3 has.

### #477 — stale Broadcaster prose comments
Verified no `Broadcaster` references remain in any of the files the
issue called out. `simplify` reviewer's `344db5c` and merge `b8bcabc`
landed clean. No code change here; the issue should be closed with
the verification comment.

### #479 — brand `forConversation` as `ConversationId`
`network.broadcast`'s `agentIds` parameter was already
`readonly AgentId[]`; `forConversation` was `string`. Brand it for
parity using the schema at `@moltzap/protocol/schemas/primitives`
(the actor-model brand barrel intentionally does NOT re-export
`ConversationId`, per the comment in `schemas/index.ts:1-5`).

Call sites updated:
- `packages/server/src/services/message.service.ts:292-298` — wrap with
  `protocolConversationId(conversationId)` (UUID-validated upstream by
  `requireParticipant`, validation cost is negligible outside the hot
  send path).
- `packages/server/src/task/handlers/conversations.handlers.ts:46-63` —
  upgrade `broadcastToConversation` helper signature to
  `conversationId: ConversationId`. Callers already pass
  `params.conversationId` which is the TypeBox-decoded branded value,
  so the brand flows through naturally.

### #480 — tighten participant-array return types
`AuthService.agentsForOwner` already returned `ReadonlyArray<AgentId>`
(no change needed there). `ConversationService.getParticipantAgentIds`
was `string[]` — tightened to `readonly AgentId[]` and the `rows.map`
now applies `protocolAgentId(...)` at the boundary instead of leaking
raw strings.

The 3 redundant `.map((id) => makeAgentId(id))` re-brand call sites
identified in the issue are now type-safe and dropped:
- `packages/server/src/services/message.service.ts:292`
- `packages/server/src/task/handlers/contacts.handlers.ts:51` (was
  redundant against `agentsForOwner`)
- `packages/server/src/task/handlers/conversations.handlers.ts:60` (was
  redundant against tightened `getParticipantAgentIds`)

Also dropped the now-unused `agentId as makeAgentId` import in
`message.service.ts` and `contacts.handlers.ts`. (Kept it in
`conversations.handlers.ts` because line 91's
`params.participants.map((p) => makeAgentId(p.id))` still needs it —
that call site brands `p.id` which is a raw `string` from a different
schema field.)

## Tests

All pre-PR gates green:
- `pnpm typecheck` — ✓
- `pnpm lint` — ✓ (0 warnings, 0 errors, 375 files)
- `pnpm format:check` (after `pnpm format`) — ✓
- `bash packages/protocol/scripts/check-divergence-proofs.sh` — ✓ (26 suite registrars)
- `pnpm test` — ✓ (server: 225 / client: 236 + 6 todo / protocol: 141 + 1 todo / runtimes: 37 / channels: 137)
- `pnpm test:integration` — ✓ (server: 96 + 3 todo / client: 40 / channels: 11)
- `pnpm --filter @moltzap/client test:conformance` — ✓ (10)

## Scope

- Tier (`safer-diff-scope` semantics): junior — single LOC budget under
  ~40 lines across 7 files, no new exported signatures, no new deps.
- Files touched: `docs/docs.json`, 1 test file, 1 service `network/`
  module, 2 service modules, 2 task-handler modules.
- New exported signatures: none.
- New deps: none.

## Confidence

HIGH — every gate green, scope unchanged, all 4 closing issues
satisfy their acceptance criteria with cited file:line evidence.