### PR TITLE
fix(server): NotInContactsError for presence/subscribe policy-rejected IDs (#508)

### DIFF
--- a/packages/server/src/__tests__/integration/27-presence-subscribe-policy.integration.test.ts
+++ b/packages/server/src/__tests__/integration/27-presence-subscribe-policy.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Integration tests for presence/subscribe contact-policy error (#508).
+ *
+ * Verifies that the server propagates NotInContactsError over the JSON-RPC
+ * wire when a caller requests agentIds outside their contact-visible set.
+ * Test 26 covers broadcast lifecycle with a shared owner; this file covers
+ * the policy-rejection path with distinct owners and no contact relationship.
+ */
+import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { it } from "@effect/vitest";
+import { Cause, Effect, Exit } from "effect";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  trackClient,
+  connectTestClient,
+} from "./helpers.js";
+import { userId, RpcResponseError } from "@moltzap/protocol/testing";
+import type { UserId } from "@moltzap/protocol/identity";
+import { NotInContactsError, PresenceSubscribe } from "@moltzap/protocol";
+
+// Two distinct owners with no contact relationship.
+const REGISTRATION_SECRET = "presence-policy-test-secret-gh508";
+const ALICE_USER_ID = userId("00000000-0000-4000-8000-00000000a5a5") as UserId;
+const CAROL_USER_ID = userId("00000000-0000-4000-8000-00000000c5c5") as UserId;
+
+let baseUrl: string;
+let wsUrl: string;
+let agentCounter = 0;
+
+beforeAll(async () => {
+  const server = await startTestServer({
+    registrationSecret: REGISTRATION_SECRET,
+  });
+  baseUrl = server.baseUrl;
+  wsUrl = server.wsUrl;
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  agentCounter = 0;
+});
+
+interface AdminRegisterResponse {
+  agentId: string;
+  apiKey: string;
+}
+
+async function adminRegister(
+  name: string,
+  ownerUserId: UserId,
+): Promise<AdminRegisterResponse> {
+  const res = await fetch(`${baseUrl}/api/v1/admin/register-agent`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name,
+      inviteCode: REGISTRATION_SECRET,
+      ownerUserId,
+    }),
+  });
+  const json = (await res.json()) as AdminRegisterResponse;
+  if (res.status !== 201 && res.status !== 200) {
+    throw new Error(
+      `admin register failed: ${res.status} ${JSON.stringify(json)}`,
+    );
+  }
+  return json;
+}
+
+function registerAndConnectOwned(opts: { name: string; ownerUserId: UserId }) {
+  return Effect.gen(function* () {
+    const idx = ++agentCounter;
+    const reg = yield* Effect.tryPromise(() =>
+      adminRegister(`${opts.name}-${idx}`, opts.ownerUserId),
+    );
+    const client = yield* connectTestClient({
+      wsUrl,
+      agentId: reg.agentId,
+      apiKey: reg.apiKey,
+    });
+    trackClient(client);
+    return { agentId: reg.agentId, client };
+  });
+}
+
+/** Extract the `RpcResponseError` from an exit's failure cause, or throw. */
+function extractRpcResponseError(
+  exit: Exit.Exit<unknown, unknown>,
+): RpcResponseError {
+  expect(Exit.isFailure(exit)).toBe(true);
+  const failureOpt = Cause.failureOption(
+    (exit as Exit.Failure<unknown, unknown>).cause,
+  );
+  expect(failureOpt._tag).toBe("Some");
+  const err = (failureOpt as { _tag: "Some"; value: unknown }).value;
+  expect(err).toBeInstanceOf(RpcResponseError);
+  return err as RpcResponseError;
+}
+
+describe("presence/subscribe — NotInContactsError wire propagation (#508)", () => {
+  it.live(
+    "returns NotInContactsError when subscribing to an agentId outside the caller's contact-visible set",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-pol",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const carol = yield* registerAndConnectOwned({
+          name: "carol-pol",
+          ownerUserId: CAROL_USER_ID,
+        });
+        // alice and carol have distinct owners and no contact relationship.
+
+        const exit = yield* Effect.exit(
+          alice.client.sendRpc(PresenceSubscribe, {
+            agentIds: [carol.agentId],
+          }),
+        );
+
+        const err = extractRpcResponseError(exit);
+        expect(err.code).toBe(NotInContactsError.code);
+        const data = err.data as { agentIds: string[] } | undefined;
+        expect(data?.agentIds).toContain(carol.agentId);
+      }),
+  );
+
+  it.live(
+    "returns NotInContactsError listing only the rejected subset when some IDs are visible",
+    () =>
+      Effect.gen(function* () {
+        // alice and alice2 share an owner → siblings, mutually visible.
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-mix",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const alice2 = yield* registerAndConnectOwned({
+          name: "alice-mix2",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const carol = yield* registerAndConnectOwned({
+          name: "carol-mix",
+          ownerUserId: CAROL_USER_ID,
+        });
+
+        // alice subscribes to [alice2 (visible sibling), carol (not visible)]
+        const exit = yield* Effect.exit(
+          alice.client.sendRpc(PresenceSubscribe, {
+            agentIds: [alice2.agentId, carol.agentId],
+          }),
+        );
+
+        const err = extractRpcResponseError(exit);
+        expect(err.code).toBe(NotInContactsError.code);
+        const data = err.data as { agentIds: string[] } | undefined;
+        // Only carol is rejected; alice2 (sibling) is visible.
+        expect(data?.agentIds).toContain(carol.agentId);
+        expect(data?.agentIds).not.toContain(alice2.agentId);
+      }),
+  );
+});

--- a/packages/server/src/task/handlers/presence.handlers.test.ts
+++ b/packages/server/src/task/handlers/presence.handlers.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for createPresenceHandlers — covers the presence/subscribe
+ * NotInContactsError path added in #508.
+ *
+ * Uses PGlite so the contact-graph visibility query runs against a real
+ * schema. The test focuses on the reject-if-non-empty invariant: any
+ * agentId outside the caller's visibility set must surface in the error's
+ * `data.agentIds` field.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Cause, Effect, Exit } from "effect";
+import { NotInContactsError } from "@moltzap/protocol";
+import { wireErrorFromInstance } from "@moltzap/protocol/testing";
+import type { Kysely } from "kysely";
+import { KyselyPGlite } from "kysely-pglite";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { makeEffectKysely } from "../../db/effect-kysely-toolkit.js";
+import type { Database } from "../../db/database.js";
+import { userId } from "@moltzap/protocol/testing";
+import type { UserId } from "@moltzap/protocol/identity";
+import type { AgentId } from "../../app/types.js";
+import { PresenceService } from "../../services/presence.service.js";
+import type { PresenceEventSink } from "../../services/presence-event-sink.js";
+import { ConnIdTag } from "../../app/layers.js";
+import { createPresenceHandlers } from "./presence.handlers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schema = readFileSync(
+  join(__dirname, "..", "..", "app", "core-schema.sql"),
+  "utf-8",
+);
+const DB_HOOK_TIMEOUT_MS = 30_000;
+
+const ALICE_OWNER = userId("00000000-0000-4000-8000-00000000a11c") as UserId;
+const CAROL_OWNER = userId("00000000-0000-4000-8000-00000000ca20") as UserId;
+
+const noopSink: PresenceEventSink = { publish: () => {} };
+
+let db: Kysely<Database>;
+let pglite: {
+  exec: (sql: string) => Promise<unknown>;
+  close: () => Promise<void>;
+};
+
+async function freshDb(): Promise<void> {
+  const kpg = await KyselyPGlite.create();
+  pglite = {
+    exec: (sql) => kpg.client.exec(sql),
+    close: () => kpg.client.close(),
+  };
+  db = makeEffectKysely<Database>({ dialect: kpg.dialect });
+  await pglite.exec(schema);
+}
+
+function insertAgent(name: string, ownerUserId: UserId | null) {
+  return db
+    .insertInto("agents")
+    .values({
+      name,
+      api_key_id: `${name}-keyid`,
+      api_key_secret_hash: `${name}-hash`,
+      claim_token: `${name}-claim`,
+      status: "active",
+      owner_user_id: ownerUserId,
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+}
+
+/** Run the PresenceSubscribe handler body directly against a PGlite db. */
+function runSubscribe(opts: {
+  callerAgentId: AgentId;
+  callerOwnerUserId: UserId | null;
+  requestedIds: AgentId[];
+}) {
+  const handlers = createPresenceHandlers({
+    presenceService: new PresenceService(noopSink),
+    db,
+  });
+  // Find the PresenceSubscribe binding (second entry in the registry).
+  const binding = handlers.find(
+    (h) => h.definition.name === "presence/subscribe",
+  );
+  if (!binding) throw new Error("presence/subscribe handler not found");
+
+  const ctx = {
+    auth: {
+      agentId: opts.callerAgentId,
+      agentStatus: "active",
+      ownerUserId: opts.callerOwnerUserId,
+    },
+    connId: "test-conn-1",
+  };
+
+  return Effect.runPromise(
+    Effect.exit(
+      (
+        binding.handle({ agentIds: opts.requestedIds }, ctx) as Effect.Effect<
+          unknown,
+          unknown
+        >
+      ).pipe(Effect.provideService(ConnIdTag, "test-conn-1")),
+    ),
+  );
+}
+
+describe("presence/subscribe — NotInContactsError (#508)", () => {
+  beforeEach(async () => {
+    await freshDb();
+  }, DB_HOOK_TIMEOUT_MS);
+
+  afterEach(async () => {
+    await pglite.close();
+  }, DB_HOOK_TIMEOUT_MS);
+
+  it("throws NotInContactsError when caller subscribes to an agentId outside their visibility set", async () => {
+    const alice = await insertAgent("alice-508", ALICE_OWNER);
+    const carol = await insertAgent("carol-508", CAROL_OWNER);
+    // alice and carol have no contact relationship → carol not visible to alice
+
+    const exit = await runSubscribe({
+      callerAgentId: alice.id as AgentId,
+      callerOwnerUserId: ALICE_OWNER,
+      requestedIds: [carol.id as AgentId],
+    });
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+
+    const failureOpt = Cause.failureOption(exit.cause);
+    expect(failureOpt._tag).toBe("Some");
+    if (failureOpt._tag !== "Some") return;
+
+    const wire = wireErrorFromInstance(failureOpt.value);
+    expect(wire).not.toBeNull();
+    expect(wire!.code).toBe(NotInContactsError.code);
+    const data = wire!.data as { agentIds: string[] };
+    expect(data.agentIds).toContain(carol.id);
+  });
+
+  it("throws NotInContactsError with only the rejected subset when some IDs are visible", async () => {
+    const alice = await insertAgent("alice-mix", ALICE_OWNER);
+    const alice2 = await insertAgent("alice-sib", ALICE_OWNER);
+    const carol = await insertAgent("carol-mix", CAROL_OWNER);
+    // alice2 is a sibling (same owner) → visible; carol is not
+
+    const exit = await runSubscribe({
+      callerAgentId: alice.id as AgentId,
+      callerOwnerUserId: ALICE_OWNER,
+      requestedIds: [alice2.id as AgentId, carol.id as AgentId],
+    });
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+
+    const failureOpt = Cause.failureOption(exit.cause);
+    expect(failureOpt._tag).toBe("Some");
+    if (failureOpt._tag !== "Some") return;
+
+    const wire = wireErrorFromInstance(failureOpt.value);
+    expect(wire).not.toBeNull();
+    expect(wire!.code).toBe(NotInContactsError.code);
+    const data = wire!.data as { agentIds: string[] };
+    // Only carol is rejected; alice2 (sibling) is visible
+    expect(data.agentIds).toEqual([carol.id]);
+    expect(data.agentIds).not.toContain(alice2.id);
+  });
+
+  it("succeeds when all requested IDs are in the caller's visibility set", async () => {
+    const alice = await insertAgent("alice-ok", ALICE_OWNER);
+    const alice2 = await insertAgent("alice-sib2", ALICE_OWNER);
+
+    const exit = await runSubscribe({
+      callerAgentId: alice.id as AgentId,
+      callerOwnerUserId: ALICE_OWNER,
+      requestedIds: [alice2.id as AgentId],
+    });
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+  });
+});

--- a/packages/server/src/task/handlers/presence.handlers.ts
+++ b/packages/server/src/task/handlers/presence.handlers.ts
@@ -2,7 +2,11 @@ import type { PresenceService } from "../../services/presence.service.js";
 import type { Db } from "../../db/client.js";
 import type { RpcMethodRegistry } from "../../rpc/context.js";
 import { defineTaskMethod } from "../../rpc/define-layered-method.js";
-import { PresenceUpdate, PresenceSubscribe } from "@moltzap/protocol";
+import {
+  PresenceUpdate,
+  PresenceSubscribe,
+  NotInContactsError,
+} from "@moltzap/protocol";
 import type { AgentId as ServerAgentId } from "../../app/types.js";
 import { Effect } from "effect";
 import { ConnIdTag } from "../../app/layers.js";
@@ -26,17 +30,25 @@ export function createPresenceHandlers(deps: {
     }),
     defineTaskMethod(PresenceSubscribe, {
       requiresActive: true,
-      // Contact-scoped per #481: silently drop any agentId outside the
-      // caller's visibility set.
+      // Contact-scoped per #481/#508: throw NotInContactsError when any
+      // requested agentId falls outside the caller's visibility set.
       handler: (params, ctx) =>
         Effect.gen(function* () {
           const connId = yield* ConnIdTag;
+          const requested = params.agentIds as ServerAgentId[];
           const visibleIds = yield* visibleAgentIds({
             db: deps.db,
             callerAgentId: ctx.agentId,
             callerOwnerUserId: ctx.ownerUserId,
-            restrictTo: params.agentIds as ServerAgentId[],
+            restrictTo: requested,
           });
+          const visibleSet = new Set(visibleIds);
+          const rejected = requested.filter((id) => !visibleSet.has(id));
+          if (rejected.length > 0) {
+            return yield* Effect.fail(
+              new NotInContactsError({ data: { agentIds: rejected } }),
+            );
+          }
           deps.presenceService.subscribe(connId, visibleIds);
           const statuses = deps.presenceService.getMany(visibleIds);
           return { statuses };


### PR DESCRIPTION
Closes #508

## Summary

- `presence/subscribe` now throws `NotInContactsError` (code -32005) when any requested `agentId` falls outside the caller's contact-visible set.
- The rejected subset (input ∖ visible) is surfaced in `data.agentIds` on the wire response.
- Callers can now distinguish "agent offline" from "agent not visible to you" instead of receiving a silently-filtered status list.

## Implementation

- **Error class**: reuses existing `NotInContactsError` in `packages/protocol/src/identity/contacts.ts` (unchanged). The `data` field from `RpcErrorPayload` carries `{ agentIds: AgentId[] }` — the rejected subset.
- **Handler** (`packages/server/src/task/handlers/presence.handlers.ts`): computes `rejected = requested.filter(id => !visibleSet.has(id))` after `visibleAgentIds()` returns; `Effect.fail(new NotInContactsError({ data: { agentIds: rejected } }))` when non-empty.

## Plan anchors

| Change | Plan anchor |
|--------|-------------|
| Throw `NotInContactsError` with `data.agentIds` | #508 decision recorded 2026-05-07: "tagged-error route, payload `{ agentIds: AgentId[] }`" |
| Unit test: mixed visible+invisible IDs | #508 acceptance: "unit test ... throws with rejected subset in payload" |
| Integration test: wire propagation | #508 acceptance: "integration test (e2e wire propagation through JSON-RPC)" |

## Tests

- **Unit** — `packages/server/src/task/handlers/presence.handlers.test.ts` (new, 3 cases, PGlite-backed): invisible-only → error with rejected IDs; mixed visible+invisible → error with only the invisible subset; all-visible → success.
- **Integration** — `packages/server/src/__tests__/integration/27-presence-subscribe-policy.integration.test.ts` (new, 2 cases): verifies `RpcResponseError.code === NotInContactsError.code` and `data.agentIds` contains the rejected agent on the live JSON-RPC wire.

## Pre-PR gates

| Gate | Result |
|------|--------|
| `pnpm --filter @moltzap/server-core exec tsc --noEmit` | ✅ 0 errors |
| `pnpm lint` | ✅ 0 errors (2 pre-existing warnings, unrelated) |
| `pnpm --filter @moltzap/server-core test` | ✅ 29 files / 230 tests |
| `pnpm --filter @moltzap/server-core test:integration` | ✅ 32 files / 107 tests |
| `SKIP_TOXIPROXY=1 pnpm --filter @moltzap/server-core test:conformance` | ✅ 24 pass / 5 deferred / 6 unavailable / 0 failed |

## Scope

- Modules touched: `packages/server` (handlers + 2 test files)
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Simplify pass

No findings. The `visibleSet` + `rejected` filter is the minimum code to implement the spec. The change is 10 LOC in production code.

## Review pass

No findings. Error channel is typed (`NotInContactsError`). Data field follows the `RpcErrorPayload.data?: unknown` contract already present on all registered errors. Empty-array short-circuit in `visibleAgentIds` means zero-element `agentIds` input succeeds (no error). All edge cases covered by unit tests.