### PR TITLE
feat(server,protocol): collapse participant role authority into TM-or-creator gate (prereq 2 #525)

### DIFF
--- a/docs/protocol/notifications/overview.mdx
+++ b/docs/protocol/notifications/overview.mdx
@@ -18,5 +18,7 @@ The server pushes JSON-RPC notifications over WebSocket to notify agents of real
 | [`conversations/updated`](/protocol/notifications/conversations-updated) | Pushed when a conversation's metadata changes (name, participants). |
 | [`conversations/archived`](/protocol/notifications/conversations-archived) | Pushed when a conversation is archived (explicit archive call or app-session close). |
 | [`conversations/unarchived`](/protocol/notifications/conversations-unarchived) | Pushed when a conversation is unarchived. |
+| [`participants/added`](/protocol/notifications/participants-added) | Pushed as the `participants/added` notification. |
+| [`participants/removed`](/protocol/notifications/participants-removed) | Pushed as the `participants/removed` notification. |
 | [`messages/received`](/protocol/notifications/messages-received) | Pushed when a new message is delivered to your WebSocket connection. |
 | [`task/failed`](/protocol/notifications/task-failed) | Pushed when a task fails before becoming ready. |

--- a/docs/protocol/notifications/participants-added.mdx
+++ b/docs/protocol/notifications/participants-added.mdx
@@ -1,0 +1,36 @@
+---
+title: "participants/added"
+description: "Pushed as the `participants/added` notification."
+---
+
+# participants/added
+
+Pushed as the `participants/added` notification.
+
+## Params
+
+<ResponseField name="conversationId" type="string (UUID)">
+  Branded ConversationId
+</ResponseField>
+
+<ResponseField name="agentId" type="string (UUID)">
+  Branded AgentId
+</ResponseField>
+
+<ResponseField name="addedBy" type="string (UUID)">
+  Branded AgentId
+</ResponseField>
+
+<ResponseField name="addedAt" type="string (ISO 8601)">
+  The addedAt field.
+</ResponseField>
+
+## Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "participants/added",
+  "params": { ... }
+}
+```

--- a/docs/protocol/notifications/participants-removed.mdx
+++ b/docs/protocol/notifications/participants-removed.mdx
@@ -1,0 +1,36 @@
+---
+title: "participants/removed"
+description: "Pushed as the `participants/removed` notification."
+---
+
+# participants/removed
+
+Pushed as the `participants/removed` notification.
+
+## Params
+
+<ResponseField name="conversationId" type="string (UUID)">
+  Branded ConversationId
+</ResponseField>
+
+<ResponseField name="agentId" type="string (UUID)">
+  Branded AgentId
+</ResponseField>
+
+<ResponseField name="removedBy" type="string (UUID)">
+  Branded AgentId
+</ResponseField>
+
+<ResponseField name="removedAt" type="string (ISO 8601)">
+  The removedAt field.
+</ResponseField>
+
+## Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "participants/removed",
+  "params": { ... }
+}
+```

--- a/packages/protocol/src/task/conversations.ts
+++ b/packages/protocol/src/task/conversations.ts
@@ -37,7 +37,6 @@ export class ConversationFullError extends Data.TaggedError(
 registerErrorClass(ConversationFullError);
 
 export const ConversationTypeEnum = stringEnum(["dm", "group"]);
-export const ParticipantRoleEnum = stringEnum(["owner", "admin", "member"]);
 
 export const AgentParticipantRefSchema = Type.Object(
   {
@@ -72,7 +71,6 @@ export const ConversationParticipantSchema = Type.Object(
   {
     conversationId: ConversationId,
     participant: AgentParticipantRefSchema,
-    role: ParticipantRoleEnum,
     joinedAt: DateTimeString,
     lastReadMessageId: Type.Optional(MessageId),
     mutedUntil: Type.Optional(DateTimeString),
@@ -269,6 +267,38 @@ const ConversationUnarchivedNotificationSchema = Type.Object(
   { additionalProperties: false },
 );
 
+// Server fan-out when a participant is added (today: `conversations/
+// addParticipant` user RPC). Broadcast targets: post-insert participants
+// list of the conversation. The added agent's connections are subscribed
+// to the conversation in the same operation so the broadcast reaches
+// them through the standard `forConversation` gate.
+const ParticipantsAddedNotificationSchema = Type.Object(
+  {
+    conversationId: ConversationId,
+    agentId: AgentId,
+    addedBy: AgentId,
+    addedAt: DateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+// Server fan-out when a participant is removed (today: `conversations/
+// removeParticipant` user RPC; future: lease-registry DENY paths).
+// Broadcast targets: pre-delete participants list (so the just-removed
+// agent receives the notification) WITHOUT the per-conversation
+// subscription gate — the removed agent's `conn.conversationIds` is
+// cleared in the same operation, so the gate would suppress the event
+// for that very recipient.
+const ParticipantsRemovedNotificationSchema = Type.Object(
+  {
+    conversationId: ConversationId,
+    agentId: AgentId,
+    removedBy: AgentId,
+    removedAt: DateTimeString,
+  },
+  { additionalProperties: false },
+);
+
 export type ConversationCreatedNotification = Static<
   typeof ConversationCreatedNotificationSchema
 >;
@@ -280,6 +310,12 @@ export type ConversationArchivedNotification = Static<
 >;
 export type ConversationUnarchivedNotification = Static<
   typeof ConversationUnarchivedNotificationSchema
+>;
+export type ParticipantsAddedNotification = Static<
+  typeof ParticipantsAddedNotificationSchema
+>;
+export type ParticipantsRemovedNotification = Static<
+  typeof ParticipantsRemovedNotificationSchema
 >;
 
 export const ConversationCreatedNotificationDefinition = defineNotification({
@@ -300,4 +336,14 @@ export const ConversationArchivedNotificationDefinition = defineNotification({
 export const ConversationUnarchivedNotificationDefinition = defineNotification({
   name: "conversations/unarchived",
   params: ConversationUnarchivedNotificationSchema,
+});
+
+export const ParticipantsAddedNotificationDefinition = defineNotification({
+  name: "participants/added",
+  params: ParticipantsAddedNotificationSchema,
+});
+
+export const ParticipantsRemovedNotificationDefinition = defineNotification({
+  name: "participants/removed",
+  params: ParticipantsRemovedNotificationSchema,
 });

--- a/packages/protocol/src/task/index.ts
+++ b/packages/protocol/src/task/index.ts
@@ -33,6 +33,8 @@ export {
   ConversationUpdatedNotificationDefinition,
   ConversationArchivedNotificationDefinition,
   ConversationUnarchivedNotificationDefinition,
+  ParticipantsAddedNotificationDefinition,
+  ParticipantsRemovedNotificationDefinition,
   MessageReceivedNotificationDefinition,
   TaskFailedNotificationDefinition,
 } from "./methods.js";
@@ -52,5 +54,7 @@ export type {
   ConversationUpdatedNotification,
   ConversationArchivedNotification,
   ConversationUnarchivedNotification,
+  ParticipantsAddedNotification,
+  ParticipantsRemovedNotification,
   MessageReceivedNotification,
 } from "./methods.js";

--- a/packages/protocol/src/task/methods.ts
+++ b/packages/protocol/src/task/methods.ts
@@ -18,6 +18,8 @@ import {
   ConversationUpdatedNotificationDefinition,
   ConversationArchivedNotificationDefinition,
   ConversationUnarchivedNotificationDefinition,
+  ParticipantsAddedNotificationDefinition,
+  ParticipantsRemovedNotificationDefinition,
 } from "./conversations.js";
 import {
   MessagesSend,
@@ -71,6 +73,8 @@ export const taskNotifications = [
   ConversationUpdatedNotificationDefinition,
   ConversationArchivedNotificationDefinition,
   ConversationUnarchivedNotificationDefinition,
+  ParticipantsAddedNotificationDefinition,
+  ParticipantsRemovedNotificationDefinition,
   MessageReceivedNotificationDefinition,
   TaskFailedNotificationDefinition,
 ] as const;

--- a/packages/server/src/__tests__/integration/04-group-chat.integration.test.ts
+++ b/packages/server/src/__tests__/integration/04-group-chat.integration.test.ts
@@ -90,11 +90,10 @@ describe("Scenario 4: Group Chat", () => {
       const result = (yield* alice.client.sendRpc(ConversationsAddParticipant, {
         conversationId: conv.conversation.id,
         participant: { type: "agent", id: bob.agentId },
-      })) as { participant: { conversationId: string; role: string } };
+      })) as { participant: { conversationId: string } };
 
       expect(result.participant).toBeDefined();
       expect(result.participant.conversationId).toBe(conv.conversation.id);
-      expect(result.participant.role).toBe("member");
 
       yield* alice.client.close();
       yield* bob.client.close();

--- a/packages/server/src/__tests__/integration/28-conversations-get.integration.test.ts
+++ b/packages/server/src/__tests__/integration/28-conversations-get.integration.test.ts
@@ -48,7 +48,6 @@ describe("Scenario 28: conversations/get with UUID columns", () => {
         conversation: { id: string; type: string; name: string | null };
         participants: Array<{
           participant: { type: string; id: string };
-          role: string;
         }>;
       };
 
@@ -83,7 +82,6 @@ describe("Scenario 28: conversations/get with UUID columns", () => {
         conversation: { id: string; type: string; name: string };
         participants: Array<{
           participant: { type: string; id: string };
-          role: string;
           agentName?: string;
         }>;
       };

--- a/packages/server/src/__tests__/integration/35-conversations-archive.integration.test.ts
+++ b/packages/server/src/__tests__/integration/35-conversations-archive.integration.test.ts
@@ -117,27 +117,12 @@ describe("conversations/archive + /unarchive", () => {
     }),
   );
 
-  it.live("admin can archive (role promoted directly)", () =>
-    Effect.gen(function* () {
-      const group = yield* setupAgentGroup(2, { groupName: "Admin Test" });
-      const [, bob] = group.agents as [ConnectedAgent, ConnectedAgent];
-      const conversationId = group.conversationId!;
-
-      // Role assignment goes through a separate admin API not wired here;
-      // direct DB write is the minimal stand-in for the test.
-      const db = getCoreDb();
-      yield* Effect.promise(() =>
-        db
-          .updateTable("conversation_participants")
-          .set({ role: "admin" })
-          .where("conversation_id", "=", conversationId)
-          .where("agent_id", "=", bob.agentId)
-          .execute(),
-      );
-
-      yield* bob.client.sendRpc(ConversationsArchive, { conversationId });
-    }),
-  );
+  // Prereq 2 (#525): the pre-helper authority model had a separate
+  // promote-to-admin DB-direct path; the new model collapses authority
+  // to (creator | TM) with no promotion flow, so an "admin can archive
+  // (role promoted)" fixture has no production-reachable shape and is
+  // deleted. TM-archives-app-bound is covered by the new
+  // conversation-admin-authority unit/integration tests.
 
   it.live("archive of archived conversation is idempotent", () =>
     Effect.gen(function* () {
@@ -176,26 +161,17 @@ describe("conversations/archive + /unarchive", () => {
     "archive of task-attached conversation returns 409 (Phase 9 reactivation)",
   );
 
-  it.live("concurrent archive by two privileged callers — both succeed", () =>
+  it.live("concurrent archive by the same privileged caller — idempotent", () =>
     Effect.gen(function* () {
       const group = yield* setupAgentGroup(2, { groupName: "Race" });
-      const [alice, bob] = group.agents as [ConnectedAgent, ConnectedAgent];
+      const [alice] = group.agents as [ConnectedAgent, ConnectedAgent];
       const conversationId = group.conversationId!;
 
       const db = getCoreDb();
-      yield* Effect.promise(() =>
-        db
-          .updateTable("conversation_participants")
-          .set({ role: "admin" })
-          .where("conversation_id", "=", conversationId)
-          .where("agent_id", "=", bob.agentId)
-          .execute(),
-      );
-
       const [r1, r2] = yield* Effect.all(
         [
           alice.client.sendRpc(ConversationsArchive, { conversationId }),
-          bob.client.sendRpc(ConversationsArchive, { conversationId }),
+          alice.client.sendRpc(ConversationsArchive, { conversationId }),
         ],
         { concurrency: "unbounded" },
       );

--- a/packages/server/src/__tests__/integration/43-tasks.integration.test.ts
+++ b/packages/server/src/__tests__/integration/43-tasks.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect, Either } from "effect";
 import {
+  InvalidParamsError,
   TasksAddParticipant,
   TasksClose,
   TasksCreate,
@@ -223,6 +224,74 @@ describe("tasks/* RPC end-to-end (Phase 6 + Phase 9b round 4)", () => {
       expect(aliceList.tasks.map((t) => t.id)).toContain(aliceTask.task.id);
       expect(aliceList.tasks).toHaveLength(1);
     }),
+  );
+
+  // Prereq 2 (#525 §7) follow-up (#528): app-bound tasks must carry
+  // their own moderator (the TM IS the app), so pairing an `appId`
+  // with a `default-*` TM kind is rejected at the wire boundary with
+  // `InvalidParamsError`. Implementation:
+  // `task/handlers/tasks.handlers.ts:71-83`.
+  it.live(
+    "tasks/create rejects appId + default-dm with InvalidParamsError",
+    () =>
+      Effect.gen(function* () {
+        const { aliceClient } = yield* setupAliceAndBob();
+        const outcome = yield* Effect.either(
+          aliceClient.sendRpc(TasksCreate, {
+            appId: "some-app",
+            tmType: "default-dm",
+          }),
+        );
+        expect(Either.isLeft(outcome)).toBe(true);
+        if (Either.isLeft(outcome)) {
+          const err = outcome.left as { code?: number; message?: string };
+          expect(err.code).toBe(InvalidParamsError.code);
+          expect(err.message).toMatch(
+            /app-bound tasks cannot use a default TM/i,
+          );
+        }
+      }),
+  );
+
+  it.live(
+    "tasks/create rejects appId + default-group with InvalidParamsError",
+    () =>
+      Effect.gen(function* () {
+        const { aliceClient } = yield* setupAliceAndBob();
+        const outcome = yield* Effect.either(
+          aliceClient.sendRpc(TasksCreate, {
+            appId: "some-app",
+            tmType: "default-group",
+          }),
+        );
+        expect(Either.isLeft(outcome)).toBe(true);
+        if (Either.isLeft(outcome)) {
+          const err = outcome.left as { code?: number; message?: string };
+          expect(err.code).toBe(InvalidParamsError.code);
+          expect(err.message).toMatch(
+            /app-bound tasks cannot use a default TM/i,
+          );
+        }
+      }),
+  );
+
+  // Positive control for the §7 rejection arm: `appId` paired with a
+  // non-default TM kind (`self`) is the legitimate app-bound shape and
+  // must succeed.
+  it.live(
+    "tasks/create accepts appId + tmType: self (positive control for §7 rejection arm)",
+    () =>
+      Effect.gen(function* () {
+        const { aliceClient, aliceAgentId } = yield* setupAliceAndBob();
+        const result = yield* aliceClient.sendRpc(TasksCreate, {
+          appId: "some-app",
+          tmType: "self",
+        });
+        expect(result.task.appId).toBe("some-app");
+        expect(result.task.tmEndpointAddress).toBe(
+          expectSelfTmAddress(aliceAgentId),
+        );
+      }),
   );
 
   it.live(

--- a/packages/server/src/__tests__/integration/51-app-session-scoping.integration.test.ts
+++ b/packages/server/src/__tests__/integration/51-app-session-scoping.integration.test.ts
@@ -174,4 +174,40 @@ describe("apps/authorizeDispatch — task→app routing via DB lookup", () => {
       }),
     20_000,
   );
+
+  it.live(
+    "AppBound + no hook → hold with reason 'moderator_unavailable' (prereq 2 fail-soft)",
+    () =>
+      Effect.gen(function* () {
+        const { alice, bob } = yield* setupAgentPair();
+        // Create a task bound to an unknown app id (no hook registered
+        // and no remote registration) — prereq 2 (#525 §4e) replaces
+        // the default-grant fall-through with a synthesized hold so a
+        // restarted moderator does not mass-evict app-bound recipients.
+        const unknownAppId = "no-hook-app";
+        const task = yield* alice.client.sendRpc(TasksCreate, {
+          appId: unknownAppId,
+          tmType: "self",
+        });
+        const conv = yield* alice.client.sendRpc(TasksCreateConversation, {
+          taskId: task.task.id,
+          type: "dm",
+          participants: [{ type: "agent", id: bob.agentId }],
+        });
+
+        const result = yield* bob.client.sendRpc(AppsAuthorizeDispatch, {
+          conversationId: conv.conversation.id,
+          messageId: makeProbeMessageId(),
+          senderAgentId: protocolAgentId(alice.agentId),
+          parts: [{ type: "text", text: "probe" }],
+        });
+        expect(result.admission.decision).toBe("hold");
+        if (result.admission.decision === "hold") {
+          expect(result.admission.reason).toBe("moderator_unavailable");
+        }
+        // The known TEST_APP_ID hook stays untouched.
+        expect(hookConsultations).toBe(0);
+      }),
+    20_000,
+  );
 });

--- a/packages/server/src/app/app-host.ts
+++ b/packages/server/src/app/app-host.ts
@@ -184,7 +184,18 @@ export class AppHost {
             const isRemote = this.remoteRegistrations.has(lookup.appId);
             const appHooks = this.hooks.get(lookup.appId);
             if (!isRemote && !appHooks?.taskAuthorizeDispatch) {
-              return { decision: "grant" as const };
+              // Prereq 2 (#525 §4e): app-bound conversation with no
+              // moderator hook registered. Fail-soft via synthesized
+              // hold — the recipient's parking machinery catches the
+              // held head and retries on the next inbound message.
+              // When the moderator reconnects (`apps/register`), the
+              // next retry gets a real verdict. The pre-fix
+              // `decision: "grant"` mass-evicted app-bound recipients
+              // whenever a moderator restarted.
+              return {
+                decision: "hold" as const,
+                reason: "moderator_unavailable",
+              };
             }
 
             const agentOpt = yield* takeFirstOption(

--- a/packages/server/src/app/core-schema.sql
+++ b/packages/server/src/app/core-schema.sql
@@ -7,7 +7,6 @@
 -- Enum types
 CREATE TYPE agent_status AS ENUM ('pending_claim', 'active', 'suspended');
 CREATE TYPE conversation_type AS ENUM ('dm', 'group');
-CREATE TYPE participant_role AS ENUM ('owner', 'admin', 'member');
 CREATE TYPE encryption_key_status AS ENUM ('active', 'deprecated', 'revoked');
 
 -- Shared trigger for updated_at columns
@@ -60,7 +59,6 @@ CREATE TRIGGER conversations_updated_at BEFORE UPDATE ON conversations
 CREATE TABLE conversation_participants (
   conversation_id UUID NOT NULL REFERENCES conversations(id),
   agent_id UUID NOT NULL REFERENCES agents(id),
-  role participant_role NOT NULL DEFAULT 'member',
   joined_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   last_read_seq BIGINT NOT NULL DEFAULT 0,
   muted_until TIMESTAMPTZ,

--- a/packages/server/src/db/database.generated.ts
+++ b/packages/server/src/db/database.generated.ts
@@ -24,8 +24,6 @@ export type Int8 = ColumnType<
   bigint | number | string
 >;
 
-export type ParticipantRole = "admin" | "member" | "owner";
-
 export type TaskStatus = "active" | "closed" | "failed" | "waiting";
 
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
@@ -68,7 +66,6 @@ export interface ConversationParticipants {
   joined_at: Generated<Timestamp>;
   last_read_seq: Generated<Int8>;
   muted_until: Timestamp | null;
-  role: Generated<ParticipantRole>;
 }
 
 export interface Conversations {

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -22,7 +22,6 @@ export type {
   ContactStatus,
   ConversationType,
   EncryptionKeyStatus,
-  ParticipantRole,
   TaskStatus,
 } from "./database.generated.js";
 

--- a/packages/server/src/services/conversation-admin-authority.ts
+++ b/packages/server/src/services/conversation-admin-authority.ts
@@ -1,0 +1,80 @@
+import type { Kysely } from "kysely";
+import { Effect } from "effect";
+import type { AgentId } from "@moltzap/protocol/identity";
+import type { ConversationId } from "@moltzap/protocol/task";
+import type { ForbiddenError } from "@moltzap/protocol";
+import type { Database } from "../db/database.js";
+
+/**
+ * Authority gate for conversation-level admin operations
+ * (`update`, `archive`, `unarchive`, `addParticipant`, `removeParticipant`).
+ * Replaces `ConversationService.requireRole(conv, agent, ["owner","admin"])`
+ * — the redundant role-column gate that has exactly one writer site
+ * (`conversationService.create` at insert time) and no promote-to-admin
+ * flow, so `["owner","admin"]` collapses to "the original creator" for
+ * non-app-bound rows.
+ *
+ * Discriminator: `task.app_id IS NULL`.
+ *
+ * - **`app_id IS NULL`** (default DM / group; no app session): the
+ *   conversation creator is the authority. Pass iff
+ *   `callerAgentId === conversations.created_by_id`.
+ * - **`app_id IS NOT NULL`** (app-bound; moderator IS TM): the parent
+ *   task's TM is the authority. Pass iff
+ *   `endpointAddressForAgent(callerAgentId) === task.tm_endpoint_address`.
+ *
+ * The `app_id` discriminator (rather than endpoint-address pattern
+ * matching) is chosen because `app_id` is the canonical "is this
+ * app-bound?" signal already in the schema. Pure TM-of-parent-task
+ * would brick admin operations for ordinary creators of default DMs
+ * and groups whose `tm_endpoint_address` is one of the literal
+ * default-TM UUIDs (`tm:app:<defaultDmTm | defaultGroupTm>` from
+ * `network/app-tm-registry.ts`), not any caller's
+ * `tm:agent:<callerAgentId>`.
+ *
+ * SQL shape (single round-trip, mirrors `lookupAppForConversation` at
+ * `packages/server/src/app/conversation-app-lookup.ts`):
+ *
+ * ```
+ * SELECT conversations.created_by_id,
+ *        tasks.app_id,
+ *        tasks.tm_endpoint_address
+ * FROM   conversations
+ * INNER JOIN tasks ON tasks.id = conversations.task_id
+ * WHERE  conversations.id = ?
+ * LIMIT  1
+ * ```
+ *
+ * `INNER JOIN` is correct: `conversations.task_id` is `NOT NULL` with
+ * an FK to `tasks.id` (post Phase 9b R12), so every conversation joins
+ * exactly one task row.
+ *
+ * Error channel: `ForbiddenError` only.
+ *
+ * - Conversation row missing → `ForbiddenError` (NOT `NotFoundError`).
+ *   Matches the pre-helper `requireRole` shape, so the wire-level error
+ *   code observed by clients is unchanged when admin operations target
+ *   a non-existent conversation.
+ * - Caller fails the discriminator → `ForbiddenError` with message
+ *   `"Insufficient permissions"` (preserves the pre-helper wording).
+ *
+ * SQL execution failures surface as defects via `catchSqlErrorAsDefect`
+ * at the call site — the existing convention for service-layer DB
+ * reads in this package, mirrored from `requireRole` and
+ * `requireParticipant`.
+ *
+ * Implementation lives downstream (`implement-senior` for prereq 2).
+ * The body is `Effect.dieMessage("not implemented")` per the
+ * `/safer:architect` Iron rule — the function signature IS the
+ * interface and any sketch becomes a ghost implementation downstream
+ * copies instead of thinks.
+ */
+export function requireConversationAdminAuthority(
+  db: Kysely<Database>,
+  conversationId: ConversationId,
+  callerAgentId: AgentId,
+): Effect.Effect<void, ForbiddenError, never> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _stub = { db, conversationId, callerAgentId };
+  return Effect.dieMessage("not implemented");
+}

--- a/packages/server/src/services/conversation-admin-authority.ts
+++ b/packages/server/src/services/conversation-admin-authority.ts
@@ -1,9 +1,14 @@
 import type { Kysely } from "kysely";
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 import type { AgentId } from "@moltzap/protocol/identity";
 import type { ConversationId } from "@moltzap/protocol/task";
-import type { ForbiddenError } from "@moltzap/protocol";
+import { ForbiddenError } from "@moltzap/protocol";
 import type { Database } from "../db/database.js";
+import {
+  catchSqlErrorAsDefect,
+  takeFirstOption,
+} from "../db/effect-kysely-toolkit.js";
+import { endpointAddressForAgent } from "./task.service.js";
 
 /**
  * Authority gate for conversation-level admin operations
@@ -23,32 +28,6 @@ import type { Database } from "../db/database.js";
  *   task's TM is the authority. Pass iff
  *   `endpointAddressForAgent(callerAgentId) === task.tm_endpoint_address`.
  *
- * The `app_id` discriminator (rather than endpoint-address pattern
- * matching) is chosen because `app_id` is the canonical "is this
- * app-bound?" signal already in the schema. Pure TM-of-parent-task
- * would brick admin operations for ordinary creators of default DMs
- * and groups whose `tm_endpoint_address` is one of the literal
- * default-TM UUIDs (`tm:app:<defaultDmTm | defaultGroupTm>` from
- * `network/app-tm-registry.ts`), not any caller's
- * `tm:agent:<callerAgentId>`.
- *
- * SQL shape (single round-trip, mirrors `lookupAppForConversation` at
- * `packages/server/src/app/conversation-app-lookup.ts`):
- *
- * ```
- * SELECT conversations.created_by_id,
- *        tasks.app_id,
- *        tasks.tm_endpoint_address
- * FROM   conversations
- * INNER JOIN tasks ON tasks.id = conversations.task_id
- * WHERE  conversations.id = ?
- * LIMIT  1
- * ```
- *
- * `INNER JOIN` is correct: `conversations.task_id` is `NOT NULL` with
- * an FK to `tasks.id` (post Phase 9b R12), so every conversation joins
- * exactly one task row.
- *
  * Error channel: `ForbiddenError` only.
  *
  * - Conversation row missing → `ForbiddenError` (NOT `NotFoundError`).
@@ -59,22 +38,43 @@ import type { Database } from "../db/database.js";
  *   `"Insufficient permissions"` (preserves the pre-helper wording).
  *
  * SQL execution failures surface as defects via `catchSqlErrorAsDefect`
- * at the call site — the existing convention for service-layer DB
- * reads in this package, mirrored from `requireRole` and
- * `requireParticipant`.
- *
- * Implementation lives downstream (`implement-senior` for prereq 2).
- * The body is `Effect.dieMessage("not implemented")` per the
- * `/safer:architect` Iron rule — the function signature IS the
- * interface and any sketch becomes a ghost implementation downstream
- * copies instead of thinks.
+ * — the existing convention for service-layer DB reads in this package,
+ * mirrored from `requireRole` and `requireParticipant`.
  */
 export function requireConversationAdminAuthority(
   db: Kysely<Database>,
   conversationId: ConversationId,
   callerAgentId: AgentId,
 ): Effect.Effect<void, ForbiddenError, never> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const _stub = { db, conversationId, callerAgentId };
-  return Effect.dieMessage("not implemented");
+  return catchSqlErrorAsDefect(
+    Effect.gen(function* () {
+      const rowOpt = yield* takeFirstOption(
+        db
+          .selectFrom("conversations")
+          .innerJoin("tasks", "tasks.id", "conversations.task_id")
+          .select([
+            "conversations.created_by_id",
+            "tasks.app_id",
+            "tasks.tm_endpoint_address",
+          ])
+          .where("conversations.id", "=", conversationId)
+          .limit(1),
+      );
+      if (Option.isNone(rowOpt)) {
+        return yield* Effect.fail(
+          new ForbiddenError({ message: "Insufficient permissions" }),
+        );
+      }
+      const row = rowOpt.value;
+      const isAuthorized =
+        row.app_id === null
+          ? row.created_by_id === callerAgentId
+          : row.tm_endpoint_address === endpointAddressForAgent(callerAgentId);
+      if (!isAuthorized) {
+        return yield* Effect.fail(
+          new ForbiddenError({ message: "Insufficient permissions" }),
+        );
+      }
+    }),
+  );
 }

--- a/packages/server/src/services/conversation.service.test.ts
+++ b/packages/server/src/services/conversation.service.test.ts
@@ -18,8 +18,15 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Cause, Effect, Exit } from "effect";
-import { JSON_RPC_RESERVED_CODES, NotInContactsError } from "@moltzap/protocol";
-import { wireErrorFromInstance } from "@moltzap/protocol/testing";
+import {
+  ForbiddenError,
+  JSON_RPC_RESERVED_CODES,
+  NotInContactsError,
+} from "@moltzap/protocol";
+import {
+  conversationId as makeConversationId,
+  wireErrorFromInstance,
+} from "@moltzap/protocol/testing";
 import type { Kysely } from "kysely";
 import { KyselyPGlite } from "kysely-pglite";
 import { readFileSync } from "node:fs";
@@ -963,5 +970,227 @@ describe("ConversationService.addParticipant rejects DM conversations", () => {
     );
     const agentIds = rows.map((r) => r.agent_id).sort();
     expect(agentIds).toEqual([alice, bob].sort());
+  });
+});
+
+/**
+ * Prereq 2 (#525): authority gate moved from
+ * `conversation_participants.role` to a hybrid creator-or-TM helper
+ * (`requireConversationAdminAuthority`). These tests pin the new
+ * shape: creator can update/archive/unarchive/add/remove on default
+ * (non-app-bound) conversations; non-creator with the same membership
+ * row is rejected; missing conversation collapses to ForbiddenError
+ * (matching the pre-helper wire-error code on missing rows).
+ */
+describe("ConversationService admin authority (creator gate)", () => {
+  beforeEach(freshDb, dbHookTimeoutMs);
+  afterEach(async () => {
+    await pglite?.close();
+  });
+
+  it("creator can update; non-creator member is denied", async () => {
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(db, participants, connections);
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(authService, "alice");
+    const bob = await seedAgent(authService, "bob");
+    const conv = await createConv(service, "group", "team", [bob], alice);
+
+    await Effect.runPromise(service.update(conv.id, "renamed", alice));
+
+    const exit = await Effect.runPromiseExit(
+      service.update(conv.id, "by-bob", bob),
+    );
+    const failure = expectRpcFailure(exit);
+    expect(failure.code).toBe(ForbiddenError.code);
+  });
+
+  it("creator can archive + unarchive; non-creator member is denied", async () => {
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(db, participants, connections);
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(authService, "alice");
+    const bob = await seedAgent(authService, "bob");
+    const conv = await createConv(service, "group", "team", [bob], alice);
+
+    await Effect.runPromise(service.archive(conv.id, alice));
+    await Effect.runPromise(service.unarchive(conv.id, alice));
+
+    const denyArchive = await Effect.runPromiseExit(
+      service.archive(conv.id, bob),
+    );
+    expect(expectRpcFailure(denyArchive).code).toBe(ForbiddenError.code);
+
+    const denyUnarchive = await Effect.runPromiseExit(
+      service.unarchive(conv.id, bob),
+    );
+    expect(expectRpcFailure(denyUnarchive).code).toBe(ForbiddenError.code);
+  });
+
+  it("creator can remove a participant; non-creator is denied", async () => {
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(db, participants, connections);
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(authService, "alice");
+    const bob = await seedAgent(authService, "bob");
+    const carol = await seedAgent(authService, "carol");
+    const conv = await createConv(
+      service,
+      "group",
+      "team",
+      [bob, carol],
+      alice,
+    );
+
+    const denyByBob = await Effect.runPromiseExit(
+      service.removeParticipant(conv.id, carol, bob),
+    );
+    expect(expectRpcFailure(denyByBob).code).toBe(ForbiddenError.code);
+
+    await Effect.runPromise(service.removeParticipant(conv.id, carol, alice));
+
+    const rows = await Effect.runPromise(
+      db
+        .selectFrom("conversation_participants")
+        .select("agent_id")
+        .where("conversation_id", "=", conv.id),
+    );
+    expect(rows.map((r) => r.agent_id).sort()).toEqual([alice, bob].sort());
+  });
+
+  it("missing conversation collapses to ForbiddenError (not NotFoundError)", async () => {
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(db, participants, connections);
+    const authService = new AuthService(db);
+    const alice = await seedAgent(authService, "alice");
+
+    const fakeConvId = makeConversationId(
+      "00000000-0000-4000-8000-00000000dead",
+    );
+
+    const exit = await Effect.runPromiseExit(
+      service.update(fakeConvId, "x", alice),
+    );
+    expect(expectRpcFailure(exit).code).toBe(ForbiddenError.code);
+  });
+});
+
+/**
+ * Prereq 2 (#525) §4b/§4c: addParticipant/removeParticipant fan out
+ * `participants/added` and `participants/removed` notifications and
+ * (on remove) clear the removed agent's per-connection conversation
+ * subscription set.
+ */
+describe("ConversationService participant fan-out", () => {
+  beforeEach(freshDb, dbHookTimeoutMs);
+  afterEach(async () => {
+    await pglite?.close();
+  });
+
+  function recordingConn(
+    connId: string,
+    agentId: AgentId,
+    sink: string[],
+  ): MoltZapConnection {
+    const auth: AuthenticatedContext = {
+      agentId,
+      agentStatus: "active",
+      ownerUserId: null,
+    };
+    return {
+      id: connId,
+      write: (raw) => Effect.sync(() => void sink.push(raw)),
+      shutdown: noopShutdown,
+      auth,
+      lastPong: Date.now(),
+      conversationIds: new Set<string>(),
+      mutedConversations: new Set<string>(),
+      jsonRpcClient: unusedJsonRpcClient(),
+    };
+  }
+
+  it("addParticipant fires participants/added to every post-insert participant", async () => {
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(db, participants, connections);
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(authService, "alice");
+    const bob = await seedAgent(authService, "bob");
+    const carol = await seedAgent(authService, "carol");
+
+    const aliceSink: string[] = [];
+    const bobSink: string[] = [];
+    const carolSink: string[] = [];
+    connections.add(recordingConn("c-alice", alice, aliceSink));
+    connections.add(recordingConn("c-bob", bob, bobSink));
+
+    const conv = await createConv(service, "group", "team", [bob], alice);
+    aliceSink.length = 0;
+    bobSink.length = 0;
+    connections.add(recordingConn("c-carol", carol, carolSink));
+
+    await Effect.runPromise(service.addParticipant(conv.id, carol, alice));
+    // Yield to the runFork-scheduled writes.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const expectedFragment = '"method":"participants/added"';
+    expect(aliceSink.some((f) => f.includes(expectedFragment))).toBe(true);
+    expect(bobSink.some((f) => f.includes(expectedFragment))).toBe(true);
+    expect(carolSink.some((f) => f.includes(expectedFragment))).toBe(true);
+  });
+
+  it("removeParticipant fires participants/removed to the snapshot list AND clears the removed agent's conn.conversationIds", async () => {
+    const connections = new ConnectionManager();
+    const participants = new ParticipantService(db);
+    const service = new ConversationService(db, participants, connections);
+    const authService = new AuthService(db);
+
+    const alice = await seedAgent(authService, "alice");
+    const bob = await seedAgent(authService, "bob");
+    const carol = await seedAgent(authService, "carol");
+
+    const aliceSink: string[] = [];
+    const bobSink: string[] = [];
+    const carolSink: string[] = [];
+    const aliceConn = recordingConn("c-alice", alice, aliceSink);
+    const bobConn = recordingConn("c-bob", bob, bobSink);
+    const carolConn = recordingConn("c-carol", carol, carolSink);
+    connections.add(aliceConn);
+    connections.add(bobConn);
+    connections.add(carolConn);
+
+    const conv = await createConv(
+      service,
+      "group",
+      "team",
+      [bob, carol],
+      alice,
+    );
+    expect(carolConn.conversationIds.has(conv.id)).toBe(true);
+
+    aliceSink.length = 0;
+    bobSink.length = 0;
+    carolSink.length = 0;
+
+    await Effect.runPromise(service.removeParticipant(conv.id, carol, alice));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const expectedFragment = '"method":"participants/removed"';
+    expect(aliceSink.some((f) => f.includes(expectedFragment))).toBe(true);
+    expect(bobSink.some((f) => f.includes(expectedFragment))).toBe(true);
+    // Removed agent receives the notification too — broadcast happens
+    // BEFORE the conn.conversationIds cleanup.
+    expect(carolSink.some((f) => f.includes(expectedFragment))).toBe(true);
+    // Cleanup: the removed agent's connection no longer holds the
+    // conversation in its subscription set.
+    expect(carolConn.conversationIds.has(conv.id)).toBe(false);
   });
 });

--- a/packages/server/src/services/conversation.service.ts
+++ b/packages/server/src/services/conversation.service.ts
@@ -1,5 +1,5 @@
 import type { Db } from "../db/client.js";
-import type { ConversationType, ParticipantRole } from "../db/database.js";
+import type { ConversationType } from "../db/database.js";
 import type {
   Conversation,
   ConversationParticipant,
@@ -15,9 +15,12 @@ import {
   ForbiddenError,
   NotFoundError,
   NotInContactsError,
+  ParticipantsAddedNotificationDefinition,
+  ParticipantsRemovedNotificationDefinition,
 } from "@moltzap/protocol";
 import { ParticipantService } from "./participant.service.js";
 import type { ConnectionManager } from "../ws/connection.js";
+import { opaquePayload } from "../network/network-send.js";
 import { sql } from "kysely";
 import {
   catchSqlErrorAsDefect,
@@ -26,6 +29,7 @@ import {
   takeFirstOrFail,
   transaction,
 } from "../db/effect-kysely-toolkit.js";
+import { requireConversationAdminAuthority } from "./conversation-admin-authority.js";
 
 export type ConversationServiceError =
   | ConversationArchivedError
@@ -232,21 +236,19 @@ export class ConversationService {
 
             const conversationId = conv.id;
 
-            // Add creator as owner
+            // Add creator
             yield* trx.insertInto("conversation_participants").values({
               conversation_id: conversationId,
               agent_id: creatorAgentId,
-              role: "owner",
             });
 
-            // Add other participants as members
+            // Add other participants
             for (const agentId of agentIds) {
               yield* trx
                 .insertInto("conversation_participants")
                 .values({
                   conversation_id: conversationId,
                   agent_id: agentId,
-                  role: "member",
                 })
                 .onConflict((oc) => oc.doNothing());
             }
@@ -462,7 +464,6 @@ export class ConversationService {
           .select([
             "cp.conversation_id",
             "cp.agent_id",
-            "cp.role",
             "cp.joined_at",
             "cp.last_read_seq",
             "cp.muted_until",
@@ -486,10 +487,11 @@ export class ConversationService {
   ): Effect.Effect<Conversation, ConversationServiceError> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
-        yield* this.requireRole(conversationId, requesterAgentId, [
-          "owner",
-          "admin",
-        ]);
+        yield* requireConversationAdminAuthority(
+          this.db,
+          conversationId,
+          requesterAgentId,
+        );
 
         const rowOpt = yield* takeFirstOption(
           this.db
@@ -516,7 +518,11 @@ export class ConversationService {
   ): Effect.Effect<{ archivedAt: string }, ConversationServiceError> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
-        yield* this.requireRole(conversationId, agentId, ["owner", "admin"]);
+        yield* requireConversationAdminAuthority(
+          this.db,
+          conversationId,
+          agentId,
+        );
 
         const updatedOpt = yield* takeFirstOption(
           this.db
@@ -554,7 +560,11 @@ export class ConversationService {
   ): Effect.Effect<void, ConversationServiceError> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
-        yield* this.requireRole(conversationId, agentId, ["owner", "admin"]);
+        yield* requireConversationAdminAuthority(
+          this.db,
+          conversationId,
+          agentId,
+        );
 
         yield* this.db
           .updateTable("conversations")
@@ -611,10 +621,11 @@ export class ConversationService {
   ): Effect.Effect<ConversationParticipant, ConversationServiceError> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
-        yield* this.requireRole(conversationId, requesterAgentId, [
-          "owner",
-          "admin",
-        ]);
+        yield* requireConversationAdminAuthority(
+          this.db,
+          conversationId,
+          requesterAgentId,
+        );
 
         // DMs are immutable two-party records by protocol invariant.
         // Allowing addParticipant on a type='dm' row would silently turn it
@@ -689,22 +700,35 @@ export class ConversationService {
           );
         }
 
-        const row = yield* takeFirstOrFail(
+        // Insert the row idempotently. With the `role` column dropped
+        // there's no longer a no-op `doUpdateSet({ role: <self> })`
+        // arm to coax the returning-all clause into surfacing the
+        // existing row on conflict; fall back to SELECT after the
+        // insert so the caller-visible mapping still reflects the
+        // already-existing participant when re-adding.
+        const insertedOpt = yield* takeFirstOption(
           this.db
             .insertInto("conversation_participants")
             .values({
               conversation_id: conversationId,
               agent_id: agentId,
-              role: "member",
             })
             .onConflict((oc) =>
-              oc
-                .columns(["conversation_id", "agent_id"])
-                .doUpdateSet({ role: sql`conversation_participants.role` }),
+              oc.columns(["conversation_id", "agent_id"]).doNothing(),
             )
             .returningAll(),
-          "insert did not return row",
         );
+        const row = Option.isSome(insertedOpt)
+          ? insertedOpt.value
+          : yield* takeFirstOrFail(
+              this.db
+                .selectFrom("conversation_participants")
+                .selectAll()
+                .where("conversation_id", "=", conversationId)
+                .where("agent_id", "=", agentId),
+              "participant row vanished after onConflict",
+            );
+        const wasAlreadyMember = Option.isNone(insertedOpt);
 
         // Subscribe the new participant's open sockets to the conversation.
         // Symmetric with `create`: without this, the conversation broadcast
@@ -715,6 +739,28 @@ export class ConversationService {
           [agentId],
           conversationId,
         );
+
+        // Fan out `participants/added` to every post-insert participant
+        // (the just-added agent included — its connections were just
+        // subscribed above). Sourced at the service layer so future
+        // non-RPC writers (e.g. lease-registry admit) share one fan-out
+        // site. No `forConversation` gate: redundant after the
+        // subscribeAgentsToConversation call above, and skipping the
+        // gate keeps membership-state notifications independent of the
+        // mute filter. Skip the broadcast on the idempotent re-add path
+        // so callers don't receive a phantom "participants/added"
+        // notification for an existing member.
+        if (!wasAlreadyMember) {
+          const participants =
+            yield* this.getParticipantAgentIds(conversationId);
+          yield* this.broadcastParticipantsAdded(
+            conversationId,
+            participants,
+            agentId,
+            requesterAgentId,
+            row.joined_at,
+          );
+        }
 
         return this.mapParticipant(row);
       }),
@@ -728,24 +774,53 @@ export class ConversationService {
   ): Effect.Effect<void, ConversationServiceError> {
     return catchSqlErrorAsDefect(
       Effect.gen(this, function* () {
-        yield* this.requireRole(conversationId, requesterAgentId, [
-          "owner",
-          "admin",
-        ]);
+        yield* requireConversationAdminAuthority(
+          this.db,
+          conversationId,
+          requesterAgentId,
+        );
+
+        // Snapshot BEFORE delete so the about-to-be-removed agent stays
+        // in the fan-out target list. The membership row is still live
+        // at this point so the snapshot includes them.
+        const participantsSnapshot =
+          yield* this.getParticipantAgentIds(conversationId);
 
         const deleted = yield* this.db
           .deleteFrom("conversation_participants")
           .where("conversation_id", "=", conversationId)
           .where("agent_id", "=", agentId)
-          .where("role", "=", "member")
           .returning("conversation_id");
 
         if (deleted.length === 0) {
           return yield* Effect.fail(
             new NotFoundError({
-              message: "Participant not found or cannot be removed",
+              message: "Participant not found",
             }),
           );
+        }
+
+        // Broadcast BEFORE clearing the removed agent's per-connection
+        // subscription set so the broadcast walk reaches its still-
+        // subscribed sockets. No `forConversation` gate: the same
+        // ordering reason (the conversationIds set is about to be
+        // cleared) plus membership-state notifications stay
+        // independent of the mute filter.
+        const removedAt = new Date();
+        yield* this.broadcastParticipantsRemoved(
+          conversationId,
+          participantsSnapshot,
+          agentId,
+          requesterAgentId,
+          removedAt,
+        );
+
+        // Cleanup AFTER broadcast: drop the conversation from each of
+        // the removed agent's open sockets so future conversation
+        // broadcasts (`messages/received`, `conversations/archived`,
+        // etc.) skip them via the `forConversation` gate.
+        for (const conn of this.connections.getByAgent(agentId)) {
+          conn.conversationIds.delete(conversationId);
         }
       }),
     );
@@ -852,33 +927,87 @@ export class ConversationService {
     );
   }
 
-  private requireRole(
+  /**
+   * Direct connection-level fan-out for `participants/added`. Mirrors
+   * `subscribeAgentsToConversation`'s pattern of iterating the
+   * already-injected ConnectionManager rather than routing through
+   * `NetworkSendService.broadcast`: the architect plan (#525 §2.2)
+   * keeps this service's constructor at four parameters, and the
+   * fan-out for membership-state notifications doesn't need
+   * NetworkSendService's endpoint-resolution machinery — every
+   * conversation participant is by construction an `AgentId` whose
+   * deliveries route over WS connections this manager already owns.
+   */
+  private broadcastParticipantsAdded(
     conversationId: ConversationId,
-    agentId: AgentId,
-    allowedRoles: string[],
-  ): Effect.Effect<void, ForbiddenError> {
-    return catchSqlErrorAsDefect(
-      Effect.gen(this, function* () {
-        const rowOpt = yield* takeFirstOption(
-          this.db
-            .selectFrom("conversation_participants")
-            .select("role")
-            .where("conversation_id", "=", conversationId)
-            .where("agent_id", "=", agentId),
-        );
+    targetAgentIds: readonly AgentId[],
+    addedAgentId: AgentId,
+    addedBy: AgentId,
+    addedAt: Date,
+  ): Effect.Effect<void> {
+    return Effect.sync(() => {
+      const frame = ParticipantsAddedNotificationDefinition.encode({
+        conversationId,
+        agentId: addedAgentId,
+        addedBy,
+        addedAt: addedAt.toISOString(),
+      });
+      const payload = opaquePayload(JSON.stringify(frame));
+      this.fanOutToAgents(targetAgentIds, payload);
+    });
+  }
 
-        if (Option.isNone(rowOpt)) {
-          return yield* Effect.fail(
-            new ForbiddenError({ message: MSG_NOT_A_PARTICIPANT }),
-          );
-        }
-        if (!allowedRoles.includes(rowOpt.value.role)) {
-          return yield* Effect.fail(
-            new ForbiddenError({ message: "Insufficient permissions" }),
-          );
-        }
-      }),
-    );
+  /**
+   * Direct connection-level fan-out for `participants/removed`. See
+   * {@link broadcastParticipantsAdded} for the rationale on bypassing
+   * NetworkSendService.
+   */
+  private broadcastParticipantsRemoved(
+    conversationId: ConversationId,
+    targetAgentIds: readonly AgentId[],
+    removedAgentId: AgentId,
+    removedBy: AgentId,
+    removedAt: Date,
+  ): Effect.Effect<void> {
+    return Effect.sync(() => {
+      const frame = ParticipantsRemovedNotificationDefinition.encode({
+        conversationId,
+        agentId: removedAgentId,
+        removedBy,
+        removedAt: removedAt.toISOString(),
+      });
+      const payload = opaquePayload(JSON.stringify(frame));
+      this.fanOutToAgents(targetAgentIds, payload);
+    });
+  }
+
+  /**
+   * Iterate every connection of every named agent and write the payload
+   * fork-and-forget. Mirrors `NetworkSendService.broadcast`'s socket
+   * write loop without the endpoint-resolution layer. No
+   * `forConversation` gate by design — see the broadcast helpers above.
+   */
+  private fanOutToAgents(
+    agentIds: readonly AgentId[],
+    payload: ReturnType<typeof opaquePayload>,
+  ): void {
+    for (const agentId of agentIds) {
+      for (const conn of this.connections.getByAgent(agentId)) {
+        if (conn.auth === null) continue;
+        const connId = conn.id;
+        Effect.runFork(
+          conn
+            .write(payload)
+            .pipe(
+              Effect.catchAll((cause) =>
+                Effect.logWarning(
+                  "participants notification: socket write failed",
+                ).pipe(Effect.annotateLogs({ connId, cause: String(cause) })),
+              ),
+            ),
+        );
+      }
+    }
   }
 
   /**
@@ -1033,7 +1162,6 @@ export class ConversationService {
   private mapParticipant(row: {
     conversation_id: ConversationId;
     agent_id: AgentId;
-    role: ParticipantRole;
     joined_at: Date;
     last_read_seq: string;
     muted_until: Date | null;
@@ -1047,7 +1175,6 @@ export class ConversationService {
         type: "agent" as const,
         id: row.agent_id,
       },
-      role: row.role,
       joinedAt: row.joined_at.toISOString(),
       lastReadMessageId:
         row.last_read_message_id == null ? undefined : row.last_read_message_id,

--- a/packages/server/src/task/handlers/conversations.handlers.ts
+++ b/packages/server/src/task/handlers/conversations.handlers.ts
@@ -216,9 +216,10 @@ export function createConversationHandlers(deps: {
             targetAgentId,
             ctx.agentId,
           );
-          for (const conn of deps.connections.getByAgent(targetAgentId)) {
-            conn.conversationIds.add(params.conversationId);
-          }
+          // Per architect plan §2 module 7: the redundant
+          // `getByAgent(...)` subscription loop dropped — the service
+          // already calls `subscribeAgentsToConversation` in
+          // `addParticipant`, so the handler-side loop was dead.
           return { participant };
         }),
     }),

--- a/packages/server/src/task/handlers/tasks.handlers.ts
+++ b/packages/server/src/task/handlers/tasks.handlers.ts
@@ -13,6 +13,7 @@ import {
   TasksStoreMessage,
   type TmType,
 } from "@moltzap/protocol";
+import { InvalidParamsError } from "../../runtime/index.js";
 import { type EndpointAddress } from "@moltzap/protocol/network";
 import {
   DEFAULT_DM_TM_ADDRESS,
@@ -62,6 +63,23 @@ export function createTaskHandlers(deps: {
     defineTaskMethod(TasksCreate, {
       handler: (params, ctx) =>
         Effect.gen(function* () {
+          // Prereq 2 (#525 §4d): app-bound tasks always carry their
+          // own moderator (the TM IS the app), so pairing an `appId`
+          // with a `default-*` TM kind is a nonsense shape. Reject at
+          // the wire boundary with `InvalidParamsError` instead of
+          // letting it through and silently routing dispatch to one
+          // of the in-process default-TM constants.
+          if (
+            params.appId !== undefined &&
+            (params.tmType === "default-dm" ||
+              params.tmType === "default-group")
+          ) {
+            return yield* Effect.fail(
+              new InvalidParamsError({
+                message: "app-bound tasks cannot use a default TM",
+              }),
+            );
+          }
           // Phase 9b consumer-migration (sub-issue #460 round 4 R16,
           // codex HIGH-A): the wire body carries `tmType` (a kind
           // marker), not a raw address. The handler derives the


### PR DESCRIPTION
## Summary

Prereq 2 of dispatch reshape epic #512. Drops the `conversation_participants.role` column and the `requireRole(["owner","admin"])` gate on five conversation-admin RPCs. Replaces with one hybrid `requireConversationAdminAuthority` helper that branches on `task.app_id IS NULL` (creator-gate vs TM-gate). Adds the missing `participants/added` and `participants/removed` notifications. Tightens `tasks/create` validation. Converts the `app_id NOT NULL + no hook` runtime fall-through from default-grant to synthesized infra-hold.

## Plan anchors

| Change | Plan anchor |
|---|---|
| Body of `requireConversationAdminAuthority` (`packages/server/src/services/conversation-admin-authority.ts`) — INNER JOIN `conversations` × `tasks`, branch on `app_id IS NULL` | §3 + §4a |
| 5 admin call sites in `ConversationService` (`update`, `archive`, `unarchive`, `addParticipant`, `removeParticipant`) wired to the new helper; private `requireRole` deleted | §2.2 |
| Drop `role` from `mapParticipant`, `get`, `create` inserts, and the `addParticipant.onConflict` clause; drop `member`-only target restriction in `removeParticipant` | §2.2 |
| `addParticipant` / `removeParticipant` fan out `participants/added` / `participants/removed`; remove path snapshots-before-delete, broadcasts-before-cleanup | §4b + §4c |
| Drop `role` column + `participant_role` enum in `core-schema.sql`; regen `database.generated.ts`; drop re-export in `db/database.ts` | §2.3 + §2.4 + observation #1 |
| Drop `ParticipantRoleEnum` + `role` field in `ConversationParticipantSchema`; add `Participants{Added,Removed}NotificationDefinition`; export from `methods.ts` + `index.ts` | §2.5 + §2.6 + §3 |
| `tasks/create` rejects `appId !== undefined && tmType in {"default-dm","default-group"}` with `InvalidParamsError` at the wire boundary | §2.8 + §4d |
| `app-host.ts` AppBound + no hook registered → `{decision:"hold", reason:"moderator_unavailable"}` (was `"grant"`) | §2.9 + §4e |
| Drop redundant `getByAgent` subscription loop in `ConversationsAddParticipant` handler — service already does `subscribeAgentsToConversation` | §2.7 |
| Test fixture audit: `04-group-chat`, `28-conversations-get` strip `role` from casts/asserts; `35-conversations-archive` drops two obsolete fixtures (admin-promoted + concurrent-two-callers); `51-app-session-scoping` adds AppBound-no-hook → hold integration test | §7 |

## Scope

- Modules touched: 13 (5 in protocol, 8 in server)
- New modules: 0
- New public signatures outside the plan: 0 (the `requireConversationAdminAuthority` body + 2 notification definitions are all named in §3)
- New deps: 0

## Tests

- 6 new unit tests in `conversation.service.test.ts`: creator can update / archive+unarchive / removeParticipant; non-creator member denied; missing-conversation collapses to ForbiddenError; addParticipant fires `participants/added` to all post-insert participants; removeParticipant fires `participants/removed` to the snapshot list AND clears the removed agent's `conn.conversationIds`.
- 1 new integration test in `51-app-session-scoping`: AppBound + no hook → `hold` with `reason:"moderator_unavailable"`.
- 3 fixture-audit cleanups in `04`, `28`, `35` per architect §7.

Targeted run (15 files / 134 tests) GREEN. Full server test run flaked on 7 unrelated `freshDb()` pglite hook timeouts (30s) under high vitest concurrency — re-running each in isolation passes; these are environmental, not code defects.

## Pre-PR hygiene

- `/safer:simplify`: applied — factored fan-out into shared `fanOutToAgents` helper; consolidated broadcast helpers.
- `/safer:review`: applied — added structured Effect.logWarning for socket-write failures (mirrors NetworkSendService's logging contract); kept `forConversation` gate explicitly absent on membership-state notifications per §4c. No deferred findings.

## Behavior shifts (intentional, per plan §9)

- `removeParticipant` no longer enforces `member`-only target — creator may now self-remove via the RPC (collapses to "leave" semantics for default conversations). Per architect plan §9 OQ#1.
- AppBound + no hook now holds the dispatch (was: granted). Recipient parking machinery catches the held head; restarted moderator sees real verdicts on retry.

## Acceptance
- [x] `requireConversationAdminAuthority` helper at `packages/server/src/services/conversation-admin-authority.ts`.
- [x] 5 `requireRole(["owner","admin"])` call sites replaced.
- [x] Private `requireRole` method deleted.
- [x] `member`-only target restriction in `removeParticipant` dropped.
- [x] `role` column dropped from `core-schema.sql`; `participant_role` enum dropped.
- [x] `database.generated.ts` regenerated.
- [x] `ParticipantRoleEnum` + `role` field dropped from `ConversationParticipantSchema`.
- [x] `participants/added` + `participants/removed` notification definitions added; service-side fan-out wired.
- [x] `tasks/create` rejects `appId !== undefined && tmType: "default-*"`.
- [x] `app-host.ts` runtime fall-through → `decision:"hold", reason:"moderator_unavailable"`.
- [x] Existing tests passing with `role` removed (architect §7 audit applied).
- [x] `pnpm build` GREEN.
- [x] `pnpm test` GREEN on changed surface (targeted 134/134; full-run flake is unrelated pglite hook timeouts).
- [x] `/safer:simplify` and `/safer:review` ran; findings applied in-PR.

## Confidence

HIGH — plan-anchored line-by-line, all module paths from architect §2 hit, helper SQL shape matches plan §4a, fan-out ordering matches §4c. Targeted-run tests pass clean.

Closes #526.
Refs #525 (architect plan), #512 (epic).