### PR TITLE
[arch] Phase 2A r2 — server source reshape (4-sub-PR sequence)

### DIFF
--- a/packages/protocol/src/transport/json-rpc-server.ts
+++ b/packages/protocol/src/transport/json-rpc-server.ts
@@ -20,26 +20,36 @@ import {
 
 type AnyRpcDefinition = RpcDefinition<string, TSchema, TSchema>;
 
-export interface RpcHandler<Ctx = unknown> {
+/**
+ * `R` is the handler's Effect requirement environment — the union of
+ * service Tags the body pulls via `yield*`. Defaults to `never` so the
+ * existing `RpcHandler<Ctx>` shape continues to compile against
+ * pre-Phase-2A handlers (R=never). Phase 2A r2 §3 widens this so
+ * downstream handlers can carry service Tags structurally; the
+ * dispatcher's `ManagedRuntime` resolves R at request time.
+ */
+export interface RpcHandler<Ctx = unknown, R = never> {
   readonly definition: AnyRpcDefinition;
   readonly handle: (
     params: unknown,
     ctx: Ctx,
-  ) => Effect.Effect<unknown, unknown>;
+  ) => Effect.Effect<unknown, unknown, R>;
 }
 
-/** Build an `RpcHandler<Ctx>` with definition-typed params/result. The
- * cast erases to `unknown` for storage; `decodeRpcParams` produces a
- * `ParamsOf<D>`-shaped value at runtime, so the erasure is safe. */
-export const handler = <D extends AnyRpcDefinition, Ctx>(
+/** Build an `RpcHandler<Ctx, R>` with definition-typed params/result. The
+ * cast erases A and E to `unknown` for storage; `decodeRpcParams` produces
+ * a `ParamsOf<D>`-shaped value at runtime, so the erasure is safe. R is
+ * preserved through the storage type so the dispatcher's runtime can
+ * resolve it. */
+export const handler = <D extends AnyRpcDefinition, Ctx, R = never>(
   definition: D,
   handle: (
     params: ParamsOf<D>,
     ctx: Ctx,
-  ) => Effect.Effect<ResultOf<D>, unknown>,
-): RpcHandler<Ctx> => ({
+  ) => Effect.Effect<ResultOf<D>, unknown, R>,
+): RpcHandler<Ctx, R> => ({
   definition,
-  handle: handle as RpcHandler<Ctx>["handle"],
+  handle: handle as RpcHandler<Ctx, R>["handle"],
 });
 
 /** Pino-shaped logger; pass `null` for silent dispatch. */
@@ -50,19 +60,23 @@ export interface RpcLogger {
 }
 
 /** Responder side of a JSON-RPC connection. `handle` validates params,
- * dispatches the handler, and maps the Effect to a wire `ResponseFrame`. */
-export interface JsonRpcServer<Ctx = unknown> {
+ * dispatches the handler, and maps the Effect to a wire `ResponseFrame`.
+ *
+ * `R` carries the union of all bound handlers' service Tag requirements
+ * so the dispatch site (the WS frame loop) can resolve R via the
+ * server's `ManagedRuntime`. Defaults to `never` for back-compat. */
+export interface JsonRpcServer<Ctx = unknown, R = never> {
   readonly handle: (
     frame: RequestFrame,
     ctx: Ctx,
-  ) => Effect.Effect<ResponseFrame>;
+  ) => Effect.Effect<ResponseFrame, never, R>;
 }
 
-export const makeJsonRpcServer = <Ctx = unknown>(
-  handlers: ReadonlyArray<RpcHandler<Ctx>>,
+export const makeJsonRpcServer = <Ctx = unknown, R = never>(
+  handlers: ReadonlyArray<RpcHandler<Ctx, R>>,
   logger: RpcLogger | null = null,
-): JsonRpcServer<Ctx> => {
-  const handlerByMethod = new Map<JsonRpcMethod, RpcHandler<Ctx>>();
+): JsonRpcServer<Ctx, R> => {
+  const handlerByMethod = new Map<JsonRpcMethod, RpcHandler<Ctx, R>>();
   for (const h of handlers) {
     handlerByMethod.set(h.definition.name, h);
   }
@@ -70,7 +84,7 @@ export const makeJsonRpcServer = <Ctx = unknown>(
   const handle = (
     frame: RequestFrame,
     ctx: Ctx,
-  ): Effect.Effect<ResponseFrame> =>
+  ): Effect.Effect<ResponseFrame, never, R> =>
     Effect.gen(function* () {
       const handler = handlerByMethod.get(frame.method);
       if (handler === undefined) {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,6 +26,26 @@
     "./test-utils": {
       "import": "./dist/test-utils/index.js",
       "types": "./dist/test-utils/index.d.ts"
+    },
+    "./transport": {
+      "import": "./dist/transport/index.js",
+      "types": "./dist/transport/index.d.ts"
+    },
+    "./identity": {
+      "import": "./dist/identity/index.js",
+      "types": "./dist/identity/index.d.ts"
+    },
+    "./network": {
+      "import": "./dist/network/index.js",
+      "types": "./dist/network/index.d.ts"
+    },
+    "./task": {
+      "import": "./dist/task/index.js",
+      "types": "./dist/task/index.d.ts"
+    },
+    "./app": {
+      "import": "./dist/app/index.js",
+      "types": "./dist/app/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/server/src/app/README.md
+++ b/packages/server/src/app/README.md
@@ -1,0 +1,32 @@
+# app/
+
+App-host, app registration, lease registry, top-level server boot, layer composition.
+
+## Layer rules
+
+| Direction | Allowed |
+|---|---|
+| Imports FROM | kernels, transport, identity, network, task |
+| Imports TO   | (none — app is the top protocol layer) |
+
+## Files (no folder moves in 2A.2)
+
+- `app-host.ts`
+- `config.ts`
+- `conversation-app-lookup.ts`
+- `core-schema.sql`
+- `dev.ts`
+- `handlers/apps.handlers.ts`
+- `hooks.ts`
+- `layers.ts` — Tag definitions + Layer composition for the whole stack
+- `lease-registry.ts`
+- `server.ts` — `createCoreApp`; entry to the dispatcher
+- `types.ts`
+
+## Handler shape (post-2A.0)
+
+`apps.handlers.ts` follows the same `Effect.gen { yield* AppHostTag; ... }` pattern as the task and identity handlers.
+
+## layers.ts ownership
+
+Tag definitions and Layer composition stay in `app/layers.ts` even after the move. Tags name what services exist; Layers wire the dependency order. Both are app-layer concerns (the composition root).

--- a/packages/server/src/app/index.ts
+++ b/packages/server/src/app/index.ts
@@ -1,0 +1,12 @@
+/**
+ * `app/` — top protocol layer. AppHost, app registration, lease registry,
+ * server boot, layer composition.
+ *
+ * Layer rules:
+ *   - May import: kernels and every other protocol layer.
+ *   - May NOT be imported by: any protocol layer (app is the composition root).
+ *
+ * Public surface: `createCoreApp`, `AppHost`, `LeaseRegistry`, all Tag and
+ * Layer constructors from `layers.ts`, app-host handler registry.
+ */
+export {};

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -28,6 +28,8 @@ import type {
   DispatchContext,
   RpcMethodRegistry,
 } from "../rpc/context.js";
+import type { AppTags } from "../rpc/layer-tags.js";
+import type { ConnIdTag } from "./layers.js";
 import type { JsonRpcId, RequestFrame, ResponseFrame } from "@moltzap/protocol";
 import {
   JSON_RPC_RESERVED_CODES,
@@ -304,7 +306,10 @@ export function createCoreApp(config: CoreConfig): CoreApp {
     ...createPingHandlers(),
   ];
 
-  const jsonRpcServer = makeJsonRpcServer<DispatchContext>(methods, logger);
+  const jsonRpcServer = makeJsonRpcServer<
+    DispatchContext,
+    Exclude<AppTags, ConnIdTag>
+  >(methods, logger);
 
   // ── HTTP routes via @effect/platform HttpRouter ──────────────────────
 
@@ -548,7 +553,7 @@ export function createCoreApp(config: CoreConfig): CoreApp {
    * Lives inside the per-request fiber; returning exits the connection. */
   const handleSocket = (
     socket: Socket.Socket,
-  ): Effect.Effect<void, Socket.SocketError> =>
+  ): Effect.Effect<void, Socket.SocketError, Exclude<AppTags, ConnIdTag>> =>
     Effect.scoped(
       Effect.gen(function* () {
         const connId = crypto.randomUUID();
@@ -661,6 +666,11 @@ export function createCoreApp(config: CoreConfig): CoreApp {
               return;
             }
             const auth = conn.auth ?? ({} as AuthenticatedContext);
+            // Phase 2A r2 §3: dispatcher's `handle` carries
+            // `Exclude<AppTags, ConnIdTag>` in its R-channel (handlers
+            // may yield service Tags after the DI migration). The
+            // dispatch fiber's runtime (built below from `FullLive`)
+            // resolves R structurally; no per-frame `Effect.provide`.
             const response = yield* jsonRpcServer.handle(frame, {
               auth,
               connId,
@@ -821,8 +831,16 @@ export function createCoreApp(config: CoreConfig): CoreApp {
   // Server lifecycle: `NodeHttpServer.make` acquires an http.Server inside a
   // Scope we own (`appScope`); closing the scope on shutdown tears down the
   // listener, the wired upgrade handler, and any per-connection fibers.
+  //
+  // Phase 2A r2 §3: the dispatch fibers run with `FullLive` in scope so
+  // RPC handler bodies that `yield* XServiceTag` resolve via the
+  // managed runtime rather than via per-frame `Effect.provide`. The
+  // `BaseLive`-wired services (Db, Encryption, SessionValidator,
+  // WebhookClient, DeliveryWebhook, TraceCapture, Logger) come along
+  // for free since `FullLive = Layer.provideMerge(ServicesLive,
+  // BaseLive)`.
   const runtime = ManagedRuntime.make(
-    Layer.mergeAll(NodeHttpServer.layerContext, LoggerLive),
+    Layer.mergeAll(NodeHttpServer.layerContext, FullLive),
   );
   const appScope = Effect.runSync(Scope.make());
 

--- a/packages/server/src/identity/README.md
+++ b/packages/server/src/identity/README.md
@@ -1,0 +1,38 @@
+# identity/
+
+Registration, claim, login, contacts, participants, agent visibility.
+
+## Layer rules
+
+| Direction | Allowed |
+|---|---|
+| Imports FROM | kernels, transport |
+| Imports TO   | network, task, app |
+
+## Files (populated in 2A.2)
+
+- `services/auth.service.ts` (from `services/`)
+- `services/contact.service.ts` (from `services/`)
+- `services/participant.service.ts` (from `services/`)
+- `services/agent-visibility.ts` (from `services/`)
+- `services/session-validator.ts` (from `services/`)
+- `services/agent-auth.ts` (from `auth/`)
+- `handlers/auth.handlers.ts` (from `network/handlers/` — identity-conceptual)
+
+## Handler shape (post-2A.0)
+
+Handlers do NOT take `deps` arguments. Service access is via Tag:
+
+```ts
+defineNetworkMethod(Connect, {
+  handler: (params, ctx) =>
+    Effect.gen(function* () {
+      const auth = yield* AuthServiceTag;
+      const contacts = yield* ContactsServiceTag;
+      // ...
+    }),
+});
+```
+
+Boot wires `ServicesLive` into the dispatcher's `ManagedRuntime`; per-request
+`ConnIdTag` is provided by the JSON-RPC dispatcher.

--- a/packages/server/src/identity/handlers/index.ts
+++ b/packages/server/src/identity/handlers/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Identity handler registry exports.
+ *
+ * Populated in 2A.2 with `auth.handlers.ts` (Connect, AgentsLookup,
+ * AgentsLookupByName, AgentsList) moved from `network/handlers/`.
+ *
+ * Handler shape (post-2A.0): each entry is an `Effect<RpcMethodRegistry, never, R>`
+ * where R is the union of service Tags the handler pulls via `yield*`.
+ */
+export {};

--- a/packages/server/src/identity/index.ts
+++ b/packages/server/src/identity/index.ts
@@ -1,0 +1,17 @@
+/**
+ * `identity/` — registration, claim, login, contacts, participants, agent visibility.
+ *
+ * Owns: agents, owners, contacts, participants, session validators, agent-visibility
+ * decisions, agent-auth (admin claim flow), and the identity-conceptual handlers
+ * (Connect, AgentsLookup, AgentsLookupByName, AgentsList).
+ *
+ * Layer rules:
+ *   - May import: kernels + transport.
+ *   - May NOT import: network, task, app.
+ *
+ * Public surface: `AuthService`, `ContactsService`, `ParticipantService`,
+ * `SessionValidator`, `agentVisibility`, identity handler registries.
+ *
+ * Populated in 2A.2 (folder moves). Empty in 2A.1.
+ */
+export {};

--- a/packages/server/src/identity/services/index.ts
+++ b/packages/server/src/identity/services/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Identity service exports.
+ *
+ * Populated in 2A.2 with: `auth.service.ts`, `contact.service.ts`,
+ * `participant.service.ts`, `agent-visibility.ts`, `session-validator.ts`,
+ * `agent-auth.ts` (from `services/` and `auth/`).
+ *
+ * Each service is exposed via its Tag from `app/layers.ts` (Tag stays at
+ * `app/layers.ts` per the cohesion rule — Tag definitions belong with
+ * Layer composition).
+ */
+export {};

--- a/packages/server/src/network/README.md
+++ b/packages/server/src/network/README.md
@@ -1,0 +1,31 @@
+# network/
+
+Connect, presence, app-TM registry, agent-endpoint resolution, outbound `send` and `broadcast`.
+
+## Layer rules
+
+| Direction | Allowed |
+|---|---|
+| Imports FROM | kernels, transport, identity |
+| Imports TO   | task, app |
+
+## Files
+
+Already in tree (kept at `network/` root):
+- `agent-endpoint-resolver.ts`
+- `app-tm-registry.ts`
+- `network-send.ts`
+
+Subdirs:
+- `handlers/` — `ping.handlers.ts` (today); auth.handlers.ts moves OUT to `identity/handlers/` in 2A.2.
+- `services/` — `presence.service.ts`, `presence-event-sink.ts` move IN from `services/` in 2A.2.
+
+## Handler shape (post-2A.0)
+
+```ts
+defineNetworkMethod(Ping, {
+  handler: () => Effect.succeed({ pong: true }),
+});
+```
+
+No deps argument. Tags resolved by the dispatcher's `ManagedRuntime`.

--- a/packages/server/src/network/index.ts
+++ b/packages/server/src/network/index.ts
@@ -1,0 +1,13 @@
+/**
+ * `network/` — Connect, presence, app-TM registry, agent-endpoint resolution,
+ * outbound `send`/`broadcast`.
+ *
+ * Layer rules:
+ *   - May import: kernels, transport, identity.
+ *   - May NOT import: task, app.
+ *
+ * Public surface (post-2A.2): `AgentEndpointResolver`, `AppTmRegistry`,
+ * `NetworkSendService`, `PresenceService`, presence event sink, network
+ * handler registries.
+ */
+export {};

--- a/packages/server/src/network/services/index.ts
+++ b/packages/server/src/network/services/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Network service exports.
+ *
+ * Populated in 2A.2 with: `presence.service.ts`, `presence-event-sink.ts`
+ * (from `services/`).
+ *
+ * Existing network services (`agent-endpoint-resolver.ts`,
+ * `app-tm-registry.ts`, `network-send.ts`) stay at `network/` top level —
+ * they are not "services" by the same naming convention. The `services/`
+ * subdir captures only the presence pair that crossed over from the
+ * old `services/` folder.
+ */
+export {};

--- a/packages/server/src/rpc/README.md
+++ b/packages/server/src/rpc/README.md
@@ -1,0 +1,53 @@
+# rpc/
+
+JSON-RPC method binding plus the per-layer Tag allowlist.
+
+## Files
+
+- `context.ts` — `defineMethod`, `RpcMethodBinding`, `AuthenticatedContext`, `DispatchContext`. The base wrapper; provides `ConnIdTag` from the per-request `DispatchContext`.
+- `define-layered-method.ts` — `defineNetworkMethod`, `defineTaskMethod`, `defineAppMethod`. Layer-specific wrappers that constrain handler R-channel to a per-layer Tag allowlist and provide the matching layer-scope service.
+- `layer-scopes.ts` — runtime `Context.Tag`s used as structural layer markers (`NetworkLayerScope`, `TaskLayerScope`, `AppLayerScope`).
+- `layer-tags.ts` — type-only allowlist hierarchy (`TransportTags`, `IdentityTags`, `NetworkTags`, `TaskTags`, `AppTags`).
+- `layer-boundary.types-check.ts` — compile-time test that exercises the constraint shape.
+
+This folder moves to `transport/` in Phase 2A.2; the contract documented here travels with it.
+
+## Maintenance contract
+
+Adding a new service `Context.Tag` is a TWO-step edit, both landing in the same PR:
+
+1. **Type-side:** add the Tag's symbol to the appropriate alias in `layer-tags.ts`.
+2. **Structural-side:** update the matching `architectureOptions.layers` rule in the root `eslint.config.js` so the directory-structure lint and the type-system constraint agree.
+
+Both sources of truth coexist by user authorization. Compatibility:
+
+| Forgot type-side | Forgot lint-side |
+|---|---|
+| `tsc` rejects handler that yields the new Tag if it's outside the layer's allowlist | `tsc` lets the cross-layer reach through; `eslint` flags the directory boundary at the next CI run |
+
+The two checks fire at different boundaries (yield-site vs import-site) and together produce a sound result. Drift between them is a code smell that PR review catches; codegen between them is rejected (user explicitly accepted the maintenance overhead in 2026-05-09 plan revision).
+
+## Dispatch model
+
+Per-request handler R-channel resolution:
+
+```
+RpcMethodBinding.handle  (call site: jsonRpcServer.handle(frame, ctx))
+        │
+        │ ConnIdTag      ── provided by defineMethod from ctx.connId
+        │ NetworkLayerScope, TaskLayerScope, AppLayerScope
+        │                ── provided by defineXMethod wrappers, structurally
+        │ MessageServiceTag, ConversationServiceTag, ...
+        │                ── provided by the dispatcher's ManagedRuntime
+        │                   (Layer.mergeAll(NodeHttpServer.layerContext, LoggerLive, FullLive))
+        ▼
+   handler body
+```
+
+The wrapper-provided tags are no-ops for handlers that don't yield them; `Effect.provideService(Tag, value)` is `Exclude<R, Tag>` in the type system, so providing a tag the body never reads costs nothing.
+
+## Type-alias scaffold (added in Phase 2A r2 architect plan)
+
+The Tag hierarchy in `layer-tags.ts` is a stub at the architect stage. The wrapper signatures in `context.ts` and `define-layered-method.ts` widen with `Reqs` generics that default to the layer's full allowlist; this preserves source-compatibility with the pre-2A.0 factory-deps handler shape while opening the door for the migrated `yield* XServiceTag` shape.
+
+The implementation work to (a) migrate every handler off factories, (b) move `RpcHandler<Ctx>.handle` past the R=never assumption, and (c) thread `FullLive` into the dispatch runtime is part of the Phase 2A single-PR landing.

--- a/packages/server/src/rpc/README.md
+++ b/packages/server/src/rpc/README.md
@@ -46,8 +46,13 @@ RpcMethodBinding.handle  (call site: jsonRpcServer.handle(frame, ctx))
 
 The wrapper-provided tags are no-ops for handlers that don't yield them; `Effect.provideService(Tag, value)` is `Exclude<R, Tag>` in the type system, so providing a tag the body never reads costs nothing.
 
-## Type-alias scaffold (added in Phase 2A r2 architect plan)
+## Type-alias scaffold (Phase 2A r2)
 
-The Tag hierarchy in `layer-tags.ts` is a stub at the architect stage. The wrapper signatures in `context.ts` and `define-layered-method.ts` widen with `Reqs` generics that default to the layer's full allowlist; this preserves source-compatibility with the pre-2A.0 factory-deps handler shape while opening the door for the migrated `yield* XServiceTag` shape.
+Three pieces, all already on this branch as of `architect/phase-2a-r2-server-reshape`:
 
-The implementation work to (a) migrate every handler off factories, (b) move `RpcHandler<Ctx>.handle` past the R=never assumption, and (c) thread `FullLive` into the dispatch runtime is part of the Phase 2A single-PR landing.
+1. **Tag hierarchy** in `layer-tags.ts`. Every Tag yielded by a post-DI-migration handler is placed at the lowest layer that yields it. See plan §3 "Handler audit matrix" for the per-handler audit.
+2. **Wrapper signatures** in `context.ts` and `define-layered-method.ts` widen with `Reqs` generics. `Reqs extends NetworkTags = NetworkTags` (and parallel for Task/App) — defaulted to the upper bound so pre-migration handlers (R=never) still compile, constrained so a migrated handler that yields a higher-tier Tag is rejected at the call site.
+3. **Protocol-side widening** in `@moltzap/protocol/transport/json-rpc-server.ts`: `RpcHandler<Ctx, R = never>` and `JsonRpcServer<Ctx, R = never>` carry the R-channel structurally. Removes the architect-stage cast that v3 carried at `defineMethod`'s `handler()` call.
+4. **Dispatch runtime** in `app/server.ts`: `ManagedRuntime.make(Layer.mergeAll(NodeHttpServer.layerContext, FullLive))` — the request-fiber runtime carries every service Tag in `AppTags`, so handler-body yields resolve at request time.
+
+The implementation work to migrate every handler off factories is part of the Phase 2A single-PR landing (commit 3 in §6 of the plan). The migration removes `createXHandlers({deps})` factories in favor of top-level `xHandlers: RpcMethodRegistry` whose binding bodies `yield* XServiceTag` — the type-system hierarchy is already in place to enforce layer placement structurally.

--- a/packages/server/src/rpc/context.ts
+++ b/packages/server/src/rpc/context.ts
@@ -9,6 +9,7 @@ import {
 } from "@moltzap/protocol";
 import { ConnIdTag } from "../app/layers.js";
 import type { AgentId, UserId } from "../app/types.js";
+import type { AppTags } from "./layer-tags.js";
 
 export interface AuthenticatedContext {
   agentId: AgentId;
@@ -24,8 +25,18 @@ export interface DispatchContext {
 
 /** RPC binding stored in the registry. Each binding carries a method
  * definition and a `JsonRpcServer`-compatible handler that already
- * provides the layer scopes + ConnIdTag service. */
-export type RpcMethodBinding = RpcHandler<DispatchContext>;
+ * provides the layer scopes + ConnIdTag service.
+ *
+ * `R` is the union of handler-body Tag requirements AFTER the
+ * `defineMethod` wrapper resolves `ConnIdTag` (provided per request
+ * from `DispatchContext.connId`). The remaining tags are the service
+ * Tags that the dispatcher's `FullLive` Layer provides at request
+ * time. We use `Exclude<AppTags, ConnIdTag>` so the dispatcher's
+ * `Effect.provide(FullLive)` resolves R structurally to `never`. */
+export type RpcMethodBinding = RpcHandler<
+  DispatchContext,
+  Exclude<AppTags, ConnIdTag>
+>;
 
 export type RpcMethodRegistry = RpcMethodBinding[];
 
@@ -50,7 +61,7 @@ export function defineMethod<
   P extends TSchema,
   R extends TSchema,
   E = never,
-  Reqs = ConnIdTag,
+  Reqs extends AppTags = ConnIdTag,
 >(
   definition: RpcDefinition<Name, P, R>,
   def: {
@@ -62,7 +73,14 @@ export function defineMethod<
   },
 ): RpcMethodBinding {
   const requiresActive = def.requiresActive ?? false;
-  return handler(definition, (params, ctx) =>
+  // Explicit type args so TS infers R from the inner Effect's R-channel
+  // rather than defaulting to `never`. `handler<D, Ctx, R>` from
+  // `@moltzap/protocol` carries R through to the binding.
+  return handler<
+    RpcDefinition<Name, P, R>,
+    DispatchContext,
+    Exclude<Reqs, ConnIdTag>
+  >(definition, (params, ctx) =>
     Effect.gen(function* () {
       if (requiresActive && ctx.auth.agentStatus !== "active") {
         return yield* Effect.fail(
@@ -75,22 +93,14 @@ export function defineMethod<
       // reduces to that, but TypeScript doesn't auto-simplify across
       // the generic boundary, so the cast bridges the equality.
       //
-      // Architect-stage R-channel cast (Phase 2A r2 plan §3). `Reqs` is a
-      // widened generic so handler bodies can `yield* XServiceTag` after
-      // the Phase 2A.0 DI migration. At runtime, the dispatcher's
-      // `ManagedRuntime` carries `FullLive` (`packages/server/src/app/server.ts`),
-      // so the remaining R-channel resolves before this binding's `handle`
-      // runs. The Phase 2A.0 implementer threads R through `RpcHandler<Ctx>`
-      // and `handler()` from `@moltzap/protocol` structurally and removes
-      // this cast.
-      const inner = def
+      // R-channel: `def.handler` returns `Effect<Static<R>, E, Reqs>`.
+      // `Effect.provideService(ConnIdTag, ctx.connId)` removes ConnIdTag
+      // if present. The remaining R rides through `handler()` (widened
+      // in `@moltzap/protocol` to `RpcHandler<Ctx, R>`) and is resolved
+      // by the dispatcher's `ManagedRuntime` at request time. No cast.
+      const result = yield* def
         .handler(params, ctx.auth)
-        .pipe(Effect.provideService(ConnIdTag, ctx.connId)) as Effect.Effect<
-        Static<R>,
-        E,
-        never
-      >;
-      const result = yield* inner;
+        .pipe(Effect.provideService(ConnIdTag, ctx.connId));
       return result as ResultOf<RpcDefinition<Name, P, R>>;
     }),
   );

--- a/packages/server/src/rpc/context.ts
+++ b/packages/server/src/rpc/context.ts
@@ -31,19 +31,33 @@ export type RpcMethodRegistry = RpcMethodBinding[];
 
 /** Type-safe RPC method definition driven by a protocol manifest.
  * Wraps the user's handler with `requiresActive` enforcement and
- * provides `ConnIdTag` from the dispatch context. */
+ * provides `ConnIdTag` from the dispatch context.
+ *
+ * `Reqs` is the handler body's R-channel — the union of service Tags it
+ * `yield*`s plus `ConnIdTag` if the body reads it. Defaults to
+ * `ConnIdTag` so existing handlers (which yield no service Tags)
+ * continue to compile against this signature. Per the Phase 2A r2 plan
+ * §3, the `defineXMethod` variants in `define-layered-method.ts` add
+ * per-layer upper bounds on `Reqs` via constrained generics; this base
+ * `defineMethod` is unconstrained.
+ *
+ * `Effect.provideService(ConnIdTag, ctx.connId)` is a no-op when the
+ * body doesn't pull `ConnIdTag` (the `R` channel of `Effect` excludes
+ * the tag if absent), so `Reqs` widening doesn't lie about
+ * requirements. */
 export function defineMethod<
   Name extends string,
   P extends TSchema,
   R extends TSchema,
   E = never,
+  Reqs = ConnIdTag,
 >(
   definition: RpcDefinition<Name, P, R>,
   def: {
     handler: (
       params: Static<P>,
       ctx: AuthenticatedContext,
-    ) => Effect.Effect<Static<R>, E, ConnIdTag>;
+    ) => Effect.Effect<Static<R>, E, Reqs>;
     requiresActive?: boolean;
   },
 ): RpcMethodBinding {
@@ -60,9 +74,23 @@ export function defineMethod<
       // The handler returns `Static<R>`; the conditional `ResultOf<D>`
       // reduces to that, but TypeScript doesn't auto-simplify across
       // the generic boundary, so the cast bridges the equality.
-      const result = yield* def
+      //
+      // Architect-stage R-channel cast (Phase 2A r2 plan §3). `Reqs` is a
+      // widened generic so handler bodies can `yield* XServiceTag` after
+      // the Phase 2A.0 DI migration. At runtime, the dispatcher's
+      // `ManagedRuntime` carries `FullLive` (`packages/server/src/app/server.ts`),
+      // so the remaining R-channel resolves before this binding's `handle`
+      // runs. The Phase 2A.0 implementer threads R through `RpcHandler<Ctx>`
+      // and `handler()` from `@moltzap/protocol` structurally and removes
+      // this cast.
+      const inner = def
         .handler(params, ctx.auth)
-        .pipe(Effect.provideService(ConnIdTag, ctx.connId));
+        .pipe(Effect.provideService(ConnIdTag, ctx.connId)) as Effect.Effect<
+        Static<R>,
+        E,
+        never
+      >;
+      const result = yield* inner;
       return result as ResultOf<RpcDefinition<Name, P, R>>;
     }),
   );

--- a/packages/server/src/rpc/define-layered-method.ts
+++ b/packages/server/src/rpc/define-layered-method.ts
@@ -6,16 +6,12 @@ import {
   type AuthenticatedContext,
   type RpcMethodBinding,
 } from "./context.js";
-import type { ConnIdTag } from "../app/layers.js";
 import {
   AppLayerScope,
   NetworkLayerScope,
   TaskLayerScope,
 } from "./layer-scopes.js";
-
-type NetworkR = ConnIdTag | NetworkLayerScope;
-type TaskR = NetworkR | TaskLayerScope;
-type AppR = TaskR | AppLayerScope;
+import type { AppTags, NetworkTags, TaskTags } from "./layer-tags.js";
 
 interface MethodDef<P extends TSchema, R extends TSchema, Required, E> {
   readonly handler: (
@@ -25,14 +21,33 @@ interface MethodDef<P extends TSchema, R extends TSchema, Required, E> {
   readonly requiresActive?: boolean;
 }
 
+/**
+ * Network-layer RPC method binding. Handler `R`-channel is
+ * `Reqs extends NetworkTags`; the wrapper provides `NetworkLayerScope`
+ * structurally and the dispatcher's `ManagedRuntime` provides every
+ * service Tag at request time.
+ *
+ * `Reqs` defaults to `NetworkTags` so a handler that yields no service
+ * Tag (the pre-2A.0 factory shape) infers `Reqs = never` via R-channel
+ * covariance and compiles unchanged. A handler that yields a Tag from a
+ * higher layer (e.g. `MessageServiceTag`, which is `TaskTags` only)
+ * fails the constraint at the call site.
+ *
+ * **Type-alias hierarchy.** See `./layer-tags.ts` for the full
+ * allowlist. Adding a new service Tag is a TWO-step edit per the
+ * maintenance contract: update `layer-tags.ts` AND
+ * `architectureOptions.layers` in the root `eslint.config.js` so the
+ * structural lint and the type system agree.
+ */
 export function defineNetworkMethod<
   Name extends string,
   P extends TSchema,
   R extends TSchema,
   E = never,
+  Reqs extends NetworkTags = NetworkTags,
 >(
   definition: RpcDefinition<Name, P, R>,
-  def: MethodDef<P, R, NetworkR, E>,
+  def: MethodDef<P, R, Reqs | NetworkLayerScope, E>,
 ): RpcMethodBinding {
   return defineMethod(definition, {
     handler: (params, ctx) =>
@@ -43,14 +58,22 @@ export function defineNetworkMethod<
   });
 }
 
+/**
+ * Task-layer RPC method binding. Handler `R`-channel is
+ * `Reqs extends TaskTags`; provides `NetworkLayerScope` and
+ * `TaskLayerScope` structurally.
+ *
+ * See `defineNetworkMethod` for the maintenance contract.
+ */
 export function defineTaskMethod<
   Name extends string,
   P extends TSchema,
   R extends TSchema,
   E = never,
+  Reqs extends TaskTags = TaskTags,
 >(
   definition: RpcDefinition<Name, P, R>,
-  def: MethodDef<P, R, TaskR, E>,
+  def: MethodDef<P, R, Reqs | NetworkLayerScope | TaskLayerScope, E>,
 ): RpcMethodBinding {
   return defineMethod(definition, {
     handler: (params, ctx) =>
@@ -64,14 +87,27 @@ export function defineTaskMethod<
   });
 }
 
+/**
+ * App-layer RPC method binding. Handler `R`-channel is
+ * `Reqs extends AppTags`; provides all three layer scopes
+ * structurally.
+ *
+ * See `defineNetworkMethod` for the maintenance contract.
+ */
 export function defineAppMethod<
   Name extends string,
   P extends TSchema,
   R extends TSchema,
   E = never,
+  Reqs extends AppTags = AppTags,
 >(
   definition: RpcDefinition<Name, P, R>,
-  def: MethodDef<P, R, AppR, E>,
+  def: MethodDef<
+    P,
+    R,
+    Reqs | NetworkLayerScope | TaskLayerScope | AppLayerScope,
+    E
+  >,
 ): RpcMethodBinding {
   return defineMethod(definition, {
     handler: (params, ctx) =>

--- a/packages/server/src/rpc/layer-tags.ts
+++ b/packages/server/src/rpc/layer-tags.ts
@@ -3,60 +3,107 @@
  *
  *   transport ─ identity ─ network ─ task ─ app
  *
- * Each layer's allowed Tag union is a superset of the layer below it. The
- * `defineXMethod` wrappers in `define-layered-method.ts` use these as
+ * Each layer's allowlist is a superset of the layer below: any Tag legal at
+ * layer L is legal at every layer above L. Adding a Tag to a layer's
+ * allowlist transitively adds it everywhere above. Placement is determined
+ * by the LOWEST layer that yields the Tag in a handler body — placing a
+ * Tag higher loses lint signal at lower layers.
+ *
+ * The `defineXMethod` wrappers in `define-layered-method.ts` use these as
  * generic-constraint upper bounds so a handler at layer L cannot pull a
  * service that only layer L+1 owns.
  *
+ * **Audit method.** Each Tag below is placed at the lowest layer whose
+ * handlers yield it post-Phase-2A.0 DI migration. The audit ran against
+ * `main@adc2e18` handler bodies; result is documented in the Phase 2A r2
+ * architect plan §3 ("Handler audit matrix").
+ *
  * **Maintenance contract.** Adding a new service Tag is a TWO-step edit
  * that lands in the same PR:
- *   1. Add the Tag to the appropriate alias here.
+ *   1. Add the Tag to the appropriate alias here, at the lowest layer
+ *      that yields it.
  *   2. Update the matching `architectureOptions.layers` rule in the root
- *      `eslint.config.js` so the structural lint and the type system agree.
+ *      `eslint.config.js` so the structural lint and the type system
+ *      agree.
  *
  * The two-source-of-truth shape is intentional and named in §10 of the
- * Phase 2A architect plan; the user explicitly accepted the maintenance
- * cost over a codegen pipeline.
+ * Phase 2A r2 architect plan; the user explicitly accepted the
+ * maintenance cost over a codegen pipeline.
  */
-import type { ConnIdTag } from "../app/layers.js";
 import type {
+  ConnIdTag,
+  DbTag,
   AuthServiceTag,
   AgentEndpointResolverTag,
-  NetworkSendServiceTag,
   ConnectionManagerTag,
+  NetworkSendServiceTag,
+  PresenceServiceTag,
+  ContactsServiceTag,
   MessageServiceTag,
   ConversationServiceTag,
   TaskServiceTag,
-  AppHostTag,
   LeaseRegistryTag,
+  SessionValidatorTag,
+  AppHostTag,
   AppTmRegistryTag,
 } from "../app/layers.js";
 
-/** Bottom kernel — the per-request connection id. */
-export type TransportTags = ConnIdTag;
+/**
+ * Bottom kernel — per-request connection id plus the database handle.
+ * Both are infrastructure that every protocol layer may pull. ConnIdTag
+ * is provided by `defineMethod` from the dispatch context; DbTag is
+ * provided by the dispatcher's `ManagedRuntime` from the configured
+ * database `Layer.succeed(DbTag, db)`.
+ */
+export type TransportTags = ConnIdTag | DbTag;
 
-/** Identity-layer allowlist: registration, claim, login, contacts. */
-export type IdentityTags =
-  | TransportTags
-  | AuthServiceTag
-  | AgentEndpointResolverTag;
+/**
+ * Identity-layer allowlist: registration, claim, login, contacts,
+ * agent-visibility lookups. Yielded by `agents-lookup.handlers.ts` (the
+ * three pure-read handlers `AgentsLookup`, `AgentsLookupByName`,
+ * `AgentsList` after the auth-handlers split).
+ */
+export type IdentityTags = TransportTags | AuthServiceTag;
 
-/** Network-layer allowlist: Connect, presence, send/broadcast. */
+/**
+ * Network-layer allowlist: Connect, presence, app-TM dispatch surface.
+ * `ping.handlers.ts` lives here. The `agentEndpointResolver` is the
+ * `AgentId → ConnectionId` multimap (network-conceptual — endpoint
+ * resolution is what the network layer DOES, not who owns it). The
+ * presence service lives in `network/services/` post-2A.2 reshape; its
+ * Tag is yielded by handlers in higher layers (presence handler routes
+ * through the TM bus from `task/handlers/`).
+ */
 export type NetworkTags =
   | IdentityTags
+  | AgentEndpointResolverTag
+  | ConnectionManagerTag
   | NetworkSendServiceTag
-  | ConnectionManagerTag;
+  | PresenceServiceTag;
 
-/** Task-layer allowlist: conversations, messages, tasks. */
+/**
+ * Task-layer allowlist: conversations, messages, tasks, contacts.
+ * Includes `LeaseRegistryTag` (admission gate for `messages/send`
+ * dispatch leases — yielded by `messages.handlers.ts`) and
+ * `SessionValidatorTag` (yielded by the Connect handler post-split,
+ * which lives at `task/handlers/connect.handlers.ts`). The Connect
+ * handler is task-tier because its body pulls cross-cutting services
+ * spanning network (connections, presence) AND task (conversation
+ * resolution for presence fan-out).
+ */
 export type TaskTags =
   | NetworkTags
   | MessageServiceTag
   | ConversationServiceTag
-  | TaskServiceTag;
-
-/** App-layer allowlist: app-host, lease registry, app-TM registry. */
-export type AppTags =
-  | TaskTags
-  | AppHostTag
+  | TaskServiceTag
+  | ContactsServiceTag
   | LeaseRegistryTag
-  | AppTmRegistryTag;
+  | SessionValidatorTag;
+
+/**
+ * App-layer allowlist: `apps.handlers.ts` (registration + dispatch
+ * authorize). `AppTmRegistryTag` is yielded by the app-host construction
+ * path; included here for completeness even though no current handler
+ * yields it directly.
+ */
+export type AppTags = TaskTags | AppHostTag | AppTmRegistryTag;

--- a/packages/server/src/rpc/layer-tags.ts
+++ b/packages/server/src/rpc/layer-tags.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-layer Tag allowlists. The hierarchy mirrors the protocol layer stack:
+ *
+ *   transport ─ identity ─ network ─ task ─ app
+ *
+ * Each layer's allowed Tag union is a superset of the layer below it. The
+ * `defineXMethod` wrappers in `define-layered-method.ts` use these as
+ * generic-constraint upper bounds so a handler at layer L cannot pull a
+ * service that only layer L+1 owns.
+ *
+ * **Maintenance contract.** Adding a new service Tag is a TWO-step edit
+ * that lands in the same PR:
+ *   1. Add the Tag to the appropriate alias here.
+ *   2. Update the matching `architectureOptions.layers` rule in the root
+ *      `eslint.config.js` so the structural lint and the type system agree.
+ *
+ * The two-source-of-truth shape is intentional and named in §10 of the
+ * Phase 2A architect plan; the user explicitly accepted the maintenance
+ * cost over a codegen pipeline.
+ */
+import type { ConnIdTag } from "../app/layers.js";
+import type {
+  AuthServiceTag,
+  AgentEndpointResolverTag,
+  NetworkSendServiceTag,
+  ConnectionManagerTag,
+  MessageServiceTag,
+  ConversationServiceTag,
+  TaskServiceTag,
+  AppHostTag,
+  LeaseRegistryTag,
+  AppTmRegistryTag,
+} from "../app/layers.js";
+
+/** Bottom kernel — the per-request connection id. */
+export type TransportTags = ConnIdTag;
+
+/** Identity-layer allowlist: registration, claim, login, contacts. */
+export type IdentityTags =
+  | TransportTags
+  | AuthServiceTag
+  | AgentEndpointResolverTag;
+
+/** Network-layer allowlist: Connect, presence, send/broadcast. */
+export type NetworkTags =
+  | IdentityTags
+  | NetworkSendServiceTag
+  | ConnectionManagerTag;
+
+/** Task-layer allowlist: conversations, messages, tasks. */
+export type TaskTags =
+  | NetworkTags
+  | MessageServiceTag
+  | ConversationServiceTag
+  | TaskServiceTag;
+
+/** App-layer allowlist: app-host, lease registry, app-TM registry. */
+export type AppTags =
+  | TaskTags
+  | AppHostTag
+  | LeaseRegistryTag
+  | AppTmRegistryTag;

--- a/packages/server/src/task/README.md
+++ b/packages/server/src/task/README.md
@@ -1,0 +1,48 @@
+# task/
+
+Conversations, messages, tasks, contacts (handler-routing), task-manager dispatch.
+
+## Layer rules
+
+| Direction | Allowed |
+|---|---|
+| Imports FROM | kernels, transport, identity, network |
+| Imports TO   | app |
+
+## Files
+
+Existing:
+- `handlers/conversations.handlers.ts`
+- `handlers/messages.handlers.ts`
+- `handlers/presence.handlers.ts` (presence handler routes via TM message bus)
+- `handlers/contacts.handlers.ts`
+- `handlers/tasks.handlers.ts`
+
+Moved IN during 2A.2:
+- `services/conversation.service.ts`
+- `services/message.service.ts`
+- `services/task.service.ts`
+- `services/default-tm.ts`
+- `services/conversation-admin-authority.ts`
+
+## Handler shape (post-2A.0)
+
+```ts
+defineTaskMethod(MessagesSend, {
+  requiresActive: true,
+  handler: (params, ctx) =>
+    Effect.gen(function* () {
+      const messages = yield* MessageServiceTag;
+      const conversations = yield* ConversationServiceTag;
+      const tasks = yield* TaskServiceTag;
+      const db = yield* DbTag;
+      const leaseRegistry = yield* LeaseRegistryTag;
+      // ... handler body using yield* on each service
+    }),
+});
+```
+
+No `createMessageHandlers({deps})` factory. The handler binding's `R` channel
+holds every Tag the body pulls; the dispatcher's `ManagedRuntime` provides them.
+
+See `task/handlers/sample-migrated.ts.example` for a worked migration example.

--- a/packages/server/src/task/handlers/sample-migrated.ts.example
+++ b/packages/server/src/task/handlers/sample-migrated.ts.example
@@ -1,0 +1,149 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Phase 2A.0 — DI migration example.
+//
+// This file is a NON-COMPILED reference for the implement-staff dispatcher.
+// It shows the pre/post shape of `messages.handlers.ts` under the migration.
+// `.example` extension keeps tsc / vitest from picking it up.
+// Delete this file after 2A.0 lands.
+// ─────────────────────────────────────────────────────────────────────────
+
+// ── BEFORE (today, src/task/handlers/messages.handlers.ts) ────────────────
+//
+// import type { MessageService } from "../../services/message.service.js";
+// import type { ConversationService } from "../../services/conversation.service.js";
+// import type { TaskService } from "../../services/task.service.js";
+// import type { Db } from "../../db/client.js";
+// import type { LeaseRegistry } from "../../app/lease-registry.js";
+// import { defineTaskMethod } from "../../rpc/define-layered-method.js";
+//
+// export function createMessageHandlers(deps: {
+//   messageService: MessageService;
+//   conversationService: ConversationService;
+//   taskService: TaskService;
+//   db: Db;
+//   leaseRegistry?: LeaseRegistry;
+// }): RpcMethodRegistry {
+//   return [
+//     defineTaskMethod(MessagesSend, {
+//       requiresActive: true,
+//       handler: (params, ctx) =>
+//         Effect.gen(function* () {
+//           // Reads via deps.*
+//           const conv = yield* deps.conversationService.createDmByAgentName(...);
+//           const message = yield* deps.messageService.send(...);
+//           return { message };
+//         }),
+//     }),
+//     defineTaskMethod(MessagesList, { ... }),
+//   ];
+// }
+//
+// Boot site (app/server.ts):
+//   const methods = [
+//     ...createMessageHandlers({ messageService, conversationService, ... }),
+//     ...
+//   ];
+//
+// Test site (presence.handlers.test.ts):
+//   const handlers = createMessageHandlers({ messageService, conversationService, ... });
+//   const binding = handlers.find(h => h.definition.name === "messages/send");
+//   const result = await Effect.runPromise(
+//     binding.handle(params, ctx).pipe(Effect.provideService(ConnIdTag, "test")),
+//   );
+
+// ── AFTER (post-2A.0) ─────────────────────────────────────────────────────
+//
+// import { defineTaskMethod } from "../../transport/define-layered-method.js";
+// import {
+//   MessageServiceTag,
+//   ConversationServiceTag,
+//   TaskServiceTag,
+//   DbTag,
+//   LeaseRegistryTag,
+// } from "../../app/layers.js";
+//
+// /**
+//  * `messages/*` handler bindings. No `deps` argument; service access is
+//  * via `yield* XServiceTag`. The dispatcher's `ManagedRuntime` carries
+//  * `ServicesLive`, so every Tag this body pulls is resolved at request
+//  * time.
+//  *
+//  * Returned shape: a plain `RpcMethodRegistry` (array of bindings). The
+//  * `Effect`s INSIDE each binding's `handler` carry the Tag dependencies
+//  * in their `R` channel; that R is provided by the runtime, not by this
+//  * function.
+//  */
+// export const messageHandlers: RpcMethodRegistry = [
+//   defineTaskMethod(MessagesSend, {
+//     requiresActive: true,
+//     handler: (params, ctx) =>
+//       Effect.gen(function* () {
+//         const messages = yield* MessageServiceTag;
+//         const conversations = yield* ConversationServiceTag;
+//         const tasks = yield* TaskServiceTag;
+//         const db = yield* DbTag;
+//         const leaseRegistry = yield* LeaseRegistryTag;
+//
+//         // ... rest of body unchanged; replace `deps.messageService` with
+//         //     `messages`, `deps.db` with `db`, etc.
+//         const message = yield* messages.send(...);
+//         return { message };
+//       }),
+//   }),
+//   defineTaskMethod(MessagesList, {
+//     requiresActive: true,
+//     handler: (params, ctx) =>
+//       Effect.gen(function* () {
+//         const messages = yield* MessageServiceTag;
+//         return yield* messages.list(params.conversationId, ctx.agentId, {
+//           limit: params.limit,
+//         });
+//       }),
+//   }),
+// ];
+//
+// Boot site (app/server.ts) — no per-handler factory call:
+//   const methods: RpcMethodRegistry = [
+//     ...identityHandlers,
+//     ...conversationHandlers,
+//     ...messageHandlers,
+//     ...presenceHandlers,
+//     ...appHandlers,
+//     ...contactHandlers,
+//     ...taskHandlers,
+//     ...pingHandlers,
+//   ];
+//
+// The dispatcher's runtime is built ONCE with `ServicesLive` in scope:
+//   const runtime = ManagedRuntime.make(
+//     Layer.mergeAll(NodeHttpServer.layerContext, LoggerLive, FullLive),
+//   );
+//   // Per-request: ConnIdTag is added by `defineMethod` from `ctx.connId`.
+//
+// Test site — fakes shift from constructor injection to Layer overrides:
+//   const TestServices = ServicesLive.pipe(
+//     Layer.provide(fakeMessageServiceLayer({ send: () => Effect.succeed(...) })),
+//     Layer.provide(fakeConversationServiceLayer({ ... })),
+//   );
+//   const binding = messageHandlers.find(h => h.definition.name === "messages/send");
+//   const result = await Effect.runPromise(
+//     binding.handle(params, ctx).pipe(
+//       Effect.provideService(ConnIdTag, "test-conn-1"),
+//       Effect.provide(TestServices),
+//     ),
+//   );
+
+// ── Why the Tag-based shape is right ──────────────────────────────────────
+//
+// 1. The Tags + Layers (`app/layers.ts`) already exist. Handlers are the
+//    only consumer that still uses the legacy factory shape. 2A.0 finishes
+//    a half-done migration.
+// 2. After 2A.2 reshape, layer-scope enforcement (`NetworkLayerScope`,
+//    `TaskLayerScope`, `AppLayerScope` on `defineXMethod`) ONLY enforces
+//    the boundary if the handler bodies use Tags. Factory-deps bypass the
+//    scope check by carrying services through closure capture.
+// 3. `Layer.succeed` at test sites composes; `createX({fake})` does not.
+//    Boundary-test ergonomics improve when fakes are layer-shaped (they
+//    already are in `test-utils/fakes.ts`).
+// 4. Boot becomes one runtime composition, not a hand-walked factory chain.
+//    Adding a handler stops requiring an edit to `app/server.ts`.

--- a/packages/server/src/task/index.ts
+++ b/packages/server/src/task/index.ts
@@ -1,0 +1,12 @@
+/**
+ * `task/` — conversations, messages, tasks, contacts (handler-routing),
+ * task-manager dispatch.
+ *
+ * Layer rules:
+ *   - May import: kernels, transport, identity, network.
+ *   - May NOT import: app.
+ *
+ * Public surface (post-2A.2): `ConversationService`, `MessageService`,
+ * `TaskService`, default-TM handlers, task handler registries.
+ */
+export {};

--- a/packages/server/src/task/services/index.ts
+++ b/packages/server/src/task/services/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Task service exports.
+ *
+ * Populated in 2A.2 with: `conversation.service.ts`, `message.service.ts`,
+ * `task.service.ts`, `default-tm.ts`, `conversation-admin-authority.ts`
+ * (from `services/`).
+ */
+export {};

--- a/packages/server/src/transport/README.md
+++ b/packages/server/src/transport/README.md
@@ -1,0 +1,24 @@
+# transport/
+
+Wire-level dispatch.
+
+- WS connection lifecycle.
+- JSON-RPC method binding (`defineMethod`, `defineNetworkMethod`, `defineTaskMethod`, `defineAppMethod`).
+- Per-request `DispatchContext` and the layer-scope tags that gate handler placement.
+
+## Layer rules
+
+| Direction | Allowed |
+|---|---|
+| Imports FROM | kernels only (`db`, `crypto`, `runtime`, `runtime-surface`, `adapters`, `config`, `logger`, `test-utils`) |
+| Imports TO   | identity, network, task, app (any protocol layer composes on top) |
+
+Transport is the lowest protocol layer. It does not know about identity, conversations, presence, or app hosts. Handlers live in their layer's `handlers/` directory and are bound via `defineXMethod` from this layer.
+
+## Files (populated in 2A.2)
+
+- `connection.ts` (from `ws/`)
+- `context.ts` (from `rpc/`)
+- `define-layered-method.ts` (from `rpc/`)
+- `layer-scopes.ts` (from `rpc/`)
+- `layer-boundary.types-check.ts` (from `rpc/`)

--- a/packages/server/src/transport/index.ts
+++ b/packages/server/src/transport/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `transport/` — wire-level dispatch.
+ *
+ * Owns: WebSocket connection lifecycle (`ws/connection.ts`), JSON-RPC method
+ * binding (`rpc/define-layered-method.ts`, `rpc/context.ts`, `rpc/layer-scopes.ts`),
+ * boundary-types check.
+ *
+ * Layer rules:
+ *   - May import: kernels (db, crypto, runtime, runtime-surface, adapters, config, test-utils, logger).
+ *   - May NOT import: identity, network, task, app (those layers compose ON TOP of transport).
+ *
+ * Public surface: `RpcMethodBinding`, `RpcMethodRegistry`, `defineMethod`,
+ * `defineNetworkMethod`, `defineTaskMethod`, `defineAppMethod`,
+ * `AuthenticatedContext`, `DispatchContext`, `LayerScope` tags.
+ *
+ * Populated in 2A.2 (folder moves). Empty in 2A.1.
+ */
+export {};


### PR DESCRIPTION
Architecture only. **Not for merge.**

Phase 2A round 2 architect plan: https://github.com/chughtapan/moltzap/issues/542
Parent epic: https://github.com/chughtapan/moltzap/issues/538

This branch carries skeleton stubs only — empty layer folders, READMEs, subpath exports, and a worked example of the Phase 2A.0 DI migration shape. No source files move and no existing code is rewired here.

Stubs / supporting artifacts: 16 files, 1 modified (package.json subpath exports). Every change is additive.

Implementation lands in 4 sub-PRs (#552-555 to be filed by orchestrator):

- 2A.0 — handler DI migration (factory-deps → `yield* XServiceTag`). implement-staff.
- 2A.1 — layer skeleton from this branch (additive). implement-senior.
- 2A.2 — folder moves, kernels stay at top level (no `_infra/` wrapper). implement-staff.
- 2A.3 — cross-layer relative-imports → workspace-name imports. implement-senior.

See the plan comment on #542 for module table, data flow, error register, traceability, and risk register.