### PR TITLE
fix(openclaw-channel): treat TaskClosedError as terminal in send retry loop (#281)

### DIFF
--- a/packages/openclaw-channel/src/openclaw-entry.delivery.test.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.delivery.test.ts
@@ -59,6 +59,8 @@ import {
   ConversationsGet,
   MessagesSend,
 } from "@moltzap/protocol";
+import { TaskClosedError } from "@moltzap/protocol/task";
+import { RpcServerError } from "@moltzap/protocol/transport";
 
 function makeMessage(overrides: Partial<Message> = {}): Message {
   return {
@@ -387,6 +389,71 @@ describe("Flow 6: Outbound delivery — deliver callback + sendText", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error!.message).toBe("Server rejected");
+  });
+
+  it("deliver callback returns true when send fails with TaskClosedError (terminal-consumed, no retry)", async () => {
+    // TaskClosedError arrives as RpcServerError with code -32020.
+    // The deliver callback signals true so OpenClaw treats the message as
+    // consumed and does not retry.
+    mockSend.mockReturnValueOnce(
+      Effect.fail(
+        new RpcServerError({
+          code: TaskClosedError.code,
+          message: TaskClosedError.message,
+        }),
+      ),
+    );
+
+    capturedOnMessage!(makeMessage());
+
+    await vi.waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledOnce();
+    });
+
+    const dispatchArgs = mockDispatch.mock.calls[0]![0] as {
+      dispatcherOptions: {
+        deliver: (payload: unknown, info?: unknown) => Promise<boolean>;
+      };
+    };
+
+    const result = await dispatchArgs.dispatcherOptions.deliver(
+      { text: "reply text" },
+      { kind: "final" },
+    );
+
+    // Terminal-consumed: true signals no retry.
+    expect(result).toBe(true);
+  });
+
+  it("deliver callback returns false when send fails with a non-TaskClosed RpcServerError (retry-eligible)", async () => {
+    mockSend.mockReturnValueOnce(
+      Effect.fail(
+        new RpcServerError({
+          code: -32001,
+          message: "Internal server error",
+        }),
+      ),
+    );
+
+    capturedOnMessage!(makeMessage());
+
+    await vi.waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledOnce();
+    });
+
+    const dispatchArgs = mockDispatch.mock.calls[0]![0] as {
+      dispatcherOptions: {
+        deliver: (payload: unknown, info?: unknown) => Promise<boolean>;
+      };
+    };
+
+    const result = await dispatchArgs.dispatcherOptions.deliver(
+      { text: "reply text" },
+      { kind: "final" },
+    );
+
+    // Retry-eligible: false signals delivery failure.
+    expect(result).toBe(false);
   });
 
   it("stopAccount removes client from active pool", async () => {

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -34,6 +34,8 @@ import {
   ContactsList,
   ConversationsList,
 } from "@moltzap/protocol";
+import { TaskClosedError } from "@moltzap/protocol/task";
+import { RpcServerError } from "@moltzap/protocol/transport";
 
 const DEFAULT_ACCOUNT_ID = "default";
 const CHANNEL_ID = "moltzap" as const;
@@ -498,6 +500,30 @@ export function createMoltzapChannelPlugin() {
                               }),
                             ),
                             Effect.map(() => true),
+                            Effect.catchTag(
+                              "RpcServerError",
+                              (err: RpcServerError) =>
+                                Effect.sync(() => {
+                                  if (err.code === TaskClosedError.code) {
+                                    // Task is closed — message is terminal.
+                                    // Signal consumed (true) so the caller
+                                    // does not retry delivery.
+                                    log?.warn?.(
+                                      {
+                                        conversationId: enriched.conversationId,
+                                        code: err.code,
+                                        msg: err.message,
+                                      },
+                                      "MoltZap: send rejected — task closed, dropping without retry",
+                                    );
+                                    return true;
+                                  }
+                                  log?.error?.(
+                                    `MoltZap: failed to send reply: ${err}`,
+                                  );
+                                  return false;
+                                }),
+                            ),
                             Effect.catchAll((err) =>
                               Effect.sync(() => {
                                 log?.error?.(


### PR DESCRIPTION
Fixes #281

## What changed

The deliver callback in `openclaw-entry.ts` previously returned `false` for all `sendReply` errors, including `TaskClosedError` (wire code -32020). OpenClaw treats a `false` return as retry-eligible. `TaskClosedError` is terminal — the task is permanently closed and no retry is useful. This PR adds an `Effect.catchTag("RpcServerError", ...)` arm before the existing `catchAll`: when the error code matches `TaskClosedError.code`, the callback returns `true` (terminal-consumed) and emits a structured `warn` log. All other `RpcServerError` variants and remaining error types fall through to the existing `catchAll` and return `false` (retry-eligible).

Arch-281 v3 plan: https://github.com/chughtapan/moltzap/issues/281#issuecomment-4412937072

## Scope

- Module: `packages/openclaw-channel/src/openclaw-entry.ts`
- Tier (from diff shape): junior — internals only, no public surface change, no new exports, no new deps
- New exported signatures: none
- New deps: none

## Changed files

- `packages/openclaw-channel/src/openclaw-entry.ts:503-523@90ed328` — `catchTag("RpcServerError", ...)` arm inserted before existing `catchAll`
- `packages/openclaw-channel/src/openclaw-entry.delivery.test.ts:391-461@90ed328` — two new tests: TaskClosedError returns true; non-TaskClosed RpcServerError returns false

## Tests

- `deliver callback returns true when send fails with TaskClosedError (terminal-consumed, no retry)` — verifies `true` return when `mockSend` fails with `RpcServerError{code: TaskClosedError.code}`
- `deliver callback returns false when send fails with a non-TaskClosed RpcServerError (retry-eligible)` — verifies `false` return when `mockSend` fails with `RpcServerError{code: -32001}`

All 74 tests pass (`pnpm --filter @moltzap/openclaw-channel test`). Full `pnpm -r build` green. Pre-commit hook passed without `--no-verify`.

## Simplify pass

No findings. The `catchTag` + `catchAll` is the minimal Effect idiom for discriminating one tagged error from the rest. No dead code, no unused variables.

## Review pass

No findings. Scope is one module, one behavior change. No exported surface change. The `consumedLeaseAt` guard is intentionally not set on the `TaskClosedError` path (no bytes written; no lease consumed).

## Confidence

HIGH — the `TaskClosedError.code` constant is the canonical discriminant for this wire error; the test confirms both the true and false return paths by injecting exactly the failing Effect the production path encounters.

## Verification matrix

| Check | Result |
|---|---|
| `pnpm --filter @moltzap/openclaw-channel build` | green |
| `pnpm --filter @moltzap/openclaw-channel test` (74 tests) | green |
| `pnpm -r build` | green |
| Pre-commit hook | passed without --no-verify |
| nanoclaw-channel spot-check (no retry loop) | confirmed |
| claude-code-channel spot-check (no retry loop) | confirmed |