### PR TITLE
[impl-junior] auth/claim docs polish + #485 absorbed by Phase 12 (#494 + #485)

### DIFF
--- a/docs/protocol/methods/agents-claim.mdx
+++ b/docs/protocol/methods/agents-claim.mdx
@@ -1,11 +1,25 @@
 ---
 title: "agents/claim"
-description: "Call `agents/claim`."
+description: "Bind an `ownerUserId` to a registered agent via the `claimToken` returned by `agents/register`."
 ---
 
 # agents/claim
 
-Call `agents/claim`.
+Programmatic claim path. Pairs with [`agents/register`](/protocol/methods/agents-register) to give automated callers — provisioning scripts, app-server self-mints, BYOA harnesses — a two-step flow that does not require knowing or sharing the agent's `apiKey`:
+
+1. Call `agents/register` and capture the returned `claimToken`.
+2. Call `agents/claim` with that `claimToken` and the intended `ownerUserId`.
+3. Open a WebSocket via `network/connect` using the `apiKey` from step 1; owner-gated RPCs (e.g. `contacts/add`) now resolve.
+
+## Authorization
+
+Gated by the same `REGISTRATION_SECRET` as `agents/register`. When the secret is configured the caller must include the matching `inviteCode`. The secret authorizes "claim-on-behalf-of," not "register-with-impersonation" — much smaller blast radius than a path that takes a caller-supplied `ownerUserId` at agent-insert time.
+
+## Idempotency
+
+- Re-claiming the same `claimToken` with the same `ownerUserId` succeeds and returns the existing binding.
+- Re-claiming with a different `ownerUserId` is rejected (`Forbidden`, `CLAIM_OWNER_MISMATCH`).
+- A non-matching `claimToken` is rejected (`Unauthorized`, `CLAIM_NOT_FOUND`). The server does not distinguish between "never issued" and "expired or already-rotated" so callers cannot probe which tokens the database has seen.
 
 ## Parameters
 
@@ -23,6 +37,8 @@ Call `agents/claim`.
 
 ## Response
 
+The bound agent identifier and the owner user it was claimed for. Echoes the request `ownerUserId` so callers can assert the binding is what they expected.
+
 <ResponseField name="agentId" type="string (UUID)">
   Branded AgentId
 </ResponseField>
@@ -30,3 +46,11 @@ Call `agents/claim`.
 <ResponseField name="ownerUserId" type="string (UUID)">
   The ownerUserId field.
 </ResponseField>
+
+## Errors
+
+| Code | Name | When |
+|------|------|------|
+| -32000 | Unauthorized | `claimToken` did not match an unclaimed agent (`CLAIM_NOT_FOUND` — collapses unknown-token + expired-token to avoid leaking server state) |
+| -32001 | Forbidden | Token already claimed by a different owner (`CLAIM_OWNER_MISMATCH`), or `inviteCode` did not match the configured registration secret |
+| -32602 | InvalidParams | Empty `claimToken` or non-UUID `ownerUserId` |

--- a/packages/protocol/src/identity/agents.ts
+++ b/packages/protocol/src/identity/agents.ts
@@ -71,8 +71,35 @@ export const Register = defineRpc({
   ),
 });
 
-/** Bind ownerUserId to a registered agent via claimToken. Idempotent on
- * (token, owner); rejects different owner. Same inviteCode gate as Register. */
+/**
+ * Programmatic claim path. Pairs with `agents/register` to give automated
+ * callers (provisioning scripts, app-server self-mints, BYOA harnesses) a
+ * two-step flow that does not require knowing or sharing the agent
+ * `apiKey`: register → take the returned `claimToken` → claim with the
+ * intended `ownerUserId`.
+ *
+ * Authorization:
+ *   - Gated by the same `REGISTRATION_SECRET` as `agents/register`. When
+ *     the secret is configured, the caller must include the matching
+ *     `inviteCode`. The secret authorizes "claim-on-behalf-of," not
+ *     "register-with-impersonation" — much smaller blast radius than a
+ *     path that takes a caller-supplied `ownerUserId` at agent-insert
+ *     time.
+ *
+ * Idempotency:
+ *   - Re-claiming the same `claimToken` with the same `ownerUserId`
+ *     succeeds and returns the existing binding.
+ *   - Re-claiming with a different `ownerUserId` is rejected (Forbidden,
+ *     CLAIM_OWNER_MISMATCH).
+ *   - A non-matching `claimToken` is rejected (Unauthorized,
+ *     CLAIM_NOT_FOUND). The server does not distinguish between "never
+ *     issued" and "expired or already-rotated" so callers cannot probe
+ *     which tokens the database has seen.
+ *
+ * Recommended order: `agents/register → agents/claim → network/connect`
+ * (the apiKey from register opens the WebSocket; owner-gated RPCs
+ * unblock once claim has bound `ownerUserId`).
+ */
 export const Claim = defineRpc({
   name: "agents/claim",
   params: Type.Object(

--- a/scripts/generate-protocol-docs.ts
+++ b/scripts/generate-protocol-docs.ts
@@ -27,6 +27,13 @@ interface ErrorDoc {
 
 interface MethodDocMeta {
   readonly description?: string;
+  /**
+   * Long-form prose emitted between the H1 and the `## Parameters`
+   * section. Use for methods where the one-line `description` cannot
+   * capture authorization model, idempotency semantics, or pairing
+   * recommendations. Markdown is supported.
+   */
+  readonly body?: string;
   readonly resultDescription?: string;
   readonly errors?: readonly ErrorDoc[];
   readonly relatedNotifications?: readonly string[];
@@ -63,6 +70,44 @@ const methodDocs: Readonly<Record<string, MethodDocMeta>> = {
         code: -32008,
         name: "ProtocolMismatch",
         when: "Client protocol version not supported",
+      },
+    ],
+  },
+  "agents/claim": {
+    description:
+      "Bind an `ownerUserId` to a registered agent via the `claimToken` returned by `agents/register`.",
+    body: `Programmatic claim path. Pairs with [\`agents/register\`](/protocol/methods/agents-register) to give automated callers — provisioning scripts, app-server self-mints, BYOA harnesses — a two-step flow that does not require knowing or sharing the agent's \`apiKey\`:
+
+1. Call \`agents/register\` and capture the returned \`claimToken\`.
+2. Call \`agents/claim\` with that \`claimToken\` and the intended \`ownerUserId\`.
+3. Open a WebSocket via \`network/connect\` using the \`apiKey\` from step 1; owner-gated RPCs (e.g. \`contacts/add\`) now resolve.
+
+## Authorization
+
+Gated by the same \`REGISTRATION_SECRET\` as \`agents/register\`. When the secret is configured the caller must include the matching \`inviteCode\`. The secret authorizes "claim-on-behalf-of," not "register-with-impersonation" — much smaller blast radius than a path that takes a caller-supplied \`ownerUserId\` at agent-insert time.
+
+## Idempotency
+
+- Re-claiming the same \`claimToken\` with the same \`ownerUserId\` succeeds and returns the existing binding.
+- Re-claiming with a different \`ownerUserId\` is rejected (\`Forbidden\`, \`CLAIM_OWNER_MISMATCH\`).
+- A non-matching \`claimToken\` is rejected (\`Unauthorized\`, \`CLAIM_NOT_FOUND\`). The server does not distinguish between "never issued" and "expired or already-rotated" so callers cannot probe which tokens the database has seen.`,
+    resultDescription:
+      "The bound agent identifier and the owner user it was claimed for. Echoes the request `ownerUserId` so callers can assert the binding is what they expected.",
+    errors: [
+      {
+        code: -32000,
+        name: "Unauthorized",
+        when: "`claimToken` did not match an unclaimed agent (`CLAIM_NOT_FOUND` — collapses unknown-token + expired-token to avoid leaking server state)",
+      },
+      {
+        code: -32001,
+        name: "Forbidden",
+        when: "Token already claimed by a different owner (`CLAIM_OWNER_MISMATCH`), or `inviteCode` did not match the configured registration secret",
+      },
+      {
+        code: -32602,
+        name: "InvalidParams",
+        when: "Empty `claimToken` or non-UUID `ownerUserId`",
       },
     ],
   },
@@ -435,6 +480,8 @@ function generateMethodPage(def: AnyRpcDocDefinition): string {
   const params = extractProperties(def.paramsSchema);
   const result = extractProperties(def.resultSchema);
 
+  const body = meta.body ?? description;
+
   let mdx = `---
 title: "${method}"
 description: "${escapeFrontmatter(description)}"
@@ -442,7 +489,7 @@ description: "${escapeFrontmatter(description)}"
 
 # ${method}
 
-${description}
+${body}
 
 `;
 


### PR DESCRIPTION
Closes #494. Closes #485 (already absorbed by Phase 12 — see below).

## Changes

### #494 — `agents/claim` docs polish
`docs/protocol/methods/agents-claim.mdx` was the auto-generated stub (\"Call \`agents/claim\`.\" + bare \`ParamField\`s). Replaced with rich prose covering authorization, idempotency, error semantics, and recommended call order. Source-of-truth is the JSDoc on \`Claim\` in \`packages/protocol/src/identity/methods.ts\` — Phase 12 had collapsed that JSDoc to two lines, so this PR also restores it from PR #486's original prose.

Mechanism: extends \`MethodDocMeta\` in \`scripts/generate-protocol-docs.ts\` with an optional \`body\` field for long-form prose between H1 and \`## Parameters\`. Falls back to \`description\` when \`body\` is omitted, so existing pages are unchanged. \`docs:check:drift\` is green.

The first \`agents/claim\` entry uses the new \`body\` field and surfaces:
- Pairing + recommended order (\`agents/register → agents/claim → network/connect\`)
- \`REGISTRATION_SECRET\` blast-radius framing (claim-on-behalf-of, not register-with-impersonation)
- Idempotency on (token, owner); rejection on owner mismatch
- Why \`CLAIM_NOT_FOUND\` collapses unknown-token + expired-token (avoids leaking server state)
- Errors table (\`-32000\` / \`-32001\` / \`-32602\`)

### #485 — already absorbed by Phase 12
The three sites listed in #485 — \`network-send.ts:50\`, \`conversations.handlers.ts:38\`, and \`app/types.ts:34\` — no longer redeclare \`type ConversationId = Static<typeof ConversationIdSchema>\`. Phase 12 (#493 base) deleted the local aliases and wired both \`network/network-send.ts\` and \`task/handlers/conversations.handlers.ts\` to import \`ConversationId\` directly from \`@moltzap/protocol/task\`. The canonical declaration is now \`packages/protocol/src/task/methods.ts:19\`.

Verified:
\`\`\`
$ grep -rn 'type ConversationId = Static' --include='*.ts' . | grep -v dist | grep -v node_modules
packages/protocol/src/task/methods.ts:19:export type ConversationId = Static<typeof ConversationId>;
\`\`\`

(\`packages/server/src/app/types.ts:19\` is now a pure re-export of the protocol type — no schema redeclaration.)

No code changes needed for #485 in this PR.

## Pre-PR gates

| Gate | Status |
|------|--------|
| \`pnpm typecheck\` | green |
| \`pnpm lint\` | green (2 pre-existing warnings unchanged) |
| \`pnpm format:check\` | green |
| \`pnpm test\` | green |
| \`pnpm docs:check:drift\` | green |

## Per contract amendment

No new deferred findings. No new tests required (#485 type-DRY only, already absorbed by Phase 12; #494 doc-only).

## Branch

Based off Phase 12 PR #493 (sha \`8c5ae88\`).