### PR TITLE
[impl-senior] identity: contact-scope agents/lookup + agents/lookupByName (closes #506)

### DIFF
--- a/packages/server/src/__tests__/integration/29-agents-list.integration.test.ts
+++ b/packages/server/src/__tests__/integration/29-agents-list.integration.test.ts
@@ -274,7 +274,7 @@ describe(`${AgentsList.name} — contact-scoped per #481`, () => {
   );
 });
 
-describe(AgentsLookup.name, () => {
+describe(`${AgentsLookup.name} — contact-scoped per #481/#506`, () => {
   it.live("returns agent cards by ID", () =>
     Effect.gen(function* () {
       const alice = yield* registerAndConnectOwned({
@@ -322,9 +322,101 @@ describe(AgentsLookup.name, () => {
       expect(result.agents[0]!.description).toBe("Has a description");
     }),
   );
+
+  it.live(
+    "drops cross-owner IDs when the caller is not in contact with the owner",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-lookup-iso",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const carol = yield* registerAndConnectOwned({
+          name: "carol-lookup-iso",
+          ownerUserId: CAROL_USER_ID,
+        });
+
+        const result = (yield* alice.client.sendRpc(AgentsLookup, {
+          agentIds: [carol.agentId],
+        })) as AgentsArrayResult;
+        expect(result.agents).toHaveLength(0);
+      }),
+  );
+
+  it.live(
+    "returns sibling-owner and accepted-contact-owner cards; drops non-contacts in same call",
+    () =>
+      Effect.gen(function* () {
+        const alice1 = yield* registerAndConnectOwned({
+          name: "alice-lookup-sib1",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const alice2 = yield* registerAndConnectOwned({
+          name: "alice-lookup-sib2",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const bob = yield* registerAndConnectOwned({
+          name: "bob-lookup",
+          ownerUserId: BOB_USER_ID,
+        });
+        const carol = yield* registerAndConnectOwned({
+          name: "carol-lookup",
+          ownerUserId: CAROL_USER_ID,
+        });
+
+        const added = yield* alice1.client.sendRpc(ContactsAdd, {
+          contactUserId: BOB_USER_ID,
+        });
+        yield* bob.client.sendRpc(ContactsAccept, {
+          contactId: added.contact.id,
+        });
+
+        const result = (yield* alice1.client.sendRpc(AgentsLookup, {
+          agentIds: [
+            alice1.agentId,
+            alice2.agentId,
+            bob.agentId,
+            carol.agentId,
+          ],
+        })) as AgentsArrayResult;
+        const ids = new Set(result.agents.map((a) => a.id));
+        expect(ids.has(alice1.agentId)).toBe(true);
+        expect(ids.has(alice2.agentId)).toBe(true);
+        expect(ids.has(bob.agentId)).toBe(true);
+        expect(ids.has(carol.agentId)).toBe(false);
+      }),
+  );
+
+  it.live(
+    "pending-status contact does NOT yet expose the requester's agent card to the recipient",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-lookup-pending",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const bob = yield* registerAndConnectOwned({
+          name: "bob-lookup-pending",
+          ownerUserId: BOB_USER_ID,
+        });
+
+        yield* alice.client.sendRpc(ContactsAdd, {
+          contactUserId: BOB_USER_ID,
+        });
+
+        const aliceLookup = (yield* alice.client.sendRpc(AgentsLookup, {
+          agentIds: [bob.agentId],
+        })) as AgentsArrayResult;
+        const bobLookup = (yield* bob.client.sendRpc(AgentsLookup, {
+          agentIds: [alice.agentId],
+        })) as AgentsArrayResult;
+        expect(aliceLookup.agents).toHaveLength(0);
+        expect(bobLookup.agents).toHaveLength(0);
+      }),
+  );
 });
 
-describe(AgentsLookupByName.name, () => {
+describe(`${AgentsLookupByName.name} — contact-scoped per #481/#506`, () => {
   it.live("returns agent cards by name", () =>
     Effect.gen(function* () {
       const alice = yield* registerAndConnectOwned({
@@ -374,10 +466,18 @@ describe(AgentsLookupByName.name, () => {
           .execute(),
       );
 
+      // Bob is in contact with Alice, but Alice is suspended — should drop.
       const bob = yield* registerAndConnectOwned({
         name: "bob-active",
         ownerUserId: BOB_USER_ID,
       });
+      const added = yield* bob.client.sendRpc(ContactsAdd, {
+        contactUserId: ALICE_USER_ID,
+      });
+      yield* alice.client.sendRpc(ContactsAccept, {
+        contactId: added.contact.id,
+      });
+
       const result = (yield* bob.client.sendRpc(AgentsLookupByName, {
         names: [aliceRow.name],
       })) as AgentsArrayResult;
@@ -399,5 +499,71 @@ describe(AgentsLookupByName.name, () => {
 
       expect(result.agents).toHaveLength(0);
     }),
+  );
+
+  it.live(
+    "drops a cross-owner name match when the caller is not in contact with the owner",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-lbyn-iso",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const carol = yield* registerAndConnectOwned({
+          name: "carol-lbyn-iso",
+          ownerUserId: CAROL_USER_ID,
+        });
+
+        const db = getKyselyDb();
+        const carolRow = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("agents")
+            .select("name")
+            .where("id", "=", carol.agentId)
+            .executeTakeFirstOrThrow(),
+        );
+
+        const result = (yield* alice.client.sendRpc(AgentsLookupByName, {
+          names: [carolRow.name],
+        })) as AgentsArrayResult;
+        expect(result.agents).toHaveLength(0);
+      }),
+  );
+
+  it.live(
+    "returns the card when the name belongs to an accepted-contact-owned agent",
+    () =>
+      Effect.gen(function* () {
+        const alice = yield* registerAndConnectOwned({
+          name: "alice-lbyn-c",
+          ownerUserId: ALICE_USER_ID,
+        });
+        const bob = yield* registerAndConnectOwned({
+          name: "bob-lbyn-c",
+          ownerUserId: BOB_USER_ID,
+        });
+
+        const added = yield* alice.client.sendRpc(ContactsAdd, {
+          contactUserId: BOB_USER_ID,
+        });
+        yield* bob.client.sendRpc(ContactsAccept, {
+          contactId: added.contact.id,
+        });
+
+        const db = getKyselyDb();
+        const bobRow = yield* Effect.tryPromise(() =>
+          db
+            .selectFrom("agents")
+            .select("name")
+            .where("id", "=", bob.agentId)
+            .executeTakeFirstOrThrow(),
+        );
+
+        const result = (yield* alice.client.sendRpc(AgentsLookupByName, {
+          names: [bobRow.name],
+        })) as AgentsArrayResult;
+        expect(result.agents).toHaveLength(1);
+        expect(result.agents[0]!.id).toBe(bob.agentId);
+      }),
   );
 });

--- a/packages/server/src/__tests__/integration/29-agents-list.integration.test.ts
+++ b/packages/server/src/__tests__/integration/29-agents-list.integration.test.ts
@@ -274,7 +274,7 @@ describe(`${AgentsList.name} — contact-scoped per #481`, () => {
   );
 });
 
-describe(`${AgentsLookup.name} — contact-scoped per #481/#506`, () => {
+describe(`${AgentsLookup.name} — NOT contact-scoped per #481`, () => {
   it.live("returns agent cards by ID", () =>
     Effect.gen(function* () {
       const alice = yield* registerAndConnectOwned({
@@ -323,96 +323,27 @@ describe(`${AgentsLookup.name} — contact-scoped per #481/#506`, () => {
     }),
   );
 
-  it.live(
-    "drops cross-owner IDs when the caller is not in contact with the owner",
-    () =>
-      Effect.gen(function* () {
-        const alice = yield* registerAndConnectOwned({
-          name: "alice-lookup-iso",
-          ownerUserId: ALICE_USER_ID,
-        });
-        const carol = yield* registerAndConnectOwned({
-          name: "carol-lookup-iso",
-          ownerUserId: CAROL_USER_ID,
-        });
+  // Per architect #481: dereference-by-known-key. The client uses this RPC to
+  // resolve peer `AgentCard`s for UI rendering of conversation messages
+  // (`packages/client/src/service.ts:resolveAgentName` and the bulk-history
+  // lookup); contact-scoping it would render conversation peers as UUIDs.
+  it.live("returns cross-owner cards regardless of contact relationship", () =>
+    Effect.gen(function* () {
+      const alice = yield* registerAndConnectOwned({
+        name: "alice-lookup-xowner",
+        ownerUserId: ALICE_USER_ID,
+      });
+      const carol = yield* registerAndConnectOwned({
+        name: "carol-lookup-xowner",
+        ownerUserId: CAROL_USER_ID,
+      });
 
-        const result = (yield* alice.client.sendRpc(AgentsLookup, {
-          agentIds: [carol.agentId],
-        })) as AgentsArrayResult;
-        expect(result.agents).toHaveLength(0);
-      }),
-  );
-
-  it.live(
-    "returns sibling-owner and accepted-contact-owner cards; drops non-contacts in same call",
-    () =>
-      Effect.gen(function* () {
-        const alice1 = yield* registerAndConnectOwned({
-          name: "alice-lookup-sib1",
-          ownerUserId: ALICE_USER_ID,
-        });
-        const alice2 = yield* registerAndConnectOwned({
-          name: "alice-lookup-sib2",
-          ownerUserId: ALICE_USER_ID,
-        });
-        const bob = yield* registerAndConnectOwned({
-          name: "bob-lookup",
-          ownerUserId: BOB_USER_ID,
-        });
-        const carol = yield* registerAndConnectOwned({
-          name: "carol-lookup",
-          ownerUserId: CAROL_USER_ID,
-        });
-
-        const added = yield* alice1.client.sendRpc(ContactsAdd, {
-          contactUserId: BOB_USER_ID,
-        });
-        yield* bob.client.sendRpc(ContactsAccept, {
-          contactId: added.contact.id,
-        });
-
-        const result = (yield* alice1.client.sendRpc(AgentsLookup, {
-          agentIds: [
-            alice1.agentId,
-            alice2.agentId,
-            bob.agentId,
-            carol.agentId,
-          ],
-        })) as AgentsArrayResult;
-        const ids = new Set(result.agents.map((a) => a.id));
-        expect(ids.has(alice1.agentId)).toBe(true);
-        expect(ids.has(alice2.agentId)).toBe(true);
-        expect(ids.has(bob.agentId)).toBe(true);
-        expect(ids.has(carol.agentId)).toBe(false);
-      }),
-  );
-
-  it.live(
-    "pending-status contact does NOT yet expose the requester's agent card to the recipient",
-    () =>
-      Effect.gen(function* () {
-        const alice = yield* registerAndConnectOwned({
-          name: "alice-lookup-pending",
-          ownerUserId: ALICE_USER_ID,
-        });
-        const bob = yield* registerAndConnectOwned({
-          name: "bob-lookup-pending",
-          ownerUserId: BOB_USER_ID,
-        });
-
-        yield* alice.client.sendRpc(ContactsAdd, {
-          contactUserId: BOB_USER_ID,
-        });
-
-        const aliceLookup = (yield* alice.client.sendRpc(AgentsLookup, {
-          agentIds: [bob.agentId],
-        })) as AgentsArrayResult;
-        const bobLookup = (yield* bob.client.sendRpc(AgentsLookup, {
-          agentIds: [alice.agentId],
-        })) as AgentsArrayResult;
-        expect(aliceLookup.agents).toHaveLength(0);
-        expect(bobLookup.agents).toHaveLength(0);
-      }),
+      const result = (yield* alice.client.sendRpc(AgentsLookup, {
+        agentIds: [carol.agentId],
+      })) as AgentsArrayResult;
+      expect(result.agents).toHaveLength(1);
+      expect(result.agents[0]!.id).toBe(carol.agentId);
+    }),
   );
 });
 

--- a/packages/server/src/network/handlers/auth.handlers.ts
+++ b/packages/server/src/network/handlers/auth.handlers.ts
@@ -174,9 +174,20 @@ export function createCoreAuthHandlers(deps: {
     }),
 
     defineNetworkMethod(AgentsLookup, {
-      handler: (params) =>
+      // Contact-scoped per #481/#506: out-of-scope IDs (non-self, non-sibling,
+      // non-accepted-contact owners) silently drop from the result. Without
+      // this filter any caller could dereference any agent's `AgentCard`
+      // (including `ownerUserId`) by guessing or harvesting an `AgentId`.
+      handler: (params, ctx) =>
         catchSqlErrorAsDefect(
           Effect.gen(function* () {
+            const visibleIds = yield* visibleAgentIds({
+              db: deps.db,
+              callerAgentId: ctx.agentId,
+              callerOwnerUserId: ctx.ownerUserId,
+              restrictTo: params.agentIds as ServerAgentId[],
+            });
+            if (visibleIds.length === 0) return { agents: [] };
             const rows = yield* deps.db
               .selectFrom("agents")
               .select([
@@ -187,16 +198,20 @@ export function createCoreAuthHandlers(deps: {
                 "status",
                 "owner_user_id",
               ])
-              .where("id", "in", params.agentIds as ServerAgentId[]);
+              .where("id", "in", visibleIds as ServerAgentId[]);
             return { agents: rows.map(toAgentCard) };
           }),
         ),
     }),
     defineNetworkMethod(AgentsLookupByName, {
-      handler: (params) =>
+      // Contact-scoped per #481/#506. Names are 1-32 chars and human-chosen,
+      // so a dictionary attack on the unfiltered RPC was tractable. The
+      // `active` status filter is preserved (existing semantics); the
+      // contact-graph filter is then layered on top of the name match.
+      handler: (params, ctx) =>
         catchSqlErrorAsDefect(
           Effect.gen(function* () {
-            const rows = yield* deps.db
+            const matches = yield* deps.db
               .selectFrom("agents")
               .select([
                 "id",
@@ -208,7 +223,19 @@ export function createCoreAuthHandlers(deps: {
               ])
               .where("name", "in", params.names)
               .where("status", "=", "active");
-            return { agents: rows.map(toAgentCard) };
+            if (matches.length === 0) return { agents: [] };
+            const visibleIds = yield* visibleAgentIds({
+              db: deps.db,
+              callerAgentId: ctx.agentId,
+              callerOwnerUserId: ctx.ownerUserId,
+              restrictTo: matches.map((r) => r.id),
+            });
+            const visibleSet = new Set<ServerAgentId>(visibleIds);
+            return {
+              agents: matches
+                .filter((r) => visibleSet.has(r.id))
+                .map(toAgentCard),
+            };
           }),
         ),
     }),

--- a/packages/server/src/network/handlers/auth.handlers.ts
+++ b/packages/server/src/network/handlers/auth.handlers.ts
@@ -174,20 +174,17 @@ export function createCoreAuthHandlers(deps: {
     }),
 
     defineNetworkMethod(AgentsLookup, {
-      // Contact-scoped per #481/#506: out-of-scope IDs (non-self, non-sibling,
-      // non-accepted-contact owners) silently drop from the result. Without
-      // this filter any caller could dereference any agent's `AgentCard`
-      // (including `ownerUserId`) by guessing or harvesting an `AgentId`.
-      handler: (params, ctx) =>
+      // NOT contact-scoped. Per architect #481: "those are dereference-by-known-key,
+      // so the privacy concern is at the enumeration verb, not the lookup verb."
+      // The client uses this RPC to resolve peer `AgentCard`s for UI rendering of
+      // conversation messages (see `service.resolveAgentName` and the bulk-history
+      // lookup in `packages/client/src/service.ts`); contact-scoping it would render
+      // conversation peers as UUIDs whenever the caller has not explicitly added
+      // them as a contact. The dictionary-attack defense lives on the
+      // `agents/lookupByName` verb below, where it actually applies.
+      handler: (params) =>
         catchSqlErrorAsDefect(
           Effect.gen(function* () {
-            const visibleIds = yield* visibleAgentIds({
-              db: deps.db,
-              callerAgentId: ctx.agentId,
-              callerOwnerUserId: ctx.ownerUserId,
-              restrictTo: params.agentIds as ServerAgentId[],
-            });
-            if (visibleIds.length === 0) return { agents: [] };
             const rows = yield* deps.db
               .selectFrom("agents")
               .select([
@@ -198,7 +195,7 @@ export function createCoreAuthHandlers(deps: {
                 "status",
                 "owner_user_id",
               ])
-              .where("id", "in", visibleIds as ServerAgentId[]);
+              .where("id", "in", params.agentIds as ServerAgentId[]);
             return { agents: rows.map(toAgentCard) };
           }),
         ),


### PR DESCRIPTION
Closes #506
Parent epic: #512 (Amendment 3)
Source decision: #481 (contact-scope) — extends PR #505

## What changed

`agents/lookupByName` is contact-scoped. `agents/lookup` is **NOT** contact-scoped — see the Scope adjustment section below for the architect-pre-authorized rationale.

`agents/lookupByName` reuses `visibleAgentIds()` from `packages/server/src/services/agent-visibility.ts` (introduced in PR #505) so the result is filtered to self + sibling-owner + accepted-contact-owner. Out-of-scope name matches silently drop. Names are 1-32 chars and human-chosen, so the contact gate is the actual defense against dictionary enumeration.

`agents/lookup` keeps its pre-PR semantics: dereference-by-known-key returns the `AgentCard` for any persisted `AgentId`, regardless of contact relationship. The client uses this RPC to resolve peer cards for UI rendering of conversation messages, so contact-scoping it would render conversation peers as UUIDs whenever the caller has not explicitly added them as a contact.

## Scope adjustment

The original #506 dispatch asked for contact-scope on BOTH lookup verbs. CI on `47191dc`'s parent commit (`535cefb`, the symmetric-scoping attempt) failed three tests in `packages/client/src/__tests__/service.integration.test.ts` — see the regression analysis at https://github.com/chughtapan/moltzap/pull/522#issuecomment-4403498835.

Architect #481 explicitly named both options as valid:

> "those are dereference-by-known-key, so the privacy concern is at the enumeration verb, not the lookup verb. They could keep current semantics, OR also become contact-scoped for symmetry. **Lower-priority sub-decision.**"

Team-lead unparked Option A (architect-pre-authorized fallback for `agents/lookup`) after user approval. This PR now reflects that selection. #506 acceptance criterion 1 (`A's agents/lookup([B.id])` returns `[]` for non-contacts) is dropped per epic #512 amendment.

## Plan anchors

| Change | Anchor |
|---|---|
| `AgentsLookup` handler reverted to pre-PR semantics at `packages/server/src/network/handlers/auth.handlers.ts:176-201@47191dc` | #481 *"could keep current semantics ... lower-priority sub-decision"* + team-lead unpark (Option A) |
| `AgentsLookupByName` handler wraps `visibleAgentIds({ restrictTo: matches.map(...) })` at `packages/server/src/network/handlers/auth.handlers.ts:202-235@47191dc` | #506 acceptance criterion 2 (the dictionary-attack-tractable verb) |
| Integration test `AgentsLookup` describe header changed to *"NOT contact-scoped per #481"*, with one positive cross-owner test that prevents regression at `packages/server/src/__tests__/integration/29-agents-list.integration.test.ts:277-339@47191dc` | Regression-prevention for the CI-failing client tests |
| Integration tests for `AgentsLookupByName` (cross-owner non-contact dropped, accepted-contact returned, suspended-status precedence) at `packages/server/src/__tests__/integration/29-agents-list.integration.test.ts:341-509@47191dc` | #506 acceptance criterion 2 |

No new modules. No new public surface. No `package.json` changes.

## Scope

- Modules touched: `packages/server` (one)
- safer-diff-scope: `tier: junior` (2 files, 1 module, 0 exports, 0 new_deps)
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Tests

- `packages/server/src/__tests__/integration/29-agents-list.integration.test.ts`:
  - **`AgentsLookup`** — *NOT contact-scoped per #481*: positive test "returns cross-owner cards regardless of contact relationship" guards the regression class CI surfaced.
  - **`AgentsLookupByName`** — *contact-scoped per #481/#506*: cross-owner no-contact name dropped; accepted-contact name returned; existing suspended-status case extended with an accepted-contact pair to prove `status='active'` filter still wins over contact membership.
- Server integration suite: 32 files, 110 passed | 3 todo (210s).
- Client integration suite (the failing surface from `535cefb`): 40/40 passed (54s) — all three previously-failing tests now green.
- Build + typecheck + guards: green (pre-commit hook).

## Simplify / Review

- simplify: no findings — diff shape is one handler revert + one handler wrap + tests.
- review: no findings — Kysely query builder (no raw SQL), no LLM trust boundary, read-only handlers, `catchSqlErrorAsDefect` matches the file's existing error-channel discipline.

## Confidence

HIGH — server diff reverts to a verbatim pre-PR shape for `AgentsLookup`; `AgentsLookupByName` keeps the helper-wrap pattern from PR #505. Both formerly-failing client tests now pass. Reproduction was deterministic (3/3 failures every run pre-revert; 0/40 post-revert).