### PR TITLE
test(protocol): json-rpc-client unregistered-code branch (#520)

### DIFF
--- a/packages/protocol/src/transport/json-rpc-client.test.ts
+++ b/packages/protocol/src/transport/json-rpc-client.test.ts
@@ -1,6 +1,7 @@
 /**
  * Unit tests for `JsonRpcClient.resolve` — focused on inbound error-frame
- * decode for codes that match the registered tagged-error registry.
+ * decode for codes that match the registered tagged-error registry, and for
+ * codes that do not match (unregistered codes → RpcServerError).
  *
  * The resolver path that constructs the failure value lives in
  * `json-rpc-client.ts` and was the site of issue #511 (the wire frame's
@@ -15,6 +16,7 @@ import { defineRpc } from "./method.js";
 import { makeJsonRpcClient } from "./json-rpc-client.js";
 import { responseFrame, type ResponseFrame } from "./wire.js";
 import { ForbiddenError } from "./wire-errors.js";
+import { RpcServerError } from "./rpc-errors.js";
 
 const TestEcho = defineRpc({
   name: "test/echo",
@@ -29,6 +31,59 @@ function parseRequestId(raw: string): string {
   }
   return parsed.id;
 }
+
+/** An error code not registered in the wire-error registry. */
+const UNREGISTERED_CODE = 9999;
+
+describe("JsonRpcClient.resolve — unregistered error code → RpcServerError", () => {
+  it("wraps an unregistered error code as RpcServerError with code, message, and data threaded through", async () => {
+    const wireData = { detail: "some-extra-info" } as const;
+
+    const exit = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const idDef = yield* Deferred.make<string>();
+          const client = yield* makeJsonRpcClient({
+            write: (raw) =>
+              Deferred.succeed(idDef, parseRequestId(raw)).pipe(Effect.ignore),
+            idPrefix: "test",
+          });
+
+          const callFiber = yield* Effect.fork(client.call(TestEcho, {}));
+          const outgoingId = yield* Deferred.await(idDef);
+
+          const inbound: ResponseFrame = responseFrame(outgoingId, {
+            error: {
+              code: UNREGISTERED_CODE,
+              message: "unknown server failure",
+              data: wireData,
+            },
+          });
+
+          const handled = yield* client.resolve(inbound);
+          expect(handled).toBe(true);
+
+          return yield* Effect.exit(Fiber.join(callFiber));
+        }),
+      ),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const failure = Cause.failureOption(exit.cause);
+    expect(failure._tag).toBe("Some");
+    if (failure._tag !== "Some") return;
+    const value = failure.value;
+    // The branch under test: cls === undefined → RpcServerError, not a
+    // registered tagged-error class. If this branch broke (e.g., cls were
+    // mistakenly defined for this code), the assertion below would fail
+    // because a registered error instance is NOT an instanceof RpcServerError.
+    expect(value).toBeInstanceOf(RpcServerError);
+    expect((value as RpcServerError).code).toBe(UNREGISTERED_CODE);
+    expect((value as RpcServerError).message).toBe("unknown server failure");
+    expect((value as RpcServerError).data).toEqual(wireData);
+  });
+});
 
 describe("JsonRpcClient.resolve — registered tagged-error decode", () => {
   it("preserves the wire frame's `data` payload on a registered error code", async () => {


### PR DESCRIPTION
Closes #520

Sibling of #517 (registered tagged-error decode). That PR verified the
`cls !== undefined` path. This PR verifies the `cls === undefined` path
at `json-rpc-client.ts:80-86@8ae45b6`: when a wire error code has no
registered class, `resolve` constructs an `RpcServerError` and threads
the wire frame's `code`, `message`, and `data` fields through unchanged.

## What changed

Added one test in `packages/protocol/src/transport/json-rpc-client.test.ts`
inside a new `describe` block mirroring the existing style from #517. The
test uses `UNREGISTERED_CODE = 9999` (absent from the registry) and asserts
`instanceof RpcServerError` with all three fields. The `instanceof` check
would fail if the branch were broken by a accidental registration of code
9999 or by a wrong type being constructed instead.

## Scope

- Module: `packages/protocol/src/transport/json-rpc-client.test.ts`
- Tier: junior (single test file, no exported surface changes)
- New exported signatures: none
- New deps: none

## Tests

- `wraps an unregistered error code as RpcServerError with code, message, and data threaded through`
- Test count delta: +1 (116 total, was 115)
- `pnpm --filter @moltzap/protocol build` green
- `pnpm --filter @moltzap/protocol test` green (all 116 pass)

## Review

simplify: no findings (single test block following established pattern)
review: no findings

## Confidence

HIGH — the branch is simple and the assertion is exact; the test would
fail if `cls === undefined` constructed a registered error or swapped
any of the three forwarded fields.

Fixes #520