### PR TITLE
impl(testing): flip rpc-semantics/spurious-app-callback-frame-handling to executable (#557)

### DIFF
--- a/packages/protocol/scripts/check-divergence-proofs.sh
+++ b/packages/protocol/scripts/check-divergence-proofs.sh
@@ -73,7 +73,6 @@ legacy_exempt_registrars=(
   registerResetPeerRecovery
   registerTimeoutSurface
   registerSlowCloseCleanup
-  registerSpuriousAppCallbackFrameHandling
   registerCallerControlledAppCallbackTimeout
   registerSchemaExhaustiveFuzz
   registerAppDisconnectFailPolicy

--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
@@ -38,6 +38,7 @@ import {
 import { registerAuthorityPositive } from "../identity/authority-positive.js";
 import { registerAuthorityNegative } from "../identity/authority-negative.js";
 import { registerIdempotence } from "../app/idempotence.js";
+import { registerSpuriousAppCallbackFrameHandling } from "../app/spurious-app-callback-frame.js";
 import { registerModelEquivalence } from "../task/model-equivalence.js";
 import { registerRequestIdUniqueness } from "../transport/request-id-uniqueness.js";
 import { registerRequestWellFormedness } from "../transport/request-well-formedness.js";
@@ -65,7 +66,8 @@ type BadServerBehavior =
   | "conversation-missing-created-event"
   | "archive-missing-event"
   | "presence-silent"
-  | "presence-stale-snapshot";
+  | "presence-stale-snapshot"
+  | "silence-after-non-request";
 
 describe("server-side conformance executable divergence proofs", () => {
   it("registerAuthorityNegative fails when pre-handshake RPCs return success", async () => {
@@ -102,6 +104,14 @@ describe("server-side conformance executable divergence proofs", () => {
     });
     expectInvariant(failure, "idempotence");
   });
+
+  it("registerSpuriousAppCallbackFrameHandling fails when the server stops responding after a spurious frame", async () => {
+    const failure = await runSingleServerProof(
+      registerSpuriousAppCallbackFrameHandling,
+      { behavior: "silence-after-non-request" },
+    );
+    expectInvariant(failure, "spurious-app-callback-frame-handling");
+  }, 10_000);
 
   it("registerRequestWellFormedness fails when sampled calls receive no reply", async () => {
     const failure = await runSingleServerProof(registerRequestWellFormedness, {
@@ -302,6 +312,10 @@ function makeBadWebSocketServer(
 ): Effect.Effect<{ readonly wsUrl: string }, never, Scope.Scope> {
   return Effect.gen(function* () {
     const requestCounter = yield* Ref.make(0);
+    // Tracks whether `silence-after-non-request` has been triggered.
+    // Per-server state is sufficient: each divergence-proof run drives a
+    // single client.
+    const silencedRef = yield* Ref.make(false);
     const server = yield* NodeSocketServer.makeWebSocket({
       port: 0,
       host: "127.0.0.1",
@@ -323,7 +337,20 @@ function makeBadWebSocketServer(
                 );
                 if (decoded._tag === "Left") return;
                 const frame = decoded.right;
-                if (!isRequestFrame(frame)) return;
+                if (!isRequestFrame(frame)) {
+                  if (behavior === "silence-after-non-request") {
+                    yield* Ref.set(silencedRef, true);
+                  }
+                  return;
+                }
+                if (
+                  behavior === "silence-after-non-request" &&
+                  (yield* Ref.get(silencedRef))
+                ) {
+                  // Spurious frame already arrived; the bad server stops
+                  // replying so the property's liveness probe times out.
+                  return;
+                }
                 const ordinal = yield* Ref.updateAndGet(
                   requestCounter,
                   (n) => n + 1,

--- a/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts
+++ b/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts
@@ -128,6 +128,18 @@ export interface TestClient {
     TransportClosedError | TransportIoError | FrameSchemaError
   >;
 
+  /**
+   * Wire-level injection seam for properties that need to send a frame
+   * the typed `sendRpc` / `sendMalformed` paths cannot produce — e.g. a
+   * JSON-RPC response frame whose `id` matches no pending request the
+   * server tracks (the `spurious-app-callback-frame-handling` property).
+   * The frame is JSON-stringified and written verbatim; no `pending`
+   * registration, no schema-encoding, no decoded capture.
+   */
+  readonly sendRawFrame: (
+    frame: unknown,
+  ) => Effect.Effect<void, TransportClosedError | TransportIoError>;
+
   readonly notifications: Stream.Stream<
     DecodedNotification<AnyNotificationDefinition>,
     TransportClosedError
@@ -716,6 +728,9 @@ export function makeTestClient(
         return outcome;
       });
 
+    const sendRawFrame: TestClient["sendRawFrame"] = (frame) =>
+      writeFrame(JSON.stringify(frame));
+
     // Notification stream — repeatedly drain `notificationQueue`, ending when the WS closes.
     const notifications: Stream.Stream<
       DecodedNotification<AnyNotificationDefinition>,
@@ -811,6 +826,7 @@ export function makeTestClient(
     const client: TestClient = {
       sendRpc,
       sendMalformed,
+      sendRawFrame,
       notifications,
       captures,
       snapshot: captures.snapshot,

--- a/packages/protocol/src/testing/conformance/_shared/suite.ts
+++ b/packages/protocol/src/testing/conformance/_shared/suite.ts
@@ -275,14 +275,6 @@ function allowedServerCoverageGaps(
       id: "boundary/app-disconnect-fail-policy",
       reasonIncludes: TasksCreate.name,
     },
-    // Spurious appCallback frame handling needs a wire-level injection seam
-    // TestClient does not expose; tombstoned where the server-side
-    // fault-injection path is reachable.
-    {
-      kind: "deferred",
-      id: "rpc-semantics/spurious-app-callback-frame-handling",
-      reasonIncludes: "B.9",
-    },
   ];
   if (toxiproxyUrl === null) {
     gaps.push(

--- a/packages/protocol/src/testing/conformance/app/spurious-app-callback-frame.ts
+++ b/packages/protocol/src/testing/conformance/app/spurious-app-callback-frame.ts
@@ -1,36 +1,130 @@
 /**
- * Spurious appCallback responses do not crash or poison the server. Architect
- * plan §3.3 + §1.7: the server's `appCallbackPending` map keys on the request id
- * it allocated; an inbound appCallback response with no matching pending entry
- * is dropped, the connection stays responsive.
+ * Spurious appCallback responses do not crash or poison the server.
+ * Architect plan §3.3 + §1.7: the server's `appCallbackPending` map keys
+ * on the request id IT allocated; an inbound appCallback response with no
+ * matching pending entry is dropped silently and the connection stays
+ * responsive to subsequent traffic.
  *
- * Phase 1A architect §5 disposition: RETOMBSTONE — verifying that
- * `TestClient.sendMalformed` exposes the wire-level injection seam and
- * writing the property body is implementer-tier behavior, outside Phase
- * 1A's structural scope.
+ * Property body opens a real TestClient, injects a JSON-RPC response
+ * frame whose `id` matches no request the server tracks (any client-
+ * minted id is necessarily unmatched), then issues a follow-up RPC. A
+ * conforming server keeps the WS open and replies; a non-conforming
+ * server crashes, disconnects, or stops responding — the follow-up
+ * surfaces the divergence as a typed liveness failure.
  */
-import { Effect } from "effect";
+import { Effect, Either } from "effect";
+import { AgentsList } from "../../../identity/methods.js";
+import { makeTestClient } from "../_shared/driver/test-client.js";
+import { registerTestAgent } from "../_shared/test-fixtures.js";
 import type { ConformanceRunContext } from "../_shared/runner.js";
-import { PropertyDeferred, registerProperty } from "../_shared/registry.js";
+import {
+  PropertyInvariantViolation,
+  PropertyUnavailable,
+  registerProperty,
+} from "../_shared/registry.js";
 
 const CATEGORY = "rpc-semantics" as const;
 const PROPERTY = "spurious-app-callback-frame-handling";
+const DEFAULT_TIMEOUT_MS = 3000;
+const DEFAULT_CAPTURE_CAPACITY = 64;
+const SPURIOUS_RESPONSE_ID = "spurious-no-pending-557";
 
 export function registerSpuriousAppCallbackFrameHandling(
   ctx: ConformanceRunContext,
 ): void {
-  void ctx;
   registerProperty(
     ctx,
     CATEGORY,
     PROPERTY,
     "stray appCallback response with no matching pending ⇒ server drops & stays alive",
-    Effect.fail(
-      new PropertyDeferred({
-        category: CATEGORY,
-        name: PROPERTY,
-        followUp:
-          "wire-level raw-frame injection requires TestClient extension; #557 covers via server-side fault injection (B.9 integration tier)",
+    Effect.scoped(
+      Effect.gen(function* () {
+        const agent = yield* registerTestAgent({
+          baseUrl: ctx.realServer.baseUrl,
+          name: "spurious-frame",
+        });
+        const client = yield* makeTestClient({
+          serverUrl: ctx.realServer.wsUrl,
+          agentKey: agent.apiKey,
+          agentId: agent.agentId,
+          defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+          captureCapacity: DEFAULT_CAPTURE_CAPACITY,
+        });
+
+        // Inject a JSON-RPC response frame whose `id` is not in the
+        // server's `appCallbackPending` map. Any id the client mints is
+        // necessarily unmatched (the server only stores ids it allocates
+        // when sending app-callback requests of its own).
+        const injection = yield* client
+          .sendRawFrame({
+            jsonrpc: "2.0",
+            id: SPURIOUS_RESPONSE_ID,
+            result: {},
+          })
+          .pipe(Effect.either);
+        yield* Either.match(injection, {
+          onLeft: (err) =>
+            Effect.fail(
+              new PropertyInvariantViolation({
+                category: CATEGORY,
+                name: PROPERTY,
+                reason: `transport faulted writing spurious frame: ${err._tag}`,
+              }),
+            ),
+          onRight: () => Effect.void,
+        });
+
+        // Liveness probe — a follow-up RPC must succeed. Dropped frame
+        // ⇒ probe returns Right; crash/disconnect/silence ⇒ probe
+        // surfaces a typed transport or timeout error and the property
+        // reports the divergence.
+        const probe = yield* client.sendRpc(AgentsList, {}).pipe(Effect.either);
+        return yield* Either.match(probe, {
+          onLeft: (err) =>
+            Effect.fail(
+              new PropertyInvariantViolation({
+                category: CATEGORY,
+                name: PROPERTY,
+                reason: `liveness probe after spurious frame failed: ${err._tag}`,
+              }),
+            ),
+          onRight: () => Effect.void,
+        });
+      }),
+    ).pipe(
+      Effect.catchTags({
+        TestingAgentRegistrationError: (e) =>
+          Effect.fail(
+            new PropertyUnavailable({
+              category: CATEGORY,
+              name: PROPERTY,
+              reason: `register: ${e.body}`,
+            }),
+          ),
+        TestingTransportIoError: (e) =>
+          Effect.fail(
+            new PropertyUnavailable({
+              category: CATEGORY,
+              name: PROPERTY,
+              reason: `transport io setup: ${String(e.cause)}`,
+            }),
+          ),
+        TestingTransportClosedError: (e) =>
+          Effect.fail(
+            new PropertyUnavailable({
+              category: CATEGORY,
+              name: PROPERTY,
+              reason: `transport closed during setup: ${e.reason}`,
+            }),
+          ),
+        TestingRpcResponseError: (e) =>
+          Effect.fail(
+            new PropertyUnavailable({
+              category: CATEGORY,
+              name: PROPERTY,
+              reason: `rpc response error during setup: ${e.message}`,
+            }),
+          ),
       }),
     ),
   );


### PR DESCRIPTION
Closes #557.

## What changed

- Replaces the `PropertyDeferred` tombstone in `packages/protocol/src/testing/conformance/app/spurious-app-callback-frame.ts` with an executable property body. Body opens a real `TestClient`, injects a JSON-RPC response frame whose `id` matches no pending request the server tracks, then issues a follow-up `agents/list` RPC; a conforming server drops the spurious frame silently and replies to the probe.
- Adds `TestClient.sendRawFrame(frame: unknown): Effect<void, TransportClosedError | TransportIoError>` — a wire-level test seam that JSON-stringifies the input and writes it verbatim, bypassing schema-encoding and `pending` registration. Required for properties that need to inject server-routed frames the typed `sendRpc` path cannot produce.
- Removes the `rpc-semantics/spurious-app-callback-frame-handling` row from `allowedServerCoverageGaps` in `_shared/suite.ts`.
- Removes `registerSpuriousAppCallbackFrameHandling` from `legacy_exempt_registrars` in `packages/protocol/scripts/check-divergence-proofs.sh`.
- Adds a divergence proof in `__divergence_proofs__/server-executable.proofs.test.ts` driving a bad server with a new `silence-after-non-request` behavior. The bad server stops replying after the spurious frame arrives, so the property's liveness probe times out and surfaces `PropertyInvariantViolation`.

## Scope

- Module: `packages/protocol/src/testing/conformance/` (plus `testing/test-client.ts` test seam authorized by the dispatch).
- Files: 5 (`+156 / -28`).
- Tier (safer-diff-scope): `junior`.
- New exported signatures: `TestClient.sendRawFrame` (test-only seam, scoped to `@moltzap/protocol/testing`).
- New deps: none.

## Tests

- New: `registerSpuriousAppCallbackFrameHandling fails when the server stops responding after a spurious frame` divergence proof under `__divergence_proofs__/server-executable.proofs.test.ts`. Passes.
- `pnpm --filter @moltzap/protocol build` green.
- `pnpm --filter @moltzap/protocol test` green (115 passed, 1 todo, 0 failed).
- `bash packages/protocol/scripts/check-divergence-proofs.sh` exits 0 (27 proofs, 37 exemptions).
- `SKIP_TOXIPROXY=1 pnpm --filter @moltzap/server-core test:conformance` green: `passed=40 deferred=4 unavailable=6 failed=0`. Baseline shifted: 1 fewer deferred, 1 more passed (`rpc-semantics/spurious-app-callback-frame-handling` is now in `passed`).

## Confidence

HIGH — all four verification matrix items reproduce locally; divergence proof exercises the assertion-vs-bad-server path the gate requires.