### PR TITLE
refactor(protocol): typed factory hook on RpcErrorClass — remove as never cast (#519)

### DIFF
--- a/packages/protocol/src/transport/json-rpc-client.ts
+++ b/packages/protocol/src/transport/json-rpc-client.ts
@@ -84,18 +84,14 @@ export const makeJsonRpcClient = (config: {
                   message: frame.error.message,
                   data: frame.error.data,
                 })
-              : // The wire-error registry stores the class factory keyed
-                // by code; the constructor produces a concrete tagged-error
-                // instance whose runtime tag matches one of the union arms
-                // in `RegisteredTaggedError`. The type system can't see
-                // through the open-ended `new (...) => { _tag: string }`
-                // factory shape, so the cast bridges the static factory
-                // to the closed runtime union. The `data` argument is
-                // forwarded so any payload set by the server reaches the
-                // typed instance rather than being dropped (#511).
-                (new cls({
-                  data: frame.error.data,
-                } as never) as RegisteredTaggedError);
+              : // `cls` accepts `RpcErrorPayload` by construction (every
+                // registered class extends `Data.TaggedError(<tag>)<RpcErrorPayload>`).
+                // The cast to `RegisteredTaggedError` bridges the registry's
+                // open factory shape (`{ _tag: string }`) to the closed
+                // runtime union; the runtime invariant — every registered
+                // class is a union arm — is asserted at registration, not
+                // at decode.
+                (new cls({ data: frame.error.data }) as RegisteredTaggedError);
           yield* Deferred.fail(deferred, failureValue).pipe(Effect.ignore);
           return true;
         }

--- a/packages/protocol/src/transport/wire-errors.ts
+++ b/packages/protocol/src/transport/wire-errors.ts
@@ -15,15 +15,29 @@ export const JSON_RPC_RESERVED_CODES = {
 
 /** A `Data.TaggedError`-derived class with static wire metadata
  * (`code` + `message`). JsonRpcServer reads `err.constructor.code` to encode;
- * JsonRpcClient looks up by code via `errorClassFor` for inbound decode. */
+ * JsonRpcClient looks up by code via `errorClassFor` for inbound decode and
+ * constructs an instance with the wire payload. The constructor parameter
+ * is `RpcErrorPayload` so the decode site can pass `{ data }` without a
+ * cast; every registered class's structural ctor accepts that shape because
+ * its tagged-error type extends `RpcErrorPayload`. */
 export type RpcErrorClass = (new (
-  ...args: never[]
+  payload: RpcErrorPayload,
 ) => {
   readonly _tag: string;
+  readonly data?: unknown;
 }) & {
   readonly code: number;
   readonly message: string;
 };
+
+/** Optional per-instance overrides for tagged-error classes. The static
+ * `message` on the class is the default; instances may carry a more
+ * specific message and/or supplemental `data` payload that JsonRpcServer
+ * forwards to the wire response. */
+export interface RpcErrorPayload {
+  readonly message?: string;
+  readonly data?: unknown;
+}
 
 const codeToClass = new Map<number, RpcErrorClass>();
 const registeredClasses = new Set<RpcErrorClass>();
@@ -52,15 +66,6 @@ export function errorClassFor(code: number): RpcErrorClass | undefined {
 /** Returns true iff `value`'s constructor is in the registered class set. */
 export function isRegisteredErrorInstance(value: object): boolean {
   return registeredClasses.has(value.constructor as RpcErrorClass);
-}
-
-/** Optional per-instance overrides for tagged-error classes. The static
- * `message` on the class is the default; instances may carry a more
- * specific message and/or supplemental `data` payload that JsonRpcServer
- * forwards to the wire response. */
-export interface RpcErrorPayload {
-  readonly message?: string;
-  readonly data?: unknown;
 }
 
 // Transport-layer cross-cutting tagged errors. Domain errors live in their
@@ -104,10 +109,14 @@ registerErrorClass(ConflictError);
 /** Boundary validation error — JSON-RPC reserved code -32602. Raised by
  * protocol- and server-layer handlers when params fail schema validation;
  * registered with the wire-error registry so handler-raised instances map
- * to a `-32602 InvalidParams` wire response via `wireErrorFromInstance`. */
-export class InvalidParamsError extends Data.TaggedError("InvalidParamsError")<{
-  readonly message: string;
-}> {
+ * to a `-32602 InvalidParams` wire response via `wireErrorFromInstance`.
+ *
+ * Shape is `RpcErrorPayload` (both `message` and `data` optional) to share
+ * the registered-class constructor signature. Callers supply `message`;
+ * the static class `message` provides the default when omitted. */
+export class InvalidParamsError extends Data.TaggedError(
+  "InvalidParamsError",
+)<RpcErrorPayload> {
   static readonly code = JSON_RPC_RESERVED_CODES.InvalidParams;
   static readonly message = "Invalid params";
 }


### PR DESCRIPTION
Closes #519

## Design choice

**Tightened constructor signature** (option 1 from the issue body) — change `RpcErrorClass`'s constructor parameter from `...args: never[]` to `payload: RpcErrorPayload`. The decode site no longer needs `as never` because the registry's stored factory now structurally accepts `{ data: unknown }`.

To keep all registered classes' structural types compatible with the tightened factory signature, `InvalidParamsError`'s tagged-error type is loosened from `{ message: string }` to `RpcErrorPayload` (both fields optional). All call sites already supply `message`; the static class `message` covers the optional default — no runtime behavior change.

The decode site retains a single `as RegisteredTaggedError` cast that bridges the registry's open factory return (`{ _tag: string }`) to the closed runtime union. Eliminating that cast requires parameterizing the registry over the union — wider scope than #519.

## Plan anchors

| Change | Issue anchor |
|---|---|
| Tighten `RpcErrorClass` ctor parameter to `RpcErrorPayload` | #519 \"Constrain constructor parameter to `{ data?: unknown }` (or whatever the registered errors' shared shape is)\" |
| Loosen `InvalidParamsError` to share `RpcErrorPayload` shape | #519 \"the registered errors' shared shape\" |
| Drop `as never` at decode site (`packages/protocol/src/transport/json-rpc-client.ts:96-98@d52a3c7`) | #519 title |

## Scope

- Modules touched: `packages/protocol/src/transport/{wire-errors,json-rpc-client}.ts`
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Verification

- `pnpm --filter @moltzap/protocol build` — green
- `pnpm --filter @moltzap/protocol test` — 115/115 pass (1 todo, pre-existing)
- `pnpm -w build` — green across protocol, server, client, runtimes, channels
- `pnpm -w lint` — 1 pre-existing warning unrelated to this diff
- `git grep 'as never' packages/protocol/src/transport/json-rpc-client.ts` — no hits
- All consumers of `RpcErrorClass` (`json-rpc-server.ts`, `wire-errors.ts`, `transport/index.ts`) compile clean against the tightened signature

## Pre-PR gates

- /simplify (inline): no findings — diff is minimal (32 add, 27 remove), comment trimmed to present tense, no dead code
- /review (inline): Principle 1 satisfied (tightening a runtime invariant into the type system); no new `any`, no new `as never`, no raw throws, no untagged catches

## Confidence

HIGH — all builds and tests pass; the remaining `as RegisteredTaggedError` cast is the registry-invariant bridge already present and out of scope for #519.