### PR TITLE
fix(server): preflight recipients before INSERT in messages/send (#463)

### DIFF
--- a/packages/server/src/__tests__/integration/task/messages-preflight.test.ts
+++ b/packages/server/src/__tests__/integration/task/messages-preflight.test.ts
@@ -1,0 +1,258 @@
+/**
+ * #463 v3 — end-to-end coverage for the pre-INSERT recipient preflight
+ * in `messages/send`.
+ *
+ * Architect plan §1: `MessageService.preflightRecipients` runs BEFORE
+ * the durable {@link MessageService.sendInsert} INSERT. When any
+ * non-sender participant has zero live connections the preflight fails
+ * closed with {@link RecipientNotResolved}; the handler maps it to
+ * `RpcFailure(HookBlocked)` and the row is never written. This is the
+ * load-bearing observable for the AC: a `messages` row never appears
+ * for a send that the broadcast loop is provably unable to fan out.
+ *
+ * Companion unit test:
+ * `packages/server/src/task/services/message.service.test.ts`
+ * (resolver-empty branch pinned at the service boundary, no WS).
+ *
+ * Memory `feedback_predicate_tautology_lesson`: the post-failure DB
+ * assertion targets `count(*) = 0` against `messages` for the
+ * conversation under test — the predicate fails on accidental
+ * INSERT, not on a vacuous "no error thrown" tautology. The happy-path
+ * companion pins `count(*) = 1` and matches the inserted id, so the
+ * test cannot pass on a regression that silently no-ops the INSERT.
+ */
+import { describe, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Either } from "effect";
+import {
+  HookBlockedError,
+  MessageReceivedNotificationDefinition,
+  MessagesList,
+  MessagesSend,
+  TasksAddParticipant,
+  TasksCreate,
+  TasksCreateConversation,
+  type Message,
+} from "@moltzap/protocol";
+import { agentId as protocolAgentId } from "@moltzap/protocol/testing";
+import {
+  startTestServer,
+  stopTestServer,
+  resetTestDb,
+  trackClient,
+  connectTestClient,
+  registerAgent,
+  getKyselyDb,
+  type ServerTestClient,
+} from "../helpers.js";
+
+let baseUrl: string;
+let wsUrl: string;
+
+beforeAll(async () => {
+  const server = await startTestServer();
+  baseUrl = server.baseUrl;
+  wsUrl = server.wsUrl;
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestServer();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+interface ThreeAgents {
+  readonly tm: ServerTestClient;
+  readonly tmAgentId: string;
+  readonly sender: ServerTestClient;
+  readonly senderAgentId: string;
+  readonly recipient: ServerTestClient;
+  readonly recipientAgentId: string;
+}
+
+/**
+ * Register three agents (TM + sender + recipient). The TM is the
+ * task-manager for the conversation; sender and recipient are both
+ * participants in the conversation alongside the TM.
+ */
+function setupThreeAgents(index: number): Effect.Effect<ThreeAgents, Error> {
+  return Effect.gen(function* () {
+    const tmReg = yield* registerAgent(baseUrl, `pre-tm-${index}`);
+    const senderReg = yield* registerAgent(baseUrl, `pre-sender-${index}`);
+    const recipientReg = yield* registerAgent(
+      baseUrl,
+      `pre-recipient-${index}`,
+    );
+    const tm = yield* connectTestClient({
+      wsUrl,
+      agentId: tmReg.agentId,
+      apiKey: tmReg.apiKey,
+    });
+    trackClient(tm);
+    const sender = yield* connectTestClient({
+      wsUrl,
+      agentId: senderReg.agentId,
+      apiKey: senderReg.apiKey,
+    });
+    trackClient(sender);
+    const recipient = yield* connectTestClient({
+      wsUrl,
+      agentId: recipientReg.agentId,
+      apiKey: recipientReg.apiKey,
+    });
+    trackClient(recipient);
+    return {
+      tm,
+      tmAgentId: tmReg.agentId,
+      sender,
+      senderAgentId: senderReg.agentId,
+      recipient,
+      recipientAgentId: recipientReg.agentId,
+    };
+  });
+}
+
+interface GroupBinding {
+  readonly conversationId: string;
+}
+
+/**
+ * Stand up a task-bound group conversation with sender + recipient as
+ * participants. The TM is the conversation creator (and so is a
+ * participant by default); sender and recipient are added explicitly so
+ * the resolver-miss test can knock out the recipient's socket without
+ * also dropping the TM.
+ */
+function setupGroupConversation(
+  agents: ThreeAgents,
+): Effect.Effect<GroupBinding, Error> {
+  return Effect.gen(function* () {
+    const task = yield* agents.tm.sendRpc(TasksCreate, { tmType: "self" });
+    yield* agents.tm.sendRpc(TasksAddParticipant, {
+      taskId: task.task.id,
+      agentId: protocolAgentId(agents.senderAgentId),
+    });
+    yield* agents.tm.sendRpc(TasksAddParticipant, {
+      taskId: task.task.id,
+      agentId: protocolAgentId(agents.recipientAgentId),
+    });
+    const conv = yield* agents.tm.sendRpc(TasksCreateConversation, {
+      taskId: task.task.id,
+      type: "group",
+      participants: [
+        { type: "agent", id: agents.senderAgentId },
+        { type: "agent", id: agents.recipientAgentId },
+      ],
+    });
+    return { conversationId: conv.conversation.id };
+  });
+}
+
+describe("#463 v3 — messages/send preflightRecipients", () => {
+  it.live(
+    "preflight fail-closed: recipient offline → RpcFailure(HookBlocked) AND no messages row inserted",
+    () =>
+      Effect.gen(function* () {
+        const agents = yield* setupThreeAgents(1);
+        const { conversationId } = yield* setupGroupConversation(agents);
+
+        // Knock out the recipient's WS. Sender + TM remain live; the
+        // preflight should still fail because the recipient has zero
+        // live connections in the AgentEndpointResolver.
+        yield* agents.recipient.close();
+        // Brief grace period for the WS finalizer to drain the resolver.
+        yield* Effect.sleep("200 millis");
+
+        const outcome = yield* Effect.either(
+          agents.sender.sendRpc(MessagesSend, {
+            conversationId,
+            parts: [{ type: "text", text: "should be rejected" }],
+          }),
+        );
+        expect(Either.isLeft(outcome)).toBe(true);
+        if (Either.isLeft(outcome)) {
+          const err = outcome.left as { code?: number; message?: string };
+          // The preflight error maps to HookBlocked via the existing
+          // `deliveryErrorToHookBlocked` helper, so the wire surface is
+          // identical to the pre-#463 post-INSERT failure mode.
+          expect(err.code).toBe(HookBlockedError.code);
+        }
+
+        // The load-bearing assertion: NO `messages` row exists for the
+        // conversation. Pre-#463 v3 the row would have committed and
+        // the TM-routing branch would have surfaced the same RPC error
+        // post-INSERT; v3 pulls the check pre-INSERT so the durable
+        // state is clean.
+        const db = getKyselyDb();
+        const rows = yield* Effect.promise(() =>
+          db
+            .selectFrom("messages")
+            .select("id")
+            .where("conversation_id", "=", conversationId)
+            .execute(),
+        );
+        expect(rows).toHaveLength(0);
+      }),
+    20_000,
+  );
+
+  it.live(
+    "preflight pass: all recipients online → row committed AND broadcast delivers AND messages/list returns the row",
+    () =>
+      // Companion happy path. With every non-sender participant live,
+      // the preflight passes, the row commits, and the broadcast fan-out
+      // reaches the recipient. `messages/list` on the durable row is the
+      // recovery channel architect plan §9 R1 points to for the
+      // post-preflight WriteFailed residual; pinning that view here lets
+      // the failure-mode test above stay focused on the no-row outcome.
+      //
+      // Memory `feedback_predicate_tautology_lesson`: count + id match
+      // is the load-bearing assertion — a regression that silently
+      // no-ops the INSERT trips the count, and a regression that
+      // inserts a stale id trips the id-match.
+      Effect.gen(function* () {
+        const agents = yield* setupThreeAgents(2);
+        const { conversationId } = yield* setupGroupConversation(agents);
+
+        const sent = yield* agents.sender.sendRpc(MessagesSend, {
+          conversationId,
+          parts: [{ type: "text", text: "happy path" }],
+        });
+        expect(sent.message.parts).toEqual([
+          { type: "text", text: "happy path" },
+        ]);
+
+        // Recipient observes the message via the conversation broadcast.
+        const received = yield* agents.recipient.waitForNotification(
+          MessageReceivedNotificationDefinition,
+        );
+        const receivedMsg = (received.params as { message: Message }).message;
+        expect(receivedMsg.id).toBe(sent.message.id);
+
+        // Row exists (preflight passed AND sendInsert committed).
+        const db = getKyselyDb();
+        const rows = yield* Effect.promise(() =>
+          db
+            .selectFrom("messages")
+            .select("id")
+            .where("conversation_id", "=", conversationId)
+            .execute(),
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.id).toBe(sent.message.id);
+
+        // Pull-recovery channel (architect plan §9 R1 mitigation):
+        // `messages/list` returns the durable row. Any participant who
+        // missed the live notification (TOCTOU residual) sees the
+        // message via this list call.
+        const listed = yield* agents.sender.sendRpc(MessagesList, {
+          conversationId,
+        });
+        const idsInList = listed.messages.map((m) => m.id);
+        expect(idsInList).toContain(sent.message.id);
+      }),
+    20_000,
+  );
+});

--- a/packages/server/src/app/layers.ts
+++ b/packages/server/src/app/layers.ts
@@ -360,6 +360,7 @@ export const MessageServiceLive = Layer.effect(
     const db = yield* DbTag;
     const conversations = yield* ConversationServiceTag;
     const networkSend = yield* NetworkSendServiceTag;
+    const resolver = yield* AgentEndpointResolverTag;
     const encryption = yield* EncryptionTag;
     const deliveryWebhook = yield* DeliveryWebhookTag;
     const webhookClient = yield* WebhookClientTag;
@@ -369,6 +370,7 @@ export const MessageServiceLive = Layer.effect(
       db,
       conversations,
       networkSend,
+      resolver,
       encryption,
       deliveryWebhook,
       webhookClient,

--- a/packages/server/src/network/network-send.ts
+++ b/packages/server/src/network/network-send.ts
@@ -32,7 +32,7 @@ import {
   type EndpointAddressKind,
 } from "@moltzap/protocol/network";
 import type { AgentId } from "@moltzap/protocol/identity";
-import type { ConversationId } from "@moltzap/protocol/task";
+import type { ConversationId, MessageId } from "@moltzap/protocol/task";
 import type * as Socket from "@effect/platform/Socket";
 import { ConnectionManager } from "../transport/connection.js";
 import { AgentEndpointResolver } from "./agent-endpoint-resolver.js";
@@ -137,11 +137,24 @@ export class NetworkSendService {
     opts?: {
       readonly forConversation?: ConversationId;
       readonly excludeConnectionId?: string;
+      /**
+       * #463 v3 — context tag threaded through to the structured log
+       * emitted inside the per-connection `WriteFailed` catchAll. The
+       * caller (`MessageService.sendCommit`) supplies the message id
+       * so operators can correlate a `broadcast.write_failed` log line
+       * with the durable row (which is unaffected — preflight already
+       * proved the recipient was reachable before INSERT; this branch
+       * fires only on a TOCTOU disconnect mid-frame). Plain log
+       * annotation, no DB column; #463 v3 dropped the v2 column +
+       * CAS scaffolding.
+       */
+      readonly messageId?: MessageId;
     },
   ): Effect.Effect<{ readonly delivered: readonly AgentId[] }, never, never> {
     return Effect.gen(this, function* () {
       const forConversation = opts?.forConversation;
       const excludeConnectionId = opts?.excludeConnectionId;
+      const messageId = opts?.messageId;
       const delivered: AgentId[] = [];
       for (const target of agentIds) {
         const connIds = yield* this.resolver.resolveAll(target);
@@ -162,8 +175,22 @@ export class NetworkSendService {
             conn.write(payload).pipe(
               Effect.catchAll((cause) =>
                 Effect.sync(() => {
+                  // #463 v3 — single structured log site for the
+                  // post-INSERT WriteFailed residual. Reason tag is
+                  // stable so operators can grep
+                  // `broadcast.write_failed`; messageId + conversationId
+                  // bind the line to the durable row (still present and
+                  // recoverable via `messages/list`).
                   logger.warn(
-                    { connId: cid, cause: String(cause), forConversation },
+                    {
+                      event: "broadcast.write_failed",
+                      reason: "WriteFailed",
+                      connId: cid,
+                      agentId: target,
+                      conversationId: forConversation,
+                      messageId,
+                      cause: String(cause),
+                    },
                     "broadcast: socket write failed",
                   );
                 }),

--- a/packages/server/src/task/services/message.service.test.ts
+++ b/packages/server/src/task/services/message.service.test.ts
@@ -1,0 +1,220 @@
+/**
+ * #463 v3 — unit coverage for {@link MessageService.preflightRecipients}.
+ *
+ * The pre-INSERT fail-closed gate is the load-bearing piece: when any
+ * non-sender participant has zero live connections in the
+ * `AgentEndpointResolver`, the preflight returns
+ * {@link RecipientNotResolved} on the error channel BEFORE
+ * {@link MessageService.sendInsert} has a chance to write the durable
+ * row. The wider end-to-end proof (no row in DB on preflight failure)
+ * lives at `__tests__/integration/task/messages-preflight.test.ts`; this
+ * test pins the resolver-empty branch at the service boundary so the
+ * fail-closed shape is regressed without spinning up the WS stack.
+ *
+ * Memory `feedback_no_raw_sql`: every DB touch goes through Kysely.
+ * Memory `feedback_predicate_tautology_lesson`: the happy-path
+ * assertion explicitly compares the returned recipient set to the
+ * expected agent ids — not just "non-empty" — so the predicate cannot
+ * pass on accident.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Cause, Effect, Exit } from "effect";
+import { KyselyPGlite } from "kysely-pglite";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Kysely } from "kysely";
+import {
+  agentId as makeAgentId,
+  conversationId as makeConversationId,
+} from "@moltzap/protocol/testing";
+import { makeEffectKysely } from "../../db/effect-kysely-toolkit.js";
+import type { Database } from "../../db/database.js";
+import type { AgentId } from "../../app/types.js";
+import type { ConversationId } from "@moltzap/protocol/task";
+import { MessageService } from "./message.service.js";
+import { ConversationService } from "./conversation.service.js";
+import { ParticipantService } from "../../identity/services/participant.service.js";
+import {
+  AgentEndpointResolver,
+  connectionId,
+} from "../../network/agent-endpoint-resolver.js";
+import {
+  NetworkSendService,
+  RecipientNotResolved,
+} from "../../network/network-send.js";
+import { ConnectionManager } from "../../transport/connection.js";
+import { AppTmRegistry } from "../../network/app-tm-registry.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schema = readFileSync(
+  join(__dirname, "..", "..", "app", "core-schema.sql"),
+  "utf-8",
+);
+const dbHookTimeoutMs = 30_000;
+
+const ALICE = makeAgentId("00000000-0000-4000-8000-00000000a11c");
+const BOB = makeAgentId("00000000-0000-4000-8000-00000000b0b0");
+
+let db: Kysely<Database>;
+let pglite: {
+  exec: (sql: string) => Promise<unknown>;
+  close: () => Promise<void>;
+};
+
+async function freshDb(): Promise<void> {
+  const kpg = await KyselyPGlite.create();
+  pglite = {
+    exec: (s) => kpg.client.exec(s),
+    close: () => kpg.client.close(),
+  };
+  db = makeEffectKysely<Database>({ dialect: kpg.dialect });
+  await pglite.exec(schema);
+}
+
+async function seedAgent(id: AgentId, name: string): Promise<void> {
+  await db
+    .insertInto("agents")
+    .values({
+      id,
+      name,
+      api_key_id: name.padEnd(16, "0").slice(0, 16),
+      api_key_secret_hash:
+        "0".repeat(64).slice(0, name.length) +
+        "0".repeat(64).slice(name.length),
+      claim_token: `claim-${name}`,
+      status: "active",
+    })
+    .execute();
+}
+
+async function seedConversation(
+  participants: AgentId[],
+): Promise<ConversationId> {
+  // Phase 9b consumer-migration R12: every conversation is task-bound and
+  // `tm_endpoint_address` is NOT NULL. Seed a minimal task row so the FK
+  // chain is satisfied; the preflight under test never reads the task.
+  const initiator = participants[0];
+  if (initiator === undefined) throw new Error("need at least one participant");
+  const task = await db
+    .insertInto("tasks")
+    .values({
+      initiator_agent_id: initiator,
+      status: "active",
+      tm_endpoint_address: `tm:agent:${initiator}`,
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+  const conv = await db
+    .insertInto("conversations")
+    .values({
+      task_id: task.id,
+      type: "group",
+      created_by_id: initiator,
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow();
+  for (const agent of participants) {
+    await db
+      .insertInto("conversation_participants")
+      .values({
+        conversation_id: conv.id,
+        agent_id: agent,
+      })
+      .execute();
+  }
+  return makeConversationId(conv.id);
+}
+
+function makeMessageService(opts: {
+  resolver: AgentEndpointResolver;
+}): MessageService {
+  const connections = new ConnectionManager();
+  const participants = new ParticipantService(db);
+  const conversations = new ConversationService(db, participants, connections);
+  const appTmRegistry = Effect.runSync(AppTmRegistry.make);
+  const networkSend = new NetworkSendService(
+    opts.resolver,
+    connections,
+    appTmRegistry,
+  );
+  return new MessageService({
+    db,
+    conversations,
+    networkSend,
+    resolver: opts.resolver,
+    encryption: null,
+    deliveryWebhook: null,
+    webhookClient: null,
+    traceCapture: null,
+    appHost: null,
+  });
+}
+
+describe("MessageService.preflightRecipients (#463 v3)", () => {
+  beforeEach(freshDb, dbHookTimeoutMs);
+  afterEach(async () => {
+    await pglite?.close();
+  });
+
+  it("fails closed with RecipientNotResolved when a non-sender participant has zero live connections", async () => {
+    await seedAgent(ALICE, "alice");
+    await seedAgent(BOB, "bob");
+    const conversationId = await seedConversation([ALICE, BOB]);
+
+    // Resolver holds zero entries — neither alice nor bob has a live
+    // connection. Alice (sender) is excluded from the preflight set; bob
+    // (recipient) is checked, hits the empty set, and the preflight
+    // fails closed.
+    const resolver = Effect.runSync(AgentEndpointResolver.make);
+    const service = makeMessageService({ resolver });
+
+    const exit = await Effect.runPromise(
+      Effect.exit(service.preflightRecipients(conversationId, ALICE)),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(failure._tag).toBe("Some");
+      if (failure._tag === "Some") {
+        expect(failure.value).toBeInstanceOf(RecipientNotResolved);
+        const err = failure.value as RecipientNotResolved;
+        expect(String(err.to)).toBe(`tm:agent:${BOB}`);
+      }
+    }
+  });
+
+  it("succeeds and returns the recipient set when every non-sender participant has at least one live connection", async () => {
+    await seedAgent(ALICE, "alice");
+    await seedAgent(BOB, "bob");
+    const conversationId = await seedConversation([ALICE, BOB]);
+
+    // Bob holds one live connection in the resolver. Alice is the sender;
+    // she is excluded from the preflight set regardless of resolver state.
+    const resolver = Effect.runSync(AgentEndpointResolver.make);
+    await Effect.runPromise(resolver.add(BOB, connectionId("conn-bob-1")));
+
+    const service = makeMessageService({ resolver });
+    const result = await Effect.runPromise(
+      service.preflightRecipients(conversationId, ALICE),
+    );
+    expect(result.recipients).toEqual([BOB]);
+  });
+
+  it("succeeds with an empty recipient set on a self-only conversation (no non-sender participant to resolve)", async () => {
+    await seedAgent(ALICE, "alice");
+    const conversationId = await seedConversation([ALICE]);
+
+    // No live resolver entries. The preflight has zero recipients to
+    // check, so the success channel returns an empty list — the durable
+    // INSERT is allowed to proceed. This pins the "no recipients to
+    // verify" branch so a future refactor cannot accidentally fail-close
+    // here (which would break the self-conversation case).
+    const resolver = Effect.runSync(AgentEndpointResolver.make);
+    const service = makeMessageService({ resolver });
+    const result = await Effect.runPromise(
+      service.preflightRecipients(conversationId, ALICE),
+    );
+    expect(result.recipients).toEqual([]);
+  });
+});

--- a/packages/server/src/task/services/message.service.ts
+++ b/packages/server/src/task/services/message.service.ts
@@ -46,7 +46,15 @@ import {
   isEndpointAddress,
   type EndpointAddress,
 } from "@moltzap/protocol/network";
-import { Duration, Effect, Fiber, Option, Schedule, Schema } from "effect";
+import {
+  Duration,
+  Effect,
+  Fiber,
+  HashSet,
+  Option,
+  Schedule,
+  Schema,
+} from "effect";
 import { SqlError } from "@effect/sql/SqlError";
 
 export type MessageServiceError =
@@ -63,6 +71,8 @@ import {
   RecipientNotResolved,
   WriteFailed,
 } from "../../network/network-send.js";
+import type { AgentEndpointResolver } from "../../network/agent-endpoint-resolver.js";
+import { makeEndpointAddress } from "@moltzap/protocol/network";
 import {
   type WebhookClient,
   signWebhookPayload,
@@ -119,6 +129,14 @@ export interface MessageServiceDeps {
   readonly db: Db;
   readonly conversations: ConversationService;
   readonly networkSend: NetworkSendService;
+  /**
+   * #463 v3: synchronous in-memory resolver used by {@link
+   * MessageService.preflightRecipients} to fail-close BEFORE the
+   * durable INSERT in `send()` when a recipient has no live socket.
+   * Same instance the `NetworkSendService` consumes — the resolver is
+   * a process-local `Ref`-backed multimap, so two views agree.
+   */
+  readonly resolver: AgentEndpointResolver;
   readonly encryption: EnvelopeEncryption | null;
   readonly deliveryWebhook: DeliveryWebhookConfig | null;
   readonly webhookClient: WebhookClient | null;
@@ -163,6 +181,7 @@ export class MessageService {
   private readonly db: Db;
   private readonly conversations: ConversationService;
   private readonly networkSendService: NetworkSendService;
+  private readonly resolver: AgentEndpointResolver;
   private readonly encryption: EnvelopeEncryption | null;
   private readonly deliveryWebhook: DeliveryWebhookConfig | null;
   private readonly webhookClient: WebhookClient | null;
@@ -173,6 +192,7 @@ export class MessageService {
     this.db = deps.db;
     this.conversations = deps.conversations;
     this.networkSendService = deps.networkSend;
+    this.resolver = deps.resolver;
     this.encryption = deps.encryption;
     this.deliveryWebhook = deps.deliveryWebhook;
     this.webhookClient = deps.webhookClient;
@@ -187,6 +207,62 @@ export class MessageService {
   }
 
   /**
+   * #463 v3 — synchronous resolver pre-check that runs BEFORE the
+   * durable INSERT in {@link send}. Resolves each conversation
+   * participant (excluding the sender) through {@link
+   * AgentEndpointResolver.resolveAll}; fails closed with {@link
+   * RecipientNotResolved} as soon as one required recipient has no
+   * live connection. On success returns the resolved recipient set so
+   * the caller does not have to re-walk the participant list.
+   *
+   * Architect plan §1 (v3): v2 attempted to catch broadcast-side
+   * failures POST-INSERT via a `broadcast_attempted_at` column + CAS.
+   * v3 simplifies: the only recoverable failure mode at fan-out time
+   * is {@link RecipientNotResolved} (synchronous lookup miss). Pulling
+   * that check PRE-INSERT shrinks the post-INSERT residual to {@link
+   * WriteFailed} (mid-frame WS errors — rare), which is observable
+   * via a structured log line and recoverable via the existing
+   * `messages/list` pull channel. No DB column, no CAS, no idempotency
+   * gate required.
+   *
+   * Architect plan §9 risk R1 (TOCTOU): a recipient may disconnect in
+   * the microsecond gap between this preflight and the {@link
+   * NetworkSendService.broadcast} fan-out; that is documented as the
+   * {@link WriteFailed} residual. Mitigation: recipient pulls via
+   * `messages/list` on reconnect; same recovery channel as before,
+   * just a narrower window.
+   *
+   * The error channel is {@link RecipientNotResolved}. The handler
+   * maps it to the RPC-visible `HookBlocked(RecipientNotResolved)`
+   * shape via the existing `deliveryErrorToHookBlocked` helper, so the
+   * wire surface is unchanged from the post-INSERT failure mode.
+   */
+  preflightRecipients(
+    conversationId: ConversationId,
+    senderAgentId: AgentId,
+  ): Effect.Effect<
+    { readonly recipients: ReadonlyArray<AgentId> },
+    RecipientNotResolved
+  > {
+    return Effect.gen(this, function* () {
+      const participants =
+        yield* this.conversations.getParticipantAgentIds(conversationId);
+      const recipients = participants.filter((id) => id !== senderAgentId);
+      for (const recipient of recipients) {
+        const conns = yield* this.resolver.resolveAll(recipient);
+        if (HashSet.size(conns) === 0) {
+          return yield* Effect.fail(
+            new RecipientNotResolved({
+              to: makeEndpointAddress("agent", recipient),
+            }),
+          );
+        }
+      }
+      return { recipients };
+    });
+  }
+
+  /**
    * #529 reshape additive — the durable insert subset of `send`.
    * Returns a `SendInsertResult` carrier that {@link sendCommit}
    * consumes for the routing/broadcast/trace tail. `send` composes both
@@ -194,6 +270,16 @@ export class MessageService {
    *
    * Architect plan §3 carrier shape: `{ message, parts, conv,
    * excludeConnectionId, bypassTmRouting }`.
+   *
+   * #463 v3 integration point: `send()` (the top-level composer) calls
+   * {@link preflightRecipients} BEFORE this method's INSERT runs.
+   * Fail-closed on {@link RecipientNotResolved} ensures the durable
+   * row is never written when the broadcast fan-out is provably unable
+   * to reach any recipient. `sendInsert` itself is unchanged — the
+   * preflight is a sibling concern composed at `send()`-level so the
+   * `tasks/storeMessage` re-entry path (which sets `bypassTmRouting`
+   * and may not have live recipients yet) opts out by not running
+   * preflight on that path.
    */
   /**
    * #560: CAS-guarded UPDATE of `messages.tm_decision` after the
@@ -376,6 +462,21 @@ export class MessageService {
    * skips the gate: the TM has already admitted the message; the
    * server records a synthetic `Forward { participants \ sender }`
    * verdict and broadcasts as usual.
+   *
+   * #463 v3 integration point: {@link preflightRecipients} runs in
+   * `send()` BEFORE the INSERT in {@link sendInsert}, so by the time
+   * `sendCommit` runs the participant set is provably resolvable. The
+   * residual failure mode here is {@link WriteFailed} from
+   * `networkSendService.broadcast` (mid-frame WS error after a
+   * recipient disconnected in the microsecond gap since preflight).
+   * Architect plan §2 names a structured log emission at the
+   * `network.send` failure site as the observability bit; v3 drops
+   * the column + CAS scaffolding (v2's `broadcast_attempted_at`) on
+   * the grounds that the residual is rare, recipient-side recovery
+   * via `messages/list` already exists, and the durable row is
+   * unchanged either way. The {@link NetworkSendService.broadcast}
+   * call below threads the `messageId` so the failure-site log line
+   * carries `{ messageId, conversationId, connId, reason: "WriteFailed" }`.
    */
   sendCommit(
     carrier: SendInsertResult,
@@ -490,6 +591,14 @@ export class MessageService {
           {
             forConversation: conversationId,
             excludeConnectionId,
+            // #463 v3 — context for the structured log emitted inside
+            // broadcast's per-connection WriteFailed catchAll. The
+            // failure site previously logged `{ connId, cause }` only;
+            // threading the messageId here lets operators correlate the
+            // log line with the durable row (which IS in the DB —
+            // preflight already proved the recipient was reachable, so
+            // this branch fires only on TOCTOU disconnects).
+            messageId: message.id,
           },
         );
         const delivered: readonly AgentId[] =
@@ -639,6 +748,17 @@ export class MessageService {
     bypassTmRouting = false,
   ): Effect.Effect<Message, MessageServiceError> {
     return Effect.gen(this, function* () {
+      // #463 v3 — fail-closed preflight BEFORE the durable INSERT so
+      // a message row is never written when broadcast fan-out is
+      // provably unable to reach any recipient. The `bypassTmRouting`
+      // branch (TM-authored insert via `tasks/storeMessage`) opts out:
+      // that path accepts that the durable row may exist without live
+      // recipients (recipient pulls via `messages/list` on reconnect).
+      if (!bypassTmRouting) {
+        yield* this.preflightRecipients(conversationId, senderAgentId).pipe(
+          Effect.mapError(deliveryErrorToHookBlocked),
+        );
+      }
       const carrier = yield* this.sendInsert(
         conversationId,
         inputParts,


### PR DESCRIPTION
## Summary

Implements the #463 architect v3 plan: pull the recipient-resolver check PRE-INSERT in `messages/send` so the durable row is never written when broadcast fan-out is provably unable to reach any recipient.

- Closes #463
- Architect plan: https://github.com/chughtapan/moltzap/issues/463#issuecomment-4414480360
- Architect stub branch: `arch/463-messages-send-broadcast-atomicity@ce7c8b8`

## What changed

- **`MessageService.preflightRecipients`** — new method (replaces the architect stub body `Effect.dieMessage`). Walks conversation participants, calls `AgentEndpointResolver.resolveAll` for each non-sender, fails closed with `RecipientNotResolved` on the first empty set.
- **`MessageService.send`** — calls `preflightRecipients` BEFORE `sendInsert` when `bypassTmRouting === false`. Maps the error to `HookBlockedError` via the existing `deliveryErrorToHookBlocked` helper, so the wire surface is identical to the pre-#463 post-INSERT failure mode.
- **`NetworkSendService.broadcast`** — new optional `messageId` opt threaded through to the per-connection `WriteFailed` catchAll's structured log line. The line now carries `{ event: "broadcast.write_failed", reason: "WriteFailed", messageId, conversationId, agentId, connId, cause }` so operators can correlate the failure with the durable row.
- **`layers.ts`** — wires the existing `AgentEndpointResolverTag` into `MessageServiceLive` (same instance `NetworkSendService` already consumes).

No new DB column. No CAS. No migration. No new dependency. v3 drops v2's `broadcast_attempted_at` scaffolding entirely.

## Plan anchors

| Plan section | What this PR does |
|---|---|
| §1 (v3 simplification) | `preflightRecipients` body + `send()` integration |
| §2 (modules) | One method on `MessageService`; structured log on `NetworkSendService.broadcast` |
| §3 (interfaces) | `preflightRecipients(conv, sender): Effect<{recipients}, RecipientNotResolved>` |
| §4 (data flow) | Preflight → sendInsert → sendCommit (unchanged tail), broadcast log carries messageId |
| §7 AC1 | No row inserted on preflight failure (integration test) |
| §7 AC2 | `messages/list` returns the durable row (integration test happy path) |
| §7 AC3 | Structured log emitted on WriteFailed mid-broadcast (log line at failure site) |
| §9 R1 (TOCTOU) | Documented as the residual; recipient pulls via `messages/list` |

## Scope

- Modules touched: `MessageService`, `NetworkSendService`, `app/layers.ts`
- New modules: 0
- New public signatures outside the plan: 0 (`preflightRecipients` is named in the plan; `broadcast` gets an optional opt with default-undefined)
- New deps: 0
- LOC delta: +152 production / +474 test = +626 total (plan estimate ~80-120 production)

## Tests

- **Unit** (`packages/server/src/task/services/message.service.test.ts`):
  - Resolver-empty branch returns `RecipientNotResolved` with `to: tm:agent:<recipient>`.
  - Happy path returns the recipient set (excluding sender) — pinned with `toEqual`, not "non-empty," per memory `feedback_predicate_tautology_lesson`.
  - Self-only conversation returns empty set (the durable INSERT is allowed to proceed).
- **Integration** (`packages/server/src/__tests__/integration/task/messages-preflight.test.ts`):
  - Recipient offline → `RpcFailure(HookBlocked)` AND `count(messages WHERE conversation_id = ...) = 0` (load-bearing predicate per memory `feedback_predicate_tautology_lesson`).
  - All online → row commits, broadcast delivers, `messages/list` returns the row.

Existing TM-offline test (`task-manager-routing.test.ts > TM offline`) still passes — the TM is also a participant, so preflight catches it; the existing RPC-error-code assertion is unchanged.

## Verification

- `pnpm --filter @moltzap/server-core build` — green
- `pnpm --filter @moltzap/server-core test` — 248 passed (3 new)
- `pnpm --filter @moltzap/server-core test:integration` — 145 passed + 5 todo (2 new)
- `pnpm --filter @moltzap/server-core test:conformance` — 42 passed
- `pnpm --filter @moltzap/server-core exec tsc --noEmit` — clean
- `pnpm lint` — 0 errors, 0 new warnings (47 pre-existing warnings unchanged)
- Pre-commit hook: passed without `--no-verify` per memory `feedback_no_skip_hooks`
- `/simplify`-equivalent manual review: no further simplifications applicable; the dangling JSDoc above `recordTmDecision` is pre-existing (architect's #560 split) and out of scope
- `/review`-equivalent manual review: error mapping, TOCTOU residual, bypass-branch opt-out, and tests all confirmed

## Confidence

HIGH — change is mechanical (one new method body, one composition point in `send()`, one log-line enrichment), the failure-mode analysis is verifiable against the existing `RecipientNotResolved` + `WriteFailed` definitions in `network-send.ts`, and the resolver-cost claim is verifiable from `AgentEndpointResolver`'s in-memory HashMap. Test predicates are load-bearing (count + id match, not vacuous error-thrown checks).

## Process issues

- Architect stub branch (`ce7c8b8`) targets `packages/server/src/services/message.service.ts`, but post-Phase-2A reshape (#542) moved the file to `packages/server/src/task/services/message.service.ts`. Rebase produced a path-rename + JSDoc conflict; resolved by resetting to `origin/main` and re-applying the architect stub's content (the `preflightRecipients` signature + JSDoc paragraphs on `sendInsert` and `sendCommit`) to the new file path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)