### PR TITLE
chore(conformance): drop closed-#186 backpressure tombstone

### DIFF
--- a/packages/protocol/scripts/check-divergence-proofs.sh
+++ b/packages/protocol/scripts/check-divergence-proofs.sh
@@ -58,7 +58,6 @@ legacy_exempt_registrars=(
   registerHookGatedDelivery
   registerMultiAppFifoShortCircuit
   registerLatencyResilience
-  registerBackpressure
   registerSlicerFraming
   registerResetPeerRecovery
   registerTimeoutSurface

--- a/packages/protocol/src/testing/conformance/adversity.ts
+++ b/packages/protocol/src/testing/conformance/adversity.ts
@@ -29,7 +29,6 @@ import { isNotificationFrame } from "../codec.js";
 import { TransportClosedError } from "../errors.js";
 import type { ConformanceRunContext } from "./runner.js";
 import {
-  PropertyDeferred,
   PropertyInvariantViolation,
   PropertyUnavailable,
   registerProperty,
@@ -265,23 +264,6 @@ export function registerLatencyResilience(ctx: ConformanceRunContext): void {
         }
       }),
   });
-}
-
-/** Backpressure — DEFERRED to epic #186. */
-export function registerBackpressure(ctx: ConformanceRunContext): void {
-  registerProperty(
-    ctx,
-    CATEGORY,
-    "backpressure",
-    "backpressure property deferred to #186 — BackpressurePolicy not extant",
-    Effect.fail(
-      new PropertyDeferred({
-        category: CATEGORY,
-        name: "backpressure",
-        followUp: "https://github.com/chughtapan/moltzap/issues/186",
-      }),
-    ),
-  );
 }
 
 /**

--- a/packages/protocol/src/testing/conformance/client/adversity.ts
+++ b/packages/protocol/src/testing/conformance/client/adversity.ts
@@ -8,8 +8,6 @@
  *   D5 — adversity-timeout
  *   D6 — adversity-slow-close
  *
- * D2 (backpressure) tombstoned to #186 (same as server side).
- *
  * Typed-error precision (O6 resolution):
  *   - D5: spec names `RpcTimeoutError`. Predicate asserts
  *     `documentedErrorTag === "RpcTimeoutError"`.

--- a/packages/protocol/src/testing/conformance/delivery.ts
+++ b/packages/protocol/src/testing/conformance/delivery.ts
@@ -504,16 +504,16 @@ function fixture_n(requested: number): number {
  * **basic-delivery-landing** — the weaker invariant that N messages
  * sent to a live conversation land in every currently-subscribed
  * participant's capture buffer. The full offline-replay assertion is
- * tracked as a follow-up under epic #186. If/when the server
- * implements C2 replay, flip this body back to the reconnect form
- * from the git history and remove the #186 pointer.
+ * not tracked: epic #186 (which named C2 replay as a follow-up) was
+ * closed as won't-do. If C2 replay is reintroduced, restore the
+ * reconnect-form body from git history.
  */
 export function registerStoreAndReplay(ctx: ConformanceRunContext): void {
   registerProperty(
     ctx,
     CATEGORY,
     STORE_AND_REPLAY_PROPERTY,
-    "every messages/send lands in a live participant's capture buffer (basic-delivery-landing; #186 tracks C2 offline-replay)",
+    "every messages/send lands in a live participant's capture buffer (basic-delivery-landing; offline-replay not tracked, #186 closed)",
     Effect.scoped(
       Effect.gen(function* () {
         const fixture = yield* acquireConversation(ctx, 1, "sr").pipe(

--- a/packages/protocol/src/testing/conformance/registry.ts
+++ b/packages/protocol/src/testing/conformance/registry.ts
@@ -55,7 +55,7 @@ export class PropertyUnavailable extends Data.TaggedError(
   readonly reason: string;
 }> {}
 
-/** Property is a tombstone for deferred work (e.g. #186 backpressure). */
+/** Property is a tombstone for deferred work tracked under a follow-up issue. */
 export class PropertyDeferred extends Data.TaggedError(
   "ConformancePropertyDeferred",
 )<{

--- a/packages/protocol/src/testing/conformance/suite.ts
+++ b/packages/protocol/src/testing/conformance/suite.ts
@@ -122,7 +122,6 @@ export function registerAllProperties(ctx: ConformanceRunContext): void {
   delivery.registerArchiveLifecycle(ctx);
 
   adversity.registerLatencyResilience(ctx);
-  adversity.registerBackpressure(ctx); // tombstoned — #186
   adversity.registerSlicerFraming(ctx);
   adversity.registerResetPeerRecovery(ctx);
   adversity.registerTimeoutSurface(ctx);
@@ -286,11 +285,6 @@ function allowedServerCoverageGaps(
   toxiproxyUrl: string | null,
 ): ReadonlyArray<AllowedCoverageGap> {
   const gaps: AllowedCoverageGap[] = [
-    {
-      kind: "deferred",
-      id: "adversity/backpressure",
-      reasonIncludes: "issues/186",
-    },
     {
       kind: "unavailable",
       id: "adversity/reset-peer-recovery",


### PR DESCRIPTION
## Summary

#186 ("Epic: Deferred conformance properties — D2 backpressure + E1 humanContact SIGKILL") is closed as won't-do. The `adversity/backpressure` property registered a pure tombstone (`Effect.fail(new PropertyDeferred(...))`) pointing to the closed ticket; the suite's allowed-coverage-gaps registry kept it as a stale deferral.

## Changes

- DELETE `registerBackpressure` function in `adversity.ts` + its registration call in `suite.ts`
- DELETE `adversity/backpressure` entry from suite.ts allowed-coverage-gaps
- DELETE `registerBackpressure` from `check-divergence-proofs.sh` legacy-exempt list
- DELETE `D2 backpressure tombstoned to #186` doc comment in `client/adversity.ts`
- DROP unused `PropertyDeferred` import from adversity.ts
- UPDATE `delivery.ts` store-and-replay property's #186 forward-pointer (C2 offline-replay was also tracked under #186) to historical context — property body unchanged
- UPDATE `registry.ts` `PropertyDeferred` docstring to drop the #186-backpressure example

## Verification

- `pnpm -F @moltzap/protocol build` GREEN
- `pnpm -F @moltzap/server-core test:conformance`: **passed=44 deferred=4 unavailable=1 failed=0** (was deferred=5)
- Pre-commit hooks GREEN (no `--no-verify`)

## Follow-up

#186 closes as won't-do alongside this PR. The remaining 4 deferrals all trace to closed #318 — separate cleanup pending the layered-test-restructure conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)