### PR TITLE
fix(presence): replace-semantics on presence/subscribe (#487)

### DIFF
--- a/packages/protocol/src/task/methods/presence.ts
+++ b/packages/protocol/src/task/methods/presence.ts
@@ -15,6 +15,14 @@ export const PresenceUpdate = defineRpc({
   result: Type.Object({}, { additionalProperties: false }),
 });
 
+/**
+ * Subscribe to presence updates for a set of agents. Replace-semantics:
+ * the call replaces the connection's full subscriber set with
+ * `agentIds`. Agents previously subscribed to but absent from `agentIds`
+ * are silently removed; passing an empty array unsubscribes from all.
+ * Long-running clients that re-evaluate their watch set per iteration
+ * can call this idempotently without leaking fan-out.
+ */
 export const PresenceSubscribe = defineRpc({
   name: "presence/subscribe",
   params: Type.Object(

--- a/packages/server/src/services/presence.service.test.ts
+++ b/packages/server/src/services/presence.service.test.ts
@@ -136,4 +136,66 @@ describe("PresenceService", () => {
       "c-w2",
     ]);
   });
+
+  it("subscribe replaces the prior set — connId removed from agents not in the new set (#487)", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+
+    service.subscribe("c-watcher", ["agent-a", "agent-b"]);
+    service.subscribe("c-watcher", ["agent-b", "agent-c"]);
+
+    expect([...service.getSubscribers("agent-a")]).toEqual([]);
+    expect([...service.getSubscribers("agent-b")]).toEqual(["c-watcher"]);
+    expect([...service.getSubscribers("agent-c")]).toEqual(["c-watcher"]);
+  });
+
+  it("subscribe replace-semantics does not disturb other connections' subscriptions (#487)", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+
+    service.subscribe("c-w1", ["agent-a", "agent-b"]);
+    service.subscribe("c-w2", ["agent-a", "agent-b"]);
+    service.subscribe("c-w1", ["agent-b"]);
+
+    expect([...service.getSubscribers("agent-a")]).toEqual(["c-w2"]);
+    expect([...service.getSubscribers("agent-b")].sort()).toEqual([
+      "c-w1",
+      "c-w2",
+    ]);
+  });
+
+  it("subscribe([]) unsubscribes the connection from all agents (#487)", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+
+    service.subscribe("c-watcher", ["agent-a", "agent-b", "agent-c"]);
+    service.subscribe("c-watcher", []);
+
+    expect([...service.getSubscribers("agent-a")]).toEqual([]);
+    expect([...service.getSubscribers("agent-b")]).toEqual([]);
+    expect([...service.getSubscribers("agent-c")]).toEqual([]);
+  });
+
+  it("subscribe is idempotent when the set is unchanged (#487)", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+
+    service.subscribe("c-watcher", ["agent-a", "agent-b"]);
+    service.subscribe("c-watcher", ["agent-b", "agent-a"]);
+
+    expect([...service.getSubscribers("agent-a")]).toEqual(["c-watcher"]);
+    expect([...service.getSubscribers("agent-b")]).toEqual(["c-watcher"]);
+  });
+
+  it("subscribe after subscribe([]) re-establishes subscriptions cleanly (#487)", () => {
+    const r = recordingSink();
+    const service = new PresenceService(r.sink);
+
+    service.subscribe("c-watcher", ["agent-a"]);
+    service.subscribe("c-watcher", []);
+    service.subscribe("c-watcher", ["agent-b"]);
+
+    expect([...service.getSubscribers("agent-a")]).toEqual([]);
+    expect([...service.getSubscribers("agent-b")]).toEqual(["c-watcher"]);
+  });
 });

--- a/packages/server/src/services/presence.service.ts
+++ b/packages/server/src/services/presence.service.ts
@@ -17,6 +17,10 @@ const EMPTY_SUBSCRIBERS: ReadonlySet<string> = new Set();
 export class PresenceService {
   private statuses = new Map<string, PresenceStatus>();
   private subscribers = new Map<string, Set<string>>();
+  // Per-connection record of which agentIds the connection is subscribed
+  // to. Tracked so `subscribe()` can replace the prior subscription set
+  // atomically without scanning every agent's subscriber set.
+  private connSubscriptions = new Map<string, Set<string>>();
 
   constructor(private readonly eventSink: PresenceEventSink) {}
 
@@ -49,14 +53,44 @@ export class PresenceService {
     }));
   }
 
+  /**
+   * Replace the connection's subscriber set with `agentIds`.
+   *
+   * Replace-semantics: after this call, `connId` appears in the subscriber
+   * set for EXACTLY the agents in `agentIds`, and ONLY those. Any agent
+   * `connId` was previously subscribed to but absent from `agentIds` has
+   * `connId` removed from its subscriber set. Pass an empty array to
+   * unsubscribe from all (functionally an unsubscribe-all). Long-running
+   * clients that re-evaluate their watch set per iteration can call this
+   * idempotently without leaking fan-out across the union of past sets.
+   */
   subscribe(connId: string, agentIds: ReadonlyArray<string>): void {
-    for (const agentId of agentIds) {
+    const next = new Set(agentIds);
+    const prev = this.connSubscriptions.get(connId);
+
+    // Remove connId from agents the connection no longer watches.
+    if (prev) {
+      for (const agentId of prev) {
+        if (!next.has(agentId)) {
+          this.subscribers.get(agentId)?.delete(connId);
+        }
+      }
+    }
+
+    // Add connId to agents in the new set (idempotent if already present).
+    for (const agentId of next) {
       let subs = this.subscribers.get(agentId);
       if (!subs) {
         subs = new Set();
         this.subscribers.set(agentId, subs);
       }
       subs.add(connId);
+    }
+
+    if (next.size === 0) {
+      this.connSubscriptions.delete(connId);
+    } else {
+      this.connSubscriptions.set(connId, next);
     }
   }
 
@@ -68,6 +102,7 @@ export class PresenceService {
     for (const subs of this.subscribers.values()) {
       subs.delete(connId);
     }
+    this.connSubscriptions.delete(connId);
   }
 
   private transition(


### PR DESCRIPTION
Closes #487. Hard blocker for arena#342 (BYOA migration epic).

`PresenceService.subscribe(connId, agentIds)` at `packages/server/src/services/presence.service.ts@69933d0` was append-only — each call merged `connId` into the union of every `agentIds` set ever passed, with no per-call un-subscription. Long-running clients that re-evaluate which agents they watch (canonical "live address book" pattern) leaked fan-out monotonically. Per Option A in #487, this PR changes the semantics to per-call replace: after the call, `connId` is in the subscriber set for EXACTLY the agents in `agentIds`, and only those. `subscribe([])` is now a functional unsubscribe-all.

## What changed

- `PresenceService` tracks a private per-connection subscription set so `subscribe()` can compute the diff without scanning every agent's subscriber set. On call: remove `connId` from each previously-watched agent absent from the new set, idempotently add to each agent in the new set, persist the new set (or delete the entry on empty).
- `removeConnection()` also clears the per-conn entry to keep the two maps in sync.
- Protocol method docstring on `PresenceSubscribe` documents replace-semantics for client authors.
- Wire RPC schema unchanged: `presence/subscribe({ agentIds })`. Handler unchanged.

## Plan anchors

| Change | Anchor |
|---|---|
| `subscribe()` becomes replace-set | #487 "Proposed fix Option A" + team-lead acceptance §1-2 |
| `connSubscriptions` private map | #487 "Implementation: replace ... in one atomic step" |
| `removeConnection()` clears per-conn entry | invariant: per-conn map mirrors `subscribers` membership |
| Protocol docstring on `PresenceSubscribe` | team-lead acceptance §6 ("document semantic shift in protocol method docstring") |
| 5 new unit tests (`presence.service.test.ts`) | team-lead acceptance §3 (the two named tests + replace-semantics edge cases) |

## Tests

Unit tests added (5 new, pinning replace-semantics):
- `subscribe replaces the prior set — connId removed from agents not in the new set` — the canonical `subscribe([A,B])` then `subscribe([B,C])` → A=∅, B=yes, C=yes test from the brief
- `subscribe replace-semantics does not disturb other connections' subscriptions` — replace on connA leaves connB's set intact
- `subscribe([]) unsubscribes the connection from all agents` — the unsubscribe-all test from the brief
- `subscribe is idempotent when the set is unchanged` — re-subscribing the same set is a no-op
- `subscribe after subscribe([]) re-establishes subscriptions cleanly` — empty doesn't poison future calls

Existing 8 `PresenceService` tests all still pass; the integration test at `26-presence-lifecycle.integration.test.ts` is wire-level and unaffected (single-call subscribe).

## Pre-PR gates

All seven green at `69933d0`:
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 warnings, 0 errors)
- `pnpm format:check` ✅
- `bash packages/protocol/scripts/check-divergence-proofs.sh` ✅ (26 proof-required, 28 legacy exemptions)
- `pnpm test` ✅ (server: 230 unit tests pass, presence.service.test.ts: 13/13 — was 8 before)
- `pnpm test:integration` ✅ (server: 96 pass + 3 todo)
- `pnpm --filter @moltzap/client test:conformance` ✅ (10 tests pass)

## Scope

- Modules touched: `packages/server/src/services/presence.service.ts`, `packages/server/src/services/presence.service.test.ts`, `packages/protocol/src/task/methods/presence.ts`
- Tier: senior (3 files, +106 −1)
- New modules: 0
- New public signatures: 0 (signature of `subscribe()` unchanged)
- New deps: 0
- Wire schema change: 0

## Phase 12 coordination

Phase 12 (protocol layered finalization, in flight on `staff/452-phase-12-protocol-finalization`) does not touch `presence.service.ts` or the `presence/subscribe` schema per its sub-issue acceptance. If Phase 12 lands first and surfaces a conflict, will rebase.

## Confidence

HIGH — the replace-semantics is the smallest possible behavior change that satisfies the issue; new tests pin the specific scenarios from the brief; all seven pre-PR gates pass.