### PR TITLE
[impl-junior] fix(protocol): json-rpc-client preserves data field on registered error decode (#511)

### DIFF
--- a/packages/protocol/src/transport/json-rpc-client.test.ts
+++ b/packages/protocol/src/transport/json-rpc-client.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for `JsonRpcClient.resolve` — focused on inbound error-frame
+ * decode for codes that match the registered tagged-error registry.
+ *
+ * The resolver path that constructs the failure value lives in
+ * `json-rpc-client.ts` and was the site of issue #511 (the wire frame's
+ * `data` payload was dropped because the registered class was constructed
+ * with no arguments).
+ */
+import { describe, expect, it } from "vitest";
+import { Cause, Deferred, Effect, Exit, Fiber } from "effect";
+import { Type } from "@sinclair/typebox";
+
+import { defineRpc } from "./method.js";
+import { makeJsonRpcClient } from "./json-rpc-client.js";
+import { responseFrame, type ResponseFrame } from "./wire.js";
+import { ForbiddenError } from "./wire-errors.js";
+
+const TestEcho = defineRpc({
+  name: "test/echo",
+  params: Type.Object({}, { additionalProperties: false }),
+  result: Type.Object({}, { additionalProperties: false }),
+});
+
+function parseRequestId(raw: string): string {
+  const parsed = JSON.parse(raw) as { id?: unknown };
+  if (typeof parsed.id !== "string") {
+    throw new Error(`expected string id in outgoing frame, got ${raw}`);
+  }
+  return parsed.id;
+}
+
+describe("JsonRpcClient.resolve — registered tagged-error decode", () => {
+  it("preserves the wire frame's `data` payload on a registered error code", async () => {
+    const wireData = { agentIds: ["agent-a", "agent-b"] } as const;
+
+    const exit = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          // Capture the request id the client mints on the first write.
+          // Effect.ignore makes a second write (none expected) a no-op.
+          const idDef = yield* Deferred.make<string>();
+          const client = yield* makeJsonRpcClient({
+            write: (raw) =>
+              Deferred.succeed(idDef, parseRequestId(raw)).pipe(Effect.ignore),
+            idPrefix: "test",
+          });
+
+          // Issue the call on a fiber so it parks on the deferred while
+          // the test feeds an inbound error frame via `resolve`.
+          const callFiber = yield* Effect.fork(client.call(TestEcho, {}));
+          const outgoingId = yield* Deferred.await(idDef);
+
+          const inbound: ResponseFrame = responseFrame(outgoingId, {
+            error: {
+              code: ForbiddenError.code,
+              message: "denied",
+              data: wireData,
+            },
+          });
+
+          const handled = yield* client.resolve(inbound);
+          expect(handled).toBe(true);
+
+          return yield* Effect.exit(Fiber.join(callFiber));
+        }),
+      ),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const failure = Cause.failureOption(exit.cause);
+    expect(failure._tag).toBe("Some");
+    if (failure._tag !== "Some") return;
+    const value = failure.value;
+    expect(value).toBeInstanceOf(ForbiddenError);
+    // Regression guard for #511: the wire `data` payload reaches the
+    // typed instance instead of arriving as `undefined`.
+    expect((value as ForbiddenError).data).toEqual(wireData);
+  });
+});

--- a/packages/protocol/src/transport/json-rpc-client.ts
+++ b/packages/protocol/src/transport/json-rpc-client.ts
@@ -90,8 +90,12 @@ export const makeJsonRpcClient = (config: {
                 // in `RegisteredTaggedError`. The type system can't see
                 // through the open-ended `new (...) => { _tag: string }`
                 // factory shape, so the cast bridges the static factory
-                // to the closed runtime union.
-                (new cls() as RegisteredTaggedError);
+                // to the closed runtime union. The `data` argument is
+                // forwarded so any payload set by the server reaches the
+                // typed instance rather than being dropped (#511).
+                (new cls({
+                  data: frame.error.data,
+                } as never) as RegisteredTaggedError);
           yield* Deferred.fail(deferred, failureValue).pipe(Effect.ignore);
           return true;
         }


### PR DESCRIPTION
Closes #511. Refs #512.

## What changed

`packages/protocol/src/transport/json-rpc-client.ts` (`resolve` function): when an inbound error frame's code matched the wire-error registry, the registered tagged-error class was constructed with `new cls()` and the wire `data` payload was silently dropped. The fix forwards `frame.error.data` to the constructor so any payload set by the server reaches the typed instance rather than arriving as `undefined`.

Adds `packages/protocol/src/transport/json-rpc-client.test.ts` — first direct unit test for `makeJsonRpcClient`. Covers the registered-class decode branch via `ForbiddenError` with a `{ agentIds: [...] }` data payload, asserting the failure reaches the call site as a typed `ForbiddenError` instance with `data` preserved.

## Scope

- Module: `packages/protocol/src/transport/json-rpc-client.{ts,test.ts}`
- Tier: junior (one-module fix + regression test)
- New exported signatures: none
- New deps: none
- The `as never` cast retained — forced by `RpcErrorClass`'s open `...args: never[]` constructor signature in `wire-errors.ts:19-21`. A typed factory hook on `RpcErrorClass` would localize the unsafety; filing as a follow-up issue rather than expanding scope here.

## Tests

- `preserves the wire frame's data payload on a registered error code` — feeds a synthetic error frame via `client.resolve`, awaits the call's failure, asserts the failure value is a `ForbiddenError` instance with the original `data` payload intact (regression guard for #511).
- Full protocol package suite: 114 passed | 1 todo (115) on `pnpm --filter @moltzap/protocol test`.

## Review skips

- `/review` (Step 4 critical pass categories): not applicable to a 5-line transport-layer object-construction fix — no SQL, LLM, shell, enum changes; no async/sync mixing (Effect-native throughout); no trust-boundary surface change (data is already on the wire, the fix forwards it).
- Three independent review passes (reuse / quality / efficiency) ran via `/simplify` against the full diff. One actionable finding applied: comment tightened to drop a misleading typed-payload example (data is `unknown` on `RpcErrorPayload`, not a structurally-typed field).
- Two follow-ups deferred to GitHub issues (filed post-merge): (a) typed factory hook on `RpcErrorClass` to remove the `as never` cast; (b) symmetric unit test for the unregistered-code branch (`RpcServerError`).

## Confidence

HIGH — fix recipe matches issue body verbatim; new test fails on prior code (verified by inspection: `new cls()` constructs with no `data` arg) and passes on new code.

## Process issues

- Recovered from a prior teammate's tmux restart; existing worktree had the diff already staged. Resumed from worktree per Amendment 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)