### PR TITLE
fix(protocol): throw on unreachable endpointAddressKind fallback (#471)

### DIFF
--- a/packages/protocol/src/network/actor-model.ts
+++ b/packages/protocol/src/network/actor-model.ts
@@ -97,10 +97,8 @@ export const endpointAddress = (value: string): EndpointAddress =>
  * lockstep — the {@link ENDPOINT_ADDRESS_KINDS}-driven loop owns the
  * exhaustiveness story.
  *
- * The trailing `return ENDPOINT_ADDRESS_KINDS[0]` is unreachable for any
- * well-formed branded value (the brand guarantees at least one match)
- * but appears for the type checker — `for...of` does not narrow to a
- * non-empty result. The brand's own tests cover the malformed case.
+ * The post-loop path is unreachable for any well-formed branded value;
+ * it throws rather than silently returning a default (Principle 4).
  */
 export const endpointAddressKind = (
   address: EndpointAddress,
@@ -110,7 +108,7 @@ export const endpointAddressKind = (
   for (const kind of ENDPOINT_ADDRESS_KINDS) {
     if (rest.startsWith(`${kind}:`)) return kind;
   }
-  return ENDPOINT_ADDRESS_KINDS[0];
+  return absurd(raw as never);
 };
 
 /**
@@ -189,3 +187,13 @@ export type AuthenticatedIdentity = {
   readonly agentId: AgentId;
   readonly userId: UserId;
 };
+
+// ---------------------------------------------------------------------------
+// Exhaustiveness helpers (Principle 4)
+// ---------------------------------------------------------------------------
+
+/** Exhaustiveness sentinel — throws at runtime if a branch believed
+ *  unreachable is ever reached (e.g. a branded-value invariant breaks). */
+function absurd(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x)}`);
+}


### PR DESCRIPTION
## Summary

- Replaces the silent `return ENDPOINT_ADDRESS_KINDS[0]` fallback in `endpointAddressKind` (actor-model.ts:113 @b50abac) with `absurd(raw as never)` — a file-local exhaustiveness sentinel that throws loudly if the post-loop path is ever reached.
- Adds a file-local `function absurd(x: never): never` helper following the same pattern as `close-info.ts` and `transport.ts`, exempt from the `agent-code-guard/no-raw-throw-new-error` lint rule.
- Updates the JSDoc comment to remove the old explanation that justified the silent fallback.

Fixes #471. Flagged again in #459.

## Verification

- `pnpm --filter @moltzap/protocol build` — green
- `pnpm --filter @moltzap/protocol test` — 114/114 pass
- `pnpm check` — 0 errors (1 pre-existing warning, not introduced here)
- No new `any`, `as never` cast exists only at the call site of `absurd` per standard pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)