### PR TITLE
[impl-junior] server: validate app-manifest config against AppManifestSchema (closes #468)

### DIFF
--- a/packages/protocol/src/app/index.ts
+++ b/packages/protocol/src/app/index.ts
@@ -1,6 +1,7 @@
 export {
   AppsRegister,
   AppsAuthorizeDispatch,
+  AppManifestSchema,
   TaskAuthorizeDispatch,
 } from "./methods.js";
 

--- a/packages/server/src/standalone.test.ts
+++ b/packages/server/src/standalone.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { Either } from "effect";
+import { decodeAppManifest, InvalidAppManifest } from "./standalone.js";
+
+// Boundary-validation tests for the on-disk app-manifest decoder.
+// Issue #468: `JSON.parse(json)` previously flowed an untyped `any`
+// straight into `app.registerApp(manifest)`. `decodeAppManifest`
+// validates against `AppManifestSchema` before the value reaches the
+// service surface; these tests exercise both branches.
+
+const VALID_MANIFEST = {
+  appId: "werewolf",
+  name: "Werewolf",
+};
+
+describe("decodeAppManifest", () => {
+  it("returns Right(manifest) for a valid manifest JSON", () => {
+    const result = decodeAppManifest(
+      JSON.stringify(VALID_MANIFEST),
+      "/path/to/werewolf.json",
+    );
+    expect(Either.isRight(result)).toBe(true);
+    if (Either.isRight(result)) {
+      expect(result.right.appId).toBe("werewolf");
+      expect(result.right.name).toBe("Werewolf");
+    }
+  });
+
+  it("accepts a full manifest with optional fields", () => {
+    const manifest = {
+      appId: "werewolf",
+      name: "Werewolf",
+      description: "Social deduction",
+      limits: { maxParticipants: 12 },
+      conversations: [
+        { key: "town_square", name: "Town Square", participantFilter: "all" },
+      ],
+      hooks: {
+        task_authorize_dispatch: { timeout_ms: 5000 },
+      },
+    };
+    const result = decodeAppManifest(
+      JSON.stringify(manifest),
+      "/path/to/werewolf.json",
+    );
+    expect(Either.isRight(result)).toBe(true);
+  });
+
+  it("returns Left(InvalidAppManifest, kind=parse) for malformed JSON", () => {
+    const result = decodeAppManifest(
+      "{ not valid json",
+      "/path/to/broken.json",
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(InvalidAppManifest);
+      expect(result.left.kind).toBe("parse");
+      expect(result.left.path).toBe("/path/to/broken.json");
+      expect(result.left.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns Left(InvalidAppManifest, kind=schema) when required fields missing", () => {
+    const result = decodeAppManifest(
+      JSON.stringify({ appId: "test" }), // missing `name`
+      "/path/to/missing-name.json",
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(InvalidAppManifest);
+      expect(result.left.kind).toBe("schema");
+      expect(result.left.path).toBe("/path/to/missing-name.json");
+      expect(result.left.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns Left(kind=schema) on additional properties", () => {
+    const result = decodeAppManifest(
+      JSON.stringify({ ...VALID_MANIFEST, unexpected: "nope" }),
+      "/path/to/extra-field.json",
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left.kind).toBe("schema");
+    }
+  });
+
+  it("returns Left(kind=schema) on retired permissions field", () => {
+    // Phase 1B deleted the entire permissions surface; a manifest still
+    // carrying a permissions block must reject — proves the deletion is
+    // enforced end-to-end, not just at the wire boundary.
+    const result = decodeAppManifest(
+      JSON.stringify({
+        ...VALID_MANIFEST,
+        permissions: { required: [], optional: [] },
+      }),
+      "/path/to/legacy-permissions.json",
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left.kind).toBe("schema");
+    }
+  });
+
+  it("returns Left(kind=schema) on wrong field type", () => {
+    const result = decodeAppManifest(
+      JSON.stringify({ appId: 42, name: "Test" }), // appId must be string
+      "/path/to/wrong-type.json",
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left.kind).toBe("schema");
+    }
+  });
+});

--- a/packages/server/src/standalone.ts
+++ b/packages/server/src/standalone.ts
@@ -8,6 +8,9 @@ import { Kysely, PostgresDialect, sql } from "kysely";
 import { Data, Effect, Either } from "effect";
 import { FileSystem } from "@effect/platform";
 import { NodeFileSystem } from "@effect/platform-node";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { AppManifestSchema, type AppManifest } from "@moltzap/protocol";
 import type { MoltZapAppConfig as MoltZapConfig } from "./config/effect-config.js";
 import { createCoreApp } from "./app/server.js";
 import { seedInitialKek } from "./crypto/key-rotation.js";
@@ -43,6 +46,17 @@ export class SchemaFileNotFound extends Data.TaggedError("SchemaFileNotFound")<{
   readonly message: string;
 }> {}
 
+/**
+ * Decode failure for an on-disk app manifest. `kind` discriminates JSON
+ * parse failures from schema-validation failures so callers can log the
+ * specific edge that fired without re-inspecting the cause.
+ */
+export class InvalidAppManifest extends Data.TaggedError("InvalidAppManifest")<{
+  readonly kind: "parse" | "schema";
+  readonly path: string;
+  readonly errors: readonly string[];
+}> {}
+
 type StandaloneServerError =
   | RuntimeConfigSurfaceError
   | RuntimeObservabilityError
@@ -58,6 +72,56 @@ const operationFailed = (
     message: cause instanceof Error ? cause.message : String(cause),
     operation,
   });
+
+// ── App-manifest boundary validation ───────────────────────────────
+//
+// Principle 2: data crossing a boundary (JSON file on disk) is decoded
+// against `AppManifestSchema` before it reaches `app.registerApp(...)`.
+// Without this, a malformed-but-JSON-parseable manifest (missing
+// `appId`, wrong `participantFilter`, retired hook key, etc.) would
+// flow as `any` into `AppHost` and only surface deep inside RPC
+// handlers. Compile once at module scope; AJV validators are
+// thread-safe and cheap to reuse.
+const ajv = addFormats(new Ajv({ strict: true, allErrors: true }));
+const validateAppManifest = ajv.compile(AppManifestSchema);
+
+/**
+ * Parse and validate a JSON manifest blob. Returns `Right(AppManifest)`
+ * on success, `Left(InvalidAppManifest)` on either JSON-parse failure
+ * (`kind: "parse"`) or schema-validation failure (`kind: "schema"`).
+ * Never throws. Exported for test access only.
+ */
+// eslint-disable-next-line agent-code-guard/manual-result -- Returns Effect's Either<A, E>; the rule's name-pattern heuristic mis-fires on Either.left/Either.right MemberExpressions inside the body. Same false-positive class as openclaw-entry.ts:185.
+export function decodeAppManifest(
+  json: string,
+  path: string,
+): Either.Either<AppManifest, InvalidAppManifest> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (cause) {
+    return Either.left(
+      new InvalidAppManifest({
+        kind: "parse",
+        path,
+        errors: [cause instanceof Error ? cause.message : String(cause)],
+      }),
+    );
+  }
+  if (!validateAppManifest(parsed)) {
+    const errors = (validateAppManifest.errors ?? []).map(
+      (e) => `${e.instancePath || "/"} ${e.message ?? "validation failed"}`,
+    );
+    return Either.left(
+      new InvalidAppManifest({
+        kind: "schema",
+        path,
+        errors: errors.length > 0 ? errors : ["unknown validation failure"],
+      }),
+    );
+  }
+  return Either.right(parsed as AppManifest);
+}
 
 // ── Database factory ────────────────────────────────────────────────
 
@@ -360,19 +424,27 @@ function startServerEffect(
                 }),
               onRight: (json) =>
                 Effect.sync(() => {
-                  try {
-                    const manifest = JSON.parse(json);
-                    app.registerApp(manifest);
-                    log.info(
-                      { appId: manifest.appId, path: appRef.manifest },
-                      "App manifest registered",
-                    );
-                  } catch (err) {
-                    log.error(
-                      { err, path: appRef.manifest },
-                      "Failed to load app manifest",
-                    );
-                  }
+                  Either.match(decodeAppManifest(json, appRef.manifest), {
+                    onLeft: (err) => {
+                      log.error(
+                        {
+                          path: err.path,
+                          kind: err.kind,
+                          errors: err.errors,
+                        },
+                        err.kind === "parse"
+                          ? "App manifest JSON parse failed; skipping registration"
+                          : "App manifest failed schema validation; skipping registration",
+                      );
+                    },
+                    onRight: (manifest) => {
+                      app.registerApp(manifest);
+                      log.info(
+                        { appId: manifest.appId, path: appRef.manifest },
+                        "App manifest registered",
+                      );
+                    },
+                  });
                 }),
             }),
           ),


### PR DESCRIPTION
Closes #468
Parent epic: #512

## What changed

`standalone.ts` previously read an on-disk app-manifest config via raw
`JSON.parse(json)` and passed the resulting untyped `any` straight to
`app.registerApp(manifest)` — defeating the boundary-once descriptor
architecture. A malformed-but-JSON-parseable manifest (missing `appId`,
retired `permissions` field, wrong field type) propagated as `any` until
something exploded deep inside an RPC handler, far from the parse site.

Adds a typed boundary decoder `decodeAppManifest(json, path)` returning
`Either.Either<AppManifest, InvalidAppManifest>` with `kind: "parse" |
"schema"` discriminating JSON-parse failures from schema-validation
failures. The registration callback in `startServerEffect` now uses
`Either.match` (both branches handled) — left logs structured failure
fields and skips registration; right registers as before.

The AJV validator is compiled once at module scope; reuses the
codebase's existing `Ajv({ strict: true, allErrors: true })` +
`ajv-formats` pattern (`packages/server/src/config/schema.ts:115`,
`packages/protocol/src/transport/wire.ts:15`).

## Scope

- Module: `packages/server/src/standalone.ts` (+ co-located test file)
- Authorized barrel touch: `packages/protocol/src/app/index.ts` re-exports
  `AppManifestSchema` (already exported from `methods.ts`).
- Tier (manual): junior — body-fill + boundary validation against an
  existing protocol schema; no new public service surface, no new deps
  (`ajv` and `ajv-formats` already in `packages/server/package.json`).
- New exported signatures: `decodeAppManifest`, `InvalidAppManifest`
  tagged error — required for the test file; consistent with this
  module's existing tagged-error exports (`SchemaFileNotFound`,
  `RuntimeConfigSurfaceError`, etc.).
- New deps: none.

## Tests

`packages/server/src/standalone.test.ts` — 7/7 passing locally:

- `returns Right(manifest) for a valid manifest JSON`
- `accepts a full manifest with optional fields`
- `returns Left(InvalidAppManifest, kind=parse) for malformed JSON`
- `returns Left(InvalidAppManifest, kind=schema) when required fields missing`
- `returns Left(kind=schema) on additional properties`
- `returns Left(kind=schema) on retired permissions field` — proves
  Phase 1B's permissions deletion is enforced at the on-disk boundary,
  not just at the wire boundary
- `returns Left(kind=schema) on wrong field type`

## Pre-PR hygiene

- `/simplify` (inline pass): no findings — pattern matches existing
  Ajv/ajv-formats usage; all imports used; validator compiled once.
- `/review` (inline pass): no findings — no SQL touched; no LLM trust
  boundary; error cause logged with structured fields, not swallowed;
  both `Either` branches handled.
- `pnpm --filter @moltzap/server-core build` green.
- `pnpm lint` clean (2 unrelated unused-import warnings in
  `services/conversation.service.test.ts`).
- `vitest run src/standalone.test.ts` 7/7 passing.

## Concerns (DONE_WITH_CONCERNS — Amendment 4)

1. **Pre-existing pglite test failures.** `pnpm --filter
   @moltzap/server-core test` surfaces 28 failures across
   `conversation.service.test.ts`, `task.service.test.ts`, and
   `presence.handlers.test.ts` (pglite hook timeouts). These modules
   are untouched by this diff and pre-date this branch (branch is two
   commits ahead of main, neither commit touches services). Flagging
   for orchestrator triage; not introduced by #468.
2. **`agent-code-guard/manual-result` false positive.** The rule
   mis-fires on the function body because `Either.left(...)` and
   `Either.right(...)` are picked up as `left`/`right` keys by the
   AST walker, matching its `RESULT_LITERAL_PAIRS` heuristic. Disabled
   with a justification comment matching the existing precedent at
   `packages/openclaw-channel/src/openclaw-entry.ts:185`. The function
   does use Effect's `Either` (which the rule's docs explicitly call
   out as preferred); this is a name-pattern false positive, not a
   manual algebra.

## Confidence

HIGH — fix recipe in #468 is followed verbatim; tests cover both
discriminator values plus four schema-violation shapes; pattern matches
existing Ajv usage in the codebase; pre-commit hooks, build, lint, and
filtered tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)