### PR TITLE
fix: contact-scope agents/list + presence/subscribe (#481)

### DIFF
--- a/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
+++ b/packages/server/src/__tests__/integration/26-presence-lifecycle.integration.test.ts
@@ -16,8 +16,12 @@ import {
   PresenceChangedNotificationDefinition,
 } from "@moltzap/protocol";
 
+// Sibling-owner cohort so #481 contact-scoping doesn't filter agents
+// out — this file exercises broadcast lifecycle, not the visibility gate.
+const PRESENCE_DEV_OWNER = "00000000-0000-4000-8000-000000000470";
+
 beforeAll(async () => {
-  await startTestServer();
+  await startTestServer({ devModeUserId: PRESENCE_DEV_OWNER });
 }, 60_000);
 
 afterAll(async () => {

--- a/packages/server/src/__tests__/integration/29-agents-list.integration.test.ts
+++ b/packages/server/src/__tests__/integration/29-agents-list.integration.test.ts
@@ -5,29 +5,40 @@ import {
   startTestServer,
   stopTestServer,
   resetTestDb,
-  registerAndConnect,
   getKyselyDb,
   trackClient,
-  registerAgent,
   connectTestClient,
 } from "./helpers.js";
 import type { AgentCard } from "@moltzap/protocol";
+import { userId } from "@moltzap/protocol/testing";
+import type { UserId } from "@moltzap/protocol/identity";
 
 import {
   AgentsList,
   AgentsLookup,
   AgentsLookupByName,
-  ConversationsCreate,
+  ContactsAdd,
+  ContactsAccept,
 } from "@moltzap/protocol";
 
 type AgentsListResult = { agents: Record<string, AgentCard> };
 type AgentsArrayResult = { agents: AgentCard[] };
 
+// agents/list is contact-scoped per #481; admin-register is used to bind
+// explicit owners so the cross-owner visibility cases can be exercised.
+const REGISTRATION_SECRET = "agents-list-test-secret-zxcv";
+const ALICE_USER_ID = userId("00000000-0000-4000-8000-00000000a11c");
+const BOB_USER_ID = userId("00000000-0000-4000-8000-00000000b0b0");
+const CAROL_USER_ID = userId("00000000-0000-4000-8000-00000000ca60");
+
 let baseUrl: string;
 let wsUrl: string;
+let pairCounter = 0;
 
 beforeAll(async () => {
-  const server = await startTestServer();
+  const server = await startTestServer({
+    registrationSecret: REGISTRATION_SECRET,
+  });
   baseUrl = server.baseUrl;
   wsUrl = server.wsUrl;
 }, 60_000);
@@ -38,12 +49,61 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await resetTestDb();
+  pairCounter = 0;
 });
 
-/** Register an agent with custom options (e.g. description), tracked for cleanup. */
-function registerWithOpts(name: string, opts: { description?: string }) {
+interface AdminRegisterResponse {
+  agentId: string;
+  apiKey: string;
+}
+
+async function adminRegister(
+  name: string,
+  ownerUserId: UserId,
+  description?: string,
+): Promise<AdminRegisterResponse> {
+  const res = await fetch(`${baseUrl}/api/v1/admin/register-agent`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name,
+      inviteCode: REGISTRATION_SECRET,
+      ownerUserId,
+      ...(description !== undefined ? { description } : {}),
+    }),
+  });
+  const json = (await res.json()) as AdminRegisterResponse;
+  if (res.status !== 201 && res.status !== 200) {
+    throw new Error(
+      `admin register failed: ${res.status} ${JSON.stringify(json)}`,
+    );
+  }
+  return json;
+}
+
+interface OwnedConnectedAgent {
+  agentId: string;
+  ownerUserId: UserId;
+  client: Awaited<
+    ReturnType<typeof connectTestClient> extends Effect.Effect<
+      infer A,
+      infer _E
+    >
+      ? A
+      : never
+  >;
+}
+
+function registerAndConnectOwned(opts: {
+  name: string;
+  ownerUserId: UserId;
+  description?: string;
+}): Effect.Effect<OwnedConnectedAgent, Error> {
   return Effect.gen(function* () {
-    const reg = yield* registerAgent(baseUrl, name, opts);
+    const idx = ++pairCounter;
+    const reg = yield* Effect.tryPromise(() =>
+      adminRegister(`${opts.name}-${idx}`, opts.ownerUserId, opts.description),
+    );
     const client = yield* connectTestClient({
       wsUrl,
       agentId: reg.agentId,
@@ -51,161 +111,193 @@ function registerWithOpts(name: string, opts: { description?: string }) {
     });
     trackClient(client);
     return {
-      client,
       agentId: reg.agentId,
-      apiKey: reg.apiKey,
-      name,
+      ownerUserId: opts.ownerUserId,
+      client,
     };
   });
 }
 
-describe(AgentsList.name, () => {
-  it.live("returns co-participant agents from shared conversations", () =>
-    Effect.gen(function* () {
-      const alice = yield* registerAndConnect("alice-ag");
-      const bob = yield* registerAndConnect("bob-agent");
-      const carol = yield* registerAndConnect("carol-ag");
+describe(`${AgentsList.name} — contact-scoped per #481`, () => {
+  it.live(
+    "returns own agents (siblings under same ownerUserId), without contacts setup",
+    () =>
+      Effect.gen(function* () {
+        const alice1 = yield* registerAndConnectOwned({
+          name: "alice-sib1",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const alice2 = yield* registerAndConnectOwned({
+          name: "alice-sib2",
+          ownerUserId: ALICE_USER_ID,
+        });
 
-      yield* alice.client.sendRpc(ConversationsCreate, {
-        type: "dm",
-        participants: [{ type: "agent", id: bob.agentId }],
-      });
-
-      yield* alice.client.sendRpc(ConversationsCreate, {
-        type: "group",
-        name: "test-group",
-        participants: [{ type: "agent", id: carol.agentId }],
-      });
-
-      const aliceResult = (yield* alice.client.sendRpc(
-        AgentsList,
-        {},
-      )) as AgentsListResult;
-      const aliceAgentIds = Object.keys(aliceResult.agents);
-      expect(aliceAgentIds).toContain(bob.agentId);
-      expect(aliceAgentIds).toContain(carol.agentId);
-      expect(aliceAgentIds).not.toContain(alice.agentId);
-
-      const bobResult = (yield* bob.client.sendRpc(
-        AgentsList,
-        {},
-      )) as AgentsListResult;
-      const bobAgentIds = Object.keys(bobResult.agents);
-      expect(bobAgentIds).toContain(alice.agentId);
-      expect(bobAgentIds).not.toContain(carol.agentId);
-
-      const carolResult = (yield* carol.client.sendRpc(
-        AgentsList,
-        {},
-      )) as AgentsListResult;
-      const carolAgentIds = Object.keys(carolResult.agents);
-      expect(carolAgentIds).toContain(alice.agentId);
-      expect(carolAgentIds).not.toContain(bob.agentId);
-    }),
+        const result = (yield* alice1.client.sendRpc(
+          AgentsList,
+          {},
+        )) as AgentsListResult;
+        const ids = Object.keys(result.agents);
+        expect(ids).toContain(alice1.agentId);
+        expect(ids).toContain(alice2.agentId);
+      }),
   );
 
-  it.live("returns empty map when agent has no conversations", () =>
-    Effect.gen(function* () {
-      const loner = yield* registerAndConnect("loner-ag");
+  it.live(
+    "does NOT return agents owned by users the caller is not in contact with",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-iso",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const carol = yield* registerAndConnectOwned({
+          name: "carol-iso",
+          ownerUserId: CAROL_USER_ID,
+        });
 
-      const result = (yield* loner.client.sendRpc(
-        AgentsList,
-        {},
-      )) as AgentsListResult;
-      expect(result.agents).toEqual({});
-    }),
+        const result = (yield* alice.client.sendRpc(
+          AgentsList,
+          {},
+        )) as AgentsListResult;
+        expect(result.agents[carol.agentId]).toBeUndefined();
+        expect(result.agents[alice.agentId]).toBeDefined();
+      }),
   );
 
-  it.live("deduplicates agents across multiple shared conversations", () =>
-    Effect.gen(function* () {
-      const alice = yield* registerAndConnect("alice-ag");
-      const bob = yield* registerAndConnect("bob-agent");
+  it.live(
+    "returns agents whose owner is an accepted contact of the caller's owner",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-x",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const bob = yield* registerAndConnectOwned({
+          name: "bob-x",
+          ownerUserId: BOB_USER_ID,
+        });
+        const carol = yield* registerAndConnectOwned({
+          name: "carol-x",
+          ownerUserId: CAROL_USER_ID,
+        });
 
-      yield* alice.client.sendRpc(ConversationsCreate, {
-        type: "dm",
-        participants: [{ type: "agent", id: bob.agentId }],
-      });
+        const added = yield* alice.client.sendRpc(ContactsAdd, {
+          contactUserId: BOB_USER_ID,
+        });
+        yield* bob.client.sendRpc(ContactsAccept, {
+          contactId: added.contact.id,
+        });
 
-      yield* alice.client.sendRpc(ConversationsCreate, {
-        type: "group",
-        name: "shared-group",
-        participants: [{ type: "agent", id: bob.agentId }],
-      });
+        const aliceList = (yield* alice.client.sendRpc(
+          AgentsList,
+          {},
+        )) as AgentsListResult;
+        const aliceIds = Object.keys(aliceList.agents);
+        expect(aliceIds).toContain(alice.agentId);
+        expect(aliceIds).toContain(bob.agentId);
+        expect(aliceIds).not.toContain(carol.agentId);
 
-      const result = (yield* alice.client.sendRpc(
-        AgentsList,
-        {},
-      )) as AgentsListResult;
-      const agentIds = Object.keys(result.agents);
-      expect(agentIds).toHaveLength(1);
-      expect(agentIds[0]).toBe(bob.agentId);
-    }),
+        // contacts/accept inserts the reverse edge — Bob sees Alice too.
+        const bobList = (yield* bob.client.sendRpc(
+          AgentsList,
+          {},
+        )) as AgentsListResult;
+        const bobIds = Object.keys(bobList.agents);
+        expect(bobIds).toContain(bob.agentId);
+        expect(bobIds).toContain(alice.agentId);
+        expect(bobIds).not.toContain(carol.agentId);
+      }),
   );
 
-  it.live("excludes the calling agent from results", () =>
-    Effect.gen(function* () {
-      const alice = yield* registerAndConnect("alice-ag");
-      const bob = yield* registerAndConnect("bob-agent");
+  it.live(
+    "pending contact request does NOT yet expose the requester's agents to the recipient (and vice versa)",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-pending",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const bob = yield* registerAndConnectOwned({
+          name: "bob-pending",
+          ownerUserId: BOB_USER_ID,
+        });
 
-      yield* alice.client.sendRpc(ConversationsCreate, {
-        type: "dm",
-        participants: [{ type: "agent", id: bob.agentId }],
-      });
+        // Pending status (no accept) must not unlock visibility.
+        yield* alice.client.sendRpc(ContactsAdd, {
+          contactUserId: BOB_USER_ID,
+        });
 
-      const result = (yield* alice.client.sendRpc(
-        AgentsList,
-        {},
-      )) as AgentsListResult;
-      expect(result.agents[alice.agentId]).toBeUndefined();
-      expect(result.agents[bob.agentId]).toBeDefined();
-    }),
+        const aliceList = (yield* alice.client.sendRpc(
+          AgentsList,
+          {},
+        )) as AgentsListResult;
+        const bobList = (yield* bob.client.sendRpc(
+          AgentsList,
+          {},
+        )) as AgentsListResult;
+        expect(aliceList.agents[bob.agentId]).toBeUndefined();
+        expect(bobList.agents[alice.agentId]).toBeUndefined();
+      }),
   );
 
-  it.live("returns agent card fields correctly", () =>
-    Effect.gen(function* () {
-      const described = yield* registerWithOpts("desc-agent", {
-        description: "A test agent",
-      });
-      const other = yield* registerAndConnect("other-ag");
+  it.live(
+    "returns the AgentCard fields correctly for contact-visible agents",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-card",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const bob = yield* registerAndConnectOwned({
+          name: "bob-card",
+          ownerUserId: BOB_USER_ID,
+          description: "A test agent",
+        });
+        const added = yield* alice.client.sendRpc(ContactsAdd, {
+          contactUserId: BOB_USER_ID,
+        });
+        yield* bob.client.sendRpc(ContactsAccept, {
+          contactId: added.contact.id,
+        });
 
-      yield* described.client.sendRpc(ConversationsCreate, {
-        type: "dm",
-        participants: [{ type: "agent", id: other.agentId }],
-      });
-
-      const result = (yield* other.client.sendRpc(
-        AgentsList,
-        {},
-      )) as AgentsListResult;
-      const card = result.agents[described.agentId];
-      expect(card).toBeDefined();
-      expect(card.id).toBe(described.agentId);
-      expect(card.name).toBe("desc-agent");
-      expect(card.description).toBe("A test agent");
-      expect(card.status).toBe("active");
-    }),
+        const result = (yield* alice.client.sendRpc(
+          AgentsList,
+          {},
+        )) as AgentsListResult;
+        const card = result.agents[bob.agentId];
+        expect(card).toBeDefined();
+        expect(card!.id).toBe(bob.agentId);
+        expect(card!.description).toBe("A test agent");
+        expect(card!.status).toBe("active");
+        expect(card!.ownerUserId).toBe(BOB_USER_ID);
+      }),
   );
 });
 
 describe(AgentsLookup.name, () => {
   it.live("returns agent cards by ID", () =>
     Effect.gen(function* () {
-      const alice = yield* registerAndConnect("alice-ag");
+      const alice = yield* registerAndConnectOwned({
+        name: "alice-lookup",
+        ownerUserId: ALICE_USER_ID,
+      });
 
       const result = (yield* alice.client.sendRpc(AgentsLookup, {
         agentIds: [alice.agentId],
       })) as AgentsArrayResult;
 
       expect(result.agents).toHaveLength(1);
-      expect(result.agents[0].id).toBe(alice.agentId);
-      expect(result.agents[0].name).toBe("alice-ag");
-      expect(result.agents[0].status).toBe("active");
+      expect(result.agents[0]!.id).toBe(alice.agentId);
+      expect(result.agents[0]!.status).toBe("active");
     }),
   );
 
   it.live("returns empty array for unknown IDs", () =>
     Effect.gen(function* () {
-      const alice = yield* registerAndConnect("alice-ag");
+      const alice = yield* registerAndConnectOwned({
+        name: "alice-lookup-empty",
+        ownerUserId: ALICE_USER_ID,
+      });
 
       const result = (yield* alice.client.sendRpc(AgentsLookup, {
         agentIds: ["00000000-0000-0000-0000-000000000000"],
@@ -217,7 +309,9 @@ describe(AgentsLookup.name, () => {
 
   it.live("includes description in lookup results", () =>
     Effect.gen(function* () {
-      const described = yield* registerWithOpts("desc-agent", {
+      const described = yield* registerAndConnectOwned({
+        name: "desc-agent",
+        ownerUserId: ALICE_USER_ID,
         description: "Has a description",
       });
 
@@ -225,7 +319,7 @@ describe(AgentsLookup.name, () => {
         agentIds: [described.agentId],
       })) as AgentsArrayResult;
 
-      expect(result.agents[0].description).toBe("Has a description");
+      expect(result.agents[0]!.description).toBe("Has a description");
     }),
   );
 });
@@ -233,23 +327,45 @@ describe(AgentsLookup.name, () => {
 describe(AgentsLookupByName.name, () => {
   it.live("returns agent cards by name", () =>
     Effect.gen(function* () {
-      const alice = yield* registerAndConnect("alice-ag");
+      const alice = yield* registerAndConnectOwned({
+        name: "alice-lbyn",
+        ownerUserId: ALICE_USER_ID,
+      });
+      // adminRegister appends a suffix; resolve the persisted name.
+      const db = getKyselyDb();
+      const row = yield* Effect.tryPromise(() =>
+        db
+          .selectFrom("agents")
+          .select("name")
+          .where("id", "=", alice.agentId)
+          .executeTakeFirstOrThrow(),
+      );
 
       const result = (yield* alice.client.sendRpc(AgentsLookupByName, {
-        names: ["alice-ag"],
+        names: [row.name],
       })) as AgentsArrayResult;
 
       expect(result.agents).toHaveLength(1);
-      expect(result.agents[0].id).toBe(alice.agentId);
-      expect(result.agents[0].name).toBe("alice-ag");
+      expect(result.agents[0]!.id).toBe(alice.agentId);
     }),
   );
 
   it.live("only returns active agents", () =>
     Effect.gen(function* () {
-      const alice = yield* registerAndConnect("alice-ag");
+      const alice = yield* registerAndConnectOwned({
+        name: "alice-active",
+        ownerUserId: ALICE_USER_ID,
+      });
 
       const db = getKyselyDb();
+      const aliceRow = yield* Effect.tryPromise(() =>
+        db
+          .selectFrom("agents")
+          .select("name")
+          .where("id", "=", alice.agentId)
+          .executeTakeFirstOrThrow(),
+      );
+
       yield* Effect.tryPromise(() =>
         db
           .updateTable("agents")
@@ -258,9 +374,12 @@ describe(AgentsLookupByName.name, () => {
           .execute(),
       );
 
-      const bob = yield* registerAndConnect("bob-agent");
+      const bob = yield* registerAndConnectOwned({
+        name: "bob-active",
+        ownerUserId: BOB_USER_ID,
+      });
       const result = (yield* bob.client.sendRpc(AgentsLookupByName, {
-        names: ["alice-ag"],
+        names: [aliceRow.name],
       })) as AgentsArrayResult;
 
       expect(result.agents).toHaveLength(0);
@@ -269,7 +388,10 @@ describe(AgentsLookupByName.name, () => {
 
   it.live("returns empty array for unknown names", () =>
     Effect.gen(function* () {
-      const alice = yield* registerAndConnect("alice-ag");
+      const alice = yield* registerAndConnectOwned({
+        name: "alice-unknown",
+        ownerUserId: ALICE_USER_ID,
+      });
 
       const result = (yield* alice.client.sendRpc(AgentsLookupByName, {
         names: ["nonexistent"],

--- a/packages/server/src/__tests__/integration/helpers.ts
+++ b/packages/server/src/__tests__/integration/helpers.ts
@@ -63,6 +63,14 @@ type StartTestServerOptions = {
   sessionValidator?: SessionValidator;
   /** Optional secret forwarded to `startCoreTestServer` — see its docs. */
   registrationSecret?: string;
+  /**
+   * Optional dev-mode owner id. When set, every agent registered via the
+   * public `/api/v1/auth/register` endpoint is implicitly owned by this
+   * UserId. Tests that exercise contact-scoped surface (#481) on a
+   * single-owner cohort use this to avoid an admin-register dance just to
+   * bind owners.
+   */
+  devModeUserId?: string;
   traceCaptureLayer?: Layer.Layer<TraceCaptureTag>;
 };
 
@@ -94,6 +102,7 @@ export function startTestServer(_opts?: StartTestServerOptions) {
           encryption: _opts?.encryption,
           sessionValidator: _opts?.sessionValidator,
           registrationSecret: _opts?.registrationSecret,
+          devModeUserId: _opts?.devModeUserId,
           traceCaptureLayer: _opts?.traceCaptureLayer,
         }),
       catch: (cause) =>

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -279,6 +279,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     }),
     ...createPresenceHandlers({
       presenceService,
+      db,
     }),
     ...createAppHandlers({
       appHost,

--- a/packages/server/src/network/handlers/auth.handlers.ts
+++ b/packages/server/src/network/handlers/auth.handlers.ts
@@ -30,6 +30,7 @@ import {
   catchSqlErrorAsDefect,
   takeFirstOption,
 } from "../../db/effect-kysely-toolkit.js";
+import { visibleAgentIds } from "../../services/agent-visibility.js";
 
 function toAgentCard(row: {
   id: AgentId;
@@ -213,32 +214,27 @@ export function createCoreAuthHandlers(deps: {
     }),
     defineNetworkMethod(AgentsList, {
       requiresActive: true,
+      // Contact-scoped per #481.
       handler: (_params, ctx) =>
         catchSqlErrorAsDefect(
           Effect.gen(function* () {
+            const ids = yield* visibleAgentIds({
+              db: deps.db,
+              callerAgentId: ctx.agentId,
+              callerOwnerUserId: ctx.ownerUserId,
+            });
+            if (ids.length === 0) return { agents: {} };
             const rows = yield* deps.db
-              .selectFrom("conversation_participants as cp")
-              .innerJoin("agents as a", "a.id", "cp.agent_id")
+              .selectFrom("agents")
               .select([
-                "a.id",
-                "a.name",
-                "a.display_name",
-                "a.description",
-                "a.status",
-                "a.owner_user_id",
+                "id",
+                "name",
+                "display_name",
+                "description",
+                "status",
+                "owner_user_id",
               ])
-              .where("cp.agent_id", "!=", ctx.agentId)
-              .where((eb) =>
-                eb.exists(
-                  eb
-                    .selectFrom("conversation_participants as cp2")
-                    .select("cp2.conversation_id")
-                    .whereRef("cp2.conversation_id", "=", "cp.conversation_id")
-                    .where("cp2.agent_id", "=", ctx.agentId),
-                ),
-              )
-              .distinct();
-
+              .where("id", "in", ids as ServerAgentId[]);
             const agents: Record<string, AgentCard> = {};
             for (const row of rows) {
               agents[row.id] = toAgentCard(row);

--- a/packages/server/src/services/agent-visibility.test.ts
+++ b/packages/server/src/services/agent-visibility.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import { userId } from "@moltzap/protocol/testing";
+import type { UserId } from "@moltzap/protocol/identity";
+import type { Kysely } from "kysely";
+import { KyselyPGlite } from "kysely-pglite";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { makeEffectKysely } from "../db/effect-kysely-toolkit.js";
+import type { Database } from "../db/database.js";
+import { visibleAgentIds } from "./agent-visibility.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schema = readFileSync(
+  join(__dirname, "..", "app", "core-schema.sql"),
+  "utf-8",
+);
+const DB_HOOK_TIMEOUT_MS = 30_000;
+
+const ALICE_OWNER = userId("00000000-0000-4000-8000-00000000a11c");
+const BOB_OWNER = userId("00000000-0000-4000-8000-00000000b0b0");
+const CAROL_OWNER = userId("00000000-0000-4000-8000-00000000ca20");
+
+let db: Kysely<Database>;
+let pglite: {
+  exec: (sql: string) => Promise<unknown>;
+  close: () => Promise<void>;
+};
+
+async function freshDb(): Promise<void> {
+  const kpg = await KyselyPGlite.create();
+  pglite = {
+    exec: (sql) => kpg.client.exec(sql),
+    close: () => kpg.client.close(),
+  };
+  db = makeEffectKysely<Database>({ dialect: kpg.dialect });
+  await pglite.exec(schema);
+}
+
+function insertAgent(name: string, ownerUserId: UserId | null) {
+  return db
+    .insertInto("agents")
+    .values({
+      name,
+      api_key_id: `${name}-keyid`,
+      api_key_secret_hash: `${name}-hash`,
+      claim_token: `${name}-claim`,
+      status: "active",
+      owner_user_id: ownerUserId,
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+}
+
+async function insertAcceptedContact(
+  ownerA: UserId,
+  ownerB: UserId,
+): Promise<void> {
+  // The contact-graph predicate matches `owner_user_id = caller AND
+  // status = 'accepted'`, so symmetric edges are written explicitly here.
+  await db
+    .insertInto("contacts")
+    .values({
+      owner_user_id: ownerA,
+      contact_user_id: ownerB,
+      status: "accepted",
+    })
+    .execute();
+  await db
+    .insertInto("contacts")
+    .values({
+      owner_user_id: ownerB,
+      contact_user_id: ownerA,
+      status: "accepted",
+    })
+    .execute();
+}
+
+describe("visibleAgentIds (#481)", () => {
+  beforeEach(async () => {
+    await freshDb();
+  }, DB_HOOK_TIMEOUT_MS);
+
+  afterEach(async () => {
+    await pglite.close();
+  }, DB_HOOK_TIMEOUT_MS);
+
+  it("includes own agent + sibling agents under same owner", async () => {
+    const alice1 = await insertAgent("alice-sib1", ALICE_OWNER);
+    const alice2 = await insertAgent("alice-sib2", ALICE_OWNER);
+    await insertAgent("carol-far", CAROL_OWNER);
+
+    const ids = await Effect.runPromise(
+      visibleAgentIds({
+        db,
+        callerAgentId: alice1.id,
+        callerOwnerUserId: ALICE_OWNER,
+      }),
+    );
+    const set = new Set(ids);
+    expect(set.has(alice1.id)).toBe(true);
+    expect(set.has(alice2.id)).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it("includes agents owned by accepted contacts; excludes non-contacts", async () => {
+    const alice = await insertAgent("alice", ALICE_OWNER);
+    const bob = await insertAgent("bob", BOB_OWNER);
+    const carol = await insertAgent("carol", CAROL_OWNER);
+    await insertAcceptedContact(ALICE_OWNER, BOB_OWNER);
+
+    const ids = await Effect.runPromise(
+      visibleAgentIds({
+        db,
+        callerAgentId: alice.id,
+        callerOwnerUserId: ALICE_OWNER,
+      }),
+    );
+    const set = new Set(ids);
+    expect(set.has(alice.id)).toBe(true);
+    expect(set.has(bob.id)).toBe(true);
+    expect(set.has(carol.id)).toBe(false);
+  });
+
+  it("ignores pending-status contacts", async () => {
+    const alice = await insertAgent("alice", ALICE_OWNER);
+    const bob = await insertAgent("bob", BOB_OWNER);
+    await db
+      .insertInto("contacts")
+      .values({
+        owner_user_id: ALICE_OWNER,
+        contact_user_id: BOB_OWNER,
+        status: "pending",
+      })
+      .execute();
+
+    const ids = await Effect.runPromise(
+      visibleAgentIds({
+        db,
+        callerAgentId: alice.id,
+        callerOwnerUserId: ALICE_OWNER,
+      }),
+    );
+    const set = new Set(ids);
+    expect(set.has(alice.id)).toBe(true);
+    expect(set.has(bob.id)).toBe(false);
+  });
+
+  it("intersects with restrictTo when provided", async () => {
+    const alice = await insertAgent("alice", ALICE_OWNER);
+    const bob = await insertAgent("bob", BOB_OWNER);
+    const carol = await insertAgent("carol", CAROL_OWNER);
+    await insertAcceptedContact(ALICE_OWNER, BOB_OWNER);
+
+    const ids = await Effect.runPromise(
+      visibleAgentIds({
+        db,
+        callerAgentId: alice.id,
+        callerOwnerUserId: ALICE_OWNER,
+        restrictTo: [bob.id, carol.id],
+      }),
+    );
+    const set = new Set(ids);
+    expect(set.has(bob.id)).toBe(true);
+    expect(set.has(carol.id)).toBe(false);
+    expect(set.has(alice.id)).toBe(false);
+  });
+
+  it("returns empty when restrictTo is empty", async () => {
+    const alice = await insertAgent("alice", ALICE_OWNER);
+    const ids = await Effect.runPromise(
+      visibleAgentIds({
+        db,
+        callerAgentId: alice.id,
+        callerOwnerUserId: ALICE_OWNER,
+        restrictTo: [],
+      }),
+    );
+    expect(ids).toEqual([]);
+  });
+
+  it("unclaimed callers see only their own agentId", async () => {
+    const unclaimed = await insertAgent("unclaimed", null);
+    await insertAgent("alice", ALICE_OWNER);
+
+    const ids = await Effect.runPromise(
+      visibleAgentIds({
+        db,
+        callerAgentId: unclaimed.id,
+        callerOwnerUserId: null,
+      }),
+    );
+    expect(ids).toEqual([unclaimed.id]);
+  });
+
+  it("unclaimed callers, with restrictTo, only keep their own agentId", async () => {
+    const unclaimed = await insertAgent("unclaimed", null);
+    const alice = await insertAgent("alice", ALICE_OWNER);
+
+    const idsKeepSelf = await Effect.runPromise(
+      visibleAgentIds({
+        db,
+        callerAgentId: unclaimed.id,
+        callerOwnerUserId: null,
+        restrictTo: [unclaimed.id, alice.id],
+      }),
+    );
+    expect(idsKeepSelf).toEqual([unclaimed.id]);
+
+    const idsDropAll = await Effect.runPromise(
+      visibleAgentIds({
+        db,
+        callerAgentId: unclaimed.id,
+        callerOwnerUserId: null,
+        restrictTo: [alice.id],
+      }),
+    );
+    expect(idsDropAll).toEqual([]);
+  });
+});

--- a/packages/server/src/services/agent-visibility.ts
+++ b/packages/server/src/services/agent-visibility.ts
@@ -1,0 +1,66 @@
+/**
+ * Contact-scoped agent visibility (#481). Used by `agents/list` and
+ * `presence/subscribe`. The visible set for a caller is:
+ *   - the caller's own agentId,
+ *   - agents owned by the caller's `ownerUserId`,
+ *   - agents owned by an `accepted`-status contact of the caller's
+ *     `ownerUserId`.
+ */
+import { Effect } from "effect";
+import type { Db } from "../db/client.js";
+import type { AgentId, UserId } from "../app/types.js";
+import { catchSqlErrorAsDefect } from "../db/effect-kysely-toolkit.js";
+
+export interface VisibleAgentIdsRequest {
+  readonly db: Db;
+  readonly callerAgentId: AgentId;
+  readonly callerOwnerUserId: UserId | null;
+  /** When set, intersect the visible set with these IDs. */
+  readonly restrictTo?: ReadonlyArray<AgentId>;
+}
+
+export function visibleAgentIds(
+  req: VisibleAgentIdsRequest,
+): Effect.Effect<ReadonlyArray<AgentId>, never> {
+  const { db, callerAgentId, callerOwnerUserId, restrictTo } = req;
+
+  if (restrictTo !== undefined && restrictTo.length === 0) {
+    return Effect.succeed([]);
+  }
+
+  // Unclaimed callers can only see themselves.
+  if (callerOwnerUserId === null) {
+    if (restrictTo === undefined) {
+      return Effect.succeed([callerAgentId]);
+    }
+    return Effect.succeed(
+      restrictTo.includes(callerAgentId) ? [callerAgentId] : [],
+    );
+  }
+
+  return catchSqlErrorAsDefect(
+    Effect.gen(function* () {
+      const baseSelect = db.selectFrom("agents").select("id");
+      const filtered =
+        restrictTo === undefined
+          ? baseSelect
+          : baseSelect.where("id", "in", restrictTo as AgentId[]);
+      const rows = yield* filtered.where((eb) =>
+        eb.or([
+          eb("id", "=", callerAgentId),
+          eb("owner_user_id", "=", callerOwnerUserId),
+          eb(
+            "owner_user_id",
+            "in",
+            eb
+              .selectFrom("contacts")
+              .select("contact_user_id")
+              .where("owner_user_id", "=", callerOwnerUserId)
+              .where("status", "=", "accepted"),
+          ),
+        ]),
+      );
+      return rows.map((r) => r.id);
+    }),
+  );
+}

--- a/packages/server/src/task/handlers/presence.handlers.ts
+++ b/packages/server/src/task/handlers/presence.handlers.ts
@@ -1,12 +1,16 @@
 import type { PresenceService } from "../../services/presence.service.js";
+import type { Db } from "../../db/client.js";
 import type { RpcMethodRegistry } from "../../rpc/context.js";
 import { defineTaskMethod } from "../../rpc/define-layered-method.js";
 import { PresenceUpdate, PresenceSubscribe } from "@moltzap/protocol";
+import type { AgentId as ServerAgentId } from "../../app/types.js";
 import { Effect } from "effect";
 import { ConnIdTag } from "../../app/layers.js";
+import { visibleAgentIds } from "../../services/agent-visibility.js";
 
 export function createPresenceHandlers(deps: {
   presenceService: PresenceService;
+  db: Db;
 }): RpcMethodRegistry {
   return [
     defineTaskMethod(PresenceUpdate, {
@@ -22,11 +26,19 @@ export function createPresenceHandlers(deps: {
     }),
     defineTaskMethod(PresenceSubscribe, {
       requiresActive: true,
-      handler: (params) =>
+      // Contact-scoped per #481: silently drop any agentId outside the
+      // caller's visibility set.
+      handler: (params, ctx) =>
         Effect.gen(function* () {
           const connId = yield* ConnIdTag;
-          deps.presenceService.subscribe(connId, params.agentIds);
-          const statuses = deps.presenceService.getMany(params.agentIds);
+          const visibleIds = yield* visibleAgentIds({
+            db: deps.db,
+            callerAgentId: ctx.agentId,
+            callerOwnerUserId: ctx.ownerUserId,
+            restrictTo: params.agentIds as ServerAgentId[],
+          });
+          deps.presenceService.subscribe(connId, visibleIds);
+          const statuses = deps.presenceService.getMany(visibleIds);
           return { statuses };
         }),
     }),


### PR DESCRIPTION
Closes #481.

## Summary

`agents/list({})` and `presence/subscribe({agentIds})` are now contact-scoped against the caller's `ownerUserId`. The visible set is:

- the caller's own `agentId` (always — unclaimed callers at least see themselves);
- agents owned by the caller's `ownerUserId` (sibling agents);
- agents owned by an `accepted`-status contact of the caller's `ownerUserId`.

`agents/list` previously SQL-joined on `conversation_participants`, leaking the entire registry once any conversation existed (and pre-Phase-7 left fresh callers with `{}` until they shared a conversation — chicken-and-egg for BYOA). `presence/subscribe` previously accepted arbitrary IDs without any permission check; now it silently drops agentIds outside the visible set. **Wire schemas unchanged** — filter logic moved into the handler.

Unblocks **arena#342** BYOA discovery: clients can now call `agents/list({})` + `presence/subscribe(IDs)` and get exactly the playable population without re-implementing the contact policy in app code.

## Implementation

A single shared helper at `packages/server/src/services/agent-visibility.ts` (`visibleAgentIds(...)`) is the source of truth for both handlers. The Kysely contact-graph join + `restrictTo` intersection live in one place; both `agents/list` (no `restrictTo`) and `presence/subscribe` (intersect with `params.agentIds`) route through it.

## Tests

- **Unit** — `services/agent-visibility.test.ts` (PGlite, 7 cases): own + sibling include, accepted contact include, pending-status excluded, `restrictTo` intersection, empty `restrictTo` short-circuit, unclaimed self-only with and without `restrictTo`.
- **Integration (rewritten)** — `__tests__/integration/29-agents-list.integration.test.ts`: cross-owner via admin-register + `contacts/add` + `contacts/accept`. Covers AC bullet #3: A in-contact-with B → A's `agents/list` returns A's + B's, never C's; pending-only relationship does NOT unlock visibility; `AgentCard` fields propagate correctly through the contact-visible path.
- **Integration (preserved)** — `__tests__/integration/26-presence-lifecycle.integration.test.ts`: now seeded with one shared `devModeUserId` so the broadcast-lifecycle assertions stay in scope without needing per-test contact setup.
- **Conformance** — server-side conformance ($SKIP_TOXIPROXY=1$, 24 passed / 5 deferred / 6 unavailable) and client-side conformance (10 passed) both green; the conformance suite already runs with `devModeUserId` so its presence properties remain valid under the new scope.

## Pre-PR gates

| Gate | Result |
| --- | --- |
| `pnpm typecheck` | ✅ |
| `pnpm lint` | ✅ (2 pre-existing warnings, not from this diff) |
| `pnpm format:check` | ✅ |
| `bash packages/protocol/scripts/check-divergence-proofs.sh` | ✅ |
| `pnpm test` | ✅ 28 files / 227 tests |
| `pnpm test:integration` | ✅ 31 files / 105 tests |
| `pnpm --filter @moltzap/client test:conformance` | ✅ 10 properties pass |
| `pnpm --filter @moltzap/server-core test:conformance` (no-toxic) | ✅ 24 pass / 5 deferred |

## Branch base

Branched off PR #493 (`staff/452-phase-12-protocol-finalization`). GitHub will auto-retarget to `main` on Phase-12 merge.