### PR TITLE
refactor(server): reuse endpointAddressForAgent helper in isTmForAppBoundTask (#585)

### DIFF
--- a/packages/server/src/task/services/message.service.ts
+++ b/packages/server/src/task/services/message.service.ts
@@ -85,6 +85,7 @@ import {
   takeFirstOption,
   takeFirstOrFail,
 } from "../../db/effect-kysely-toolkit.js";
+import { endpointAddressForAgent } from "./task.service.js";
 
 /** pg returns bytea as Buffer, PGlite returns Uint8Array. Normalize so .toString("utf-8") works. */
 function toBuf(v: Buffer | Uint8Array): Buffer {
@@ -832,9 +833,9 @@ export class MessageService {
         if (Option.isNone(rowOpt)) return false;
         const row = rowOpt.value;
         if (row.app_id === null) return false;
-        // The canonical wire shape is "tm:agent:<agentId>"; compare
-        // direct-string-equality.
-        return row.tm_endpoint_address === `tm:agent:${callerAgentId}`;
+        return (
+          row.tm_endpoint_address === endpointAddressForAgent(callerAgentId)
+        );
       }),
     );
   }


### PR DESCRIPTION
Closes #585

## What changed
Replaces the inline template literal ```tm:agent:${callerAgentId}``` in `isTmForAppBoundTask` (message.service.ts:837@f2fdac4) with a call to `endpointAddressForAgent(callerAgentId)` from task.service.ts. Adds the corresponding import. This eliminates the duplicate address-construction site introduced alongside #584 so future shape changes to the `tm:agent:<id>` form need only update the helper.

## Scope
- Module: `packages/server/src/task/services/message.service.ts`
- Tier (from safer-diff-scope): junior
- New exported signatures: none
- New deps: none

## Tests
- No new tests needed — this is a pure refactor with identical runtime behavior; existing 143/143 integration tests cover the `isTmForAppBoundTask` code path and all pass.

## Simplify + Review
- simplify: no findings (two-line change with no structural complexity)
- review: no findings

## Confidence
HIGH — the helper `endpointAddressForAgent` returns `makeEndpointAddress("agent", agent)` which produces exactly `tm:agent:<agentId>` per task.service.ts:73-74@f2fdac4. Behavior is provably identical; 143/143 integration tests green.