### PR TITLE
[impl-junior] sidecar #507 — fix stale agents/list + presence/subscribe descriptions

### DIFF
--- a/docs/protocol/methods/agents-list.mdx
+++ b/docs/protocol/methods/agents-list.mdx
@@ -1,11 +1,11 @@
 ---
 title: "agents/list"
-description: "List all registered agents on the server."
+description: "List agents visible to the caller — the caller's own agents (siblings under the same ownerUserId) plus agents owned by an accepted-status contact of the caller. Unclaimed callers see only themselves."
 ---
 
 # agents/list
 
-List all registered agents on the server.
+List agents visible to the caller — the caller's own agents (siblings under the same ownerUserId) plus agents owned by an accepted-status contact of the caller. Unclaimed callers see only themselves.
 
 ## Parameters
 

--- a/docs/protocol/methods/presence-subscribe.mdx
+++ b/docs/protocol/methods/presence-subscribe.mdx
@@ -1,11 +1,11 @@
 ---
 title: "presence/subscribe"
-description: "Subscribe to presence changes for a list of participants."
+description: "Subscribe to presence changes for the caller's contact-visible subset of agentIds. AgentIds outside that subset are silently dropped — no presence will arrive for them. Replace-semantics per #487."
 ---
 
 # presence/subscribe
 
-Subscribe to presence changes for a list of participants.
+Subscribe to presence changes for the caller's contact-visible subset of agentIds. AgentIds outside that subset are silently dropped — no presence will arrive for them. Replace-semantics per #487.
 
 ## Parameters
 

--- a/scripts/generate-protocol-docs.ts
+++ b/scripts/generate-protocol-docs.ts
@@ -122,7 +122,8 @@ Gated by the same \`REGISTRATION_SECRET\` as \`agents/register\`. When the secre
     description: "Look up agents by their short names.",
   },
   "agents/list": {
-    description: "List all registered agents on the server.",
+    description:
+      "List agents visible to the caller — the caller's own agents (siblings under the same ownerUserId) plus agents owned by an accepted-status contact of the caller. Unclaimed callers see only themselves.",
   },
   "messages/send": {
     description:
@@ -246,7 +247,8 @@ Gated by the same \`REGISTRATION_SECRET\` as \`agents/register\`. When the secre
     relatedNotifications: ["presence/changed"],
   },
   "presence/subscribe": {
-    description: "Subscribe to presence changes for a list of participants.",
+    description:
+      "Subscribe to presence changes for the caller's contact-visible subset of agentIds. AgentIds outside that subset are silently dropped — no presence will arrive for them. Replace-semantics per #487.",
   },
   "apps/register": {
     description: "Register an app manifest for the current connection.",


### PR DESCRIPTION
Closes #507. Sub-issue #514. Catches `scripts/generate-protocol-docs.ts` up to the post-#481 contact-scoping behavior.

## What changed

Two description strings + their regenerated MDX:

- `agents/list`: now names the contact-scoped subset rule (caller's siblings + accepted-contact-owned agents; unclaimed callers see only themselves).
- `presence/subscribe`: now states the silent-drop behavior for out-of-subset agentIds and references the #487 replace-semantics.

Re-ran `pnpm docs:generate`; committed `docs/protocol/methods/agents-list.mdx` + `docs/protocol/methods/presence-subscribe.mdx`.

## Scope

- Module: `scripts/generate-protocol-docs.ts` (+ its generated artifacts in `docs/protocol/methods/`).
- New exported signatures: none.
- New deps: none.
- Tier: junior — text edits + regen.

## Tests

No code paths changed; relying on `pnpm build` + `pnpm typecheck` + the pre-commit guardrails (all green locally). `docs:check:drift` will catch any regen mismatch on CI if configured.

## Hygiene gates

- simplify: no findings (description strings have no reusable shape).
- review: no findings (text matches #507 fix recipe verbatim; em-dashes preserved per "verbatim" instruction).

## Related

- #481 (contact-scoping fix this description is catching up to)
- #487 (presence replace-semantics the new text references)

## Confidence

HIGH — verbatim application of the #507 fix recipe; regen passes; build + typecheck green.