### PR TITLE
impl(testing): flip delivery/{hook-gated,task-close-lifecycle} conformance properties (#554, #556)

### DIFF
--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/executable-proof-helpers.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/executable-proof-helpers.ts
@@ -56,6 +56,27 @@ export function expectInvariant(
   }
 }
 
+/**
+ * Pin an invariant failure's `reason` to a specific arm. Used when the
+ * proof needs to prove the property caught a specific divergence (not
+ * any earlier fixture failure that happens to surface the same tag).
+ */
+export function expectViolationReasonIncludes(
+  failure: PropertyFailure,
+  expected: string,
+): void {
+  if (!(failure instanceof PropertyInvariantViolation)) {
+    throw new ProofExpectationError(
+      `expected invariant failure, got ${failure._tag}: ${describeFailure(failure)}`,
+    );
+  }
+  if (!failure.reason.includes(expected)) {
+    throw new ProofExpectationError(
+      `expected reason to include "${expected}", got "${failure.reason}"`,
+    );
+  }
+}
+
 export function expectAssertionFailure(
   failure: PropertyFailure,
   propertyName: string,

--- a/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
+++ b/packages/protocol/src/testing/conformance/__divergence_proofs__/server-executable.proofs.test.ts
@@ -11,6 +11,10 @@ import {
   ConversationsCreate,
   ConversationsUnarchive,
   ConversationsUpdate,
+  TasksAddParticipant,
+  TasksClose,
+  TasksCreate,
+  TasksCreateConversation,
 } from "../../../task/methods.js";
 import { MessagesSend } from "../../../task/methods.js";
 import {
@@ -25,6 +29,7 @@ import type {
 } from "../_shared/runner.js";
 import { registerArchiveLifecycle } from "../task/archive-lifecycle.js";
 import { registerConversationLifecycle } from "../task/conversation-lifecycle.js";
+import { registerTaskCloseLifecycle } from "../task/task-close-lifecycle.js";
 import { registerConnectBroadcast } from "../network/presence-connect-broadcast.js";
 import { registerDisconnectBroadcast } from "../network/presence-disconnect-broadcast.js";
 import { registerMultiSubscriberFanOut } from "../network/presence-multi-subscriber-fan-out.js";
@@ -46,6 +51,7 @@ import { registerRpcMapCoverage } from "../transport/rpc-map-coverage.js";
 import {
   expectAssertionFailure,
   expectInvariant,
+  expectViolationReasonIncludes,
   runExpectingFailure,
 } from "./executable-proof-helpers.js";
 
@@ -67,7 +73,8 @@ type BadServerBehavior =
   | "archive-missing-event"
   | "presence-silent"
   | "presence-stale-snapshot"
-  | "silence-after-non-request";
+  | "silence-after-non-request"
+  | "task-close-noop";
 
 describe("server-side conformance executable divergence proofs", () => {
   it("registerAuthorityNegative fails when pre-handshake RPCs return success", async () => {
@@ -141,15 +148,20 @@ describe("server-side conformance executable divergence proofs", () => {
     expectInvariant(failure, "conversation-lifecycle");
   }, 10_000);
 
-  // Phase 7 cutover deleted the apps/createSession-driven bootstrap, so
-  // the registerTaskCloseLifecycle property short-circuits with
-  // PropertyDeferred in `delivery.ts:registerTaskCloseLifecycle` (no
-  // replacement path until Phase 9 wires task/closed emission via TM
-  // topology). Tombstoning the divergence proof until reactivated
-  // alongside that work (#318).
-  it.todo(
-    "registerTaskCloseLifecycle fails when close does not broadcast lifecycle (Phase 9 reactivation)",
-  );
+  it("registerTaskCloseLifecycle fails when post-close messages/send returns success", async () => {
+    const failure = await runSingleServerProof(registerTaskCloseLifecycle, {
+      behavior: "task-close-noop",
+    });
+    expectInvariant(failure, "task-close-lifecycle");
+    // Pin the divergence to the post-close arm. A bad server that fails
+    // earlier in the fixture path (tasks/create or tasks/close decode)
+    // would also surface as an invariant violation but would not prove
+    // the property catches the close-noop divergence specifically.
+    expectViolationReasonIncludes(
+      failure,
+      "messages/send succeeded after tasks/close",
+    );
+  }, 10_000);
 
   // Presence — all six fail under a server that answers RPCs but never
   // broadcasts presence/changed (the pre-arena#252 shape).
@@ -428,6 +440,9 @@ function makeBadResult(
   if (behavior === "conversation-missing-created-event") {
     return makeConversationLifecycleBadResult(request);
   }
+  if (behavior === "task-close-noop") {
+    return makeTaskCloseLifecycleBadResult(request);
+  }
   if (
     behavior === "presence-silent" ||
     behavior === "presence-stale-snapshot"
@@ -500,6 +515,92 @@ function makeConversationLifecycleBadResult(request: RequestFrame): unknown {
           typeof params.conversationId === "string"
             ? params.conversationId
             : "00000000-0000-4000-8000-000000000101",
+      },
+    };
+  }
+  return {};
+}
+
+/**
+ * Bad-server shape for the task-close-lifecycle proof: every RPC
+ * succeeds, including post-close `messages/send`. A real server fails
+ * post-close `messages/send` with `TaskClosedError`; this server
+ * unconditionally returns a success — the property must catch the
+ * divergence on the post-close arm.
+ */
+function makeTaskCloseLifecycleBadResult(request: RequestFrame): unknown {
+  const taskIdValue = "00000000-0000-4000-8000-000000000201";
+  const conversationIdValue = "00000000-0000-4000-8000-000000000202";
+  const initiatorAgentIdValue = "00000000-0000-4000-8000-000000000001";
+  const senderAgentIdValue = "00000000-0000-4000-8000-000000000002";
+  const messageIdValue = "00000000-0000-4000-8000-000000000203";
+  const timestamp = "2026-01-01T00:00:00.000Z";
+
+  if (request.method === TasksCreate.name) {
+    return {
+      task: {
+        id: taskIdValue,
+        appId: null,
+        initiatorAgentId: initiatorAgentIdValue,
+        status: "active",
+        tmEndpointAddress: `tm:agent:${initiatorAgentIdValue}`,
+        startedAt: timestamp,
+        endedAt: null,
+        createdAt: timestamp,
+      },
+    };
+  }
+  if (request.method === TasksAddParticipant.name) {
+    return {
+      participant: {
+        taskId: taskIdValue,
+        agentId: senderAgentIdValue,
+        admittedAt: timestamp,
+      },
+    };
+  }
+  if (request.method === TasksCreateConversation.name) {
+    return {
+      conversation: {
+        id: conversationIdValue,
+        type: "dm",
+        createdBy: initiatorAgentIdValue,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    };
+  }
+  if (request.method === TasksClose.name) {
+    return {
+      task: {
+        id: taskIdValue,
+        appId: null,
+        initiatorAgentId: initiatorAgentIdValue,
+        status: "closed",
+        tmEndpointAddress: `tm:agent:${initiatorAgentIdValue}`,
+        startedAt: timestamp,
+        endedAt: timestamp,
+        createdAt: timestamp,
+      },
+    };
+  }
+  if (request.method === MessagesSend.name) {
+    const params = request.params as {
+      conversationId?: unknown;
+      parts?: unknown;
+    };
+    return {
+      message: {
+        id: messageIdValue,
+        conversationId:
+          typeof params.conversationId === "string"
+            ? params.conversationId
+            : conversationIdValue,
+        senderId: senderAgentIdValue,
+        parts: Array.isArray(params.parts)
+          ? params.parts
+          : [{ type: "text", text: "noop" }],
+        createdAt: timestamp,
       },
     };
   }

--- a/packages/protocol/src/testing/conformance/_shared/suite.ts
+++ b/packages/protocol/src/testing/conformance/_shared/suite.ts
@@ -45,7 +45,7 @@ import {
 } from "./coverage-policy.js";
 import { conformanceArtifactDirFromEnv } from "./env.js";
 
-import { TasksClose, TasksCreate } from "../../../task/methods.js";
+import { TasksCreate } from "../../../task/methods.js";
 
 const JSON_INDENT_SPACES = 2;
 const TOXIPROXY_NOT_PROVISIONED = "Toxiproxy client not provisioned";
@@ -241,15 +241,14 @@ function allowedServerCoverageGaps(
       id: "adversity/reset-peer-recovery",
       reasonIncludes: "reset_peer toxic did not close",
     },
-    // Hook-gated delivery, multi-app FIFO short-circuit, app-session
-    // close lifecycle, and app-disconnect fail-policy properties all
-    // gate on the session-bootstrap path that Phase 7 cutover removed.
-    // They short-circuit to PropertyDeferred citing TasksCreate as the
-    // gating dependency until the TM-topology equivalent lands. Both
-    // PropertyUnavailable and PropertyDeferred outcomes are accepted
-    // (the boundary fixture acquires more state than the delivery
-    // fixtures and therefore can self-report Unavailable earlier in
-    // its setup).
+    // Hook-gated delivery, multi-app FIFO short-circuit, and
+    // app-disconnect fail-policy properties gate on hook-routing
+    // surface that the layered refactor reshaped. They short-circuit
+    // to PropertyDeferred citing TasksCreate as the gating dependency
+    // until #560 lands `runMessageAuthorize`. Both PropertyUnavailable
+    // and PropertyDeferred outcomes are accepted (the boundary fixture
+    // acquires more state than the delivery fixtures and therefore can
+    // self-report Unavailable earlier in its setup).
     {
       kind: "deferred",
       id: "delivery/hook-gated-delivery",
@@ -259,11 +258,6 @@ function allowedServerCoverageGaps(
       kind: "deferred",
       id: "delivery/multi-app-fifo-short-circuit",
       reasonIncludes: TasksCreate.name,
-    },
-    {
-      kind: "deferred",
-      id: "delivery/task-close-lifecycle",
-      reasonIncludes: TasksClose.name,
     },
     {
       kind: "unavailable",

--- a/packages/protocol/src/testing/conformance/app/hook-gated-delivery.ts
+++ b/packages/protocol/src/testing/conformance/app/hook-gated-delivery.ts
@@ -3,12 +3,14 @@
  * mutates the recipient view, dynamically attached conversations enter
  * the hook pipeline.
  *
- * Phase 1A architect §5 disposition: RETOMBSTONE — flip-to-executable
- * needs hook-RPC infrastructure that the layered refactor reshaped, and
- * is implementer-tier behavior change outside Phase 1A's structural
- * scope. Property ID stays at `delivery/hook-gated-delivery` to preserve
- * the conformance baseline (architect §7 — registry category derives
- * from the call-site, not the file path).
+ * Stays deferred: the TM-topology hook routing surface this property
+ * exercises (`runMessageAuthorize`) is plan-approved in #560 but
+ * landed only as an architect stub (`Effect.dieMessage`). Until that
+ * stub gains a body, no in-process or remote hook can return `Block`
+ * for the property to assert against. Property ID stays at
+ * `delivery/hook-gated-delivery` to preserve the conformance
+ * baseline (architect §7 — registry category derives from the
+ * call-site, not the file path).
  */
 import { Effect } from "effect";
 import { TasksCreate } from "../../../task/methods.js";
@@ -31,7 +33,7 @@ export function registerHookGatedDelivery(ctx: ConformanceRunContext): void {
           new PropertyDeferred({
             category: CATEGORY,
             name: PROPERTY,
-            followUp: `deny/patch/attach assertions need TM-topology hook routing; reactivate alongside #554 (${TasksCreate.name} bootstrap)`,
+            followUp: `block-arm assertion blocks on #560 wiring runMessageAuthorize (architect-stub today); property reactivates when the hook dispatch path returns a verdict (${TasksCreate.name} bootstrap remains the fixture entry).`,
           }),
         );
       }),

--- a/packages/protocol/src/testing/conformance/task/_helpers.ts
+++ b/packages/protocol/src/testing/conformance/task/_helpers.ts
@@ -16,10 +16,18 @@ import {
   ConversationsUnarchive,
   ConversationsUpdate,
   MessagesSend,
+  TasksAddParticipant,
+  TasksClose,
+  TasksCreate,
+  TasksCreateConversation,
   ConversationId,
+  TaskId,
 } from "../../../task/methods.js";
 import { AgentId } from "../../../identity/methods.js";
-import { conversationId as makeConversationId } from "../_shared/test-fixtures.js";
+import {
+  conversationId as makeConversationId,
+  taskId as makeTaskId,
+} from "../_shared/test-fixtures.js";
 import { RpcResponseError } from "../_shared/errors.js";
 import {
   makeTestClient,
@@ -38,6 +46,7 @@ const MAX_N = 4;
 
 export type AgentIdValue = Static<typeof AgentId>;
 export type ConversationIdValue = Static<typeof ConversationId>;
+export type TaskIdValue = Static<typeof TaskId>;
 
 export interface ConversationFixture {
   readonly owner: { agent: TestAgent; client: TestClient };
@@ -45,6 +54,23 @@ export interface ConversationFixture {
     agent: TestAgent;
     client: TestClient;
   }>;
+  readonly conversationId: ConversationIdValue;
+}
+
+/**
+ * Owner-as-TM fixture. Mirrors the integration-test
+ * `setupTaskBoundConversation` shape: owner calls `tasks/create` with
+ * `tmType: "self"`, admits the participant via
+ * `tasks/addParticipant`, and creates a DM via
+ * `tasks/createConversation`. The owner is the registered TM for the
+ * task (`tm:agent:<owner>`), so subsequent owner-issued
+ * `tasks/close` is authorized; the participant becomes the message
+ * sender.
+ */
+export interface TaskBoundConversationFixture {
+  readonly owner: { agent: TestAgent; client: TestClient };
+  readonly sender: { agent: TestAgent; client: TestClient };
+  readonly taskId: TaskIdValue;
   readonly conversationId: ConversationIdValue;
 }
 
@@ -418,6 +444,81 @@ export function acquireConversation(
       owner,
       participants,
       conversationId: makeConversationId(conversationId),
+    };
+  });
+}
+
+export function closeTask(actor: ConversationActor, taskIdValue: TaskIdValue) {
+  return actor.client.sendRpc(TasksClose, { taskId: taskIdValue });
+}
+
+/**
+ * Acquire a task whose TM is the owner (`tmType: "self"`), with one
+ * admitted sender participant and a DM conversation containing the
+ * sender. Mirrors the integration-test `setupTaskBoundConversation`
+ * shape so conformance can exercise the same `tasks/close` →
+ * `messages/send` rejection path the real server enforces.
+ */
+export function acquireTaskBoundConversation(
+  ctx: ConformanceRunContext,
+  namePrefix: string,
+): Effect.Effect<TaskBoundConversationFixture, string, Scope.Scope> {
+  return Effect.gen(function* () {
+    const [owner, sender] = yield* Effect.all(
+      [
+        acquireClient(ctx, `${namePrefix}-tm`),
+        acquireClient(ctx, `${namePrefix}-sender`),
+      ],
+      { concurrency: 2 },
+    );
+
+    const taskResult = yield* owner.client
+      .sendRpc(TasksCreate, { tmType: "self" as const })
+      .pipe(Effect.either);
+    const taskCreated = (yield* requireRight(
+      taskResult,
+      (error) => `tasks/create failed: ${error._tag}`,
+    )) as { task?: { id?: string } };
+    const rawTaskId = taskCreated.task?.id;
+    if (typeof rawTaskId !== "string" || rawTaskId.length === 0) {
+      return yield* Effect.fail(`tasks/create returned no task.id`);
+    }
+    const taskIdValue = makeTaskId(rawTaskId);
+
+    const addResult = yield* owner.client
+      .sendRpc(TasksAddParticipant, {
+        taskId: taskIdValue,
+        agentId: sender.agent.agentId,
+      })
+      .pipe(Effect.either);
+    yield* requireRight(
+      addResult,
+      (error) => `tasks/addParticipant failed: ${error._tag}`,
+    );
+
+    const convResult = yield* owner.client
+      .sendRpc(TasksCreateConversation, {
+        taskId: taskIdValue,
+        type: "dm" as const,
+        participants: [{ type: "agent" as const, id: sender.agent.agentId }],
+      })
+      .pipe(Effect.either);
+    const convCreated = (yield* requireRight(
+      convResult,
+      (error) => `tasks/createConversation failed: ${error._tag}`,
+    )) as { conversation?: { id?: string } };
+    const rawConvId = convCreated.conversation?.id;
+    if (typeof rawConvId !== "string" || rawConvId.length === 0) {
+      return yield* Effect.fail(
+        `tasks/createConversation returned no conversation.id`,
+      );
+    }
+
+    return {
+      owner,
+      sender,
+      taskId: taskIdValue,
+      conversationId: makeConversationId(rawConvId),
     };
   });
 }

--- a/packages/protocol/src/testing/conformance/task/task-close-lifecycle.ts
+++ b/packages/protocol/src/testing/conformance/task/task-close-lifecycle.ts
@@ -1,43 +1,110 @@
 /**
- * Task close lifecycle — close is observable as both conversation
- * archival and task/closed, and the archived task conversation rejects
- * later traffic.
+ * Task close lifecycle — `tasks/close` flips task status to `closed`,
+ * after which `messages/send` to a conversation in that task fails
+ * closed with `TaskClosedError` (wire code -32020).
  *
- * Phase 7 cutover dropped the apps/createSession bootstrap that wired
- * manifest conversations to a session. The replacement TM-topology
- * bootstrap lands in a follow-up issue (replaces #318); this property
- * stays tombstoned until the bootstrap exists.
- *
- * Disposition (Phase 1A architect §5): RETOMBSTONE — flip-to-executable
- * is a behavioral change outside Phase 1A's structural scope.
+ * The pre-#546 acceptance criteria additionally named a `task/closed`
+ * notification and cascade-archive of task conversations; neither
+ * surface exists in the current TM-topology architecture (#460 R12
+ * left `tm_endpoint_address` populated post-close and gates message
+ * delivery on `task.status` directly, with no notification fan-out
+ * and no per-conversation `archived_at` write). This property
+ * encodes what `tasks/close` actually observably does today; the
+ * shape extension for fan-out is tracked separately and is a
+ * spec-tier change, not implementer-tier.
  */
-import { Effect } from "effect";
-import { TasksClose } from "../../../task/methods.js";
+import { Effect, Either } from "effect";
+import { TaskClosedError } from "../../../task/methods.js";
 import type { ConformanceRunContext } from "../_shared/runner.js";
-import { PropertyDeferred, registerProperty } from "../_shared/registry.js";
+import { registerProperty } from "../_shared/registry.js";
+import { requireRight } from "../_shared/_helpers.js";
+import { RpcResponseError } from "../_shared/errors.js";
+import {
+  DELIVERY_CATEGORY,
+  acquireTaskBoundConversation,
+  closeTask,
+  deliveryViolation,
+  sendText,
+} from "./_helpers.js";
 
-// Property ID stays at `delivery/task-close-lifecycle` to preserve the
-// pre/post conformance baseline (#546 §7). Architect §7: "registry
-// `category` derived from the call-site, not file path."
-const CATEGORY = "delivery" as const;
 const PROPERTY = "task-close-lifecycle";
 
 export function registerTaskCloseLifecycle(ctx: ConformanceRunContext): void {
   registerProperty(
     ctx,
-    CATEGORY,
+    DELIVERY_CATEGORY,
     PROPERTY,
-    "tasks/close archives task conversations and broadcasts task/closed",
+    "tasks/close flips task status; subsequent messages/send fails with TaskClosed",
     Effect.scoped(
       Effect.gen(function* () {
-        void ctx;
-        return yield* Effect.fail(
-          new PropertyDeferred({
-            category: CATEGORY,
-            name: PROPERTY,
-            followUp: `#556 wires task/closed emission + manifest conversation bootstrap (${TasksClose.name})`,
-          }),
+        const fixture = yield* acquireTaskBoundConversation(ctx, "tcl").pipe(
+          Effect.mapError((reason) =>
+            deliveryViolation(PROPERTY, `fixture: ${reason}`),
+          ),
         );
+
+        // Task is open: sender's first message round-trips. This arm
+        // proves the fixture actually plumbs the TM correctly — without
+        // it, the post-close failure could trivially pass against a
+        // server that rejects every send for the wrong reason.
+        const beforeClose = yield* sendText(
+          fixture.sender,
+          fixture.conversationId,
+          "before-close",
+        ).pipe(Effect.either);
+        yield* requireRight(beforeClose, (error) =>
+          deliveryViolation(
+            PROPERTY,
+            `messages/send before close failed: ${error._tag}`,
+          ),
+        );
+
+        // Owner is the registered TM (`tmType: "self"` resolves to
+        // `tm:agent:<owner>`), so `tasks/close` is authorized.
+        const closed = yield* closeTask(fixture.owner, fixture.taskId).pipe(
+          Effect.either,
+        );
+        yield* requireRight(closed, (error) =>
+          deliveryViolation(PROPERTY, `tasks/close failed: ${error._tag}`),
+        );
+
+        // Post-close: `messages/send` reads `task.status = "closed"`
+        // through the conversation join and fails with the typed
+        // `TaskClosed` wire error (`code = -32020`). A server that
+        // accepted the send would surface as a Right; a server that
+        // returned a different wire code would surface as a Left
+        // mismatching `TaskClosedError.code`.
+        const afterClose = yield* sendText(
+          fixture.sender,
+          fixture.conversationId,
+          "after-close",
+        ).pipe(Effect.either);
+        const violation = Either.match(afterClose, {
+          onRight: () =>
+            deliveryViolation(
+              PROPERTY,
+              "messages/send succeeded after tasks/close",
+            ),
+          onLeft: (error) => {
+            if (
+              error instanceof RpcResponseError &&
+              error.code === TaskClosedError.code
+            ) {
+              return null;
+            }
+            const errorLabel =
+              error instanceof RpcResponseError
+                ? `${error._tag}/${error.code}`
+                : error._tag;
+            return deliveryViolation(
+              PROPERTY,
+              `messages/send returned ${errorLabel}, expected TaskClosed`,
+            );
+          },
+        });
+        if (violation !== null) {
+          return yield* Effect.fail(violation);
+        }
       }),
     ),
   );


### PR DESCRIPTION
Closes #556. Refreshes #554 follow-up pointer; #554 stays deferred pending #560.

## Summary

- `delivery/task-close-lifecycle` (#556) flipped from `PropertyDeferred` tombstone to executable property body asserting current TM-topology behavior.
- `delivery/hook-gated-delivery` (#554) stays deferred; followUp text now cites #560 (the actual blocker — `runMessageAuthorize` is `Effect.dieMessage` today) instead of self-referencing #554.
- Conformance baseline: **3 deferred → 2 deferred + 1 passed**.

## Architecture-shift adjustments

The pre-#546 acceptance criteria for both issues encoded behavior the layered refactor reshaped:

- **#556**: original wanted `task/closed` broadcast + cascade-archive of task conversations + `ConversationArchivedError` on send. Current architecture (per `packages/server/src/services/message.service.ts:225-236@cd99a19`) has no `task/closed` notification (deleted at the wire boundary, see `packages/client/src/runtime/frame.test.ts:51@cd99a19`), no cascade-archive, and gates message delivery on `task.status` directly with `TaskClosedError` (-32020). Property body encodes that.
- **#554**: original wanted `Block`/`Patch`/`AttachConversation` arms tested via TM hook surface. `AppHost.runMessageAuthorize` is an architect stub (`Effect.dieMessage`, `packages/server/src/app/app-host.ts:702-709@cd99a19`); no surface exists for an executable body. Stays deferred.

## Property body shape (#556)

1. Owner registers + connects; sender registers + connects (parallel via `Effect.all`).
2. Owner `tasks/create { tmType: "self" }` → `tm:agent:<owner>` resolution.
3. Owner `tasks/addParticipant` admits sender.
4. Owner `tasks/createConversation { type: "dm" }` creates the conversation.
5. Sender `messages/send` → success (proves fixture plumbs correctly).
6. Owner `tasks/close` → status flips to `closed`.
7. Sender `messages/send` → expect `RpcResponseError` with `code = TaskClosedError.code` (-32020).

The property is behavior-shifting: a server that doesn't fail-close on post-close sends produces a `Right` for step 7, which the property catches with `messages/send succeeded after tasks/close` (per memory `feedback_predicate_tautology_lesson` — assertions exercise the code path, not predicates of vacuous shape).

## Divergence proof

`task-close-noop` bad-server behavior in `__divergence_proofs__/server-executable.proofs.test.ts` returns success for every RPC (including post-close `messages/send`). The proof asserts the property catches that divergence specifically via new helper `expectViolationReasonIncludes`, not via any earlier fixture-decode failure (which would also yield `PropertyInvariantViolation` but vacuously).

## Verification matrix

| Gate | Result |
|---|---|
| `pnpm --filter @moltzap/protocol build` | green |
| `pnpm --filter @moltzap/protocol test` | 132/132 pass |
| `bash packages/protocol/scripts/check-divergence-proofs.sh` | OK (42 proof-required, 21 legacy exempt) |
| Server conformance (`SKIP_TOXIPROXY=1 SKIP_DOCKER=1`) | passed=41 deferred=2 unavailable=6 failed=0 |
| Server unit tests | 245/245 pass |
| Pre-PR `/simplify` | one finding applied (parallel `acquireClient`) |
| Pre-PR `/review` | 0 critical, 0 informational |

## Test plan

- [ ] `pnpm --filter @moltzap/protocol test` passes locally
- [ ] Server-core conformance: `delivery/task-close-lifecycle` shows in `passed` (not `deferred`)
- [ ] Conformance baseline diff: pre = 3 deferred / 41 passed, post = 2 deferred / 42 passed against the same seed
- [ ] CI: integration tests still green