### PR TITLE
[impl-junior] docs: transport.mdx pre-auth wording matches server behavior (closes #509)

### DIFF
--- a/docs/protocol/transport.mdx
+++ b/docs/protocol/transport.mdx
@@ -25,7 +25,7 @@ sequenceDiagram
 
 ## Authentication handshake
 
-The first message on any connection MUST be `network/connect`. If the server receives any other method before authentication, it closes the connection with an error.
+The first message on any connection MUST be `network/connect`. If the server receives any other method before authentication, it replies with an `Unauthorized` JSON-RPC error (code `-32000`, message `"Not authenticated. Send network/connect first."`) and keeps the socket open. Clients can retry with `network/connect` on the same connection.
 
 import WsConnect from '/snippets/ws-connect-example.mdx'
 


### PR DESCRIPTION
Closes #509
Parent epic: #512 (Amendment 3)

## What changed

`docs/protocol/transport.mdx:28` claimed pre-auth requests close the connection. The server actually replies with a JSON-RPC `Unauthorized` error and keeps the socket open. Reworded the paragraph so the docs match the implementation at `packages/server/src/app/server.ts:644-651@ca311e0`.

## Source-of-truth alignment

- Error class + code + exact message: `packages/protocol/src/transport/wire-errors.ts:69-73@ca311e0` (`UnauthorizedError`, `code = -32000`, `message = "Not authenticated. Send network/connect first."`).
- Server behavior on pre-auth non-`network/connect` frame: `packages/server/src/app/server.ts:644-651@ca311e0` (sends `encodeErrorResponse`, then `return;` — no close, connection stays in `connections` map).
- "Retry on the same connection" follows mechanically: `conn.auth` is still unset, so the next `network/connect` frame takes the `isConnect` branch normally.

## Scope

- Module: `docs/protocol/transport.mdx` (one paragraph)
- Tier (from diff shape): junior (single doc file, prose-only)
- New exported signatures: none
- New deps: none

## Pre-PR hygiene

- /simplify: 3 reviewer agents (reuse / quality / efficiency). Quality agent flagged conformance-suite test-infra leak into user-facing protocol docs and minor wordiness — applied: dropped the `registerAuthorityNegative` reference and tightened phrasing.
- /review: 1-line MDX prose, well below 50-line specialist threshold; ran focused accuracy verification against `wire-errors.ts` and `server.ts`. No findings.
- `pnpm build`: passes (pre-commit hook ran lint + format + docs:generate + build).

## Confidence

HIGH — the new wording quotes the literal `code` and `message` constants from `wire-errors.ts` and the control-flow claim ("socket stays open") matches a direct read of `server.ts:644-651`.