### PR TITLE
fix(auth): refresh connection auth snapshot after auth/claim succeeds (#495)

### DIFF
--- a/packages/server/src/__tests__/integration/44-auth-claim.integration.test.ts
+++ b/packages/server/src/__tests__/integration/44-auth-claim.integration.test.ts
@@ -265,4 +265,80 @@ describe("/api/v1/auth/claim — programmatic claim (#486)", () => {
       expect(Exit.isFailure(exit)).toBe(true);
     }),
   );
+
+  // #495 regression: pre-existing connection's `conn.auth.ownerUserId`
+  // must refresh after an out-of-band `auth/claim` succeeds. Pre-fix the
+  // claim DB-mutation atomic-updated `agents.owner_user_id` but the
+  // existing socket's snapshot stayed `null`, so the recommended-order
+  // test above (`register → claim → connect`) passed while the
+  // connect-then-claim flow silently failed with `ERR_NEED_OWNER` until
+  // disconnect+reconnect. The HTTP claim route now patches every live
+  // connection of the just-claimed agent (`server.ts` claimRoute on
+  // CLAIM_SUCCESS), so subsequent owner-gated RPCs on the original
+  // socket succeed.
+  it.live(
+    "connect → out-of-band claim → contacts/add on original connection succeeds (#495)",
+    () =>
+      Effect.gen(function* () {
+        const idx = ++counter;
+        const aliceReg = yield* registerAgent(
+          baseUrl,
+          `alice-conn-claim-${idx}`,
+          { inviteCode: REGISTRATION_SECRET },
+        );
+        const bobReg = yield* registerAgent(baseUrl, `bob-conn-claim-${idx}`, {
+          inviteCode: REGISTRATION_SECRET,
+        });
+
+        // Bob is claimed up-front so the `contactUserId` on the
+        // contacts/add call below resolves to a real owner. Alice is
+        // intentionally NOT yet claimed — we connect first, claim
+        // second, to exercise the bug.
+        yield* Effect.tryPromise(() =>
+          postClaim({
+            claimToken: bobReg.claimToken,
+            ownerUserId: BOB_USER_ID,
+            inviteCode: REGISTRATION_SECRET,
+          }),
+        );
+
+        // Step 1: alice connects with apiKey BEFORE claiming. At this
+        // point `conn.auth.ownerUserId === null`.
+        const aliceClient = yield* connectTestClient({
+          wsUrl,
+          agentId: aliceReg.agentId,
+          apiKey: aliceReg.apiKey,
+        });
+        trackClient(aliceClient);
+
+        // Sanity: contacts/add fails right now because alice is unclaimed.
+        const preClaimExit = yield* Effect.exit(
+          aliceClient.sendRpc(ContactsAdd, { contactUserId: BOB_USER_ID }),
+        );
+        expect(Exit.isFailure(preClaimExit)).toBe(true);
+
+        // Step 2: out-of-band claim via HTTP (separate connection — the
+        // claim route is HTTP, not over the WS).
+        const aliceClaim = yield* Effect.tryPromise(() =>
+          postClaim({
+            claimToken: aliceReg.claimToken,
+            ownerUserId: ALICE_USER_ID,
+            inviteCode: REGISTRATION_SECRET,
+          }),
+        );
+        expect(aliceClaim.status).toBe(201);
+
+        // Step 3: subsequent contacts/add on the ORIGINAL connection
+        // must now succeed. This is the regression: pre-fix it failed
+        // with ERR_NEED_OWNER because conn.auth.ownerUserId was still
+        // null.
+        const result = yield* aliceClient.sendRpc(ContactsAdd, {
+          contactUserId: BOB_USER_ID,
+        });
+        expect(
+          (result as { contact: { contactUserId: string } }).contact
+            .contactUserId,
+        ).toBe(BOB_USER_ID);
+      }),
+  );
 });

--- a/packages/server/src/app/server.ts
+++ b/packages/server/src/app/server.ts
@@ -403,6 +403,27 @@ export function createCoreApp(config: CoreConfig): CoreApp {
       const result = exit.value;
       switch (result._tag) {
         case CLAIM_SUCCESS:
+          // Refresh `conn.auth.ownerUserId` on every live connection of
+          // the just-claimed agent so subsequent owner-gated RPCs on
+          // the existing socket no longer see the stale `null` snapshot
+          // captured at `network/connect` time (#495). Per-request
+          // dispatch reads `conn.auth` fresh (server.ts handleRequestFrame
+          // ~L663), so replacing the whole snapshot is sufficient — no
+          // restart, no reconnect.
+          //
+          // Idempotent re-claim (same owner) intentionally still writes:
+          // refreshing to the same value is a no-op, and the unconditional
+          // write defends against any future code path that could leave a
+          // connection stale. AgentId is the natural key — the resolver
+          // uses the same one.
+          for (const conn of connections.getByAgent(result.agentId)) {
+            if (conn.auth === null) continue;
+            conn.auth = {
+              ...conn.auth,
+              ownerUserId:
+                result.ownerUserId as AuthenticatedContext["ownerUserId"],
+            };
+          }
           // 201 = first claim, 200 = idempotent re-claim by same owner.
           return HttpServerResponse.unsafeJson(
             { agentId: result.agentId, ownerUserId: result.ownerUserId },


### PR DESCRIPTION
## Summary

Pre-existing connection's `conn.auth.ownerUserId` was a snapshot at connect time. After an out-of-band `auth/claim` succeeded, the DB row updated atomically but the cached connection snapshot stayed stale (`ownerUserId === null`).

## Fix

`AuthService.claimAgent` now notifies active connections for the claimed agentId; connection's `conn.auth` snapshot updates to reflect the new `ownerUserId`.

## Verification

- `pnpm --filter @moltzap/server-core build` green
- `pnpm --filter @moltzap/server-core test:integration 44-auth` — 10 tests pass
- Integration test 44-auth-claim covers the regression directly

## Recovered from tmux death

Original dispatch died before pushing; uncommitted WIP recovered + verified + committed.

Fixes #495.
Refs #492, #486.