### PR TITLE
docs: per-package ARCHITECTURE.md + detail diagrams

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# moltzap
+
+Workspace-root instructions for Claude. Per-package CLAUDE.md files
+under `packages/*/` extend these.
+
+## Architecture documentation
+
+Every published package has an `ARCHITECTURE.md` index and per-flow
+detail docs under `docs/architecture/`. Keep them in sync with code
+changes:
+
+- **When you change a flow** (request routing, state machine,
+  dispatcher logic, lifecycle, error handling, etc.), update the
+  corresponding `packages/<pkg>/docs/architecture/NN-<topic>.md` in
+  the same PR. The doc is wrong the moment the code drifts from it.
+- **When you add a new flow** that warrants its own diagram, create
+  a new `docs/architecture/NN-<topic>.md`, link it from the package's
+  top-level `ARCHITECTURE.md` index table, and cross-link from any
+  sibling docs that reference it.
+- **When you add a new published package**, mirror the structure:
+  package-level `ARCHITECTURE.md` index (§1 Project Structure, §2
+  Public Surface, §3 link table, §4 Dependencies, §5 Tests,
+  §6 Glossary) plus per-flow detail docs.
+
+### Citation style — symbol names, not line numbers
+
+Cite functions/classes/methods by name, never by line. `file.ts:123`
+rots at the next refactor; `file.ts → handleFrame` survives because
+the symbol is grep-able. For a code block inside a function, use
+the enclosing function plus a verbal pointer:
+`server.ts → handleFrame, the Match.value dispatch block`.
+
+The only acceptable uses of `file.ts:NNN` are in PR descriptions, code
+review comments, and investigation reports — short-lived artifacts
+pinned to a specific commit.
+
+### Cross-package DRY
+
+If a flow lives canonically in another package, **link to it**, don't
+re-explain it. Example: the dispatch lease FSM lives in `server/06-lease-lifecycle.md`;
+channel docs that touch the lease should link there and describe only
+their channel-local concerns (projection logic, local state).
+
+### Mermaid diagrams
+
+Diagrams use Mermaid (GitHub renders them natively). Validate locally
+before push — GitHub's parser is stricter than many local renderers.
+Common patterns that BREAK GitHub's renderer:
+
+- `<br/>` (XHTML) in `sequenceDiagram` message labels → use `<br>` (HTML5)
+- `&lt;` / `&gt;` HTML escapes inside `sequenceDiagram` message text →
+  use literal `<` `>` (not operators in message position)
+- `;` (semicolon) inside `Note over X: ...` text → use `—` or `,`
+  (`;` is a statement terminator)
+- `<br>` in `participant X as <label>` aliases → strip; move multi-line
+  detail to a sibling `Note over X: ...`
+- `\n` literal in `stateDiagram` descriptions → use `<br>`
+- `<word>` literals in `stateDiagram` descriptions → use `[word]` or
+  rewrite into prose under the diagram
+
+Validate via the local parser loop in
+`~/.claude/projects/-home-tapanc-moltzap/memory/reference_github_mermaid_gotchas.md`
+(no browser needed; uses `mermaid` + `jsdom`).

--- a/packages/claude-code-channel/ARCHITECTURE.md
+++ b/packages/claude-code-channel/ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# Architecture — `@moltzap/claude-code-channel`
+
+Claude Code channel plugin for MoltZap. Implements Anthropic's official
+channel contract via the Model Context Protocol SDK: boots a Claude Code
+subprocess, gates inbound messages against an allowlist, surfaces a reply
+tool, and emits push notifications when new messages arrive.
+
+## 1. Project Structure
+
+```
+packages/claude-code-channel/src/
+├── entry.ts                # bootClaudeCodeChannel — the public boot fn
+├── server.ts               # MCP server + reply tool implementation
+├── routing.ts              # RoutingState — message_id → chat_id LRU map
+├── event.ts                # toClaudeChannelNotification — protocol translator
+├── types.ts                # BootOptions, Handle, GateInbound, ID brands
+├── errors.ts               # Typed errors for boot, push, allowlist, reply
+├── cli.ts                  # moltzap-claude-code-channel bin (env-var driven)
+└── __tests__/conformance/  # Cross-channel conformance harness
+```
+
+## 2. Public Surface
+
+| Export | Purpose |
+|---|---|
+| `bootClaudeCodeChannel` | Boot the channel — spawns MCP server, returns Handle |
+| `BootResult`, `BootOptions`, `Handle` | Boot inputs/outputs |
+| `ClaudeChannelNotification` | Shape of inbound notifications surfaced to Claude |
+| `GateInbound` | Caller-supplied gate fn — return allow/deny per message |
+| `ConversationId`, `MessageId`, `UserId`, `IsoTimestamp` | Re-exported brands |
+| `BootError`, `PushError`, `AllowlistError`, `ReplyError`, `EventShapeError` | Typed failures |
+
+CLI bin (`moltzap-claude-code-channel`) wraps `bootClaudeCodeChannel` for
+process-level use.
+
+## 3. Communication Flows
+
+| # | Flow | Detail doc |
+|---|---|---|
+| 3.1 | Boot sequence | [docs/architecture/01-boot-sequence.md](docs/architecture/01-boot-sequence.md) |
+| 3.2 | Inbound message → Claude push | [docs/architecture/02-inbound-message-to-claude-push.md](docs/architecture/02-inbound-message-to-claude-push.md) |
+| 3.3 | Claude reply → MoltZap outbound | [docs/architecture/03-claude-reply-to-moltzap-outbound.md](docs/architecture/03-claude-reply-to-moltzap-outbound.md) |
+| 3.4 | Lease state machine | [docs/architecture/04-lease-state-machine.md](docs/architecture/04-lease-state-machine.md) |
+| 3.5 | Allowlist gating | [docs/architecture/05-allowlist-gating.md](docs/architecture/05-allowlist-gating.md) |
+| 3.6 | Shutdown | [docs/architecture/06-shutdown.md](docs/architecture/06-shutdown.md) |
+
+## 4. Dependencies
+
+**Runtime**: `effect`, `@modelcontextprotocol/sdk`.
+**Internal**: `@moltzap/protocol`, `@moltzap/client`.
+**Consumers**: `@moltzap/runtimes` (workspace adapter spawns this binary).
+
+## 5. Tests
+
+- `src/__tests__/conformance/` — cross-channel conformance suite
+- `src/__tests__/echo.integration.test.ts` — E2E boot → inbound → reply round-trip
+- `src/__tests__/server.test.ts` — MCP server unit tests via InMemoryTransport
+- `src/event.test.ts` — `toClaudeChannelNotification` translator unit tests
+- Vitest; `pnpm -F @moltzap/claude-code-channel test`
+
+## 6. Glossary
+
+- **Channel** — A MoltZap concept: a plugin that bridges MoltZap's wire
+  protocol to a specific agent runtime (Claude Code, OpenClaw, Nanoclaw).
+  Implements `registerChannel(...)` on the client side.
+- **MCP** — Model Context Protocol; Anthropic's tool-protocol for Claude
+  Code. This package speaks MCP outbound (to Claude) and MoltZap inbound
+  (from the server).
+- **Gate** — Caller-supplied predicate that decides which inbound MoltZap
+  messages reach Claude. Used to enforce contact-allowlist policies.
+- **Reply tool** — MCP tool exposed to Claude; invoking it sends a
+  MoltZap `messages/send` consuming the current dispatch lease.
+- **Routing state** — In-process LRU map (`routing.ts`) from `MessageId`
+  to `ConversationId`. Lets the `reply` tool resolve its target chat
+  without requiring Claude to supply a `conversationId` argument.
+- **Dispatch lease** — Server-side single-use token attached to each
+  dispatch turn. Consumed on first `messages/send`; a second attempt
+  returns `LeaseInvalid` which this package surfaces as `LeaseAlreadyConsumed`.
+- **Pending buffer** — `state.pending[]` in `server.ts`. Holds
+  notifications that arrive before the MCP handshake completes
+  (`server.oninitialized`). Flushed in FIFO order at handshake.

--- a/packages/claude-code-channel/ARCHITECTURE.md
+++ b/packages/claude-code-channel/ARCHITECTURE.md
@@ -40,7 +40,7 @@ process-level use.
 | 3.1 | Boot sequence | [docs/architecture/01-boot-sequence.md](docs/architecture/01-boot-sequence.md) |
 | 3.2 | Inbound message → Claude push | [docs/architecture/02-inbound-message-to-claude-push.md](docs/architecture/02-inbound-message-to-claude-push.md) |
 | 3.3 | Claude reply → MoltZap outbound | [docs/architecture/03-claude-reply-to-moltzap-outbound.md](docs/architecture/03-claude-reply-to-moltzap-outbound.md) |
-| 3.4 | Lease state machine | [docs/architecture/04-lease-state-machine.md](docs/architecture/04-lease-state-machine.md) |
+| 3.4 | Channel projection of the dispatch lease | [docs/architecture/04-lease-state-machine.md](docs/architecture/04-lease-state-machine.md) |
 | 3.5 | Allowlist gating | [docs/architecture/05-allowlist-gating.md](docs/architecture/05-allowlist-gating.md) |
 | 3.6 | Shutdown | [docs/architecture/06-shutdown.md](docs/architecture/06-shutdown.md) |
 

--- a/packages/claude-code-channel/docs/architecture/01-boot-sequence.md
+++ b/packages/claude-code-channel/docs/architecture/01-boot-sequence.md
@@ -1,0 +1,116 @@
+# Boot Sequence
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`bootClaudeCodeChannel` is the single public entry point (in `entry.ts`).
+In production the CLI binary (`cli.ts`) calls it; in tests `echo.integration.test.ts`
+calls it directly with an injected in-memory MCP transport. The
+`@moltzap/runtimes` adapter (`runtimes/src/claude-code-process.ts`) writes
+an `mcp-config.json` and then Claude Code itself spawns the binary as a
+subprocess — that spawning step happens outside this package.
+
+```text
+Caller                   entry.ts                   server.ts           @moltzap/client
+  |                          |                           |                     |
+  |  bootClaudeCodeChannel   |                           |                     |
+  |  (opts: BootOptions)     |                           |                     |
+  |------------------------->|                           |                     |
+  |                          |                           |                     |
+  |              [1] validateBootOptions                 |                     |
+  |                          |                           |                     |
+  |                          | agentKey empty / serverUrl empty                |
+  |                          |---> BootResult { _tag:"Err",                   |
+  |                          |      error: AgentKeyInvalid }                  |
+  |                          |                           |                     |
+  |                          | [2] new MoltZapService({serverUrl, agentKey})  |
+  |                          |-------------------------------------------->   |
+  |                          | [3] new MoltZapChannelCore({ service })         |
+  |                          |-------------------------------------------->   |
+  |                          |                           |                     |
+  |                          | [4] createRoutingState()  |                     |
+  |                          | (in routing.ts)           |                     |
+  |                          |                           |                     |
+  |                          | [5] makeSendReply(core)   |                     |
+  |                          | (in entry.ts)             |                     |
+  |                          |                           |                     |
+  |                          | [6] bootChannelMcpServer  |                     |
+  |                          |    (config, deps)         |                     |
+  |                          |-------------------------->|                     |
+  |                          |                           |                     |
+  |                          |              [6a] makeMcpServer(config)        |
+  |                          |              in server.ts                      |
+  |                          |              capabilities: { tools: {},        |
+  |                          |                experimental:                   |
+  |                          |                 { "claude/channel": {} } }     |
+  |                          |              instructions: <contract default>  |
+  |                          |                           |                     |
+  |                          |              [6b] registerServerHandlers       |
+  |                          |              in server.ts                      |
+  |                          |              setRequestHandler(ListTools)      |
+  |                          |              setRequestHandler(CallTool)       |
+  |                          |                           |                     |
+  |                          |              [6b-fail] ToolRegistrationFailed  |
+  |                          |              (entry maps to McpTransportFailed)|
+  |                          |              --> BootResult { _tag:"Err" }     |
+  |                          |                           |                     |
+  |                          |              [6c] connectServer(server, deps)  |
+  |                          |              in server.ts                      |
+  |                          |              transportFactory?                 |
+  |                          |              (test seam, in types.ts)         |
+  |                          |              : new StdioServerTransport()      |
+  |                          |              server.connect(transport)          |
+  |                          |                           |                     |
+  |                          |              [6c-fail] StdioConnectFailed      |
+  |                          |              (entry maps to McpTransportFailed)|
+  |                          |              --> BootResult { _tag:"Err" }     |
+  |                          |                           |                     |
+  |                          |              [6d] server.oninitialized =       |
+  |                          |              markServerInitialized             |
+  |                          |              in server.ts                      |
+  |                          |              (flushes pending[] buffer on      |
+  |                          |               MCP handshake completion)        |
+  |                          |                           |                     |
+  |                          |              [6e] return ServerHandle          |
+  |                          |              { push, stop }                    |
+  |                          |<--------------------------|                     |
+  |                          |                           |                     |
+  |                          | [7] core.onInbound(handler)                    |
+  |                          | registers handleInboundMessage callback        |
+  |                          | in entry.ts                                    |
+  |                          |                           |                     |
+  |                          | [8] connectCore(core, serverHandle)            |
+  |                          | core.connect() — WS auth handshake             |
+  |                          |-------------------------------------------->   |
+  |                          |                           |                     |
+  |                          | [8-fail] ServiceRpcError / connect failure     |
+  |                          | serverHandle.stop() is called first            |
+  |                          | --> BootResult { _tag:"Err" }                  |
+  |                          |                           |                     |
+  |                          | [9] makeHandle(core, serverHandle)             |
+  |                          | in entry.ts                                    |
+  |                          | returns Handle { push, stop }                  |
+  |                          |                           |                     |
+  |<-------------------------|                           |                     |
+     BootResult { _tag:"Ok",
+       value: Handle }
+
+BootError union (in errors.ts):
+  AgentKeyInvalid     — opts.agentKey or opts.serverUrl blank   (step 1)
+  McpTransportFailed  — server init / stdio connect rejected     (step 6)
+  ServiceRpcError     — WS connect / auth rejected               (step 8)
+  SchemaDecodeFailed  — reserved (not yet reachable in v1)
+```
+
+**Foreign-protocol bridge point**: step 6c is where the MCP stdio transport
+attaches. From this moment onward the process owns two concurrent channels:
+the MCP stdio stream (outbound to Claude) and the MoltZap WS connection
+(inbound from server). They meet only inside the inbound handler
+([§ Inbound Message → Claude Push](02-inbound-message-to-claude-push.md))
+and the reply tool ([§ Claude Reply → MoltZap Outbound](03-claude-reply-to-moltzap-outbound.md)).
+
+---
+
+See also:
+- [Inbound Message → Claude Push](02-inbound-message-to-claude-push.md)
+- [Claude Reply → MoltZap Outbound](03-claude-reply-to-moltzap-outbound.md)
+- [Shutdown](06-shutdown.md)

--- a/packages/claude-code-channel/docs/architecture/01-boot-sequence.md
+++ b/packages/claude-code-channel/docs/architecture/01-boot-sequence.md
@@ -31,31 +31,31 @@ sequenceDiagram
 
     entry->>server: [6] bootChannelMcpServer(config, deps)
 
-    note over server: [6a] makeMcpServer(config)<br/>capabilities: { tools: {}, experimental: { "claude/channel": {} } }<br/>instructions: &lt;contract default&gt;
+    note over server: [6a] makeMcpServer(config)<br>capabilities: { tools: {}, experimental: { "claude/channel": {} } }<br>instructions: <contract default>
 
-    note over server: [6b] registerServerHandlers<br/>setRequestHandler(ListTools)<br/>setRequestHandler(CallTool)
+    note over server: [6b] registerServerHandlers<br>setRequestHandler(ListTools)<br>setRequestHandler(CallTool)
     alt [6b-fail] ToolRegistrationFailed
         server-->>Caller: BootResult { _tag:"Err" } (McpTransportFailed)
     end
 
-    note over server: [6c] connectServer(server, deps)<br/>transportFactory? (test seam, in types.ts)<br/>: new StdioServerTransport()<br/>server.connect(transport)
+    note over server: [6c] connectServer(server, deps)<br>transportFactory? (test seam, in types.ts)<br>: new StdioServerTransport()<br>server.connect(transport)
     alt [6c-fail] StdioConnectFailed
         server-->>Caller: BootResult { _tag:"Err" } (McpTransportFailed)
     end
 
-    note over server: [6d] server.oninitialized = markServerInitialized<br/>(flushes pending[] buffer on MCP handshake completion)
+    note over server: [6d] server.oninitialized = markServerInitialized<br>(flushes pending[] buffer on MCP handshake completion)
 
     server-->>entry: [6e] ServerHandle { push, stop }
 
-    note over entry: [7] core.onInbound(handler)<br/>registers handleInboundMessage callback
+    note over entry: [7] core.onInbound(handler)<br>registers handleInboundMessage callback
 
-    entry->>client: [8] connectCore(core, serverHandle)<br/>core.connect() — WS auth handshake
+    entry->>client: [8] connectCore(core, serverHandle)<br>core.connect() — WS auth handshake
     alt [8-fail] ServiceRpcError / connect failure
         note over entry: serverHandle.stop() called first
         entry-->>Caller: BootResult { _tag:"Err" }
     end
 
-    note over entry: [9] makeHandle(core, serverHandle)<br/>returns Handle { push, stop }
+    note over entry: [9] makeHandle(core, serverHandle)<br>returns Handle { push, stop }
     entry-->>Caller: BootResult { _tag:"Ok", value: Handle }
 ```
 

--- a/packages/claude-code-channel/docs/architecture/01-boot-sequence.md
+++ b/packages/claude-code-channel/docs/architecture/01-boot-sequence.md
@@ -9,97 +9,61 @@ calls it directly with an injected in-memory MCP transport. The
 an `mcp-config.json` and then Claude Code itself spawns the binary as a
 subprocess — that spawning step happens outside this package.
 
-```text
-Caller                   entry.ts                   server.ts           @moltzap/client
-  |                          |                           |                     |
-  |  bootClaudeCodeChannel   |                           |                     |
-  |  (opts: BootOptions)     |                           |                     |
-  |------------------------->|                           |                     |
-  |                          |                           |                     |
-  |              [1] validateBootOptions                 |                     |
-  |                          |                           |                     |
-  |                          | agentKey empty / serverUrl empty                |
-  |                          |---> BootResult { _tag:"Err",                   |
-  |                          |      error: AgentKeyInvalid }                  |
-  |                          |                           |                     |
-  |                          | [2] new MoltZapService({serverUrl, agentKey})  |
-  |                          |-------------------------------------------->   |
-  |                          | [3] new MoltZapChannelCore({ service })         |
-  |                          |-------------------------------------------->   |
-  |                          |                           |                     |
-  |                          | [4] createRoutingState()  |                     |
-  |                          | (in routing.ts)           |                     |
-  |                          |                           |                     |
-  |                          | [5] makeSendReply(core)   |                     |
-  |                          | (in entry.ts)             |                     |
-  |                          |                           |                     |
-  |                          | [6] bootChannelMcpServer  |                     |
-  |                          |    (config, deps)         |                     |
-  |                          |-------------------------->|                     |
-  |                          |                           |                     |
-  |                          |              [6a] makeMcpServer(config)        |
-  |                          |              in server.ts                      |
-  |                          |              capabilities: { tools: {},        |
-  |                          |                experimental:                   |
-  |                          |                 { "claude/channel": {} } }     |
-  |                          |              instructions: <contract default>  |
-  |                          |                           |                     |
-  |                          |              [6b] registerServerHandlers       |
-  |                          |              in server.ts                      |
-  |                          |              setRequestHandler(ListTools)      |
-  |                          |              setRequestHandler(CallTool)       |
-  |                          |                           |                     |
-  |                          |              [6b-fail] ToolRegistrationFailed  |
-  |                          |              (entry maps to McpTransportFailed)|
-  |                          |              --> BootResult { _tag:"Err" }     |
-  |                          |                           |                     |
-  |                          |              [6c] connectServer(server, deps)  |
-  |                          |              in server.ts                      |
-  |                          |              transportFactory?                 |
-  |                          |              (test seam, in types.ts)         |
-  |                          |              : new StdioServerTransport()      |
-  |                          |              server.connect(transport)          |
-  |                          |                           |                     |
-  |                          |              [6c-fail] StdioConnectFailed      |
-  |                          |              (entry maps to McpTransportFailed)|
-  |                          |              --> BootResult { _tag:"Err" }     |
-  |                          |                           |                     |
-  |                          |              [6d] server.oninitialized =       |
-  |                          |              markServerInitialized             |
-  |                          |              in server.ts                      |
-  |                          |              (flushes pending[] buffer on      |
-  |                          |               MCP handshake completion)        |
-  |                          |                           |                     |
-  |                          |              [6e] return ServerHandle          |
-  |                          |              { push, stop }                    |
-  |                          |<--------------------------|                     |
-  |                          |                           |                     |
-  |                          | [7] core.onInbound(handler)                    |
-  |                          | registers handleInboundMessage callback        |
-  |                          | in entry.ts                                    |
-  |                          |                           |                     |
-  |                          | [8] connectCore(core, serverHandle)            |
-  |                          | core.connect() — WS auth handshake             |
-  |                          |-------------------------------------------->   |
-  |                          |                           |                     |
-  |                          | [8-fail] ServiceRpcError / connect failure     |
-  |                          | serverHandle.stop() is called first            |
-  |                          | --> BootResult { _tag:"Err" }                  |
-  |                          |                           |                     |
-  |                          | [9] makeHandle(core, serverHandle)             |
-  |                          | in entry.ts                                    |
-  |                          | returns Handle { push, stop }                  |
-  |                          |                           |                     |
-  |<-------------------------|                           |                     |
-     BootResult { _tag:"Ok",
-       value: Handle }
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant entry as entry.ts
+    participant server as server.ts
+    participant client as @moltzap/client
+
+    Caller->>entry: bootClaudeCodeChannel(opts: BootOptions)
+
+    note over entry: [1] validateBootOptions
+    alt agentKey empty / serverUrl empty
+        entry-->>Caller: BootResult { _tag:"Err", error: AgentKeyInvalid }
+    end
+
+    entry->>client: [2] new MoltZapService({ serverUrl, agentKey })
+    entry->>client: [3] new MoltZapChannelCore({ service })
+
+    note over entry: [4] createRoutingState() — in routing.ts
+    note over entry: [5] makeSendReply(core) — in entry.ts
+
+    entry->>server: [6] bootChannelMcpServer(config, deps)
+
+    note over server: [6a] makeMcpServer(config)<br/>capabilities: { tools: {}, experimental: { "claude/channel": {} } }<br/>instructions: &lt;contract default&gt;
+
+    note over server: [6b] registerServerHandlers<br/>setRequestHandler(ListTools)<br/>setRequestHandler(CallTool)
+    alt [6b-fail] ToolRegistrationFailed
+        server-->>Caller: BootResult { _tag:"Err" } (McpTransportFailed)
+    end
+
+    note over server: [6c] connectServer(server, deps)<br/>transportFactory? (test seam, in types.ts)<br/>: new StdioServerTransport()<br/>server.connect(transport)
+    alt [6c-fail] StdioConnectFailed
+        server-->>Caller: BootResult { _tag:"Err" } (McpTransportFailed)
+    end
+
+    note over server: [6d] server.oninitialized = markServerInitialized<br/>(flushes pending[] buffer on MCP handshake completion)
+
+    server-->>entry: [6e] ServerHandle { push, stop }
+
+    note over entry: [7] core.onInbound(handler)<br/>registers handleInboundMessage callback
+
+    entry->>client: [8] connectCore(core, serverHandle)<br/>core.connect() — WS auth handshake
+    alt [8-fail] ServiceRpcError / connect failure
+        note over entry: serverHandle.stop() called first
+        entry-->>Caller: BootResult { _tag:"Err" }
+    end
+
+    note over entry: [9] makeHandle(core, serverHandle)<br/>returns Handle { push, stop }
+    entry-->>Caller: BootResult { _tag:"Ok", value: Handle }
+```
 
 BootError union (in errors.ts):
   AgentKeyInvalid     — opts.agentKey or opts.serverUrl blank   (step 1)
   McpTransportFailed  — server init / stdio connect rejected     (step 6)
   ServiceRpcError     — WS connect / auth rejected               (step 8)
   SchemaDecodeFailed  — reserved (not yet reachable in v1)
-```
 
 **Foreign-protocol bridge point**: step 6c is where the MCP stdio transport
 attaches. From this moment onward the process owns two concurrent channels:

--- a/packages/claude-code-channel/docs/architecture/02-inbound-message-to-claude-push.md
+++ b/packages/claude-code-channel/docs/architecture/02-inbound-message-to-claude-push.md
@@ -1,0 +1,111 @@
+# Inbound Message → Claude Push
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+When the WS connection delivers a message, `MoltZapChannelCore` calls every
+registered `onInbound` callback. The channel registered one at boot step 7.
+
+```text
+MoltZap server     @moltzap/client         entry.ts                event.ts       server.ts
+     |                    |                    |                       |               |
+     | WS frame           |                    |                       |               |
+     |..........> MoltZapChannelCore           |                       |               |
+     |                    | onInbound(enriched)|                       |               |
+     |                    |------------------->|                       |               |
+     |                    |               handleInboundMessage         |               |
+     |                    |               (in entry.ts)               |               |
+     |                    |                    |                       |               |
+     |                    |               [A] opts.gateInbound?        |               |
+     |                    |                    |                       |               |
+     |                    |               YES: gateInbound(enriched)  |               |
+     |                    |               (pure, sync — in types.ts)  |               |
+     |                    |                    |                       |               |
+     |                    |               { _tag:"Failure" }          |               |
+     |                    |               logGateDropped              |               |
+     |                    |               (in entry.ts) + return      |               |
+     |                    |               AllowlistError surfaced      |               |
+     |                    |               as log only, not propagated  |               |
+     |                    |                    |                       |               |
+     |                    |               NO gate / { _tag:"Success" }|               |
+     |                    |                    |                       |               |
+     |                    |               [B] toClaudeChannelNotification(gated.value)|
+     |                    |                    |---------------------->|               |
+     |                    |                    |                       |               |
+     |                    |                    |        [B1] content check (in event.ts)
+     |                    |                    |        event.text empty              |
+     |                    |                    |        --> { _tag:"Err", ContentEmpty }
+     |                    |                    |        logTranslationFailed + return |
+     |                    |                    |                       |               |
+     |                    |                    |        [B2] decodeNotificationMeta   |
+     |                    |                    |        (in event.ts)                |
+     |                    |                    |        chat_id  = conversationId     |
+     |                    |                    |        message_id = id               |
+     |                    |                    |        user     = sender.id          |
+     |                    |                    |        ts       = createdAt (ISO)    |
+     |                    |                    |                       |               |
+     |                    |                    |        any brand fails:              |
+     |                    |                    |        MetaInvalid / ContentEmpty    |
+     |                    |                    |        logTranslationFailed + return |
+     |                    |                    |<----------------------|               |
+     |                    |                    |                       |               |
+     |                    |               [C] routing.recordInbound(message_id, chat_id)
+     |                    |               (in routing.ts) — advances lastActive,     |
+     |                    |               inserts into LRU map (cap 256)             |
+     |                    |                    |                       |               |
+     |                    |               [D] serverHandle.push(notification)        |
+     |                    |               (in entry.ts)               |               |
+     |                    |                    |-------------------------------------->|
+     |                    |                    |                       |               |
+     |                    |                    |                       | state.initialized?
+     |                    |                    |                       |               |
+     |                    |                    |                       |  NO (pre-handshake):
+     |                    |                    |                       |  state.pending.push()
+     |                    |                    |                       |  (in server.ts)
+     |                    |                    |                       |  flushed later
+     |                    |                    |                       |  at oninitialized
+     |                    |                    |                       |               |
+     |                    |                    |                       |  YES:          |
+     |                    |                    |                       |  server.notification({
+     |                    |                    |                       |   method: "notifications/claude/channel",
+     |                    |                    |                       |   params: { content, meta }
+     |                    |                    |                       |  })           |
+     |                    |                    |                       |  (in server.ts)
+     |                    |                    |                       |               |
+     |                    |                    |                       |    EmitFailed  |
+     |                    |                    |                       |    logWarning, |
+     |                    |                    |                       |    swallowed   |
+     |                    |                    |                       |    (in entry.ts)
+     |                    |                    |                       |               |
+     |                    |                    |                       | MCP stdio frame|
+     |                    |                    |                       |..............>|
+                                                                               Claude Code
+                                                                               sees:
+                                                                               <channel
+                                                                                source="moltzap"
+                                                                                chat_id="..."
+                                                                                message_id="..."
+                                                                                user="..."
+                                                                                ts="...">
+                                                                               content
+                                                                               </channel>
+
+Error taxonomy for this path:
+  AllowlistError   — gateInbound returned Failure; logged, dropped (no push)
+  EventShapeError  — toClaudeChannelNotification returned Err; logged, dropped
+    ContentEmpty   — message text is blank
+    MetaInvalid    — conversationId / id / sender.id / createdAt malformed
+  PushError        — MCP emit rejected; logged, dropped (spec I5)
+    EmitFailed     — server.notification() promise rejected
+    NotConnected   — push called before transport attached (reserved, rare)
+```
+
+**Foreign-protocol bridge**: step D is the seam where MoltZap's wire
+`EnrichedInboundMessage` becomes an MCP `notifications/claude/channel`
+frame. The MCP SDK serialises it as JSON-RPC 2.0 over stdio.
+
+---
+
+See also:
+- [Boot Sequence](01-boot-sequence.md)
+- [Allowlist Gating](05-allowlist-gating.md)
+- [Claude Reply → MoltZap Outbound](03-claude-reply-to-moltzap-outbound.md)

--- a/packages/claude-code-channel/docs/architecture/02-inbound-message-to-claude-push.md
+++ b/packages/claude-code-channel/docs/architecture/02-inbound-message-to-claude-push.md
@@ -21,34 +21,34 @@ sequenceDiagram
     alt gate present
         entry->>entry: gateInbound(enriched) — pure, sync (types.ts)
         alt { _tag:"Failure" }
-            note over entry: logGateDropped (AllowlistError)<br/>logged only, not propagated — return
+            note over entry: logGateDropped (AllowlistError)<br>logged only, not propagated — return
         end
     end
     note over entry: NO gate / { _tag:"Success" } — continue
 
     entry->>event: [B] toClaudeChannelNotification(gated.value)
 
-    note over event: [B1] content check<br/>event.text empty → { _tag:"Err", ContentEmpty }<br/>logTranslationFailed + return
+    note over event: [B1] content check<br>event.text empty → { _tag:"Err", ContentEmpty }<br>logTranslationFailed + return
 
-    note over event: [B2] decodeNotificationMeta<br/>chat_id = conversationId<br/>message_id = id<br/>user = sender.id<br/>ts = createdAt (ISO)<br/>any brand fails → MetaInvalid / ContentEmpty<br/>logTranslationFailed + return
+    note over event: [B2] decodeNotificationMeta<br>chat_id = conversationId<br>message_id = id<br>user = sender.id<br>ts = createdAt (ISO)<br>any brand fails → MetaInvalid / ContentEmpty<br>logTranslationFailed + return
 
     event-->>entry: ClaudeChannelNotification
 
-    note over entry: [C] routing.recordInbound(message_id, chat_id)<br/>advances lastActive, inserts into LRU map (cap 256)
+    note over entry: [C] routing.recordInbound(message_id, chat_id)<br>advances lastActive, inserts into LRU map (cap 256)
 
     entry->>server: [D] serverHandle.push(notification)
 
     alt state.initialized == false (pre-handshake)
-        note over server: state.pending.push()<br/>flushed later at oninitialized
+        note over server: state.pending.push()<br>flushed later at oninitialized
     else state.initialized == true
-        server->>server: server.notification({<br/>  method: "notifications/claude/channel",<br/>  params: { content, meta }<br/>})
+        server->>server: server.notification({<br>  method: "notifications/claude/channel",<br>  params: { content, meta }<br>})
         alt EmitFailed
             note over server: logWarning — swallowed (entry.ts)
         end
         server-->>Claude: MCP stdio frame
     end
 
-    Note over Claude: &lt;channel source="moltzap" chat_id="..." message_id="..." user="..." ts="..."&gt;<br/>content<br/>&lt;/channel&gt;
+    Note over Claude: <channel source="moltzap" chat_id="..." message_id="..." user="..." ts="..."><br>content<br></channel>
 ```
 
 Error taxonomy for this path:

--- a/packages/claude-code-channel/docs/architecture/02-inbound-message-to-claude-push.md
+++ b/packages/claude-code-channel/docs/architecture/02-inbound-message-to-claude-push.md
@@ -5,89 +5,51 @@
 When the WS connection delivers a message, `MoltZapChannelCore` calls every
 registered `onInbound` callback. The channel registered one at boot step 7.
 
-```text
-MoltZap server     @moltzap/client         entry.ts                event.ts       server.ts
-     |                    |                    |                       |               |
-     | WS frame           |                    |                       |               |
-     |..........> MoltZapChannelCore           |                       |               |
-     |                    | onInbound(enriched)|                       |               |
-     |                    |------------------->|                       |               |
-     |                    |               handleInboundMessage         |               |
-     |                    |               (in entry.ts)               |               |
-     |                    |                    |                       |               |
-     |                    |               [A] opts.gateInbound?        |               |
-     |                    |                    |                       |               |
-     |                    |               YES: gateInbound(enriched)  |               |
-     |                    |               (pure, sync — in types.ts)  |               |
-     |                    |                    |                       |               |
-     |                    |               { _tag:"Failure" }          |               |
-     |                    |               logGateDropped              |               |
-     |                    |               (in entry.ts) + return      |               |
-     |                    |               AllowlistError surfaced      |               |
-     |                    |               as log only, not propagated  |               |
-     |                    |                    |                       |               |
-     |                    |               NO gate / { _tag:"Success" }|               |
-     |                    |                    |                       |               |
-     |                    |               [B] toClaudeChannelNotification(gated.value)|
-     |                    |                    |---------------------->|               |
-     |                    |                    |                       |               |
-     |                    |                    |        [B1] content check (in event.ts)
-     |                    |                    |        event.text empty              |
-     |                    |                    |        --> { _tag:"Err", ContentEmpty }
-     |                    |                    |        logTranslationFailed + return |
-     |                    |                    |                       |               |
-     |                    |                    |        [B2] decodeNotificationMeta   |
-     |                    |                    |        (in event.ts)                |
-     |                    |                    |        chat_id  = conversationId     |
-     |                    |                    |        message_id = id               |
-     |                    |                    |        user     = sender.id          |
-     |                    |                    |        ts       = createdAt (ISO)    |
-     |                    |                    |                       |               |
-     |                    |                    |        any brand fails:              |
-     |                    |                    |        MetaInvalid / ContentEmpty    |
-     |                    |                    |        logTranslationFailed + return |
-     |                    |                    |<----------------------|               |
-     |                    |                    |                       |               |
-     |                    |               [C] routing.recordInbound(message_id, chat_id)
-     |                    |               (in routing.ts) — advances lastActive,     |
-     |                    |               inserts into LRU map (cap 256)             |
-     |                    |                    |                       |               |
-     |                    |               [D] serverHandle.push(notification)        |
-     |                    |               (in entry.ts)               |               |
-     |                    |                    |-------------------------------------->|
-     |                    |                    |                       |               |
-     |                    |                    |                       | state.initialized?
-     |                    |                    |                       |               |
-     |                    |                    |                       |  NO (pre-handshake):
-     |                    |                    |                       |  state.pending.push()
-     |                    |                    |                       |  (in server.ts)
-     |                    |                    |                       |  flushed later
-     |                    |                    |                       |  at oninitialized
-     |                    |                    |                       |               |
-     |                    |                    |                       |  YES:          |
-     |                    |                    |                       |  server.notification({
-     |                    |                    |                       |   method: "notifications/claude/channel",
-     |                    |                    |                       |   params: { content, meta }
-     |                    |                    |                       |  })           |
-     |                    |                    |                       |  (in server.ts)
-     |                    |                    |                       |               |
-     |                    |                    |                       |    EmitFailed  |
-     |                    |                    |                       |    logWarning, |
-     |                    |                    |                       |    swallowed   |
-     |                    |                    |                       |    (in entry.ts)
-     |                    |                    |                       |               |
-     |                    |                    |                       | MCP stdio frame|
-     |                    |                    |                       |..............>|
-                                                                               Claude Code
-                                                                               sees:
-                                                                               <channel
-                                                                                source="moltzap"
-                                                                                chat_id="..."
-                                                                                message_id="..."
-                                                                                user="..."
-                                                                                ts="...">
-                                                                               content
-                                                                               </channel>
+```mermaid
+sequenceDiagram
+    participant WS as MoltZap server
+    participant client as @moltzap/client
+    participant entry as entry.ts
+    participant event as event.ts
+    participant server as server.ts
+    participant Claude as Claude Code
+
+    WS-->>client: WS frame → MoltZapChannelCore
+    client->>entry: onInbound(enriched) — handleInboundMessage
+
+    note over entry: [A] opts.gateInbound?
+    alt gate present
+        entry->>entry: gateInbound(enriched) — pure, sync (types.ts)
+        alt { _tag:"Failure" }
+            note over entry: logGateDropped (AllowlistError)<br/>logged only, not propagated — return
+        end
+    end
+    note over entry: NO gate / { _tag:"Success" } — continue
+
+    entry->>event: [B] toClaudeChannelNotification(gated.value)
+
+    note over event: [B1] content check<br/>event.text empty → { _tag:"Err", ContentEmpty }<br/>logTranslationFailed + return
+
+    note over event: [B2] decodeNotificationMeta<br/>chat_id = conversationId<br/>message_id = id<br/>user = sender.id<br/>ts = createdAt (ISO)<br/>any brand fails → MetaInvalid / ContentEmpty<br/>logTranslationFailed + return
+
+    event-->>entry: ClaudeChannelNotification
+
+    note over entry: [C] routing.recordInbound(message_id, chat_id)<br/>advances lastActive, inserts into LRU map (cap 256)
+
+    entry->>server: [D] serverHandle.push(notification)
+
+    alt state.initialized == false (pre-handshake)
+        note over server: state.pending.push()<br/>flushed later at oninitialized
+    else state.initialized == true
+        server->>server: server.notification({<br/>  method: "notifications/claude/channel",<br/>  params: { content, meta }<br/>})
+        alt EmitFailed
+            note over server: logWarning — swallowed (entry.ts)
+        end
+        server-->>Claude: MCP stdio frame
+    end
+
+    Note over Claude: &lt;channel source="moltzap" chat_id="..." message_id="..." user="..." ts="..."&gt;<br/>content<br/>&lt;/channel&gt;
+```
 
 Error taxonomy for this path:
   AllowlistError   — gateInbound returned Failure; logged, dropped (no push)
@@ -97,7 +59,6 @@ Error taxonomy for this path:
   PushError        — MCP emit rejected; logged, dropped (spec I5)
     EmitFailed     — server.notification() promise rejected
     NotConnected   — push called before transport attached (reserved, rare)
-```
 
 **Foreign-protocol bridge**: step D is the seam where MoltZap's wire
 `EnrichedInboundMessage` becomes an MCP `notifications/claude/channel`

--- a/packages/claude-code-channel/docs/architecture/03-claude-reply-to-moltzap-outbound.md
+++ b/packages/claude-code-channel/docs/architecture/03-claude-reply-to-moltzap-outbound.md
@@ -13,7 +13,7 @@ sequenceDiagram
     participant entry as entry.ts
     participant client as @moltzap/client
 
-    Claude->>mcp: tool call JSON<br/>{ name:"reply", arguments:{ text:"...", reply_to?:"msg-id" } }
+    Claude->>mcp: tool call JSON<br>{ name:"reply", arguments:{ text:"...", reply_to?:"msg-id" } }
     mcp->>server: CallToolRequest — handleCallToolRequest
 
     alt [1] name != "reply"
@@ -56,9 +56,9 @@ sequenceDiagram
     alt [6] LeaseAlreadyConsumed
         server-->>mcp: toolErrorResult("LeaseAlreadyConsumed: ...")
     else SendFailed
-        server-->>mcp: toolErrorResult("send failed: &lt;cause&gt;")
+        server-->>mcp: toolErrorResult("send failed: <cause>")
     else Success
-        server-->>mcp: toolOkResult("Reply sent to &lt;conversationId&gt;.")
+        server-->>mcp: toolOkResult("Reply sent to <conversationId>.")
     end
 
     mcp-->>Claude: CallToolResult — { content:[{ type:"text", text:"..." }], isError?:true }

--- a/packages/claude-code-channel/docs/architecture/03-claude-reply-to-moltzap-outbound.md
+++ b/packages/claude-code-channel/docs/architecture/03-claude-reply-to-moltzap-outbound.md
@@ -1,0 +1,108 @@
+# Claude Reply → MoltZap Outbound
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Claude invokes the `reply` MCP tool. The MCP SDK deserializes the
+JSON-RPC call and hands it to the registered `CallTool` handler.
+
+```text
+Claude Code     MCP SDK (stdio)      server.ts             entry.ts       @moltzap/client
+     |                 |                 |                     |                  |
+     | tool call JSON  |                 |                     |                  |
+     | { name:"reply", |                 |                     |                  |
+     |   arguments:{   |                 |                     |                  |
+     |     text: "...",|                 |                     |                  |
+     |     reply_to?:  |                 |                     |                  |
+     |     "msg-id"    |                 |                     |                  |
+     |   }             |                 |                     |                  |
+     | }               |                 |                     |                  |
+     |---------------->|                 |                     |                  |
+     |                 | CallToolRequest |                     |                  |
+     |                 |---------------->|                     |                  |
+     |                 |            handleCallToolRequest      |                  |
+     |                 |            (in server.ts)            |                  |
+     |                 |                 |                     |                  |
+     |                 |            [1] name == "reply"?       |                  |
+     |                 |            NO: toolErrorResult("unknown tool: ...")     |
+     |                 |                 |                     |                  |
+     |                 |            YES: decodeReplyArgs(request.params.arguments)
+     |                 |            (in server.ts)            |                  |
+     |                 |                 |                     |                  |
+     |                 |            arguments not object / text missing or blank |
+     |                 |            --> toolErrorResult(ReplyArgsInvalid.reason) |
+     |                 |                 |                     |                  |
+     |                 |            handleDecodedReplyCall(decoded, deps)        |
+     |                 |            (in server.ts)            |                  |
+     |                 |                 |                     |                  |
+     |                 |            [2] decoded.files non-empty?                 |
+     |                 |            YES: filesUnsupportedResult (v1 limitation)  |
+     |                 |                 |                     |                  |
+     |                 |            [3] routing.resolveTarget(decoded.replyTo)   |
+     |                 |            (in routing.ts)           |                  |
+     |                 |                 |                     |                  |
+     |                 |            NoActiveConversation:      |                  |
+     |                 |            toolErrorResult("no active conversation...") |
+     |                 |                 |                     |                  |
+     |                 |            ReplyToUnknown:            |                  |
+     |                 |            toolErrorResult("reply_to does not match...") |
+     |                 |                 |                     |                  |
+     |                 |            Resolved { conversationId }|                  |
+     |                 |                 |                     |                  |
+     |                 |            [4] deps.sendReply(conversationId, text)     |
+     |                 |                 |-------------------->|                  |
+     |                 |                 |                     |                  |
+     |                 |                 |              makeSendReply:            |
+     |                 |                 |              core.sendReply(conv, text)|
+     |                 |                 |                     |----------------->|
+     |                 |                 |                     |                  |
+     |                 |                 |                     |   MoltZap WS RPC |
+     |                 |                 |                     |   messages/send  |
+     |                 |                 |                     |   with lease     |
+     |                 |                 |                     |                  |
+     |                 |                 |                     | [5a] RpcServerError
+     |                 |                 |                     | data.reason ==   |
+     |                 |                 |                     | "LeaseInvalid"   |
+     |                 |                 |                     | projectLeaseInvalid
+     |                 |                 |                     | --> LeaseAlreadyConsumed
+     |                 |                 |                     | (in entry.ts)    |
+     |                 |                 |                     |                  |
+     |                 |                 |                     | [5b] other error |
+     |                 |                 |                     | --> SendFailed   |
+     |                 |                 |<--------------------|                  |
+     |                 |                 |                     |                  |
+     |                 |            [6] ReplyError?            |                  |
+     |                 |            LeaseAlreadyConsumed:      |                  |
+     |                 |            toolErrorResult("LeaseAlreadyConsumed: ...")  |
+     |                 |            (in server.ts)            |                  |
+     |                 |                 |                     |                  |
+     |                 |            SendFailed:                |                  |
+     |                 |            toolErrorResult("send failed: <cause>")       |
+     |                 |                 |                     |                  |
+     |                 |            Success:                   |                  |
+     |                 |            toolOkResult("Reply sent to <conversationId>.")|
+     |                 |                 |                     |                  |
+     |                 | CallToolResult  |                     |                  |
+     |                 |<----------------|                     |                  |
+     | tool result JSON|                 |                     |                  |
+     |<----------------|                 |                     |                  |
+     |  { content:[{   |                 |                     |                  |
+     |      type:"text"|                 |                     |                  |
+     |      text:"..."                   |                     |                  |
+     |    }],          |                 |                     |                  |
+     |    isError?:true|                 |                     |                  |
+     |  }              |                 |                     |                  |
+
+ReplyError union (in errors.ts):
+  LeaseAlreadyConsumed — server returned LeaseInvalid for a consumed lease
+  SendFailed           — WS RPC call rejected for any other reason
+  NoActiveConversation — no inbound observed yet (routing state empty)
+  ReplyToUnknown       — reply_to given but not in LRU map
+  FilesUnsupported     — files[] non-empty (v1 not implemented)
+```
+
+---
+
+See also:
+- [Lease State Machine](04-lease-state-machine.md)
+- [Inbound Message → Claude Push](02-inbound-message-to-claude-push.md)
+- [Boot Sequence](01-boot-sequence.md)

--- a/packages/claude-code-channel/docs/architecture/03-claude-reply-to-moltzap-outbound.md
+++ b/packages/claude-code-channel/docs/architecture/03-claude-reply-to-moltzap-outbound.md
@@ -5,92 +5,64 @@
 Claude invokes the `reply` MCP tool. The MCP SDK deserializes the
 JSON-RPC call and hands it to the registered `CallTool` handler.
 
-```text
-Claude Code     MCP SDK (stdio)      server.ts             entry.ts       @moltzap/client
-     |                 |                 |                     |                  |
-     | tool call JSON  |                 |                     |                  |
-     | { name:"reply", |                 |                     |                  |
-     |   arguments:{   |                 |                     |                  |
-     |     text: "...",|                 |                     |                  |
-     |     reply_to?:  |                 |                     |                  |
-     |     "msg-id"    |                 |                     |                  |
-     |   }             |                 |                     |                  |
-     | }               |                 |                     |                  |
-     |---------------->|                 |                     |                  |
-     |                 | CallToolRequest |                     |                  |
-     |                 |---------------->|                     |                  |
-     |                 |            handleCallToolRequest      |                  |
-     |                 |            (in server.ts)            |                  |
-     |                 |                 |                     |                  |
-     |                 |            [1] name == "reply"?       |                  |
-     |                 |            NO: toolErrorResult("unknown tool: ...")     |
-     |                 |                 |                     |                  |
-     |                 |            YES: decodeReplyArgs(request.params.arguments)
-     |                 |            (in server.ts)            |                  |
-     |                 |                 |                     |                  |
-     |                 |            arguments not object / text missing or blank |
-     |                 |            --> toolErrorResult(ReplyArgsInvalid.reason) |
-     |                 |                 |                     |                  |
-     |                 |            handleDecodedReplyCall(decoded, deps)        |
-     |                 |            (in server.ts)            |                  |
-     |                 |                 |                     |                  |
-     |                 |            [2] decoded.files non-empty?                 |
-     |                 |            YES: filesUnsupportedResult (v1 limitation)  |
-     |                 |                 |                     |                  |
-     |                 |            [3] routing.resolveTarget(decoded.replyTo)   |
-     |                 |            (in routing.ts)           |                  |
-     |                 |                 |                     |                  |
-     |                 |            NoActiveConversation:      |                  |
-     |                 |            toolErrorResult("no active conversation...") |
-     |                 |                 |                     |                  |
-     |                 |            ReplyToUnknown:            |                  |
-     |                 |            toolErrorResult("reply_to does not match...") |
-     |                 |                 |                     |                  |
-     |                 |            Resolved { conversationId }|                  |
-     |                 |                 |                     |                  |
-     |                 |            [4] deps.sendReply(conversationId, text)     |
-     |                 |                 |-------------------->|                  |
-     |                 |                 |                     |                  |
-     |                 |                 |              makeSendReply:            |
-     |                 |                 |              core.sendReply(conv, text)|
-     |                 |                 |                     |----------------->|
-     |                 |                 |                     |                  |
-     |                 |                 |                     |   MoltZap WS RPC |
-     |                 |                 |                     |   messages/send  |
-     |                 |                 |                     |   with lease     |
-     |                 |                 |                     |                  |
-     |                 |                 |                     | [5a] RpcServerError
-     |                 |                 |                     | data.reason ==   |
-     |                 |                 |                     | "LeaseInvalid"   |
-     |                 |                 |                     | projectLeaseInvalid
-     |                 |                 |                     | --> LeaseAlreadyConsumed
-     |                 |                 |                     | (in entry.ts)    |
-     |                 |                 |                     |                  |
-     |                 |                 |                     | [5b] other error |
-     |                 |                 |                     | --> SendFailed   |
-     |                 |                 |<--------------------|                  |
-     |                 |                 |                     |                  |
-     |                 |            [6] ReplyError?            |                  |
-     |                 |            LeaseAlreadyConsumed:      |                  |
-     |                 |            toolErrorResult("LeaseAlreadyConsumed: ...")  |
-     |                 |            (in server.ts)            |                  |
-     |                 |                 |                     |                  |
-     |                 |            SendFailed:                |                  |
-     |                 |            toolErrorResult("send failed: <cause>")       |
-     |                 |                 |                     |                  |
-     |                 |            Success:                   |                  |
-     |                 |            toolOkResult("Reply sent to <conversationId>.")|
-     |                 |                 |                     |                  |
-     |                 | CallToolResult  |                     |                  |
-     |                 |<----------------|                     |                  |
-     | tool result JSON|                 |                     |                  |
-     |<----------------|                 |                     |                  |
-     |  { content:[{   |                 |                     |                  |
-     |      type:"text"|                 |                     |                  |
-     |      text:"..."                   |                     |                  |
-     |    }],          |                 |                     |                  |
-     |    isError?:true|                 |                     |                  |
-     |  }              |                 |                     |                  |
+```mermaid
+sequenceDiagram
+    participant Claude as Claude Code
+    participant mcp as MCP SDK (stdio)
+    participant server as server.ts
+    participant entry as entry.ts
+    participant client as @moltzap/client
+
+    Claude->>mcp: tool call JSON<br/>{ name:"reply", arguments:{ text:"...", reply_to?:"msg-id" } }
+    mcp->>server: CallToolRequest — handleCallToolRequest
+
+    alt [1] name != "reply"
+        server-->>mcp: toolErrorResult("unknown tool: ...")
+    end
+
+    note over server: YES: decodeReplyArgs(request.params.arguments)
+    alt arguments not object / text missing or blank
+        server-->>mcp: toolErrorResult(ReplyArgsInvalid.reason)
+    end
+
+    note over server: handleDecodedReplyCall(decoded, deps)
+
+    alt [2] decoded.files non-empty
+        server-->>mcp: filesUnsupportedResult (v1 limitation)
+    end
+
+    note over server: [3] routing.resolveTarget(decoded.replyTo) — routing.ts
+    alt NoActiveConversation
+        server-->>mcp: toolErrorResult("no active conversation...")
+    else ReplyToUnknown
+        server-->>mcp: toolErrorResult("reply_to does not match...")
+    end
+
+    note over server: Resolved { conversationId }
+
+    server->>entry: [4] deps.sendReply(conversationId, text)
+    note over entry: makeSendReply: core.sendReply(conv, text)
+    entry->>client: MoltZap WS RPC — messages/send with lease
+
+    alt [5a] RpcServerError { data.reason: "LeaseInvalid" }
+        note over entry: projectLeaseInvalid → LeaseAlreadyConsumed
+        client-->>entry: LeaseAlreadyConsumed
+    else [5b] other error
+        client-->>entry: SendFailed
+    end
+
+    entry-->>server: ReplyError | void
+
+    alt [6] LeaseAlreadyConsumed
+        server-->>mcp: toolErrorResult("LeaseAlreadyConsumed: ...")
+    else SendFailed
+        server-->>mcp: toolErrorResult("send failed: &lt;cause&gt;")
+    else Success
+        server-->>mcp: toolOkResult("Reply sent to &lt;conversationId&gt;.")
+    end
+
+    mcp-->>Claude: CallToolResult — { content:[{ type:"text", text:"..." }], isError?:true }
+```
 
 ReplyError union (in errors.ts):
   LeaseAlreadyConsumed — server returned LeaseInvalid for a consumed lease
@@ -98,7 +70,6 @@ ReplyError union (in errors.ts):
   NoActiveConversation — no inbound observed yet (routing state empty)
   ReplyToUnknown       — reply_to given but not in LRU map
   FilesUnsupported     — files[] non-empty (v1 not implemented)
-```
 
 ---
 

--- a/packages/claude-code-channel/docs/architecture/04-lease-state-machine.md
+++ b/packages/claude-code-channel/docs/architecture/04-lease-state-machine.md
@@ -1,23 +1,16 @@
-# Lease State Machine
+# Channel projection of the dispatch lease
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 
-The server-side single-use lease semantics are enforced by the MoltZap
-server, not by a local state machine in this package. The channel's job
-is to project the server's typed rejection onto a structured `ReplyError`
-before it reaches Claude's tool result.
+The dispatch lease FSM lives on the MoltZap server — see
+[`server/06-lease-lifecycle.md`](../../../server/docs/architecture/06-lease-lifecycle.md)
+for the authoritative state machine
+(`PENDING → GRANTED → CLAIMED → CONSUMED/EXPIRED/...`). This page covers
+only the channel-local concerns: how the channel projects the server's
+typed rejection onto a `ReplyError` Claude can see, and what local state
+the channel tracks.
 
-**MoltZap server — lease state machine:**
-
-```mermaid
-stateDiagram-v2
-    [*] --> PENDING
-    PENDING --> GRANTED : dispatch
-    GRANTED --> CONSUMED : consume (first sendReply)
-    CONSUMED --> CONSUMED : second consume → LeaseInvalid
-```
-
-**Channel projection of the lease (entry.ts + server.ts):**
+## 1. Server rejection → channel `ReplyError` projection
 
 ```mermaid
 flowchart TD
@@ -28,14 +21,19 @@ flowchart TD
     E -->|"RpcServerError { data.reason: 'LeaseInvalid' }"| G["projectLeaseInvalid (entry.ts)"]
     G --> H["LeaseAlreadyConsumed { leaseId }"]
     H --> I["server.ts sendFailureResult"]
-    I --> J["toolErrorResult('LeaseAlreadyConsumed: dispatch lease &lt;id&gt; was already consumed by an earlier reply in this dispatch turn.')"]
+    I --> J["toolErrorResult('LeaseAlreadyConsumed: dispatch lease was already consumed by an earlier reply in this dispatch turn.')"]
 ```
 
-Annotations:
-- The server enforces the single-use lease constraint; this package only projects the typed rejection.
-- The channel's local `routing.ts` LRU map (`Map<MessageId, ConversationId>`, cap=256) is separate from the lease and tracks conversation targets for `reply_to` resolution.
+The server enforces the single-use lease constraint. This package only
+projects the typed rejection into a `ReplyError` arm.
 
-Local routing state (routing.ts) — what the channel DOES track:
+## 2. Channel-local state — the routing LRU map
+
+The channel does NOT track lease tokens at all. It tracks message-id →
+conversation-id for `reply_to` resolution:
+
+```text
+routing.ts:
   Map<MessageId, ConversationId>   bounded LRU, cap=256
   lastActive: ConversationId | undefined
 
@@ -44,16 +42,21 @@ Local routing state (routing.ts) — what the channel DOES track:
     2. map.set(messageId, conversationId)
     3. while map.size > cap: evict oldest (Map insertion-order)
     4. lastActive = conversationId
+```
 
-  Eviction: when map.size exceeds 256, oldest MessageId is dropped.
-  A reply_to referencing an evicted message_id → ReplyToUnknown.
+Eviction: when `map.size` exceeds 256, the oldest `MessageId` is dropped.
+A `reply_to` referencing an evicted message-id surfaces as
+`ReplyToUnknown`.
 
-Lease cleanup: the channel holds no lease tokens. When a dispatch ends
-(or the WS connection drops), no local cleanup is needed — the server
-holds and expires leases independently.
+## 3. Cleanup
+
+The channel holds no lease tokens — there's nothing to clean up when a
+dispatch ends or the WS connection drops. The server holds and expires
+leases independently (see the server doc linked above).
 
 ---
 
 See also:
-- [Claude Reply → MoltZap Outbound](03-claude-reply-to-moltzap-outbound.md)
-- [Inbound Message → Claude Push](02-inbound-message-to-claude-push.md)
+- [Claude Reply → MoltZap Outbound](03-claude-reply-to-moltzap-outbound.md) — where the rejection projection runs
+- [Inbound Message → Claude Push](02-inbound-message-to-claude-push.md) — where `routing.recordInbound` is called
+- [Server lease lifecycle](../../../server/docs/architecture/06-lease-lifecycle.md) — the authoritative state machine

--- a/packages/claude-code-channel/docs/architecture/04-lease-state-machine.md
+++ b/packages/claude-code-channel/docs/architecture/04-lease-state-machine.md
@@ -7,41 +7,33 @@ server, not by a local state machine in this package. The channel's job
 is to project the server's typed rejection onto a structured `ReplyError`
 before it reaches Claude's tool result.
 
-```text
-Lease lifecycle from the channel's perspective
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+**MoltZap server — lease state machine:**
 
-  ┌─────────────────────────────────────────────────────────┐
-  │                   MoltZap server                         │
-  │                                                          │
-  │  PENDING ──dispatch──> GRANTED ──consume──> CONSUMED     │
-  │                                     │                    │
-  │                              only one consume            │
-  │                              allowed; second             │
-  │                              returns LeaseInvalid        │
-  └─────────────────────────────────────────────────────────┘
-            │                                │
-            │ inbound message                │ sendReply() call
-            ▼                                ▼
-  channel.onInbound()                core.sendReply(conv, text)
-  routing.recordInbound()            WS RPC → messages/send
-  serverHandle.push(notification)           │
-  (LRU map updated)                         │
-                                    success: void
-                                            │
-                                    RpcServerError { data.reason: "LeaseInvalid" }
-                                            │
-                                    projectLeaseInvalid (in entry.ts)
-                                            │
-                                    LeaseAlreadyConsumed { leaseId }
-                                            │
-                                    server.ts sendFailureResult
-                                            │
-                                    toolErrorResult(
-                                      "LeaseAlreadyConsumed: dispatch
-                                       lease <id> was already consumed
-                                       by an earlier reply in this
-                                       dispatch turn.")
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING
+    PENDING --> GRANTED : dispatch
+    GRANTED --> CONSUMED : consume (first sendReply)
+    CONSUMED --> CONSUMED : second consume → LeaseInvalid
+```
+
+**Channel projection of the lease (entry.ts + server.ts):**
+
+```mermaid
+flowchart TD
+    A["inbound message"] --> B["channel.onInbound()\nrouting.recordInbound()\nserverHandle.push(notification)\nLRU map updated"]
+    C["sendReply() call"] --> D["core.sendReply(conv, text)\nWS RPC → messages/send"]
+    D --> E{result}
+    E -->|success| F["void"]
+    E -->|"RpcServerError { data.reason: 'LeaseInvalid' }"| G["projectLeaseInvalid (entry.ts)"]
+    G --> H["LeaseAlreadyConsumed { leaseId }"]
+    H --> I["server.ts sendFailureResult"]
+    I --> J["toolErrorResult('LeaseAlreadyConsumed: dispatch lease &lt;id&gt; was already consumed by an earlier reply in this dispatch turn.')"]
+```
+
+Annotations:
+- The server enforces the single-use lease constraint; this package only projects the typed rejection.
+- The channel's local `routing.ts` LRU map (`Map<MessageId, ConversationId>`, cap=256) is separate from the lease and tracks conversation targets for `reply_to` resolution.
 
 Local routing state (routing.ts) — what the channel DOES track:
   Map<MessageId, ConversationId>   bounded LRU, cap=256
@@ -59,7 +51,6 @@ Local routing state (routing.ts) — what the channel DOES track:
 Lease cleanup: the channel holds no lease tokens. When a dispatch ends
 (or the WS connection drops), no local cleanup is needed — the server
 holds and expires leases independently.
-```
 
 ---
 

--- a/packages/claude-code-channel/docs/architecture/04-lease-state-machine.md
+++ b/packages/claude-code-channel/docs/architecture/04-lease-state-machine.md
@@ -1,0 +1,68 @@
+# Lease State Machine
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+The server-side single-use lease semantics are enforced by the MoltZap
+server, not by a local state machine in this package. The channel's job
+is to project the server's typed rejection onto a structured `ReplyError`
+before it reaches Claude's tool result.
+
+```text
+Lease lifecycle from the channel's perspective
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ┌─────────────────────────────────────────────────────────┐
+  │                   MoltZap server                         │
+  │                                                          │
+  │  PENDING ──dispatch──> GRANTED ──consume──> CONSUMED     │
+  │                                     │                    │
+  │                              only one consume            │
+  │                              allowed; second             │
+  │                              returns LeaseInvalid        │
+  └─────────────────────────────────────────────────────────┘
+            │                                │
+            │ inbound message                │ sendReply() call
+            ▼                                ▼
+  channel.onInbound()                core.sendReply(conv, text)
+  routing.recordInbound()            WS RPC → messages/send
+  serverHandle.push(notification)           │
+  (LRU map updated)                         │
+                                    success: void
+                                            │
+                                    RpcServerError { data.reason: "LeaseInvalid" }
+                                            │
+                                    projectLeaseInvalid (in entry.ts)
+                                            │
+                                    LeaseAlreadyConsumed { leaseId }
+                                            │
+                                    server.ts sendFailureResult
+                                            │
+                                    toolErrorResult(
+                                      "LeaseAlreadyConsumed: dispatch
+                                       lease <id> was already consumed
+                                       by an earlier reply in this
+                                       dispatch turn.")
+
+Local routing state (routing.ts) — what the channel DOES track:
+  Map<MessageId, ConversationId>   bounded LRU, cap=256
+  lastActive: ConversationId | undefined
+
+  recordInbound(messageId, conversationId):
+    1. delete(messageId) if present  — refresh LRU position
+    2. map.set(messageId, conversationId)
+    3. while map.size > cap: evict oldest (Map insertion-order)
+    4. lastActive = conversationId
+
+  Eviction: when map.size exceeds 256, oldest MessageId is dropped.
+  A reply_to referencing an evicted message_id → ReplyToUnknown.
+
+Lease cleanup: the channel holds no lease tokens. When a dispatch ends
+(or the WS connection drops), no local cleanup is needed — the server
+holds and expires leases independently.
+```
+
+---
+
+See also:
+- [Claude Reply → MoltZap Outbound](03-claude-reply-to-moltzap-outbound.md)
+- [Inbound Message → Claude Push](02-inbound-message-to-claude-push.md)

--- a/packages/claude-code-channel/docs/architecture/04-lease-state-machine.md
+++ b/packages/claude-code-channel/docs/architecture/04-lease-state-machine.md
@@ -21,8 +21,8 @@ stateDiagram-v2
 
 ```mermaid
 flowchart TD
-    A["inbound message"] --> B["channel.onInbound()\nrouting.recordInbound()\nserverHandle.push(notification)\nLRU map updated"]
-    C["sendReply() call"] --> D["core.sendReply(conv, text)\nWS RPC → messages/send"]
+    A["inbound message"] --> B["channel.onInbound()<br>routing.recordInbound()<br>serverHandle.push(notification)<br>LRU map updated"]
+    C["sendReply() call"] --> D["core.sendReply(conv, text)<br>WS RPC → messages/send"]
     D --> E{result}
     E -->|success| F["void"]
     E -->|"RpcServerError { data.reason: 'LeaseInvalid' }"| G["projectLeaseInvalid (entry.ts)"]

--- a/packages/claude-code-channel/docs/architecture/05-allowlist-gating.md
+++ b/packages/claude-code-channel/docs/architecture/05-allowlist-gating.md
@@ -1,0 +1,62 @@
+# Allowlist Gating
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`gateInbound` is a caller-supplied predicate injected at boot. It is
+**optional** — when absent, every inbound message passes through.
+
+```text
+Concrete code path (in entry.ts — handleInboundMessage):
+
+  handleInboundMessage(opts, routing, serverHandle, enriched)
+        │
+        ├── opts.gateInbound present?
+        │         │
+        │   YES   │  gated = opts.gateInbound(enriched)
+        │         │
+        │         │  Contract (in types.ts — GateInbound):
+        │         │    type GateInbound = (
+        │         │      event: EnrichedInboundMessage
+        │         │    ) =>
+        │         │      | { _tag: "Success"; value: EnrichedInboundMessage }
+        │         │      | { _tag: "Failure"; error: AllowlistError }
+        │         │
+        │         │  Invariants enforced by the type system:
+        │         │    - Pure, synchronous (no Promise return, no I/O)
+        │         │    - Must return a tagged union; no throw
+        │         │    - Can MODIFY the returned EnrichedInboundMessage
+        │         │      (e.g. strip metadata) by returning a new value
+        │         │      inside Success — the translated notification is
+        │         │      built from gated.value, not enriched directly
+        │         │
+        │   NO    │  gated = { _tag: "Success", value: enriched }
+        │
+        ├── gated._tag == "Failure"?
+        │         │
+        │   YES   │  logGateDropped(gated.error)   ← in entry.ts
+        │         │  Effect.logInfo with AllowlistError tag
+        │         │  return (no push, no routing update)
+        │         │
+        │   NO    │  continue to toClaudeChannelNotification(gated.value)
+        │
+        AllowlistError union (in errors.ts):
+          SenderNotAllowed      { senderId, reason }
+          ConversationNotAllowed { conversationId, reason }
+
+Context the gate function receives — EnrichedInboundMessage fields:
+  .id              message UUID (MessageId)
+  .conversationId  conversation UUID (ConversationId)
+  .sender.id       sender agent UUID (UserId)
+  .text            message text body
+  .createdAt       ISO-8601 timestamp
+  (+ any other fields from @moltzap/client EnrichedInboundMessage)
+
+The gate is evaluated BEFORE routing.recordInbound; a denied message
+is never added to the LRU map, so it cannot be targeted by reply_to.
+```
+
+---
+
+See also:
+- [Inbound Message → Claude Push](02-inbound-message-to-claude-push.md)
+- [Boot Sequence](01-boot-sequence.md)

--- a/packages/claude-code-channel/docs/architecture/05-allowlist-gating.md
+++ b/packages/claude-code-channel/docs/architecture/05-allowlist-gating.md
@@ -9,11 +9,11 @@
 flowchart TD
     A["handleInboundMessage(opts, routing, serverHandle, enriched)"]
     A --> B{opts.gateInbound present?}
-    B -->|YES| C["gated = opts.gateInbound(enriched)\n— pure, sync (types.ts)"]
+    B -->|YES| C["gated = opts.gateInbound(enriched)<br>— pure, sync (types.ts)"]
     B -->|NO| D["gated = { _tag:'Success', value: enriched }"]
     C --> E{gated._tag}
     D --> E
-    E -->|"Failure"| F["logGateDropped(gated.error)\nEffect.logInfo with AllowlistError tag\nreturn — no push, no routing update"]
+    E -->|"Failure"| F["logGateDropped(gated.error)<br>Effect.logInfo with AllowlistError tag<br>return — no push, no routing update"]
     E -->|"Success"| G["continue to toClaudeChannelNotification(gated.value)"]
 ```
 

--- a/packages/claude-code-channel/docs/architecture/05-allowlist-gating.md
+++ b/packages/claude-code-channel/docs/architecture/05-allowlist-gating.md
@@ -5,43 +5,26 @@
 `gateInbound` is a caller-supplied predicate injected at boot. It is
 **optional** — when absent, every inbound message passes through.
 
-```text
-Concrete code path (in entry.ts — handleInboundMessage):
+```mermaid
+flowchart TD
+    A["handleInboundMessage(opts, routing, serverHandle, enriched)"]
+    A --> B{opts.gateInbound present?}
+    B -->|YES| C["gated = opts.gateInbound(enriched)\n— pure, sync (types.ts)"]
+    B -->|NO| D["gated = { _tag:'Success', value: enriched }"]
+    C --> E{gated._tag}
+    D --> E
+    E -->|"Failure"| F["logGateDropped(gated.error)\nEffect.logInfo with AllowlistError tag\nreturn — no push, no routing update"]
+    E -->|"Success"| G["continue to toClaudeChannelNotification(gated.value)"]
+```
 
-  handleInboundMessage(opts, routing, serverHandle, enriched)
-        │
-        ├── opts.gateInbound present?
-        │         │
-        │   YES   │  gated = opts.gateInbound(enriched)
-        │         │
-        │         │  Contract (in types.ts — GateInbound):
-        │         │    type GateInbound = (
-        │         │      event: EnrichedInboundMessage
-        │         │    ) =>
-        │         │      | { _tag: "Success"; value: EnrichedInboundMessage }
-        │         │      | { _tag: "Failure"; error: AllowlistError }
-        │         │
-        │         │  Invariants enforced by the type system:
-        │         │    - Pure, synchronous (no Promise return, no I/O)
-        │         │    - Must return a tagged union; no throw
-        │         │    - Can MODIFY the returned EnrichedInboundMessage
-        │         │      (e.g. strip metadata) by returning a new value
-        │         │      inside Success — the translated notification is
-        │         │      built from gated.value, not enriched directly
-        │         │
-        │   NO    │  gated = { _tag: "Success", value: enriched }
-        │
-        ├── gated._tag == "Failure"?
-        │         │
-        │   YES   │  logGateDropped(gated.error)   ← in entry.ts
-        │         │  Effect.logInfo with AllowlistError tag
-        │         │  return (no push, no routing update)
-        │         │
-        │   NO    │  continue to toClaudeChannelNotification(gated.value)
-        │
-        AllowlistError union (in errors.ts):
-          SenderNotAllowed      { senderId, reason }
-          ConversationNotAllowed { conversationId, reason }
+Annotations:
+- `GateInbound` contract (types.ts): pure, synchronous, returns a tagged union — no `throw`, no `Promise`.
+- The gate may modify the returned `EnrichedInboundMessage` (e.g. strip metadata) by returning a new value inside `Success` — the notification is built from `gated.value`, not `enriched` directly.
+- The gate runs BEFORE `routing.recordInbound`; a denied message is never added to the LRU map and cannot be targeted by `reply_to`.
+
+AllowlistError union (in errors.ts):
+  SenderNotAllowed      { senderId, reason }
+  ConversationNotAllowed { conversationId, reason }
 
 Context the gate function receives — EnrichedInboundMessage fields:
   .id              message UUID (MessageId)
@@ -50,10 +33,6 @@ Context the gate function receives — EnrichedInboundMessage fields:
   .text            message text body
   .createdAt       ISO-8601 timestamp
   (+ any other fields from @moltzap/client EnrichedInboundMessage)
-
-The gate is evaluated BEFORE routing.recordInbound; a denied message
-is never added to the LRU map, so it cannot be targeted by reply_to.
-```
 
 ---
 

--- a/packages/claude-code-channel/docs/architecture/06-shutdown.md
+++ b/packages/claude-code-channel/docs/architecture/06-shutdown.md
@@ -15,17 +15,17 @@ sequenceDiagram
     Caller->>entry: Handle.stop() — makeHandle in entry.ts
 
     entry->>client: [1] core.disconnect()
-    note over client: WS close / deregister inbound<br/>onInbound callback ceases
+    note over client: WS close / deregister inbound<br>onInbound callback ceases
     client-->>entry: done
 
     entry->>server: [2] serverHandle.stop()
-    note over server: closeMcpServer(server)<br/>server.close()<br/>MCP SDK closes stdio transport
+    note over server: closeMcpServer(server)<br>server.close()<br>MCP SDK closes stdio transport
     alt close failure
         note over server: logMcpCloseFailure (spec I8: teardown logs, never propagates)
     end
     server-->>entry: done
 
-    entry-->>Caller: Effect&lt;void&gt; (infallible)
+    entry-->>Caller: Effect<void> (infallible)
 ```
 
 Alternate path — boot-time connect failure (in entry.ts):

--- a/packages/claude-code-channel/docs/architecture/06-shutdown.md
+++ b/packages/claude-code-channel/docs/architecture/06-shutdown.md
@@ -1,0 +1,70 @@
+# Shutdown
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Shutdown is initiated either by `Handle.stop()` (caller-driven) or by
+the OS delivering SIGTERM to the CLI process.
+
+```text
+Caller / OS                 entry.ts                 server.ts      @moltzap/client
+     |                          |                        |                |
+     |  Handle.stop()           |                        |                |
+     |  (in entry.ts —          |                        |                |
+     |   makeHandle)            |                        |                |
+     |------------------------->|                        |                |
+     |                          |                        |                |
+     |                          | [1] core.disconnect()  |                |
+     |                          |------------------------------------->   |
+     |                          |        WS close / deregister inbound   |
+     |                          |        onInbound callback ceases        |
+     |                          |<-------------------------------------   |
+     |                          |                        |                |
+     |                          | [2] serverHandle.stop()|                |
+     |                          |----------------------->|                |
+     |                          |                   closeMcpServer(server)|
+     |                          |                   in server.ts          |
+     |                          |                   server.close()        |
+     |                          |                   MCP SDK closes stdio  |
+     |                          |                   transport             |
+     |                          |                        |                |
+     |                          |              close failure swallowed:   |
+     |                          |              logMcpCloseFailure         |
+     |                          |              in server.ts               |
+     |                          |              (spec I8: teardown logs,   |
+     |                          |               never propagates)         |
+     |                          |<-----------------------|                |
+     |                          |                        |                |
+     |<-------------------------|                        |                |
+        Effect<void> (infallible)
+
+Alternate path — boot-time connect failure (in entry.ts):
+  connectCore() fails
+  --> serverHandle.stop() called immediately via Effect.tapError
+  --> BootResult { _tag:"Err" } returned before Handle is issued
+  --> no Handle.stop() ever needed
+
+CLI process SIGTERM path (cli.ts — no explicit signal handler):
+  Node.js default SIGTERM kills the process. stdio transport
+  closes; MCP SDK cleans up on process exit. The MoltZap WS
+  connection closes via OS socket teardown. No explicit
+  Handle.stop() is called in the CLI binary's v1 — the server
+  observes the WS disconnect and expires the agent's session.
+
+Pending notifications at shutdown:
+  If stop() is called while state.initialized == false and
+  state.pending[] is non-empty, those notifications are
+  never flushed. The buffer is an in-process [] with no
+  persistence. This is acceptable because the MCP client
+  (Claude Code) is closing alongside the server.
+
+Lease state at shutdown:
+  The local LRU map (routing.ts) is garbage-collected with
+  the process. No persistence. Server-side leases expire
+  independently per the MoltZap server's dispatch TTL.
+```
+
+---
+
+See also:
+- [Boot Sequence](01-boot-sequence.md)
+- [Lease State Machine](04-lease-state-machine.md)

--- a/packages/claude-code-channel/docs/architecture/06-shutdown.md
+++ b/packages/claude-code-channel/docs/architecture/06-shutdown.md
@@ -5,37 +5,28 @@
 Shutdown is initiated either by `Handle.stop()` (caller-driven) or by
 the OS delivering SIGTERM to the CLI process.
 
-```text
-Caller / OS                 entry.ts                 server.ts      @moltzap/client
-     |                          |                        |                |
-     |  Handle.stop()           |                        |                |
-     |  (in entry.ts —          |                        |                |
-     |   makeHandle)            |                        |                |
-     |------------------------->|                        |                |
-     |                          |                        |                |
-     |                          | [1] core.disconnect()  |                |
-     |                          |------------------------------------->   |
-     |                          |        WS close / deregister inbound   |
-     |                          |        onInbound callback ceases        |
-     |                          |<-------------------------------------   |
-     |                          |                        |                |
-     |                          | [2] serverHandle.stop()|                |
-     |                          |----------------------->|                |
-     |                          |                   closeMcpServer(server)|
-     |                          |                   in server.ts          |
-     |                          |                   server.close()        |
-     |                          |                   MCP SDK closes stdio  |
-     |                          |                   transport             |
-     |                          |                        |                |
-     |                          |              close failure swallowed:   |
-     |                          |              logMcpCloseFailure         |
-     |                          |              in server.ts               |
-     |                          |              (spec I8: teardown logs,   |
-     |                          |               never propagates)         |
-     |                          |<-----------------------|                |
-     |                          |                        |                |
-     |<-------------------------|                        |                |
-        Effect<void> (infallible)
+```mermaid
+sequenceDiagram
+    participant Caller as Caller / OS
+    participant entry as entry.ts
+    participant server as server.ts
+    participant client as @moltzap/client
+
+    Caller->>entry: Handle.stop() — makeHandle in entry.ts
+
+    entry->>client: [1] core.disconnect()
+    note over client: WS close / deregister inbound<br/>onInbound callback ceases
+    client-->>entry: done
+
+    entry->>server: [2] serverHandle.stop()
+    note over server: closeMcpServer(server)<br/>server.close()<br/>MCP SDK closes stdio transport
+    alt close failure
+        note over server: logMcpCloseFailure (spec I8: teardown logs, never propagates)
+    end
+    server-->>entry: done
+
+    entry-->>Caller: Effect&lt;void&gt; (infallible)
+```
 
 Alternate path — boot-time connect failure (in entry.ts):
   connectCore() fails
@@ -61,7 +52,6 @@ Lease state at shutdown:
   The local LRU map (routing.ts) is garbage-collected with
   the process. No persistence. Server-side leases expire
   independently per the MoltZap server's dispatch TTL.
-```
 
 ---
 

--- a/packages/client/ARCHITECTURE.md
+++ b/packages/client/ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# Architecture — `@moltzap/client`
+
+Client SDK for MoltZap: WebSocket transport, RPC service object, channel-core
+inbound handling, runtime utilities, CLI binary (`moltzap`). Everything a
+process needs to authenticate, connect, send messages, and consume inbound
+work.
+
+## Project Structure
+
+```
+packages/client/src/
+├── service.ts          # MoltZapService — high-level RPC + conversation state
+├── ws-client.ts        # MoltZapWsClient — low-level WS + JSON-RPC transport
+├── channel-core.ts     # MoltZapChannelCore — inbound dispatch + admission
+├── auth.ts             # registerAgent, invite/claim token flows
+├── runtime/            # subscribers, errors, close-info, frame projection
+├── cli/                # `moltzap` binary (Effect/CLI)
+│   └── commands/       # register, send, …
+├── test-utils/         # in-memory test driver helpers
+├── test/               # exported test-support shape (subpath: ./test)
+└── __tests__/          # unit + integration + conformance harnesses
+```
+
+## Public Surface
+
+Three layered entry points; pick the lowest level that meets your need.
+
+| Surface | Use when |
+|---|---|
+| `MoltZapWsClient` | You need raw RPC + notification subscription |
+| `MoltZapChannelCore` | You need inbound dispatch + admission lease handling |
+| `MoltZapService` | You want managed conversation/context state too |
+
+Plus `registerAgent` for auth bootstrap, `subscribe*` types for notifications,
+and the published CLI bin.
+
+## Communication Flows
+
+Detailed sequence diagrams and prose live in `docs/architecture/`. Read
+[§07 State Machines](docs/architecture/07-state-machines.md) first to
+understand the lease and connection state machines that underpin all flows.
+
+| Doc | Description |
+|---|---|
+| [01 — Connection Lifecycle](docs/architecture/01-connection-lifecycle.md) | HTTP register → WS connect → `network/connect` handshake → subscribe → steady state; reconnect arm |
+| [02 — Outbound `messages/send`](docs/architecture/02-outbound-messages-send.md) | Caller → `MoltZapService.send` → `MoltZapWsClient.sendRpc` → wire → server |
+| [03 — Inbound Dispatch](docs/architecture/03-inbound-dispatch.md) | Wire bytes → reader fiber → `SubscriberRegistry` → `MoltZapChannelCore` → `InboundHandler`; ack/release race |
+| [04 — Notification Subscription](docs/architecture/04-notification-subscription.md) | `subscribe` registration, filter semantics, `waitForNotification` one-shot awaiter |
+| [05 — Error Taxonomy](docs/architecture/05-error-taxonomy.md) | All Effect-tagged error types, where each is raised, and propagation invariants |
+| [06 — CLI Command Flow](docs/architecture/06-cli-command-flow.md) | `moltzap register` and `moltzap send` command flows, daemon socket delegation |
+| [07 — State Machines](docs/architecture/07-state-machines.md) | Dispatch lease and connection state machines |
+
+## Dependencies
+
+**Runtime**: `effect`, `@effect/platform[-node]`, `@effect/rpc`, `@effect/cli`,
+`@effect/printer[-ansi]`, `@effect/typeclass`.
+**Internal**: `@moltzap/protocol`.
+**Consumers**: `@moltzap/server-core` (for conformance harness only),
+`@moltzap/openclaw-channel`, `@moltzap/nanoclaw-channel`,
+`@moltzap/claude-code-channel`.
+
+WS transport uses `@effect/platform[-node]` exclusively; raw `ws` is
+disallowed (see project memory `feedback_effect_native_transport`).
+
+## Tests
+
+- `src/__tests__/` — integration tests (real WS, in-process server)
+- `src/__tests__/conformance/` — client-side conformance harness
+- `src/cli/__tests__/` — CLI command tests
+- Vitest; `pnpm -F @moltzap/client test`
+
+## Glossary
+
+- **Lease** — Server-issued single-use token granting admission to deliver
+  one inbound message. `dispatch/request` mints, `dispatch/release` resolves
+  (grant/deny/hold), `messages/send` consumes.
+- **Channel-core** — The dispatch + admission state machine that sits
+  between raw transport and caller-supplied `InboundHandler`s.
+- **Cross-conversation context** — `MoltZapService` enriches inbound
+  messages with snippets from other conversations the agent participates
+  in; the `formatCrossConversationBlock` helper renders the block.

--- a/packages/client/docs/architecture/01-connection-lifecycle.md
+++ b/packages/client/docs/architecture/01-connection-lifecycle.md
@@ -13,30 +13,30 @@ sequenceDiagram
     participant wsClient as MoltZapWsClient
     participant server
 
-    caller->>auth: registerAgent()<br/>(auth.ts → registerAgent)
+    caller->>auth: registerAgent()<br>(auth.ts → registerAgent)
     auth->>server: POST /api/v1/auth/register
     server-->>auth: HTTP 200
     auth-->>caller: {agentId, apiKey, claimUrl}
 
-    caller->>wsClient: new MoltZapWsClient({serverUrl, agentKey})<br/>(ws-client.ts → MoltZapWsClient constructor)
-    Note over wsClient: Refs + ManagedRuntime initialized<br/>SubscriberRegistry created
+    caller->>wsClient: new MoltZapWsClient({serverUrl, agentKey})<br>(ws-client.ts → MoltZapWsClient constructor)
+    Note over wsClient: Refs + ManagedRuntime initialized<br>SubscriberRegistry created
 
-    caller->>wsClient: subscribe({}, handler)<br/>(service.ts → MoltZapService.connect)
-    Note over wsClient: registry.register()<br/>(subscribers.ts → SubscriberRegistry.register)
+    caller->>wsClient: subscribe({}, handler)<br>(service.ts → MoltZapService.connect)
+    Note over wsClient: registry.register()<br>(subscribers.ts → SubscriberRegistry.register)
     wsClient-->>caller: NotificationSubscription
 
-    caller->>wsClient: connect()<br/>(ws-client.ts → MoltZapWsClient.connect)
-    Note over wsClient: connectEffect():<br/>Scope.make()<br/>Socket.makeWebSocket(url, {openTimeout: 10s})<br/>(ws-client.ts → openSocket)
+    caller->>wsClient: connect()<br>(ws-client.ts → MoltZapWsClient.connect)
+    Note over wsClient: connectEffect():<br>Scope.make()<br>Socket.makeWebSocket(url, {openTimeout: 10s})<br>(ws-client.ts → openSocket)
     wsClient->>server: TCP open
     server-->>wsClient: WS upgrade
-    Note over wsClient: makeJsonRpcClient()<br/>startTaskCallbackDispatcher()<br/>→ bounded Queue(8192) + drain fiber<br/>(ws-client.ts → startTaskCallbackDispatcher)<br/>readerFiber = runFork(readerEffect())<br/>(ws-client.ts → readerEffect)
+    Note over wsClient: makeJsonRpcClient()<br>startTaskCallbackDispatcher()<br>→ bounded Queue(8192) + drain fiber<br>(ws-client.ts → startTaskCallbackDispatcher)<br>readerFiber = runFork(readerEffect())<br>(ws-client.ts → readerEffect)
 
-    Note over wsClient: awaitConnectAuth():<br/>sendRpc(Connect, {agentKey, minProtocol, maxProtocol})<br/>(ws-client.ts → awaitConnectAuth)
+    Note over wsClient: awaitConnectAuth():<br>sendRpc(Connect, {agentKey, minProtocol, maxProtocol})<br>(ws-client.ts → awaitConnectAuth)
     wsClient->>server: JSON-RPC "network/connect"
     server-->>wsClient: HelloOk
     Note over wsClient: _helloOk = value
     wsClient-->>caller: HelloOk
-    Note over caller: _connected = true<br/>_ownAgentId set<br/>(service.ts → MoltZapService.connect, post-HelloOk)
+    Note over caller: _connected = true<br>_ownAgentId set<br>(service.ts → MoltZapService.connect, post-HelloOk)
 
     Note over wsClient,server: steady state: reader fiber loops on socket.runRaw
 ```
@@ -50,12 +50,12 @@ sequenceDiagram
     participant server
 
     Note over wsClient: reader fiber exits
-    Note over wsClient: handleReaderExit():<br/>failAllPending("not connected")<br/>notifyDisconnect(extractCloseInfo(exit))<br/>(ws-client.ts → handleReaderExit)
+    Note over wsClient: handleReaderExit():<br>failAllPending("not connected")<br>notifyDisconnect(extractCloseInfo(exit))<br>(ws-client.ts → handleReaderExit)
     Note over wsClient: closed? → No → scheduleReconnect()
-    Note over wsClient: reconnectFiber = runFork(<br/>  attempt.pipe(<br/>    retry(exponential(1s, ×2, cap 30s) + jitter)))<br/>(ws-client.ts → scheduleReconnect)
+    Note over wsClient: reconnectFiber = runFork(<br>  attempt.pipe(<br>    retry(exponential(1s, ×2, cap 30s) + jitter)))<br>(ws-client.ts → scheduleReconnect)
     reconnect->>server: connectEffect()
     server-->>reconnect: HelloOk
-    reconnect-->>wsClient: onReconnect(helloOk)<br/>(service.ts → MoltZapService.onReconnect)
+    reconnect-->>wsClient: onReconnect(helloOk)<br>(service.ts → MoltZapService.onReconnect)
 ```
 
 **State that survives reconnect**: `SubscriberRegistry` entries (registered

--- a/packages/client/docs/architecture/01-connection-lifecycle.md
+++ b/packages/client/docs/architecture/01-connection-lifecycle.md
@@ -1,0 +1,97 @@
+# Connection Lifecycle
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+The full bootstrap path: HTTP register → WS connect → `network/connect`
+handshake → subscribe → steady state. Reconnect and retry arms are shown
+separately.
+
+```text
+  caller                  auth.ts            MoltZapWsClient        server
+    │                       │                       │                  │
+    │──registerAgent()──▶   │                       │                  │
+    │  (auth.ts → registerAgent)                    │                  │
+    │                       │──POST /api/v1/──────▶ │                  │
+    │                       │  auth/register        │──────────────────▶
+    │                       │                       │     HTTP 200     │
+    │ ◀── {agentId,apiKey,  │ ◀────────────────────────────────────── │
+    │       claimUrl}        │                       │                  │
+    │                       │                       │                  │
+    │   new MoltZapWsClient({serverUrl, agentKey})  │                  │
+    │──────────────────────────────────────────────▶│                  │
+    │   (ws-client.ts → MoltZapWsClient constructor)│                  │
+    │                       │   Refs + ManagedRuntime initialized      │
+    │                       │   SubscriberRegistry created             │
+    │                       │                       │                  │
+    │──subscribe({}, handler)──────────────────────▶│                  │
+    │   (service.ts → MoltZapService.connect)       │                  │
+    │                       │  registry.register()  │                  │
+    │                       │  (subscribers.ts → SubscriberRegistry.register)
+    │ ◀── NotificationSubscription ────────────────ー│                  │
+    │                       │                       │                  │
+    │──connect()───────────────────────────────────▶│                  │
+    │   (ws-client.ts → MoltZapWsClient.connect)    │                  │
+    │                       │   connectEffect():    │                  │
+    │                       │   Scope.make()        │                  │
+    │                       │   Socket.makeWebSocket(url, {openTimeout:│
+    │                       │     10s}) ────────────▶ TCP open        │
+    │                       │     (ws-client.ts → openSocket)         │
+    │                       │                       │◀─── WS upgrade ─│
+    │                       │   makeJsonRpcClient() │                  │
+    │                       │   startTaskCallbackDispatcher()          │
+    │                       │     → bounded Queue(8192) + drain fiber  │
+    │                       │     (ws-client.ts → startTaskCallbackDispatcher)
+    │                       │   ║ readerFiber = runFork(readerEffect()) │
+    │                       │     (ws-client.ts → readerEffect)        │
+    │                       │                       │                  │
+    │                       │   awaitConnectAuth(): │                  │
+    │                       │   sendRpc(Connect,    │                  │
+    │                       │    {agentKey,          │                  │
+    │                       │     minProtocol,      │──JSON-RPC ──────▶│
+    │                       │     maxProtocol})      │  "network/connect"
+    │                       │   (ws-client.ts → awaitConnectAuth)     │
+    │                       │                       │ ◀── HelloOk ────│
+    │                       │   _helloOk = value    │                  │
+    │ ◀── HelloOk ──────────────────────────────────│                  │
+    │   _connected = true   │                       │                  │
+    │   _ownAgentId set     │                       │                  │
+    │   (service.ts → MoltZapService.connect, post-HelloOk)           │
+    │                       │                       │                  │
+    │   [steady state: reader fiber loops on socket.runRaw]            │
+```
+
+**Reconnect arm** (triggered on reader fiber exit when `closed == false`):
+
+```text
+  MoltZapWsClient          scheduleReconnect()     server
+    │                              │                  │
+    │ reader fiber exits ──▶       │                  │
+    │ handleReaderExit():          │                  │
+    │   failAllPending("not connected")               │
+    │   notifyDisconnect(extractCloseInfo(exit))      │
+    │   (ws-client.ts → handleReaderExit)             │
+    │   closed? ──No──▶ scheduleReconnect()           │
+    │                              │                  │
+    │   reconnectFiber = runFork(  │                  │
+    │     attempt.pipe(            │                  │
+    │       retry(exponential(1s,  │                  │
+    │         ×2, cap 30s) +       │                  │
+    │         jitter)))            │                  │
+    │   (ws-client.ts → scheduleReconnect)            │
+    │                              │──connectEffect()─▶
+    │                              │ ◀── HelloOk ─────│
+    │   onReconnect(helloOk) ◀─────│                  │
+    │   (service.ts → MoltZapService.onReconnect)     │
+```
+
+**State that survives reconnect**: `SubscriberRegistry` entries (registered
+before `connect()`), `appCallbackHandlersRef` (server-RPC handlers),
+`ManagedRuntime`. Per-connection `ConnState` (scope, reader fiber, queue,
+dispatcher scope) is rebuilt fresh on each `connectEffect()` call.
+
+**State that does NOT survive reconnect**: in-flight RPC Deferreds (all
+failed via `failAllPending` on disconnect), the previous `JsonRpcClient`
+instance, the previous drain fiber.
+
+See also: [State Machines](./07-state-machines.md) for the connection state
+machine that formalises these transitions.

--- a/packages/client/docs/architecture/01-connection-lifecycle.md
+++ b/packages/client/docs/architecture/01-connection-lifecycle.md
@@ -6,82 +6,56 @@ The full bootstrap path: HTTP register → WS connect → `network/connect`
 handshake → subscribe → steady state. Reconnect and retry arms are shown
 separately.
 
-```text
-  caller                  auth.ts            MoltZapWsClient        server
-    │                       │                       │                  │
-    │──registerAgent()──▶   │                       │                  │
-    │  (auth.ts → registerAgent)                    │                  │
-    │                       │──POST /api/v1/──────▶ │                  │
-    │                       │  auth/register        │──────────────────▶
-    │                       │                       │     HTTP 200     │
-    │ ◀── {agentId,apiKey,  │ ◀────────────────────────────────────── │
-    │       claimUrl}        │                       │                  │
-    │                       │                       │                  │
-    │   new MoltZapWsClient({serverUrl, agentKey})  │                  │
-    │──────────────────────────────────────────────▶│                  │
-    │   (ws-client.ts → MoltZapWsClient constructor)│                  │
-    │                       │   Refs + ManagedRuntime initialized      │
-    │                       │   SubscriberRegistry created             │
-    │                       │                       │                  │
-    │──subscribe({}, handler)──────────────────────▶│                  │
-    │   (service.ts → MoltZapService.connect)       │                  │
-    │                       │  registry.register()  │                  │
-    │                       │  (subscribers.ts → SubscriberRegistry.register)
-    │ ◀── NotificationSubscription ────────────────ー│                  │
-    │                       │                       │                  │
-    │──connect()───────────────────────────────────▶│                  │
-    │   (ws-client.ts → MoltZapWsClient.connect)    │                  │
-    │                       │   connectEffect():    │                  │
-    │                       │   Scope.make()        │                  │
-    │                       │   Socket.makeWebSocket(url, {openTimeout:│
-    │                       │     10s}) ────────────▶ TCP open        │
-    │                       │     (ws-client.ts → openSocket)         │
-    │                       │                       │◀─── WS upgrade ─│
-    │                       │   makeJsonRpcClient() │                  │
-    │                       │   startTaskCallbackDispatcher()          │
-    │                       │     → bounded Queue(8192) + drain fiber  │
-    │                       │     (ws-client.ts → startTaskCallbackDispatcher)
-    │                       │   ║ readerFiber = runFork(readerEffect()) │
-    │                       │     (ws-client.ts → readerEffect)        │
-    │                       │                       │                  │
-    │                       │   awaitConnectAuth(): │                  │
-    │                       │   sendRpc(Connect,    │                  │
-    │                       │    {agentKey,          │                  │
-    │                       │     minProtocol,      │──JSON-RPC ──────▶│
-    │                       │     maxProtocol})      │  "network/connect"
-    │                       │   (ws-client.ts → awaitConnectAuth)     │
-    │                       │                       │ ◀── HelloOk ────│
-    │                       │   _helloOk = value    │                  │
-    │ ◀── HelloOk ──────────────────────────────────│                  │
-    │   _connected = true   │                       │                  │
-    │   _ownAgentId set     │                       │                  │
-    │   (service.ts → MoltZapService.connect, post-HelloOk)           │
-    │                       │                       │                  │
-    │   [steady state: reader fiber loops on socket.runRaw]            │
+```mermaid
+sequenceDiagram
+    participant caller
+    participant auth as auth.ts
+    participant wsClient as MoltZapWsClient
+    participant server
+
+    caller->>auth: registerAgent()<br/>(auth.ts → registerAgent)
+    auth->>server: POST /api/v1/auth/register
+    server-->>auth: HTTP 200
+    auth-->>caller: {agentId, apiKey, claimUrl}
+
+    caller->>wsClient: new MoltZapWsClient({serverUrl, agentKey})<br/>(ws-client.ts → MoltZapWsClient constructor)
+    Note over wsClient: Refs + ManagedRuntime initialized<br/>SubscriberRegistry created
+
+    caller->>wsClient: subscribe({}, handler)<br/>(service.ts → MoltZapService.connect)
+    Note over wsClient: registry.register()<br/>(subscribers.ts → SubscriberRegistry.register)
+    wsClient-->>caller: NotificationSubscription
+
+    caller->>wsClient: connect()<br/>(ws-client.ts → MoltZapWsClient.connect)
+    Note over wsClient: connectEffect():<br/>Scope.make()<br/>Socket.makeWebSocket(url, {openTimeout: 10s})<br/>(ws-client.ts → openSocket)
+    wsClient->>server: TCP open
+    server-->>wsClient: WS upgrade
+    Note over wsClient: makeJsonRpcClient()<br/>startTaskCallbackDispatcher()<br/>→ bounded Queue(8192) + drain fiber<br/>(ws-client.ts → startTaskCallbackDispatcher)<br/>readerFiber = runFork(readerEffect())<br/>(ws-client.ts → readerEffect)
+
+    Note over wsClient: awaitConnectAuth():<br/>sendRpc(Connect, {agentKey, minProtocol, maxProtocol})<br/>(ws-client.ts → awaitConnectAuth)
+    wsClient->>server: JSON-RPC "network/connect"
+    server-->>wsClient: HelloOk
+    Note over wsClient: _helloOk = value
+    wsClient-->>caller: HelloOk
+    Note over caller: _connected = true<br/>_ownAgentId set<br/>(service.ts → MoltZapService.connect, post-HelloOk)
+
+    Note over wsClient,server: steady state: reader fiber loops on socket.runRaw
 ```
 
 **Reconnect arm** (triggered on reader fiber exit when `closed == false`):
 
-```text
-  MoltZapWsClient          scheduleReconnect()     server
-    │                              │                  │
-    │ reader fiber exits ──▶       │                  │
-    │ handleReaderExit():          │                  │
-    │   failAllPending("not connected")               │
-    │   notifyDisconnect(extractCloseInfo(exit))      │
-    │   (ws-client.ts → handleReaderExit)             │
-    │   closed? ──No──▶ scheduleReconnect()           │
-    │                              │                  │
-    │   reconnectFiber = runFork(  │                  │
-    │     attempt.pipe(            │                  │
-    │       retry(exponential(1s,  │                  │
-    │         ×2, cap 30s) +       │                  │
-    │         jitter)))            │                  │
-    │   (ws-client.ts → scheduleReconnect)            │
-    │                              │──connectEffect()─▶
-    │                              │ ◀── HelloOk ─────│
-    │   onReconnect(helloOk) ◀─────│                  │
-    │   (service.ts → MoltZapService.onReconnect)     │
+```mermaid
+sequenceDiagram
+    participant wsClient as MoltZapWsClient
+    participant reconnect as scheduleReconnect()
+    participant server
+
+    Note over wsClient: reader fiber exits
+    Note over wsClient: handleReaderExit():<br/>failAllPending("not connected")<br/>notifyDisconnect(extractCloseInfo(exit))<br/>(ws-client.ts → handleReaderExit)
+    Note over wsClient: closed? → No → scheduleReconnect()
+    Note over wsClient: reconnectFiber = runFork(<br/>  attempt.pipe(<br/>    retry(exponential(1s, ×2, cap 30s) + jitter)))<br/>(ws-client.ts → scheduleReconnect)
+    reconnect->>server: connectEffect()
+    server-->>reconnect: HelloOk
+    reconnect-->>wsClient: onReconnect(helloOk)<br/>(service.ts → MoltZapService.onReconnect)
 ```
 
 **State that survives reconnect**: `SubscriberRegistry` entries (registered

--- a/packages/client/docs/architecture/02-outbound-messages-send.md
+++ b/packages/client/docs/architecture/02-outbound-messages-send.md
@@ -1,0 +1,79 @@
+# Outbound `messages/send` Sequence
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+```text
+  caller             MoltZapService        MoltZapWsClient      wire       server
+    │                     │                      │               │            │
+    │──service.send(──────▶│                     │               │            │
+    │   convId, text,      │                     │               │            │
+    │   {dispatchLeaseId}) │                     │               │            │
+    │  (service.ts → MoltZapService.send)        │               │            │
+    │                      │ isConversationArchived?             │            │
+    │                      │  yes → Effect.fail(RpcServerError)  │            │
+    │                      │  no → sendRpc(MessagesSend, {...})  │            │
+    │                      │  (service.ts → send, the dispatchLeaseId branch) │
+    │                      │                     │               │            │
+    │                      │──sendRpc(def, params)──────────────▶│            │
+    │                      │  (service.ts → sendRpc)             │            │
+    │                      │                     │               │            │
+    │                      │   client.sendRpc(definition,        │            │
+    │                      │     params, opts)   │               │            │
+    │                      │   (ws-client.ts → MoltZapWsClient.sendRpc)      │
+    │                      │   timeoutMs = opts?.timeoutMs       │            │
+    │                      │              ?? 30_000              │            │
+    │                      │                     │               │            │
+    │                      │   sendRpcEffect():  │               │            │
+    │                      │   Ref.get(stateRef) │               │            │
+    │                      │    None → fail(NotConnectedError)   │            │
+    │                      │    Some → jsonRpcClient.call(       │            │
+    │                      │      definition, params)            │            │
+    │                      │   (ws-client.ts → sendRpcEffect)    │            │
+    │                      │                     │               │            │
+    │                      │   jsonRpcClient allocates JsonRpcId │            │
+    │                      │   encodes JSON-RPC request frame    │            │
+    │                      │   write(JSON.stringify(frame)) ─────▶──────────▶│
+    │                      │                     │    {"jsonrpc":"2.0",       │
+    │                      │                     │     "method":"messages/send",
+    │                      │                     │     "id":"rpc-N",          │
+    │                      │                     │     "params":{             │
+    │                      │                     │       conversationId,      │
+    │                      │                     │       parts:[{type:"text"  │
+    │                      │                     │         text}],            │
+    │                      │                     │       dispatchLeaseId?}}   │
+    │                      │                     │               │            │
+    │                      │   Deferred<ResultOf<MessagesSend>>  │            │
+    │                      │   raced against 30s timeout         │            │
+    │                      │                     │               │            │
+    │                      │                     │ ◀────────────────response─│
+    │                      │                     │  {"jsonrpc":"2.0",         │
+    │                      │                     │   "id":"rpc-N",            │
+    │                      │                     │   "result":{message:{id}}} │
+    │                      │                     │               │            │
+    │                      │   readerFiber decodes frame:        │            │
+    │                      │   handleIncoming(raw) →             │            │
+    │                      │   decodeFrames(raw) →               │            │
+    │                      │   handleDecodedResponse(decoded) →  │            │
+    │                      │   jsonRpcClient.resolve(frame)      │            │
+    │                      │   (ws-client.ts → handleDecodedResponse)        │
+    │                      │   settles Deferred → caller resumes │            │
+    │ ◀── Effect.void ──────│                     │               │            │
+```
+
+**dispatchLeaseId path**: when `opts.dispatchLeaseId` is set, the param is
+forwarded verbatim in the JSON-RPC params frame. The server uses it to
+mark a dispatch lease as consumed, preventing the TM from timing it out.
+`MoltZapChannelCore.sendReply` passes `this.leaseIdInFlight` automatically
+when the caller does not supply an explicit lease id (channel-core.ts →
+`sendReply`, the auto-lease branch).
+
+**Error paths**:
+- `NotConnectedError` — `stateRef` is `None` (not connected yet, or
+  disconnect raced); fails immediately without a network round-trip.
+- `RpcTimeoutError` — no response within 30 s; in-flight Deferred is
+  cancelled; the outstanding JSON-RPC id is left unreserved on the server.
+- `RpcServerError` — server returned an `error` response frame; code/message
+  forwarded verbatim. `ConversationArchivedError` (code 4002) is one example.
+
+See also: [Error Taxonomy](./05-error-taxonomy.md) for full error type
+descriptions and propagation invariants.

--- a/packages/client/docs/architecture/02-outbound-messages-send.md
+++ b/packages/client/docs/architecture/02-outbound-messages-send.md
@@ -2,62 +2,30 @@
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 
-```text
-  caller             MoltZapService        MoltZapWsClient      wire       server
-    │                     │                      │               │            │
-    │──service.send(──────▶│                     │               │            │
-    │   convId, text,      │                     │               │            │
-    │   {dispatchLeaseId}) │                     │               │            │
-    │  (service.ts → MoltZapService.send)        │               │            │
-    │                      │ isConversationArchived?             │            │
-    │                      │  yes → Effect.fail(RpcServerError)  │            │
-    │                      │  no → sendRpc(MessagesSend, {...})  │            │
-    │                      │  (service.ts → send, the dispatchLeaseId branch) │
-    │                      │                     │               │            │
-    │                      │──sendRpc(def, params)──────────────▶│            │
-    │                      │  (service.ts → sendRpc)             │            │
-    │                      │                     │               │            │
-    │                      │   client.sendRpc(definition,        │            │
-    │                      │     params, opts)   │               │            │
-    │                      │   (ws-client.ts → MoltZapWsClient.sendRpc)      │
-    │                      │   timeoutMs = opts?.timeoutMs       │            │
-    │                      │              ?? 30_000              │            │
-    │                      │                     │               │            │
-    │                      │   sendRpcEffect():  │               │            │
-    │                      │   Ref.get(stateRef) │               │            │
-    │                      │    None → fail(NotConnectedError)   │            │
-    │                      │    Some → jsonRpcClient.call(       │            │
-    │                      │      definition, params)            │            │
-    │                      │   (ws-client.ts → sendRpcEffect)    │            │
-    │                      │                     │               │            │
-    │                      │   jsonRpcClient allocates JsonRpcId │            │
-    │                      │   encodes JSON-RPC request frame    │            │
-    │                      │   write(JSON.stringify(frame)) ─────▶──────────▶│
-    │                      │                     │    {"jsonrpc":"2.0",       │
-    │                      │                     │     "method":"messages/send",
-    │                      │                     │     "id":"rpc-N",          │
-    │                      │                     │     "params":{             │
-    │                      │                     │       conversationId,      │
-    │                      │                     │       parts:[{type:"text"  │
-    │                      │                     │         text}],            │
-    │                      │                     │       dispatchLeaseId?}}   │
-    │                      │                     │               │            │
-    │                      │   Deferred<ResultOf<MessagesSend>>  │            │
-    │                      │   raced against 30s timeout         │            │
-    │                      │                     │               │            │
-    │                      │                     │ ◀────────────────response─│
-    │                      │                     │  {"jsonrpc":"2.0",         │
-    │                      │                     │   "id":"rpc-N",            │
-    │                      │                     │   "result":{message:{id}}} │
-    │                      │                     │               │            │
-    │                      │   readerFiber decodes frame:        │            │
-    │                      │   handleIncoming(raw) →             │            │
-    │                      │   decodeFrames(raw) →               │            │
-    │                      │   handleDecodedResponse(decoded) →  │            │
-    │                      │   jsonRpcClient.resolve(frame)      │            │
-    │                      │   (ws-client.ts → handleDecodedResponse)        │
-    │                      │   settles Deferred → caller resumes │            │
-    │ ◀── Effect.void ──────│                     │               │            │
+```mermaid
+sequenceDiagram
+    participant caller
+    participant svc as MoltZapService
+    participant wsClient as MoltZapWsClient
+    participant wire
+    participant server
+
+    caller->>svc: service.send(convId, text, {dispatchLeaseId})<br/>(service.ts → MoltZapService.send)
+    Note over svc: isConversationArchived?<br/>yes → Effect.fail(RpcServerError)<br/>no → sendRpc(MessagesSend, {...})<br/>(service.ts → send, the dispatchLeaseId branch)
+
+    svc->>wsClient: sendRpc(def, params)<br/>(service.ts → sendRpc)
+    Note over wsClient: client.sendRpc(definition, params, opts)<br/>(ws-client.ts → MoltZapWsClient.sendRpc)<br/>timeoutMs = opts?.timeoutMs ?? 30_000
+
+    Note over wsClient: sendRpcEffect():<br/>Ref.get(stateRef)<br/>None → fail(NotConnectedError)<br/>Some → jsonRpcClient.call(definition, params)<br/>(ws-client.ts → sendRpcEffect)
+
+    Note over wsClient: jsonRpcClient allocates JsonRpcId<br/>encodes JSON-RPC request frame
+    wsClient->>server: write(JSON.stringify(frame))<br/>{"jsonrpc":"2.0","method":"messages/send",<br/>"id":"rpc-N","params":{conversationId,<br/>parts:[{type:"text",text}],dispatchLeaseId?}}
+    Note over wsClient: Deferred&lt;ResultOf&lt;MessagesSend&gt;&gt;<br/>raced against 30s timeout
+
+    server-->>wsClient: {"jsonrpc":"2.0","id":"rpc-N",<br/>"result":{message:{id}}}
+    Note over wsClient: readerFiber decodes frame:<br/>handleIncoming(raw) → decodeFrames(raw) →<br/>handleDecodedResponse(decoded) →<br/>jsonRpcClient.resolve(frame)<br/>(ws-client.ts → handleDecodedResponse)<br/>settles Deferred → caller resumes
+    wsClient-->>svc: Effect.void
+    svc-->>caller: Effect.void
 ```
 
 **dispatchLeaseId path**: when `opts.dispatchLeaseId` is set, the param is

--- a/packages/client/docs/architecture/02-outbound-messages-send.md
+++ b/packages/client/docs/architecture/02-outbound-messages-send.md
@@ -10,20 +10,20 @@ sequenceDiagram
     participant wire
     participant server
 
-    caller->>svc: service.send(convId, text, {dispatchLeaseId})<br/>(service.ts → MoltZapService.send)
-    Note over svc: isConversationArchived?<br/>yes → Effect.fail(RpcServerError)<br/>no → sendRpc(MessagesSend, {...})<br/>(service.ts → send, the dispatchLeaseId branch)
+    caller->>svc: service.send(convId, text, {dispatchLeaseId})<br>(service.ts → MoltZapService.send)
+    Note over svc: isConversationArchived?<br>yes → Effect.fail(RpcServerError)<br>no → sendRpc(MessagesSend, {...})<br>(service.ts → send, the dispatchLeaseId branch)
 
-    svc->>wsClient: sendRpc(def, params)<br/>(service.ts → sendRpc)
-    Note over wsClient: client.sendRpc(definition, params, opts)<br/>(ws-client.ts → MoltZapWsClient.sendRpc)<br/>timeoutMs = opts?.timeoutMs ?? 30_000
+    svc->>wsClient: sendRpc(def, params)<br>(service.ts → sendRpc)
+    Note over wsClient: client.sendRpc(definition, params, opts)<br>(ws-client.ts → MoltZapWsClient.sendRpc)<br>timeoutMs = opts?.timeoutMs ?? 30_000
 
-    Note over wsClient: sendRpcEffect():<br/>Ref.get(stateRef)<br/>None → fail(NotConnectedError)<br/>Some → jsonRpcClient.call(definition, params)<br/>(ws-client.ts → sendRpcEffect)
+    Note over wsClient: sendRpcEffect():<br>Ref.get(stateRef)<br>None → fail(NotConnectedError)<br>Some → jsonRpcClient.call(definition, params)<br>(ws-client.ts → sendRpcEffect)
 
-    Note over wsClient: jsonRpcClient allocates JsonRpcId<br/>encodes JSON-RPC request frame
-    wsClient->>server: write(JSON.stringify(frame))<br/>{"jsonrpc":"2.0","method":"messages/send",<br/>"id":"rpc-N","params":{conversationId,<br/>parts:[{type:"text",text}],dispatchLeaseId?}}
-    Note over wsClient: Deferred&lt;ResultOf&lt;MessagesSend&gt;&gt;<br/>raced against 30s timeout
+    Note over wsClient: jsonRpcClient allocates JsonRpcId<br>encodes JSON-RPC request frame
+    wsClient->>server: write(JSON.stringify(frame))<br>{"jsonrpc":"2.0","method":"messages/send",<br>"id":"rpc-N","params":{conversationId,<br>parts:[{type:"text",text}],dispatchLeaseId?}}
+    Note over wsClient: Deferred<ResultOf<MessagesSend>><br>raced against 30s timeout
 
-    server-->>wsClient: {"jsonrpc":"2.0","id":"rpc-N",<br/>"result":{message:{id}}}
-    Note over wsClient: readerFiber decodes frame:<br/>handleIncoming(raw) → decodeFrames(raw) →<br/>handleDecodedResponse(decoded) →<br/>jsonRpcClient.resolve(frame)<br/>(ws-client.ts → handleDecodedResponse)<br/>settles Deferred → caller resumes
+    server-->>wsClient: {"jsonrpc":"2.0","id":"rpc-N",<br>"result":{message:{id}}}
+    Note over wsClient: readerFiber decodes frame:<br>handleIncoming(raw) → decodeFrames(raw) →<br>handleDecodedResponse(decoded) →<br>jsonRpcClient.resolve(frame)<br>(ws-client.ts → handleDecodedResponse)<br>settles Deferred → caller resumes
     wsClient-->>svc: Effect.void
     svc-->>caller: Effect.void
 ```

--- a/packages/client/docs/architecture/03-inbound-dispatch.md
+++ b/packages/client/docs/architecture/03-inbound-dispatch.md
@@ -13,22 +13,22 @@ sequenceDiagram
     participant core as MoltZapChannelCore
     participant handler as InboundHandler
 
-    server->>reader: JSON-RPC notification<br/>("dispatch/release" OR "messages/received")
-    Note over reader: handleIncoming()<br/>decodeFrames()<br/>(frame.ts → decodeFrame)<br/>JSON.parse(raw)<br/>decodeServerInbound()<br/>(ws-client.ts → handleIncoming)
+    server->>reader: JSON-RPC notification<br>("dispatch/release" OR "messages/received")
+    Note over reader: handleIncoming()<br>decodeFrames()<br>(frame.ts → decodeFrame)<br>JSON.parse(raw)<br>decodeServerInbound()<br>(ws-client.ts → handleIncoming)
 
     Note over reader: [notification frame route]
-    Note over reader: handleDecodedNotification()<br/>(ws-client.ts → handleDecodedNotification):<br/>subscribers.dispatch(frame)<br/>(subscribers.ts → SubscriberRegistry.dispatch)<br/>snapshot subs → filter-match → each sub calls handler(frame)
+    Note over reader: handleDecodedNotification()<br>(ws-client.ts → handleDecodedNotification):<br>subscribers.dispatch(frame)<br>(subscribers.ts → SubscriberRegistry.dispatch)<br>snapshot subs → filter-match → each sub calls handler(frame)
     reader->>core: handler(frame) → MoltZapService.handleNotification()
 
     Note over core: [messages/received notification]
-    Note over core: service.handleMessageReceivedNotification()<br/>(service.ts → handleMessageReceivedNotification):<br/>recordMessageIdIfNew → dedup<br/>storeMessage → messagesRef<br/>fanout(handlers.message, msg)
+    Note over core: service.handleMessageReceivedNotification()<br>(service.ts → handleMessageReceivedNotification):<br>recordMessageIdIfNew → dedup<br>storeMessage → messagesRef<br>fanout(handlers.message, msg)
 
-    Note over core: channel-core "message" listener<br/>(channel-core.ts → message listener):<br/>closedConversation? → drop<br/>Queue.unsafeOffer(inboundQueue, {message, attempt:0, clock})
+    Note over core: channel-core "message" listener<br>(channel-core.ts → message listener):<br>closedConversation? → drop<br>Queue.unsafeOffer(inboundQueue, {message, attempt:0, clock})
 
-    Note over core: [consumer fiber loops on queue]<br/>Queue.take(inboundQueue)<br/>(channel-core.ts → consumer fiber loop)<br/>takeDispatchCandidate():<br/>if parked[convId] → dequeue oldest instead
+    Note over core: [consumer fiber loops on queue]<br>Queue.take(inboundQueue)<br>(channel-core.ts → consumer fiber loop)<br>takeDispatchCandidate():<br>if parked[convId] → dequeue oldest instead
 
     Note over core: [admission: dispatch/request round-trip]
-    Note over core: dispatchAdmission(work)<br/>(channel-core.ts → dispatchAdmission)<br/>service.requestDispatch({...})
+    Note over core: dispatchAdmission(work)<br>(channel-core.ts → dispatchAdmission)<br>service.requestDispatch({...})
     core->>server: JSON-RPC "dispatch/request"
     server-->>core: {leaseId, dispatchId}
 
@@ -36,25 +36,25 @@ sequenceDiagram
 
     Note over reader,core: Case A: release arrives BEFORE ack returns
     server->>reader: dispatch/release notification
-    Note over reader: subscribers.dispatch() → service<br/>→ fanout(handlers.dispatchRelease)<br/>→ channel-core recordDispatchRelease()<br/>(channel-core.ts → recordDispatchRelease):<br/>pendingDispatchesByLease.get(leaseId)<br/>= None → insert into pendingReleasesByLease ring<br/>(cap 256, soft-TTL 30s)
-    Note over core: ack returns → leaseId from server<br/>awaitDispatchRelease(leaseId):<br/>consumeDispatchRelease(leaseId)<br/>hit! → projectVerdict()<br/>(channel-core.ts → consumeDispatchRelease)
+    Note over reader: subscribers.dispatch() → service<br>→ fanout(handlers.dispatchRelease)<br>→ channel-core recordDispatchRelease()<br>(channel-core.ts → recordDispatchRelease):<br>pendingDispatchesByLease.get(leaseId)<br>= None → insert into pendingReleasesByLease ring<br>(cap 256, soft-TTL 30s)
+    Note over core: ack returns → leaseId from server<br>awaitDispatchRelease(leaseId):<br>consumeDispatchRelease(leaseId)<br>hit! → projectVerdict()<br>(channel-core.ts → consumeDispatchRelease)
 
     Note over reader,core: Case B: ack returns BEFORE release
-    Note over core: awaitDispatchRelease(leaseId):<br/>Deferred.make() →<br/>pendingDispatchesByLease.set(leaseId, deferred)<br/>Deferred.await(deferred)<br/>(timeout = admissionTimeoutMs 30s)
+    Note over core: awaitDispatchRelease(leaseId):<br>Deferred.make() →<br>pendingDispatchesByLease.set(leaseId, deferred)<br>Deferred.await(deferred)<br>(timeout = admissionTimeoutMs 30s)
     server->>reader: dispatch/release notification
-    Note over reader: recordDispatchRelease():<br/>pendingDispatchesByLease.get(leaseId)<br/>= Some(deferred) → Deferred.succeed()<br/>(channel-core.ts → recordDispatchRelease, deferred path)
+    Note over reader: recordDispatchRelease():<br>pendingDispatchesByLease.get(leaseId)<br>= Some(deferred) → Deferred.succeed()<br>(channel-core.ts → recordDispatchRelease, deferred path)
     reader-->>core: settled
     Note over core: projectVerdict()
 
-    Note over core: [verdict routing]<br/>decision._tag:<br/>"deny" → log + drop<br/>"hold" → parkDispatchWork() (re-queues front of parked)<br/>"grant" → dispatchGrantedWork()<br/>(channel-core.ts → dispatchGrantedWork)
+    Note over core: [verdict routing]<br>decision._tag:<br>"deny" → log + drop<br>"hold" → parkDispatchWork() (re-queues front of parked)<br>"grant" → dispatchGrantedWork()<br>(channel-core.ts → dispatchGrantedWork)
 
     Note over core: [grant: enrich + invoke handler]
-    Note over core: takeCoalescedConversationMessages()<br/>drains same-conv msgs from queue + parked<br/>(channel-core.ts → takeCoalescedConversationMessages)<br/>dispatchWithLease():<br/>leaseIdInFlight = leaseId<br/>dispatchInboundEffect(messages):<br/>enrichMessage() → resolveAgentName,<br/>getConversation, peekContextEntries<br/>(channel-core-enrichment.ts → enrichMessage)
+    Note over core: takeCoalescedConversationMessages()<br>drains same-conv msgs from queue + parked<br>(channel-core.ts → takeCoalescedConversationMessages)<br>dispatchWithLease():<br>leaseIdInFlight = leaseId<br>dispatchInboundEffect(messages):<br>enrichMessage() → resolveAgentName,<br>getConversation, peekContextEntries<br>(channel-core-enrichment.ts → enrichMessage)
     core->>handler: inboundHandler(enriched)
     handler-->>core: Effect.void
-    Note over core: leaseIdInFlight = previous<br/>(channel-core.ts → dispatchWithLease)
+    Note over core: leaseIdInFlight = previous<br>(channel-core.ts → dispatchWithLease)
 
-    Note over core: lease timeout gate (default 90s):<br/>if handler takes > leaseTimeoutMs<br/>→ DispatchLeaseExpired logged<br/>(channel-core.ts → dispatchWithLease, timeout branch)
+    Note over core: lease timeout gate (default 90s):<br>if handler takes > leaseTimeoutMs<br>→ DispatchLeaseExpired logged<br>(channel-core.ts → dispatchWithLease, timeout branch)
 ```
 
 **parkedByConversation logic**: when a `hold` verdict is issued,

--- a/packages/client/docs/architecture/03-inbound-dispatch.md
+++ b/packages/client/docs/architecture/03-inbound-dispatch.md
@@ -1,0 +1,145 @@
+# Inbound Dispatch Sequence
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Full path from raw wire bytes to `InboundHandler` invocation, including the
+lease admission state machine and the ack/release race buffer.
+
+```text
+  server        WS reader fiber     MoltZapWsClient     MoltZapChannelCore   InboundHandler
+    │                  │                   │                    │                   │
+    │──JSON-RPC ──────▶│                   │                    │                   │
+    │  notification    │                   │                    │                   │
+    │  "dispatch/      │                   │                    │                   │
+    │   release"       │ handleIncoming()  │                    │                   │
+    │  OR              │  decodeFrames()   │                    │                   │
+    │  messages/       │  (frame.ts → decodeFrame)              │                   │
+    │  received        │   JSON.parse(raw) │                    │                   │
+    │   notification   │   decodeServer-   │                    │                   │
+    │                  │   Inbound()       │                    │                   │
+    │                  │  (ws-client.ts → handleIncoming)       │                   │
+    │                  │                   │                    │                   │
+    │ [notification frame route]           │                    │                   │
+    │                  │ handleDecoded-    │                    │                   │
+    │                  │  Notification()   │                    │                   │
+    │                  │  (ws-client.ts → handleDecodedNotification):              │
+    │                  │  subscribers.     │                    │                   │
+    │                  │   dispatch(frame) │                    │                   │
+    │                  │   (subscribers.ts → SubscriberRegistry.dispatch)          │
+    │                  │   snapshot subs   │                    │                   │
+    │                  │   filter-match    │                    │                   │
+    │                  │   each sub calls  │                    │                   │
+    │                  │    handler(frame) │                    │                   │
+    │                  │                  ──────────────────────▶ [MoltZapService.  │
+    │                  │                   │                    │  handleNotifi-    │
+    │                  │                   │                    │  cation()]        │
+    │                  │                   │                    │                   │
+    │ [messages/received notification]     │                    │                   │
+    │                  │                   │      service.handleMessageReceived-    │
+    │                  │                   │      Notification() (service.ts →      │
+    │                  │                   │      handleMessageReceivedNotification):
+    │                  │                   │      recordMessageIdIfNew → dedup     │
+    │                  │                   │      storeMessage → messagesRef       │
+    │                  │                   │      fanout(handlers.message, msg)    │
+    │                  │                   │                    │                   │
+    │                  │                   │      channel-core "message" listener   │
+    │                  │                   │      (channel-core.ts → message listener):
+    │                  │                   │      closedConversation? → drop        │
+    │                  │                   │      Queue.unsafeOffer(inboundQueue,   │
+    │                  │                   │        {message, attempt:0, clock})    │
+    │                  │                   │                    │                   │
+    │                  │                   │      [consumer fiber loops on queue]   │
+    │                  │                   │      Queue.take(inboundQueue)          │
+    │                  │                   │      (channel-core.ts → consumer fiber loop)
+    │                  │                   │      takeDispatchCandidate():          │
+    │                  │                   │        if parked[convId] → dequeue     │
+    │                  │                   │        oldest instead                  │
+    │                  │                   │                    │                   │
+    │ [admission: dispatch/request round-trip]                  │                   │
+    │                  │                   │      dispatchAdmission(work):          │
+    │                  │                   │      (channel-core.ts → dispatchAdmission)
+    │                  │                   │      service.requestDispatch({...})    │
+    │                  │                   │◀─────────────────────────────────────  │
+    │◀─────────────────────────────────── JSON-RPC "dispatch/request"               │
+    │                  │                   │ ──────────────────▶ {leaseId,          │
+    │                  │                   │                     dispatchId}        │
+    │                  │                   │                    │                   │
+    │ [release arrives — two races: ack-first vs release-first] │                   │
+    │                  │                   │                    │                   │
+    │ Case A: release arrives BEFORE ack returns:               │                   │
+    │ ──dispatch/release notification ────▶│                    │                   │
+    │                  │ subscribers.dispatch() → service        │                   │
+    │                  │  → fanout(handlers.dispatchRelease)     │                   │
+    │                  │  → channel-core recordDispatchRelease() │                   │
+    │                  │  (channel-core.ts → recordDispatchRelease):                │
+    │                  │  pendingDispatchesByLease.get(leaseId)  │                   │
+    │                  │   = None → insert into                  │                   │
+    │                  │     pendingReleasesByLease ring (cap 256│                   │
+    │                  │     soft-TTL 30s)                       │                   │
+    │                  │                   │                    │                   │
+    │  ack returns → leaseId from server   │                    │                   │
+    │                  │                   │ awaitDispatchRelease(leaseId):         │
+    │                  │                   │ consumeDispatchRelease(leaseId)        │
+    │                  │                   │   hit! → projectVerdict()             │
+    │                  │                   │   (channel-core.ts → consumeDispatchRelease)
+    │                  │                   │                    │                   │
+    │ Case B: ack returns BEFORE release:  │                    │                   │
+    │                  │                   │ awaitDispatchRelease(leaseId):         │
+    │                  │                   │ Deferred.make() →                      │
+    │                  │                   │ pendingDispatchesByLease.set(leaseId,  │
+    │                  │                   │   deferred)        │                   │
+    │                  │                   │ Deferred.await(deferred)               │
+    │                  │                   │   (timeout = admissionTimeoutMs 30s)   │
+    │ ──dispatch/release notification ────▶│                    │                   │
+    │                  │  recordDispatchRelease():              │                   │
+    │                  │  pendingDispatchesByLease.get(leaseId) │                   │
+    │                  │   = Some(deferred) → Deferred.succeed()│                   │
+    │                  │   (channel-core.ts → recordDispatchRelease, deferred path) │
+    │                  │                   │ ◀── settled ───────│                   │
+    │                  │                   │ projectVerdict()   │                   │
+    │                  │                   │                    │                   │
+    │ [verdict routing]│                   │                    │                   │
+    │                  │                   │  decision._tag:    │                   │
+    │                  │                   │  "deny"  → log + drop                 │
+    │                  │                   │  "hold"  → parkDispatchWork()          │
+    │                  │                   │            (re-queues front of parked) │
+    │                  │                   │  "grant" → dispatchGrantedWork()       │
+    │                  │                   │   (channel-core.ts → dispatchGrantedWork)
+    │                  │                   │                    │                   │
+    │ [grant: enrich + invoke handler]     │                    │                   │
+    │                  │                   │ takeCoalescedConversationMessages()    │
+    │                  │                   │  drains same-conv msgs from queue +    │
+    │                  │                   │  parked (channel-core.ts →             │
+    │                  │                   │  takeCoalescedConversationMessages)    │
+    │                  │                   │ dispatchWithLease():                   │
+    │                  │                   │  leaseIdInFlight = leaseId             │
+    │                  │                   │  dispatchInboundEffect(messages):      │
+    │                  │                   │   enrichMessage() → resolveAgentName,  │
+    │                  │                   │    getConversation, peekContextEntries │
+    │                  │                   │   (channel-core-enrichment.ts →        │
+    │                  │                   │    enrichMessage)                      │
+    │                  │                   │   inboundHandler(enriched) ───────────▶│
+    │                  │                   │                    │ ◀── Effect.void ──│
+    │                  │                   │   leaseIdInFlight = previous           │
+    │                  │                   │   (channel-core.ts → dispatchWithLease)│
+    │                  │                   │                    │                   │
+    │                  │                   │   lease timeout gate (default 90s):    │
+    │                  │                   │   if handler takes > leaseTimeoutMs    │
+    │                  │                   │   → DispatchLeaseExpired logged        │
+    │                  │                   │   (channel-core.ts → dispatchWithLease, timeout branch)
+```
+
+**parkedByConversation logic**: when a `hold` verdict is issued,
+`parkDispatchWork()` in `channel-core.ts` inserts the item at the front of
+the `parked[convId]` queue. `takeDispatchCandidate` prioritises parked items
+for that conversation so backpressure within one conversation does not starve
+others.
+
+See also:
+- [Notification Subscription Flow](./04-notification-subscription.md) — how
+  the `subscribers.dispatch` call above routes to registered handlers.
+- [State Machines](./07-state-machines.md) — the dispatch lease state machine
+  that formalises the PENDING → AWAITING_RELEASE → GRANTED/DENIED/HELD →
+  IN_FLIGHT → CONSUMED/EXPIRED transitions.
+- [Error Taxonomy](./05-error-taxonomy.md) — `DispatchAdmissionTimedOut` and
+  `DispatchLeaseExpired` error types.

--- a/packages/client/docs/architecture/03-inbound-dispatch.md
+++ b/packages/client/docs/architecture/03-inbound-dispatch.md
@@ -5,128 +5,56 @@
 Full path from raw wire bytes to `InboundHandler` invocation, including the
 lease admission state machine and the ack/release race buffer.
 
-```text
-  server        WS reader fiber     MoltZapWsClient     MoltZapChannelCore   InboundHandler
-    │                  │                   │                    │                   │
-    │──JSON-RPC ──────▶│                   │                    │                   │
-    │  notification    │                   │                    │                   │
-    │  "dispatch/      │                   │                    │                   │
-    │   release"       │ handleIncoming()  │                    │                   │
-    │  OR              │  decodeFrames()   │                    │                   │
-    │  messages/       │  (frame.ts → decodeFrame)              │                   │
-    │  received        │   JSON.parse(raw) │                    │                   │
-    │   notification   │   decodeServer-   │                    │                   │
-    │                  │   Inbound()       │                    │                   │
-    │                  │  (ws-client.ts → handleIncoming)       │                   │
-    │                  │                   │                    │                   │
-    │ [notification frame route]           │                    │                   │
-    │                  │ handleDecoded-    │                    │                   │
-    │                  │  Notification()   │                    │                   │
-    │                  │  (ws-client.ts → handleDecodedNotification):              │
-    │                  │  subscribers.     │                    │                   │
-    │                  │   dispatch(frame) │                    │                   │
-    │                  │   (subscribers.ts → SubscriberRegistry.dispatch)          │
-    │                  │   snapshot subs   │                    │                   │
-    │                  │   filter-match    │                    │                   │
-    │                  │   each sub calls  │                    │                   │
-    │                  │    handler(frame) │                    │                   │
-    │                  │                  ──────────────────────▶ [MoltZapService.  │
-    │                  │                   │                    │  handleNotifi-    │
-    │                  │                   │                    │  cation()]        │
-    │                  │                   │                    │                   │
-    │ [messages/received notification]     │                    │                   │
-    │                  │                   │      service.handleMessageReceived-    │
-    │                  │                   │      Notification() (service.ts →      │
-    │                  │                   │      handleMessageReceivedNotification):
-    │                  │                   │      recordMessageIdIfNew → dedup     │
-    │                  │                   │      storeMessage → messagesRef       │
-    │                  │                   │      fanout(handlers.message, msg)    │
-    │                  │                   │                    │                   │
-    │                  │                   │      channel-core "message" listener   │
-    │                  │                   │      (channel-core.ts → message listener):
-    │                  │                   │      closedConversation? → drop        │
-    │                  │                   │      Queue.unsafeOffer(inboundQueue,   │
-    │                  │                   │        {message, attempt:0, clock})    │
-    │                  │                   │                    │                   │
-    │                  │                   │      [consumer fiber loops on queue]   │
-    │                  │                   │      Queue.take(inboundQueue)          │
-    │                  │                   │      (channel-core.ts → consumer fiber loop)
-    │                  │                   │      takeDispatchCandidate():          │
-    │                  │                   │        if parked[convId] → dequeue     │
-    │                  │                   │        oldest instead                  │
-    │                  │                   │                    │                   │
-    │ [admission: dispatch/request round-trip]                  │                   │
-    │                  │                   │      dispatchAdmission(work):          │
-    │                  │                   │      (channel-core.ts → dispatchAdmission)
-    │                  │                   │      service.requestDispatch({...})    │
-    │                  │                   │◀─────────────────────────────────────  │
-    │◀─────────────────────────────────── JSON-RPC "dispatch/request"               │
-    │                  │                   │ ──────────────────▶ {leaseId,          │
-    │                  │                   │                     dispatchId}        │
-    │                  │                   │                    │                   │
-    │ [release arrives — two races: ack-first vs release-first] │                   │
-    │                  │                   │                    │                   │
-    │ Case A: release arrives BEFORE ack returns:               │                   │
-    │ ──dispatch/release notification ────▶│                    │                   │
-    │                  │ subscribers.dispatch() → service        │                   │
-    │                  │  → fanout(handlers.dispatchRelease)     │                   │
-    │                  │  → channel-core recordDispatchRelease() │                   │
-    │                  │  (channel-core.ts → recordDispatchRelease):                │
-    │                  │  pendingDispatchesByLease.get(leaseId)  │                   │
-    │                  │   = None → insert into                  │                   │
-    │                  │     pendingReleasesByLease ring (cap 256│                   │
-    │                  │     soft-TTL 30s)                       │                   │
-    │                  │                   │                    │                   │
-    │  ack returns → leaseId from server   │                    │                   │
-    │                  │                   │ awaitDispatchRelease(leaseId):         │
-    │                  │                   │ consumeDispatchRelease(leaseId)        │
-    │                  │                   │   hit! → projectVerdict()             │
-    │                  │                   │   (channel-core.ts → consumeDispatchRelease)
-    │                  │                   │                    │                   │
-    │ Case B: ack returns BEFORE release:  │                    │                   │
-    │                  │                   │ awaitDispatchRelease(leaseId):         │
-    │                  │                   │ Deferred.make() →                      │
-    │                  │                   │ pendingDispatchesByLease.set(leaseId,  │
-    │                  │                   │   deferred)        │                   │
-    │                  │                   │ Deferred.await(deferred)               │
-    │                  │                   │   (timeout = admissionTimeoutMs 30s)   │
-    │ ──dispatch/release notification ────▶│                    │                   │
-    │                  │  recordDispatchRelease():              │                   │
-    │                  │  pendingDispatchesByLease.get(leaseId) │                   │
-    │                  │   = Some(deferred) → Deferred.succeed()│                   │
-    │                  │   (channel-core.ts → recordDispatchRelease, deferred path) │
-    │                  │                   │ ◀── settled ───────│                   │
-    │                  │                   │ projectVerdict()   │                   │
-    │                  │                   │                    │                   │
-    │ [verdict routing]│                   │                    │                   │
-    │                  │                   │  decision._tag:    │                   │
-    │                  │                   │  "deny"  → log + drop                 │
-    │                  │                   │  "hold"  → parkDispatchWork()          │
-    │                  │                   │            (re-queues front of parked) │
-    │                  │                   │  "grant" → dispatchGrantedWork()       │
-    │                  │                   │   (channel-core.ts → dispatchGrantedWork)
-    │                  │                   │                    │                   │
-    │ [grant: enrich + invoke handler]     │                    │                   │
-    │                  │                   │ takeCoalescedConversationMessages()    │
-    │                  │                   │  drains same-conv msgs from queue +    │
-    │                  │                   │  parked (channel-core.ts →             │
-    │                  │                   │  takeCoalescedConversationMessages)    │
-    │                  │                   │ dispatchWithLease():                   │
-    │                  │                   │  leaseIdInFlight = leaseId             │
-    │                  │                   │  dispatchInboundEffect(messages):      │
-    │                  │                   │   enrichMessage() → resolveAgentName,  │
-    │                  │                   │    getConversation, peekContextEntries │
-    │                  │                   │   (channel-core-enrichment.ts →        │
-    │                  │                   │    enrichMessage)                      │
-    │                  │                   │   inboundHandler(enriched) ───────────▶│
-    │                  │                   │                    │ ◀── Effect.void ──│
-    │                  │                   │   leaseIdInFlight = previous           │
-    │                  │                   │   (channel-core.ts → dispatchWithLease)│
-    │                  │                   │                    │                   │
-    │                  │                   │   lease timeout gate (default 90s):    │
-    │                  │                   │   if handler takes > leaseTimeoutMs    │
-    │                  │                   │   → DispatchLeaseExpired logged        │
-    │                  │                   │   (channel-core.ts → dispatchWithLease, timeout branch)
+```mermaid
+sequenceDiagram
+    participant server
+    participant reader as WS reader fiber
+    participant wsClient as MoltZapWsClient
+    participant core as MoltZapChannelCore
+    participant handler as InboundHandler
+
+    server->>reader: JSON-RPC notification<br/>("dispatch/release" OR "messages/received")
+    Note over reader: handleIncoming()<br/>decodeFrames()<br/>(frame.ts → decodeFrame)<br/>JSON.parse(raw)<br/>decodeServerInbound()<br/>(ws-client.ts → handleIncoming)
+
+    Note over reader: [notification frame route]
+    Note over reader: handleDecodedNotification()<br/>(ws-client.ts → handleDecodedNotification):<br/>subscribers.dispatch(frame)<br/>(subscribers.ts → SubscriberRegistry.dispatch)<br/>snapshot subs → filter-match → each sub calls handler(frame)
+    reader->>core: handler(frame) → MoltZapService.handleNotification()
+
+    Note over core: [messages/received notification]
+    Note over core: service.handleMessageReceivedNotification()<br/>(service.ts → handleMessageReceivedNotification):<br/>recordMessageIdIfNew → dedup<br/>storeMessage → messagesRef<br/>fanout(handlers.message, msg)
+
+    Note over core: channel-core "message" listener<br/>(channel-core.ts → message listener):<br/>closedConversation? → drop<br/>Queue.unsafeOffer(inboundQueue, {message, attempt:0, clock})
+
+    Note over core: [consumer fiber loops on queue]<br/>Queue.take(inboundQueue)<br/>(channel-core.ts → consumer fiber loop)<br/>takeDispatchCandidate():<br/>if parked[convId] → dequeue oldest instead
+
+    Note over core: [admission: dispatch/request round-trip]
+    Note over core: dispatchAdmission(work)<br/>(channel-core.ts → dispatchAdmission)<br/>service.requestDispatch({...})
+    core->>server: JSON-RPC "dispatch/request"
+    server-->>core: {leaseId, dispatchId}
+
+    Note over server,core: [release arrives — two races: ack-first vs release-first]
+
+    Note over reader,core: Case A: release arrives BEFORE ack returns
+    server->>reader: dispatch/release notification
+    Note over reader: subscribers.dispatch() → service<br/>→ fanout(handlers.dispatchRelease)<br/>→ channel-core recordDispatchRelease()<br/>(channel-core.ts → recordDispatchRelease):<br/>pendingDispatchesByLease.get(leaseId)<br/>= None → insert into pendingReleasesByLease ring<br/>(cap 256, soft-TTL 30s)
+    Note over core: ack returns → leaseId from server<br/>awaitDispatchRelease(leaseId):<br/>consumeDispatchRelease(leaseId)<br/>hit! → projectVerdict()<br/>(channel-core.ts → consumeDispatchRelease)
+
+    Note over reader,core: Case B: ack returns BEFORE release
+    Note over core: awaitDispatchRelease(leaseId):<br/>Deferred.make() →<br/>pendingDispatchesByLease.set(leaseId, deferred)<br/>Deferred.await(deferred)<br/>(timeout = admissionTimeoutMs 30s)
+    server->>reader: dispatch/release notification
+    Note over reader: recordDispatchRelease():<br/>pendingDispatchesByLease.get(leaseId)<br/>= Some(deferred) → Deferred.succeed()<br/>(channel-core.ts → recordDispatchRelease, deferred path)
+    reader-->>core: settled
+    Note over core: projectVerdict()
+
+    Note over core: [verdict routing]<br/>decision._tag:<br/>"deny" → log + drop<br/>"hold" → parkDispatchWork() (re-queues front of parked)<br/>"grant" → dispatchGrantedWork()<br/>(channel-core.ts → dispatchGrantedWork)
+
+    Note over core: [grant: enrich + invoke handler]
+    Note over core: takeCoalescedConversationMessages()<br/>drains same-conv msgs from queue + parked<br/>(channel-core.ts → takeCoalescedConversationMessages)<br/>dispatchWithLease():<br/>leaseIdInFlight = leaseId<br/>dispatchInboundEffect(messages):<br/>enrichMessage() → resolveAgentName,<br/>getConversation, peekContextEntries<br/>(channel-core-enrichment.ts → enrichMessage)
+    core->>handler: inboundHandler(enriched)
+    handler-->>core: Effect.void
+    Note over core: leaseIdInFlight = previous<br/>(channel-core.ts → dispatchWithLease)
+
+    Note over core: lease timeout gate (default 90s):<br/>if handler takes > leaseTimeoutMs<br/>→ DispatchLeaseExpired logged<br/>(channel-core.ts → dispatchWithLease, timeout branch)
 ```
 
 **parkedByConversation logic**: when a `hold` verdict is issued,

--- a/packages/client/docs/architecture/04-notification-subscription.md
+++ b/packages/client/docs/architecture/04-notification-subscription.md
@@ -2,51 +2,32 @@
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 
-```text
-  caller             MoltZapWsClient        SubscriberRegistry    server
-    │                      │                       │                 │
-    │──client.subscribe(───▶│                       │                 │
-    │   filter, handler)    │                       │                 │
-    │  (ws-client.ts → MoltZapWsClient.subscribe)  │                 │
-    │                       │ closed? → fail(NotConnectedError)       │
-    │                       │ subscribers.register(filter, handler)   │
-    │                       │──────────────────────▶│                 │
-    │                       │                       │ nextSubscriptionId()
-    │                       │                       │ Ref.update(subsRef,
-    │                       │                       │   append LiveSubscription)
-    │                       │                       │ (subscribers.ts → SubscriberRegistry.register)
-    │ ◀── NotificationSubscription {id, unsubscribe} │                 │
-    │   (handle held by caller for lifetime)         │                 │
-    │                       │                       │                 │
-    │   [notification arrives from server]           │                 │
-    │                       │ ◀─ frame (any method) ──────────────────│
-    │                       │ handleDecodedNotification():            │
-    │                       │ subscribers.dispatch(frame)             │
-    │                       │──────────────────────▶│                 │
-    │                       │                       │ snapshot = Ref.get(subsRef)
-    │                       │                       │ for sub of snapshot:
-    │                       │                       │   matchesFilter(sub.filter, frame)?
-    │                       │                       │    emissionTag exact match
-    │                       │                       │    conversationId exact match
-    │                       │                       │    notificationNamePrefix startsWith
-    │                       │                       │    (subscribers.ts → matchesFilter)
-    │                       │                       │   yes → sub.handler(frame)
-    │                       │                       │   (await Effect, catchAllDefect)
-    │                       │                       │   (subscribers.ts → SubscriberRegistry.dispatch)
-    │                       │                       │                 │
-    │                       │ takeNotificationWaiter(frame):          │
-    │                       │  waitersMap bucket pop                  │
-    │                       │  waiter present → Deferred.succeed()    │
-    │                       │  no waiter → bufferNotification()       │
-    │                       │  (ws-client.ts → takeNotificationWaiter)│
-    │                       │                       │                 │
-    │   [caller unsubscribes]│                      │                 │
-    │──handle.unsubscribe───▶│                       │                 │
-    │  (Effect<void,never>)  │                       │                 │
-    │                       │                       │ Ref.update(subsRef,
-    │                       │                       │   filter out id)
-    │                       │                       │ (subscribers.ts → SubscriberRegistry.unsubscribe)
-    │                       │                       │ next frame sees updated snapshot
+```mermaid
+sequenceDiagram
+    participant caller
+    participant wsClient as MoltZapWsClient
+    participant registry as SubscriberRegistry
+    participant server
+
+    caller->>wsClient: client.subscribe(filter, handler)<br/>(ws-client.ts → MoltZapWsClient.subscribe)
+    Note over wsClient: closed? → fail(NotConnectedError)
+    wsClient->>registry: subscribers.register(filter, handler)
+    Note over registry: nextSubscriptionId()<br/>Ref.update(subsRef, append LiveSubscription)<br/>(subscribers.ts → SubscriberRegistry.register)
+    registry-->>wsClient: NotificationSubscription {id, unsubscribe}
+    wsClient-->>caller: NotificationSubscription {id, unsubscribe}<br/>(handle held by caller for lifetime)
+
+    Note over caller,server: [notification arrives from server]
+    server->>wsClient: frame (any method)
+    Note over wsClient: handleDecodedNotification()<br/>subscribers.dispatch(frame)
+    wsClient->>registry: subscribers.dispatch(frame)
+    Note over registry: snapshot = Ref.get(subsRef)<br/>for sub of snapshot:<br/>  matchesFilter(sub.filter, frame)?<br/>    emissionTag exact match<br/>    conversationId exact match<br/>    notificationNamePrefix startsWith<br/>    (subscribers.ts → matchesFilter)<br/>  yes → sub.handler(frame)<br/>  (await Effect, catchAllDefect)<br/>  (subscribers.ts → SubscriberRegistry.dispatch)
+
+    Note over wsClient: takeNotificationWaiter(frame):<br/>waitersMap bucket pop<br/>waiter present → Deferred.succeed()<br/>no waiter → bufferNotification()<br/>(ws-client.ts → takeNotificationWaiter)
+
+    Note over caller,server: [caller unsubscribes]
+    caller->>wsClient: handle.unsubscribe (Effect&lt;void,never&gt;)
+    wsClient->>registry: unsubscribe(id)
+    Note over registry: Ref.update(subsRef, filter out id)<br/>(subscribers.ts → SubscriberRegistry.unsubscribe)<br/>next frame sees updated snapshot
 ```
 
 **Filter semantics** (in `subscribers.ts → matchesFilter`): all three fields

--- a/packages/client/docs/architecture/04-notification-subscription.md
+++ b/packages/client/docs/architecture/04-notification-subscription.md
@@ -9,25 +9,25 @@ sequenceDiagram
     participant registry as SubscriberRegistry
     participant server
 
-    caller->>wsClient: client.subscribe(filter, handler)<br/>(ws-client.ts → MoltZapWsClient.subscribe)
+    caller->>wsClient: client.subscribe(filter, handler)<br>(ws-client.ts → MoltZapWsClient.subscribe)
     Note over wsClient: closed? → fail(NotConnectedError)
     wsClient->>registry: subscribers.register(filter, handler)
-    Note over registry: nextSubscriptionId()<br/>Ref.update(subsRef, append LiveSubscription)<br/>(subscribers.ts → SubscriberRegistry.register)
+    Note over registry: nextSubscriptionId()<br>Ref.update(subsRef, append LiveSubscription)<br>(subscribers.ts → SubscriberRegistry.register)
     registry-->>wsClient: NotificationSubscription {id, unsubscribe}
-    wsClient-->>caller: NotificationSubscription {id, unsubscribe}<br/>(handle held by caller for lifetime)
+    wsClient-->>caller: NotificationSubscription {id, unsubscribe}<br>(handle held by caller for lifetime)
 
     Note over caller,server: [notification arrives from server]
     server->>wsClient: frame (any method)
-    Note over wsClient: handleDecodedNotification()<br/>subscribers.dispatch(frame)
+    Note over wsClient: handleDecodedNotification()<br>subscribers.dispatch(frame)
     wsClient->>registry: subscribers.dispatch(frame)
-    Note over registry: snapshot = Ref.get(subsRef)<br/>for sub of snapshot:<br/>  matchesFilter(sub.filter, frame)?<br/>    emissionTag exact match<br/>    conversationId exact match<br/>    notificationNamePrefix startsWith<br/>    (subscribers.ts → matchesFilter)<br/>  yes → sub.handler(frame)<br/>  (await Effect, catchAllDefect)<br/>  (subscribers.ts → SubscriberRegistry.dispatch)
+    Note over registry: snapshot = Ref.get(subsRef)<br>for sub of snapshot:<br>  matchesFilter(sub.filter, frame)?<br>    emissionTag exact match<br>    conversationId exact match<br>    notificationNamePrefix startsWith<br>    (subscribers.ts → matchesFilter)<br>  yes → sub.handler(frame)<br>  (await Effect, catchAllDefect)<br>  (subscribers.ts → SubscriberRegistry.dispatch)
 
-    Note over wsClient: takeNotificationWaiter(frame):<br/>waitersMap bucket pop<br/>waiter present → Deferred.succeed()<br/>no waiter → bufferNotification()<br/>(ws-client.ts → takeNotificationWaiter)
+    Note over wsClient: takeNotificationWaiter(frame):<br>waitersMap bucket pop<br>waiter present → Deferred.succeed()<br>no waiter → bufferNotification()<br>(ws-client.ts → takeNotificationWaiter)
 
     Note over caller,server: [caller unsubscribes]
-    caller->>wsClient: handle.unsubscribe (Effect&lt;void,never&gt;)
+    caller->>wsClient: handle.unsubscribe (Effect<void,never>)
     wsClient->>registry: unsubscribe(id)
-    Note over registry: Ref.update(subsRef, filter out id)<br/>(subscribers.ts → SubscriberRegistry.unsubscribe)<br/>next frame sees updated snapshot
+    Note over registry: Ref.update(subsRef, filter out id)<br>(subscribers.ts → SubscriberRegistry.unsubscribe)<br>next frame sees updated snapshot
 ```
 
 **Filter semantics** (in `subscribers.ts → matchesFilter`): all three fields

--- a/packages/client/docs/architecture/04-notification-subscription.md
+++ b/packages/client/docs/architecture/04-notification-subscription.md
@@ -1,0 +1,73 @@
+# Notification Subscription Flow
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+```text
+  caller             MoltZapWsClient        SubscriberRegistry    server
+    │                      │                       │                 │
+    │──client.subscribe(───▶│                       │                 │
+    │   filter, handler)    │                       │                 │
+    │  (ws-client.ts → MoltZapWsClient.subscribe)  │                 │
+    │                       │ closed? → fail(NotConnectedError)       │
+    │                       │ subscribers.register(filter, handler)   │
+    │                       │──────────────────────▶│                 │
+    │                       │                       │ nextSubscriptionId()
+    │                       │                       │ Ref.update(subsRef,
+    │                       │                       │   append LiveSubscription)
+    │                       │                       │ (subscribers.ts → SubscriberRegistry.register)
+    │ ◀── NotificationSubscription {id, unsubscribe} │                 │
+    │   (handle held by caller for lifetime)         │                 │
+    │                       │                       │                 │
+    │   [notification arrives from server]           │                 │
+    │                       │ ◀─ frame (any method) ──────────────────│
+    │                       │ handleDecodedNotification():            │
+    │                       │ subscribers.dispatch(frame)             │
+    │                       │──────────────────────▶│                 │
+    │                       │                       │ snapshot = Ref.get(subsRef)
+    │                       │                       │ for sub of snapshot:
+    │                       │                       │   matchesFilter(sub.filter, frame)?
+    │                       │                       │    emissionTag exact match
+    │                       │                       │    conversationId exact match
+    │                       │                       │    notificationNamePrefix startsWith
+    │                       │                       │    (subscribers.ts → matchesFilter)
+    │                       │                       │   yes → sub.handler(frame)
+    │                       │                       │   (await Effect, catchAllDefect)
+    │                       │                       │   (subscribers.ts → SubscriberRegistry.dispatch)
+    │                       │                       │                 │
+    │                       │ takeNotificationWaiter(frame):          │
+    │                       │  waitersMap bucket pop                  │
+    │                       │  waiter present → Deferred.succeed()    │
+    │                       │  no waiter → bufferNotification()       │
+    │                       │  (ws-client.ts → takeNotificationWaiter)│
+    │                       │                       │                 │
+    │   [caller unsubscribes]│                      │                 │
+    │──handle.unsubscribe───▶│                       │                 │
+    │  (Effect<void,never>)  │                       │                 │
+    │                       │                       │ Ref.update(subsRef,
+    │                       │                       │   filter out id)
+    │                       │                       │ (subscribers.ts → SubscriberRegistry.unsubscribe)
+    │                       │                       │ next frame sees updated snapshot
+```
+
+**Filter semantics** (in `subscribers.ts → matchesFilter`): all three fields
+are optional wildcards. `{}` matches every notification — used by
+`MoltZapService.connect` (in `service.ts`) to hook all inbound notifications
+for its internal handlers before calling `connect()`.
+`notificationNamePrefix` uses `String.startsWith`; `emissionTag` and
+`conversationId` use strict `===` against `frame.params.__emissionTag` and
+`frame.params.conversationId` respectively.
+
+**Unsubscribe semantics** (OQ-3 A): `unsubscribe` mutates `subsRef`
+immediately. In-flight `dispatch` walks a snapshot captured at dispatch
+start, so the unsubscribed handler may still fire for the current frame but
+will not fire for frame N+1.
+
+**`waitForNotification` vs `subscribe`**: `waitForNotification`
+(in `ws-client.ts → waitForNotification`) is a one-shot awaiter used in
+tests. It checks the notification buffer first; if empty it parks a
+`Deferred` in `notificationWaitersRef`. Subscriber registry and one-shot
+waiters are parallel paths — a notification satisfies both if both are
+registered.
+
+See also: [Inbound Dispatch Sequence](./03-inbound-dispatch.md) for how
+`subscribers.dispatch` is called from the reader fiber.

--- a/packages/client/docs/architecture/05-error-taxonomy.md
+++ b/packages/client/docs/architecture/05-error-taxonomy.md
@@ -5,91 +5,19 @@
 All errors are Effect tagged errors unless noted. "Raised at" means the
 effect fails with this type; callers pattern-match on `._tag`.
 
-```text
-Error                       Package/File                 Raised when
-─────────────────────────── ──────────────────────────── ──────────────────────────────
-NotConnectedError           @moltzap/protocol             sendRpc() called while
-                            transport/rpc-errors.ts       stateRef=None; or socket
-                            → NotConnectedError           closed mid-call during
-                                                         failAllPending() sweep
-                                                         (ws-client.ts → sendRpcEffect)
-                            ┗━ callers: catch and surface
-                               to user as "not connected"
-
-RpcTimeoutError             @moltzap/protocol             No response frame in
-                            transport/rpc-errors.ts       timeoutMs (default 30_000ms)
-                            → RpcTimeoutError             (ws-client.ts → sendRpcEffect,
-                                                         timeout race)
-                            ┗━ callers: retry or report
-                               timeout to user
-
-RpcServerError              @moltzap/protocol             Server returned JSON-RPC
-                            transport/rpc-errors.ts       error frame with unknown
-                            → RpcServerError              code; or ConversationArchi-
-                                                         vedError (code 4002) etc.
-                                                         (ws-client.ts → sendRpcEffect)
-                            ┗━ inspect .code for known
-                               protocol codes
-
-MalformedFrameError         @moltzap/protocol             JSON.parse fails or
-                            transport/wire-errors.ts      decodeServerInbound rejects
-                            → MalformedFrameError         the shape
-                                                         (frame.ts → decodeFrame;
-                                                         ws-client.ts → handleIncoming)
-                            ┗━ logged + dropped (1-of-50
-                               logged); never propagates
-                               to callers
-
-AgentNotFoundError          @moltzap/client               AgentsLookupByName returns
-                            runtime/errors.ts             no agents for the requested
-                            → AgentNotFoundError          name
-                                                         (service.ts → resolveAgentName)
-                            ┗━ surface to user as
-                               "agent not found"
-
-DuplicateServerRpcHandler-  @moltzap/client               handleServerRpc() called
-Error                       runtime/errors.ts             twice for same definition
-                            → DuplicateServerRpcHandlerError
-                                                         (ws-client.ts → handleServerRpc)
-                            ┗━ programming error; never
-                               retry
-
-RegisterAgentError          @moltzap/client               HTTP register endpoint
-                            auth.ts                       returned non-2xx, or
-                            → RegisterAgentError          request/decode failed
-                            ┗━ print .message to user
-
-DispatchAdmissionTimedOut   @moltzap/client               dispatch/request RPC +
-                            channel-core-errors.ts        awaitDispatchRelease
-                            → DispatchAdmissionTimedOut   exceeded admissionTimeoutMs
-                                                         (default 30s)
-                                                         (channel-core.ts →
-                                                         dispatchAdmission)
-                            ┗━ fail-closed: treated as
-                               "deny"; message dropped
-
-DispatchLeaseExpired        @moltzap/client               InboundHandler took longer
-                            channel-core-errors.ts        than leaseTimeoutMs (default
-                            → DispatchLeaseExpired        90s) inside dispatchWithLease
-                                                         (channel-core.ts →
-                                                         dispatchWithLease, timeout branch)
-                            ┗━ logged as warning; handler
-                               result discarded; lease
-                               server-side times out
-
-ServiceInputError           @moltzap/client               Local socket daemon received
-                            runtime/service-helpers.ts    unknown/invalid RPC method
-                            → ServiceInputError           (service.ts → handleSocketRequest)
-                            ┗━ daemon responds with error
-                               to CLI caller
-
-SocketRequestError          @moltzap/client               Unix-socket dial failed
-                            cli/socket-client.ts          (ENOENT/ECONNREFUSED =
-                            → SocketRequestError          daemon not running),
-                                                         10s timeout, or RPC error
-                            ┗━ CLI prints message to
-                               stderr and exits 1
-```
+| Error | Package / File | Raised when | Caller guidance |
+|---|---|---|---|
+| `NotConnectedError` | `@moltzap/protocol`<br/>`transport/rpc-errors.ts → NotConnectedError` | `sendRpc()` called while `stateRef=None`; or socket closed mid-call during `failAllPending()` sweep<br/>`(ws-client.ts → sendRpcEffect)` | Catch and surface to user as "not connected" |
+| `RpcTimeoutError` | `@moltzap/protocol`<br/>`transport/rpc-errors.ts → RpcTimeoutError` | No response frame in `timeoutMs` (default 30,000 ms)<br/>`(ws-client.ts → sendRpcEffect, timeout race)` | Retry or report timeout to user |
+| `RpcServerError` | `@moltzap/protocol`<br/>`transport/rpc-errors.ts → RpcServerError` | Server returned JSON-RPC error frame with unknown code; or `ConversationArchivedError` (code 4002) etc.<br/>`(ws-client.ts → sendRpcEffect)` | Inspect `.code` for known protocol codes |
+| `MalformedFrameError` | `@moltzap/protocol`<br/>`transport/wire-errors.ts → MalformedFrameError` | `JSON.parse` fails or `decodeServerInbound` rejects the shape<br/>`(frame.ts → decodeFrame; ws-client.ts → handleIncoming)` | Logged + dropped (1-of-50 logged); never propagates to callers |
+| `AgentNotFoundError` | `@moltzap/client`<br/>`runtime/errors.ts → AgentNotFoundError` | `AgentsLookupByName` returns no agents for the requested name<br/>`(service.ts → resolveAgentName)` | Surface to user as "agent not found" |
+| `DuplicateServerRpcHandlerError` | `@moltzap/client`<br/>`runtime/errors.ts → DuplicateServerRpcHandlerError` | `handleServerRpc()` called twice for same definition<br/>`(ws-client.ts → handleServerRpc)` | Programming error; never retry |
+| `RegisterAgentError` | `@moltzap/client`<br/>`auth.ts → RegisterAgentError` | HTTP register endpoint returned non-2xx, or request/decode failed | Print `.message` to user |
+| `DispatchAdmissionTimedOut` | `@moltzap/client`<br/>`channel-core-errors.ts → DispatchAdmissionTimedOut` | `dispatch/request` RPC + `awaitDispatchRelease` exceeded `admissionTimeoutMs` (default 30s)<br/>`(channel-core.ts → dispatchAdmission)` | Fail-closed: treated as "deny"; message dropped |
+| `DispatchLeaseExpired` | `@moltzap/client`<br/>`channel-core-errors.ts → DispatchLeaseExpired` | `InboundHandler` took longer than `leaseTimeoutMs` (default 90s) inside `dispatchWithLease`<br/>`(channel-core.ts → dispatchWithLease, timeout branch)` | Logged as warning; handler result discarded; lease server-side times out independently |
+| `ServiceInputError` | `@moltzap/client`<br/>`runtime/service-helpers.ts → ServiceInputError` | Local socket daemon received unknown/invalid RPC method<br/>`(service.ts → handleSocketRequest)` | Daemon responds with error to CLI caller |
+| `SocketRequestError` | `@moltzap/client`<br/>`cli/socket-client.ts → SocketRequestError` | Unix-socket dial failed (`ENOENT`/`ECONNREFUSED` = daemon not running), 10s timeout, or RPC error | CLI prints message to stderr and exits 1 |
 
 **Error propagation invariants**:
 1. `MalformedFrameError` never escapes the reader fiber — logged + dropped.

--- a/packages/client/docs/architecture/05-error-taxonomy.md
+++ b/packages/client/docs/architecture/05-error-taxonomy.md
@@ -1,0 +1,102 @@
+# Error Taxonomy
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+All errors are Effect tagged errors unless noted. "Raised at" means the
+effect fails with this type; callers pattern-match on `._tag`.
+
+```text
+Error                       Package/File                 Raised when
+─────────────────────────── ──────────────────────────── ──────────────────────────────
+NotConnectedError           @moltzap/protocol             sendRpc() called while
+                            transport/rpc-errors.ts       stateRef=None; or socket
+                            → NotConnectedError           closed mid-call during
+                                                         failAllPending() sweep
+                                                         (ws-client.ts → sendRpcEffect)
+                            ┗━ callers: catch and surface
+                               to user as "not connected"
+
+RpcTimeoutError             @moltzap/protocol             No response frame in
+                            transport/rpc-errors.ts       timeoutMs (default 30_000ms)
+                            → RpcTimeoutError             (ws-client.ts → sendRpcEffect,
+                                                         timeout race)
+                            ┗━ callers: retry or report
+                               timeout to user
+
+RpcServerError              @moltzap/protocol             Server returned JSON-RPC
+                            transport/rpc-errors.ts       error frame with unknown
+                            → RpcServerError              code; or ConversationArchi-
+                                                         vedError (code 4002) etc.
+                                                         (ws-client.ts → sendRpcEffect)
+                            ┗━ inspect .code for known
+                               protocol codes
+
+MalformedFrameError         @moltzap/protocol             JSON.parse fails or
+                            transport/wire-errors.ts      decodeServerInbound rejects
+                            → MalformedFrameError         the shape
+                                                         (frame.ts → decodeFrame;
+                                                         ws-client.ts → handleIncoming)
+                            ┗━ logged + dropped (1-of-50
+                               logged); never propagates
+                               to callers
+
+AgentNotFoundError          @moltzap/client               AgentsLookupByName returns
+                            runtime/errors.ts             no agents for the requested
+                            → AgentNotFoundError          name
+                                                         (service.ts → resolveAgentName)
+                            ┗━ surface to user as
+                               "agent not found"
+
+DuplicateServerRpcHandler-  @moltzap/client               handleServerRpc() called
+Error                       runtime/errors.ts             twice for same definition
+                            → DuplicateServerRpcHandlerError
+                                                         (ws-client.ts → handleServerRpc)
+                            ┗━ programming error; never
+                               retry
+
+RegisterAgentError          @moltzap/client               HTTP register endpoint
+                            auth.ts                       returned non-2xx, or
+                            → RegisterAgentError          request/decode failed
+                            ┗━ print .message to user
+
+DispatchAdmissionTimedOut   @moltzap/client               dispatch/request RPC +
+                            channel-core-errors.ts        awaitDispatchRelease
+                            → DispatchAdmissionTimedOut   exceeded admissionTimeoutMs
+                                                         (default 30s)
+                                                         (channel-core.ts →
+                                                         dispatchAdmission)
+                            ┗━ fail-closed: treated as
+                               "deny"; message dropped
+
+DispatchLeaseExpired        @moltzap/client               InboundHandler took longer
+                            channel-core-errors.ts        than leaseTimeoutMs (default
+                            → DispatchLeaseExpired        90s) inside dispatchWithLease
+                                                         (channel-core.ts →
+                                                         dispatchWithLease, timeout branch)
+                            ┗━ logged as warning; handler
+                               result discarded; lease
+                               server-side times out
+
+ServiceInputError           @moltzap/client               Local socket daemon received
+                            runtime/service-helpers.ts    unknown/invalid RPC method
+                            → ServiceInputError           (service.ts → handleSocketRequest)
+                            ┗━ daemon responds with error
+                               to CLI caller
+
+SocketRequestError          @moltzap/client               Unix-socket dial failed
+                            cli/socket-client.ts          (ENOENT/ECONNREFUSED =
+                            → SocketRequestError          daemon not running),
+                                                         10s timeout, or RPC error
+                            ┗━ CLI prints message to
+                               stderr and exits 1
+```
+
+**Error propagation invariants**:
+1. `MalformedFrameError` never escapes the reader fiber — logged + dropped.
+2. Dispatch admission errors (timeout, network) are fail-closed to "deny";
+   they do not propagate to `InboundHandler`.
+3. `InboundHandler` errors propagate to the consumer fiber's
+   `catchAllCause` → logged, then the fiber continues with the next item.
+
+See also: [Inbound Dispatch Sequence](./03-inbound-dispatch.md) for where
+`DispatchAdmissionTimedOut` and `DispatchLeaseExpired` are raised in context.

--- a/packages/client/docs/architecture/06-cli-command-flow.md
+++ b/packages/client/docs/architecture/06-cli-command-flow.md
@@ -11,20 +11,20 @@ sequenceDiagram
     participant reg as register.ts
     participant auth as auth.ts / HTTP
 
-    shell->>cli: moltzap register &lt;name&gt; &lt;code&gt;
-    Note over cli: parse args/options<br/>NAME_PATTERN test<br/>fail → console.error + process.exit(1)
+    shell->>cli: moltzap register <name> <code>
+    Note over cli: parse args/options<br>NAME_PATTERN test<br>fail → console.error + process.exit(1)
 
-    Note over cli: Effect.gen():<br/>registerAgent(name, inviteCode, desc)
+    Note over cli: Effect.gen():<br>registerAgent(name, inviteCode, desc)
     cli->>reg: registerAgent(name, inviteCode, desc)
-    Note over reg: registerAgentRequest():<br/>HttpClientRequest.post(baseUrl + "/api/v1/auth/register")
+    Note over reg: registerAgentRequest():<br>HttpClientRequest.post(baseUrl + "/api/v1/auth/register")
     reg->>auth: client.execute(request)
-    auth-->>reg: HTTP 200<br/>{agentId, apiKey, claimUrl}<br/>(auth.ts → registerAgentRequest)
+    auth-->>reg: HTTP 200<br>{agentId, apiKey, claimUrl}<br>(auth.ts → registerAgentRequest)
     reg-->>cli: RegisterResponse
 
-    Note over cli: getServerUrl<br/>(reads ~/.moltzap/config.json)
+    Note over cli: getServerUrl<br>(reads ~/.moltzap/config.json)
 
-    Note over cli: noPersist?<br/>yes → emitNoPersist() → print to stdout<br/>no → persistRegistration():<br/>  profile set?<br/>    yes → writeProfile(name, record)<br/>    no → updateConfig({serverUrl, apiKey, agentName})<br/>         + writeOpenClawChannelConfig()<br/>           (~/.openclaw/openclaw.json)<br/>  (register.ts → persistRegistration)<br/>printPersistedRegistration()
-    cli-->>shell: stdout: Agent "&lt;name&gt;" registered
+    Note over cli: noPersist?<br>yes → emitNoPersist() → print to stdout<br>no → persistRegistration():<br>  profile set?<br>    yes → writeProfile(name, record)<br>    no → updateConfig({serverUrl, apiKey, agentName})<br>         + writeOpenClawChannelConfig()<br>           (~/.openclaw/openclaw.json)<br>  (register.ts → persistRegistration)<br>printPersistedRegistration()
+    cli-->>shell: stdout: Agent "<name>" registered
 ```
 
 ## `moltzap send <target> <message>`
@@ -41,23 +41,23 @@ sequenceDiagram
     participant sock as socket-client.ts
     participant daemon
 
-    shell->>cli: moltzap send &lt;target&gt; &lt;msg&gt;
+    shell->>cli: moltzap send <target> <msg>
     cli->>send: parse args/options
-    Note over send: target starts with "conv:"?<br/>yes → request(MessagesSend, {conversationId: target.slice(5), parts:[{type:"text",text}]})<br/>no → request(MessagesSend, {to: target, parts:[...]})<br/>(send.ts → buildRequest)
+    Note over send: target starts with "conv:"?<br>yes → request(MessagesSend, {conversationId: target.slice(5), parts:[{type:"text",text}]})<br>no → request(MessagesSend, {to: target, parts:[...]})<br>(send.ts → buildRequest)
 
-    Note over send: request(def, params):<br/>MoltZapService.SOCKET_PATH<br/>(~/.moltzap/service.sock)<br/>sendSocketRequest()<br/>(socket-client.ts → sendSocketRequest)
+    Note over send: request(def, params):<br>MoltZapService.SOCKET_PATH<br>(~/.moltzap/service.sock)<br>sendSocketRequest()<br>(socket-client.ts → sendSocketRequest)
     send->>sock: sendSocketRequest(def, params)
-    Note over sock: NodeSocket.makeNet(path, timeout:10s)<br/>ENOENT/ECONNREFUSED → SocketRequestError("not running")
+    Note over sock: NodeSocket.makeNet(path, timeout:10s)<br>ENOENT/ECONNREFUSED → SocketRequestError("not running")
     sock->>daemon: connect
 
-    Note over sock: @effect/rpc RpcClient.make(LocalDaemonRpcs)<br/>client.LocalDaemonCall({method: "messages/send", params})
+    Note over sock: @effect/rpc RpcClient.make(LocalDaemonRpcs)<br>client.LocalDaemonCall({method: "messages/send", params})
     sock->>daemon: NDJSON RPC
 
-    Note over daemon: handleSocketRequest →<br/>sendRpc(MessagesSend, params) →<br/>ws-client → server
+    Note over daemon: handleSocketRequest →<br>sendRpc(MessagesSend, params) →<br>ws-client → server
     daemon-->>sock: {message: {id}}
-    Note over sock: definition.validateResult<br/>(socket-client.ts → validateResult)
+    Note over sock: definition.validateResult<br>(socket-client.ts → validateResult)
     sock-->>send: {message: {id}}
-    send-->>shell: stdout: Message sent (id: &lt;id&gt;)
+    send-->>shell: stdout: Message sent (id: <id>)
 ```
 
 See also: [Error Taxonomy](./05-error-taxonomy.md) for `SocketRequestError`

--- a/packages/client/docs/architecture/06-cli-command-flow.md
+++ b/packages/client/docs/architecture/06-cli-command-flow.md
@@ -4,42 +4,27 @@
 
 ## `moltzap register <name> <invite-code>`
 
-```text
-  shell            @effect/cli          register.ts         auth.ts / HTTP
-    │                    │                    │                    │
-    │──moltzap register──▶│                    │                    │
-    │  <name> <code>      │                    │                    │
-    │                     │ parse args/options │                    │
-    │                     │──NAME_PATTERN test─▶                   │
-    │                     │   fail → console.error + process.exit(1)
-    │                     │                    │                    │
-    │                     │  Effect.gen():     │                    │
-    │                     │  registerAgent(name, inviteCode, desc)  │
-    │                     │──────────────────────────────────────── ▶
-    │                     │                    │ registerAgentRequest():
-    │                     │                    │ HttpClientRequest.post(
-    │                     │                    │   baseUrl + "/api/v1/auth/register")
-    │                     │                    │ client.execute(request) ──────────▶
-    │                     │                    │                    │  HTTP 200
-    │                     │                    │ ◀──{agentId, apiKey, claimUrl} ────
-    │                     │                    │ (auth.ts → registerAgentRequest)   │
-    │                     │ ◀── RegisterResponse                    │
-    │                     │                    │                    │
-    │                     │ getServerUrl       │                    │
-    │                     │ (reads ~/.moltzap/config.json)          │
-    │                     │                    │                    │
-    │                     │ noPersist?         │                    │
-    │                     │  yes → emitNoPersist() → print to stdout│
-    │                     │  no  → persistRegistration():           │
-    │                     │    profile set?                         │
-    │                     │     yes → writeProfile(name, record)    │
-    │                     │     no  → updateConfig({serverUrl,      │
-    │                     │              apiKey, agentName})        │
-    │                     │            + writeOpenClawChannelConfig()
-    │                     │              (~/.openclaw/openclaw.json)│
-    │                     │              (register.ts → persistRegistration)
-    │                     │  printPersistedRegistration()           │
-    │──stdout: Agent "<name>" registered ─────│                    │
+```mermaid
+sequenceDiagram
+    participant shell
+    participant cli as @effect/cli
+    participant reg as register.ts
+    participant auth as auth.ts / HTTP
+
+    shell->>cli: moltzap register &lt;name&gt; &lt;code&gt;
+    Note over cli: parse args/options<br/>NAME_PATTERN test<br/>fail → console.error + process.exit(1)
+
+    Note over cli: Effect.gen():<br/>registerAgent(name, inviteCode, desc)
+    cli->>reg: registerAgent(name, inviteCode, desc)
+    Note over reg: registerAgentRequest():<br/>HttpClientRequest.post(baseUrl + "/api/v1/auth/register")
+    reg->>auth: client.execute(request)
+    auth-->>reg: HTTP 200<br/>{agentId, apiKey, claimUrl}<br/>(auth.ts → registerAgentRequest)
+    reg-->>cli: RegisterResponse
+
+    Note over cli: getServerUrl<br/>(reads ~/.moltzap/config.json)
+
+    Note over cli: noPersist?<br/>yes → emitNoPersist() → print to stdout<br/>no → persistRegistration():<br/>  profile set?<br/>    yes → writeProfile(name, record)<br/>    no → updateConfig({serverUrl, apiKey, agentName})<br/>         + writeOpenClawChannelConfig()<br/>           (~/.openclaw/openclaw.json)<br/>  (register.ts → persistRegistration)<br/>printPersistedRegistration()
+    cli-->>shell: stdout: Agent "&lt;name&gt;" registered
 ```
 
 ## `moltzap send <target> <message>`
@@ -48,62 +33,31 @@
 create its own `MoltZapWsClient`; it delegates to the running
 channel-plugin daemon via a Unix socket RPC call.
 
-```text
-  shell            @effect/cli          send.ts         socket-client.ts     daemon
-    │                    │                    │                 │               │
-    │──moltzap send──────▶│                    │                 │               │
-    │  <target> <msg>     │                    │                 │               │
-    │                     │ parse args/options │                 │               │
-    │                     │──────────────────▶│                 │               │
-    │                     │  target starts with "conv:"?        │               │
-    │                     │   yes → request(MessagesSend, {     │               │
-    │                     │     conversationId: target.slice(5),│               │
-    │                     │     parts:[{type:"text",text}]})    │               │
-    │                     │   no  → request(MessagesSend, {     │               │
-    │                     │     to: target, parts:[...]})        │               │
-    │                     │  (send.ts → buildRequest)           │               │
-    │                     │                   │ request(def,    │               │
-    │                     │                   │   params):      │               │
-    │                     │                   │ MoltZapService  │               │
-    │                     │                   │  .SOCKET_PATH   │               │
-    │                     │                   │  (~/.moltzap/   │               │
-    │                     │                   │   service.sock) │               │
-    │                     │                   │ sendSocketRequest()             │
-    │                     │                   │ (socket-client.ts →             │
-    │                     │                   │  sendSocketRequest):            │
-    │                     │                   │ NodeSocket.     │               │
-    │                     │                   │  makeNet(path,  │               │
-    │                     │                   │  timeout:10s) ──▶──── connect ─▶│
-    │                     │                   │                 │  ENOENT/ECONN │
-    │                     │                   │                 │  REFUSED →    │
-    │                     │                   │                 │  SocketRequest│
-    │                     │                   │                 │  Error("not   │
-    │                     │                   │                 │   running")   │
-    │                     │                   │                 │               │
-    │                     │                   │ @effect/rpc     │               │
-    │                     │                   │ RpcClient.make  │               │
-    │                     │                   │  (LocalDaemon-  │               │
-    │                     │                   │   Rpcs)         │               │
-    │                     │                   │ client.Local-   │               │
-    │                     │                   │  DaemonCall({   │               │
-    │                     │                   │   method:       │               │
-    │                     │                   │   "messages/send",              │
-    │                     │                   │   params})      │               │
-    │                     │                   │  ──NDJSON RPC──────────────────▶│
-    │                     │                   │                 │               │
-    │                     │                   │                 │ handleSocket  │
-    │                     │                   │                 │  Request →    │
-    │                     │                   │                 │  sendRpc(     │
-    │                     │                   │                 │   MessagesSend│
-    │                     │                   │                 │   params) →   │
-    │                     │                   │                 │  ws-client →  │
-    │                     │                   │                 │  server       │
-    │                     │                   │  ◀── {message: {id}} ──────────│
-    │                     │                   │ definition.     │               │
-    │                     │                   │  validateResult │               │
-    │                     │                   │ (socket-client.ts →             │
-    │                     │                   │  validateResult)                │
-    │──stdout: Message sent (id: <id>) ───────│                 │               │
+```mermaid
+sequenceDiagram
+    participant shell
+    participant cli as @effect/cli
+    participant send as send.ts
+    participant sock as socket-client.ts
+    participant daemon
+
+    shell->>cli: moltzap send &lt;target&gt; &lt;msg&gt;
+    cli->>send: parse args/options
+    Note over send: target starts with "conv:"?<br/>yes → request(MessagesSend, {conversationId: target.slice(5), parts:[{type:"text",text}]})<br/>no → request(MessagesSend, {to: target, parts:[...]})<br/>(send.ts → buildRequest)
+
+    Note over send: request(def, params):<br/>MoltZapService.SOCKET_PATH<br/>(~/.moltzap/service.sock)<br/>sendSocketRequest()<br/>(socket-client.ts → sendSocketRequest)
+    send->>sock: sendSocketRequest(def, params)
+    Note over sock: NodeSocket.makeNet(path, timeout:10s)<br/>ENOENT/ECONNREFUSED → SocketRequestError("not running")
+    sock->>daemon: connect
+
+    Note over sock: @effect/rpc RpcClient.make(LocalDaemonRpcs)<br/>client.LocalDaemonCall({method: "messages/send", params})
+    sock->>daemon: NDJSON RPC
+
+    Note over daemon: handleSocketRequest →<br/>sendRpc(MessagesSend, params) →<br/>ws-client → server
+    daemon-->>sock: {message: {id}}
+    Note over sock: definition.validateResult<br/>(socket-client.ts → validateResult)
+    sock-->>send: {message: {id}}
+    send-->>shell: stdout: Message sent (id: &lt;id&gt;)
 ```
 
 See also: [Error Taxonomy](./05-error-taxonomy.md) for `SocketRequestError`

--- a/packages/client/docs/architecture/06-cli-command-flow.md
+++ b/packages/client/docs/architecture/06-cli-command-flow.md
@@ -1,0 +1,110 @@
+# CLI Command Flow
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+## `moltzap register <name> <invite-code>`
+
+```text
+  shell            @effect/cli          register.ts         auth.ts / HTTP
+    │                    │                    │                    │
+    │──moltzap register──▶│                    │                    │
+    │  <name> <code>      │                    │                    │
+    │                     │ parse args/options │                    │
+    │                     │──NAME_PATTERN test─▶                   │
+    │                     │   fail → console.error + process.exit(1)
+    │                     │                    │                    │
+    │                     │  Effect.gen():     │                    │
+    │                     │  registerAgent(name, inviteCode, desc)  │
+    │                     │──────────────────────────────────────── ▶
+    │                     │                    │ registerAgentRequest():
+    │                     │                    │ HttpClientRequest.post(
+    │                     │                    │   baseUrl + "/api/v1/auth/register")
+    │                     │                    │ client.execute(request) ──────────▶
+    │                     │                    │                    │  HTTP 200
+    │                     │                    │ ◀──{agentId, apiKey, claimUrl} ────
+    │                     │                    │ (auth.ts → registerAgentRequest)   │
+    │                     │ ◀── RegisterResponse                    │
+    │                     │                    │                    │
+    │                     │ getServerUrl       │                    │
+    │                     │ (reads ~/.moltzap/config.json)          │
+    │                     │                    │                    │
+    │                     │ noPersist?         │                    │
+    │                     │  yes → emitNoPersist() → print to stdout│
+    │                     │  no  → persistRegistration():           │
+    │                     │    profile set?                         │
+    │                     │     yes → writeProfile(name, record)    │
+    │                     │     no  → updateConfig({serverUrl,      │
+    │                     │              apiKey, agentName})        │
+    │                     │            + writeOpenClawChannelConfig()
+    │                     │              (~/.openclaw/openclaw.json)│
+    │                     │              (register.ts → persistRegistration)
+    │                     │  printPersistedRegistration()           │
+    │──stdout: Agent "<name>" registered ─────│                    │
+```
+
+## `moltzap send <target> <message>`
+
+`moltzap send` routes through the local daemon socket — it does NOT
+create its own `MoltZapWsClient`; it delegates to the running
+channel-plugin daemon via a Unix socket RPC call.
+
+```text
+  shell            @effect/cli          send.ts         socket-client.ts     daemon
+    │                    │                    │                 │               │
+    │──moltzap send──────▶│                    │                 │               │
+    │  <target> <msg>     │                    │                 │               │
+    │                     │ parse args/options │                 │               │
+    │                     │──────────────────▶│                 │               │
+    │                     │  target starts with "conv:"?        │               │
+    │                     │   yes → request(MessagesSend, {     │               │
+    │                     │     conversationId: target.slice(5),│               │
+    │                     │     parts:[{type:"text",text}]})    │               │
+    │                     │   no  → request(MessagesSend, {     │               │
+    │                     │     to: target, parts:[...]})        │               │
+    │                     │  (send.ts → buildRequest)           │               │
+    │                     │                   │ request(def,    │               │
+    │                     │                   │   params):      │               │
+    │                     │                   │ MoltZapService  │               │
+    │                     │                   │  .SOCKET_PATH   │               │
+    │                     │                   │  (~/.moltzap/   │               │
+    │                     │                   │   service.sock) │               │
+    │                     │                   │ sendSocketRequest()             │
+    │                     │                   │ (socket-client.ts →             │
+    │                     │                   │  sendSocketRequest):            │
+    │                     │                   │ NodeSocket.     │               │
+    │                     │                   │  makeNet(path,  │               │
+    │                     │                   │  timeout:10s) ──▶──── connect ─▶│
+    │                     │                   │                 │  ENOENT/ECONN │
+    │                     │                   │                 │  REFUSED →    │
+    │                     │                   │                 │  SocketRequest│
+    │                     │                   │                 │  Error("not   │
+    │                     │                   │                 │   running")   │
+    │                     │                   │                 │               │
+    │                     │                   │ @effect/rpc     │               │
+    │                     │                   │ RpcClient.make  │               │
+    │                     │                   │  (LocalDaemon-  │               │
+    │                     │                   │   Rpcs)         │               │
+    │                     │                   │ client.Local-   │               │
+    │                     │                   │  DaemonCall({   │               │
+    │                     │                   │   method:       │               │
+    │                     │                   │   "messages/send",              │
+    │                     │                   │   params})      │               │
+    │                     │                   │  ──NDJSON RPC──────────────────▶│
+    │                     │                   │                 │               │
+    │                     │                   │                 │ handleSocket  │
+    │                     │                   │                 │  Request →    │
+    │                     │                   │                 │  sendRpc(     │
+    │                     │                   │                 │   MessagesSend│
+    │                     │                   │                 │   params) →   │
+    │                     │                   │                 │  ws-client →  │
+    │                     │                   │                 │  server       │
+    │                     │                   │  ◀── {message: {id}} ──────────│
+    │                     │                   │ definition.     │               │
+    │                     │                   │  validateResult │               │
+    │                     │                   │ (socket-client.ts →             │
+    │                     │                   │  validateResult)                │
+    │──stdout: Message sent (id: <id>) ───────│                 │               │
+```
+
+See also: [Error Taxonomy](./05-error-taxonomy.md) for `SocketRequestError`
+and `ServiceInputError` which are raised in these flows.

--- a/packages/client/docs/architecture/07-state-machines.md
+++ b/packages/client/docs/architecture/07-state-machines.md
@@ -1,0 +1,135 @@
+# State Machines
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+## Dispatch Lease State Machine
+
+One lease per `dispatch/request` call. Managed jointly by server
+(LeaseRegistry) and `MoltZapChannelCore` on the client side.
+
+```text
+         ┌──────────────────────────────────────────┐
+         │            PENDING                       │
+         │  dispatch/request sent                   │
+         │  (channel-core.ts → dispatchAdmission);  │
+         │  server minting lease                    │
+         └──────────┬───────────────────────────────┘
+                    │
+          dispatch/request ack returns {leaseId}
+                    │
+         ┌──────────▼───────────────────────────────┐
+         │       AWAITING_RELEASE                   │
+         │  Deferred registered (or ring-buffered   │
+         │  entry consumed)                         │
+         │  (channel-core.ts → awaitDispatchRelease)│
+         └──────────┬───────────────────────────────┘
+                    │ dispatch/release notification arrives
+                    │ verdict.decision:
+          ┌─────────┼─────────────────────────┐
+          ▼         ▼                         ▼
+       GRANTED    DENIED                    HELD
+  (proceed to    (drop message;          (parkDispatch-
+   enrichment)    log; consumer           Work(); re-
+                  fiber continues)        queued at
+                                          front of
+                                          parked[convId])
+          │
+          ▼
+      IN_FLIGHT
+  leaseIdInFlight = leaseId
+  (channel-core.ts → dispatchWithLease)
+  InboundHandler executing
+  (lease authorizes one
+   messages/send call)
+          │
+          ├─── handler completes within leaseTimeoutMs (90s default)
+          │         ▼
+          │     CONSUMED
+          │    (server marks via dispatchLeaseId
+          │     in messages/send params)
+          │
+          └─── handler exceeds leaseTimeoutMs
+                    ▼
+               EXPIRED (client side)
+               DispatchLeaseExpired logged;
+               server-side lease times out
+               independently
+```
+
+See also: [Inbound Dispatch Sequence](./03-inbound-dispatch.md) for the full
+sequence that drives these state transitions, including the ack/release race
+(Cases A and B).
+
+## Connection State Machine
+
+`MoltZapWsClient` transitions, driven by `stateRef` and the `closed` flag.
+
+```text
+         ┌──────────────────────────────────┐
+         │         INIT                     │
+         │  stateRef = None                 │
+         │  closed = false                  │
+         └──────────┬───────────────────────┘
+                    │ connect() called
+                    │
+         ┌──────────▼───────────────────────┐
+         │      CONNECTING                  │
+         │  openSocket() (10s timeout)      │
+         │  startTaskCallbackDispatcher()   │
+         │  readerFiber forked              │
+         │  sendRpc(Connect) in flight      │
+         └──────┬───────────────────────────┘
+                │ HelloOk received
+                │ stateRef = Some(ConnState)
+                ▼
+         ┌──────────────────────────────────┐
+         │       CONNECTED                  │
+         │  stateRef = Some(ConnState)      │
+         │  _helloOk set                    │
+         │  closed = false                  │
+         └──────┬───────────────────────────┘
+                │ reader fiber exits (network error,
+                │ server close, etc.)
+                │ _helloOk = null
+                │ failAllPending()
+                │ stateRef = None
+                │ onDisconnect(closeInfo) called
+                ▼
+         ┌──────────────────────────────────┐
+         │     DISCONNECTED                 │
+         │  stateRef = None                 │
+         │  closed = false (reconnectable)  │
+         └──────┬───────────────────────────┘
+                │ scheduleReconnect() fires:
+                │   exponential backoff (1s–30s, jitter)
+                │   loops via Effect.retry(Schedule)
+                │   TestClock-compatible
+                ╔══════════════════════╗
+                ║   [reconnect loop]   ║
+                ╚═════════════════════╝
+                │ connectEffect() succeeds
+                │ onReconnect(helloOk) called
+                └──────────────▶ CONNECTED
+
+         close() called at any state:
+                │ closed = true
+                │ reconnectFiber interrupted
+                │ failAllPending()
+                │ failAllNotificationWaiters()
+                │ subscribers.closeAll
+                │ write(CloseEvent(1000)) if handshake completed
+                │ Scope.close(scope)
+                │ Scope.close(dispatcherScope) [via runFork]
+                │ runtime.dispose()
+                ▼
+         ┌──────────────────────────────────┐
+         │         CLOSED (terminal)        │
+         │  closed = true                   │
+         │  stateRef = None                 │
+         │  reconnectFiber = null           │
+         │  No further reconnects           │
+         └──────────────────────────────────┘
+```
+
+See also: [Connection Lifecycle](./01-connection-lifecycle.md) for the
+bootstrap sequence and reconnect arm that drive these transitions.

--- a/packages/client/docs/architecture/07-state-machines.md
+++ b/packages/client/docs/architecture/07-state-machines.md
@@ -11,26 +11,26 @@ One lease per `dispatch/request` call. Managed jointly by server
 stateDiagram-v2
     [*] --> PENDING
 
-    PENDING : PENDING\ndispatch/request sent\n(channel-core.ts → dispatchAdmission)\nserver minting lease
+    PENDING : PENDING[br]dispatch/request sent[br](channel-core.ts → dispatchAdmission)[br]server minting lease
 
     PENDING --> AWAITING_RELEASE : dispatch/request ack returns {leaseId}
 
-    AWAITING_RELEASE : AWAITING_RELEASE\nDeferred registered (or ring-buffered entry consumed)\n(channel-core.ts → awaitDispatchRelease)
+    AWAITING_RELEASE : AWAITING_RELEASE[br]Deferred registered (or ring-buffered entry consumed)[br](channel-core.ts → awaitDispatchRelease)
 
-    AWAITING_RELEASE --> GRANTED : dispatch/release arrives\nverdict.decision = "grant"
-    AWAITING_RELEASE --> DENIED : dispatch/release arrives\nverdict.decision = "deny"
-    AWAITING_RELEASE --> HELD : dispatch/release arrives\nverdict.decision = "hold"
+    AWAITING_RELEASE --> GRANTED : dispatch/release arrives[br]verdict.decision = "grant"
+    AWAITING_RELEASE --> DENIED : dispatch/release arrives[br]verdict.decision = "deny"
+    AWAITING_RELEASE --> HELD : dispatch/release arrives[br]verdict.decision = "hold"
 
-    GRANTED : GRANTED\nproceed to enrichment
-    DENIED : DENIED\ndrop message; log;\nconsumer fiber continues
-    HELD : HELD\nparkDispatchWork();\nre-queued at front of parked[convId]
+    GRANTED : GRANTED[br]proceed to enrichment
+    DENIED : DENIED[br]drop message, log,[br]consumer fiber continues
+    HELD : HELD[br]parkDispatchWork(),[br]re-queued at front of parked[convId]
 
     GRANTED --> IN_FLIGHT : dispatchGrantedWork()
 
-    IN_FLIGHT : IN_FLIGHT\nleaseIdInFlight = leaseId\n(channel-core.ts → dispatchWithLease)\nInboundHandler executing\n(lease authorizes one messages/send call)
+    IN_FLIGHT : IN_FLIGHT[br]leaseIdInFlight = leaseId[br](channel-core.ts → dispatchWithLease)[br]InboundHandler executing[br](lease authorizes one messages/send call)
 
-    IN_FLIGHT --> CONSUMED : handler completes within leaseTimeoutMs (90s default)\nserver marks via dispatchLeaseId in messages/send params
-    IN_FLIGHT --> EXPIRED : handler exceeds leaseTimeoutMs\nDispatchLeaseExpired logged;\nserver-side lease times out independently
+    IN_FLIGHT --> CONSUMED : handler completes within leaseTimeoutMs (90s default)[br]server marks via dispatchLeaseId in messages/send params
+    IN_FLIGHT --> EXPIRED : handler exceeds leaseTimeoutMs[br]DispatchLeaseExpired logged,[br]server-side lease times out independently
 
     CONSUMED --> [*]
     DENIED --> [*]
@@ -52,28 +52,28 @@ sequence that drives these state transitions, including the ack/release race
 stateDiagram-v2
     [*] --> INIT
 
-    INIT : INIT\nstateRef = None\nclosed = false
+    INIT : INIT[br]stateRef = None[br]closed = false
 
     INIT --> CONNECTING : connect() called
 
-    CONNECTING : CONNECTING\nopenSocket() (10s timeout)\nstartTaskCallbackDispatcher()\nreaderFiber forked\nsendRpc(Connect) in flight
+    CONNECTING : CONNECTING[br]openSocket() (10s timeout)[br]startTaskCallbackDispatcher()[br]readerFiber forked[br]sendRpc(Connect) in flight
 
-    CONNECTING --> CONNECTED : HelloOk received\nstateRef = Some(ConnState)
+    CONNECTING --> CONNECTED : HelloOk received[br]stateRef = Some(ConnState)
 
-    CONNECTED : CONNECTED\nstateRef = Some(ConnState)\n_helloOk set\nclosed = false
+    CONNECTED : CONNECTED[br]stateRef = Some(ConnState)[br]_helloOk set[br]closed = false
 
-    CONNECTED --> DISCONNECTED : reader fiber exits (network error / server close)\n_helloOk = null\nfailAllPending()\nstateRef = None\nonDisconnect(closeInfo) called
+    CONNECTED --> DISCONNECTED : reader fiber exits (network error / server close)[br]_helloOk = null[br]failAllPending()[br]stateRef = None[br]onDisconnect(closeInfo) called
 
-    DISCONNECTED : DISCONNECTED\nstateRef = None\nclosed = false (reconnectable)
+    DISCONNECTED : DISCONNECTED[br]stateRef = None[br]closed = false (reconnectable)
 
-    DISCONNECTED --> CONNECTING : scheduleReconnect() fires\nexponential backoff (1s–30s, jitter)\nEffect.retry(Schedule) — TestClock-compatible\nconnectEffect() succeeds → onReconnect(helloOk) called
+    DISCONNECTED --> CONNECTING : scheduleReconnect() fires[br]exponential backoff (1s–30s, jitter)[br]Effect.retry(Schedule) — TestClock-compatible[br]connectEffect() succeeds → onReconnect(helloOk) called
 
     INIT --> CLOSED : close() called
     CONNECTING --> CLOSED : close() called
     CONNECTED --> CLOSED : close() called
     DISCONNECTED --> CLOSED : close() called
 
-    CLOSED : CLOSED (terminal)\nclosed = true\nstateRef = None\nreconnectFiber = null\nNo further reconnects
+    CLOSED : CLOSED (terminal)[br]closed = true[br]stateRef = None[br]reconnectFiber = null[br]No further reconnects
     CLOSED --> [*]
 ```
 

--- a/packages/client/docs/architecture/07-state-machines.md
+++ b/packages/client/docs/architecture/07-state-machines.md
@@ -7,54 +7,38 @@
 One lease per `dispatch/request` call. Managed jointly by server
 (LeaseRegistry) and `MoltZapChannelCore` on the client side.
 
-```text
-         ┌──────────────────────────────────────────┐
-         │            PENDING                       │
-         │  dispatch/request sent                   │
-         │  (channel-core.ts → dispatchAdmission);  │
-         │  server minting lease                    │
-         └──────────┬───────────────────────────────┘
-                    │
-          dispatch/request ack returns {leaseId}
-                    │
-         ┌──────────▼───────────────────────────────┐
-         │       AWAITING_RELEASE                   │
-         │  Deferred registered (or ring-buffered   │
-         │  entry consumed)                         │
-         │  (channel-core.ts → awaitDispatchRelease)│
-         └──────────┬───────────────────────────────┘
-                    │ dispatch/release notification arrives
-                    │ verdict.decision:
-          ┌─────────┼─────────────────────────┐
-          ▼         ▼                         ▼
-       GRANTED    DENIED                    HELD
-  (proceed to    (drop message;          (parkDispatch-
-   enrichment)    log; consumer           Work(); re-
-                  fiber continues)        queued at
-                                          front of
-                                          parked[convId])
-          │
-          ▼
-      IN_FLIGHT
-  leaseIdInFlight = leaseId
-  (channel-core.ts → dispatchWithLease)
-  InboundHandler executing
-  (lease authorizes one
-   messages/send call)
-          │
-          ├─── handler completes within leaseTimeoutMs (90s default)
-          │         ▼
-          │     CONSUMED
-          │    (server marks via dispatchLeaseId
-          │     in messages/send params)
-          │
-          └─── handler exceeds leaseTimeoutMs
-                    ▼
-               EXPIRED (client side)
-               DispatchLeaseExpired logged;
-               server-side lease times out
-               independently
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING
+
+    PENDING : PENDING\ndispatch/request sent\n(channel-core.ts → dispatchAdmission)\nserver minting lease
+
+    PENDING --> AWAITING_RELEASE : dispatch/request ack returns {leaseId}
+
+    AWAITING_RELEASE : AWAITING_RELEASE\nDeferred registered (or ring-buffered entry consumed)\n(channel-core.ts → awaitDispatchRelease)
+
+    AWAITING_RELEASE --> GRANTED : dispatch/release arrives\nverdict.decision = "grant"
+    AWAITING_RELEASE --> DENIED : dispatch/release arrives\nverdict.decision = "deny"
+    AWAITING_RELEASE --> HELD : dispatch/release arrives\nverdict.decision = "hold"
+
+    GRANTED : GRANTED\nproceed to enrichment
+    DENIED : DENIED\ndrop message; log;\nconsumer fiber continues
+    HELD : HELD\nparkDispatchWork();\nre-queued at front of parked[convId]
+
+    GRANTED --> IN_FLIGHT : dispatchGrantedWork()
+
+    IN_FLIGHT : IN_FLIGHT\nleaseIdInFlight = leaseId\n(channel-core.ts → dispatchWithLease)\nInboundHandler executing\n(lease authorizes one messages/send call)
+
+    IN_FLIGHT --> CONSUMED : handler completes within leaseTimeoutMs (90s default)\nserver marks via dispatchLeaseId in messages/send params
+    IN_FLIGHT --> EXPIRED : handler exceeds leaseTimeoutMs\nDispatchLeaseExpired logged;\nserver-side lease times out independently
+
+    CONSUMED --> [*]
+    DENIED --> [*]
+    EXPIRED --> [*]
 ```
+
+**Annotations:**
+- `HELD` re-enters the queue: `takeDispatchCandidate` prioritises the `parked[convId]` front so the same conversation gets another dispatch attempt without starving other conversations.
 
 See also: [Inbound Dispatch Sequence](./03-inbound-dispatch.md) for the full
 sequence that drives these state transitions, including the ack/release race
@@ -64,72 +48,37 @@ sequence that drives these state transitions, including the ack/release race
 
 `MoltZapWsClient` transitions, driven by `stateRef` and the `closed` flag.
 
-```text
-         ┌──────────────────────────────────┐
-         │         INIT                     │
-         │  stateRef = None                 │
-         │  closed = false                  │
-         └──────────┬───────────────────────┘
-                    │ connect() called
-                    │
-         ┌──────────▼───────────────────────┐
-         │      CONNECTING                  │
-         │  openSocket() (10s timeout)      │
-         │  startTaskCallbackDispatcher()   │
-         │  readerFiber forked              │
-         │  sendRpc(Connect) in flight      │
-         └──────┬───────────────────────────┘
-                │ HelloOk received
-                │ stateRef = Some(ConnState)
-                ▼
-         ┌──────────────────────────────────┐
-         │       CONNECTED                  │
-         │  stateRef = Some(ConnState)      │
-         │  _helloOk set                    │
-         │  closed = false                  │
-         └──────┬───────────────────────────┘
-                │ reader fiber exits (network error,
-                │ server close, etc.)
-                │ _helloOk = null
-                │ failAllPending()
-                │ stateRef = None
-                │ onDisconnect(closeInfo) called
-                ▼
-         ┌──────────────────────────────────┐
-         │     DISCONNECTED                 │
-         │  stateRef = None                 │
-         │  closed = false (reconnectable)  │
-         └──────┬───────────────────────────┘
-                │ scheduleReconnect() fires:
-                │   exponential backoff (1s–30s, jitter)
-                │   loops via Effect.retry(Schedule)
-                │   TestClock-compatible
-                ╔══════════════════════╗
-                ║   [reconnect loop]   ║
-                ╚═════════════════════╝
-                │ connectEffect() succeeds
-                │ onReconnect(helloOk) called
-                └──────────────▶ CONNECTED
+```mermaid
+stateDiagram-v2
+    [*] --> INIT
 
-         close() called at any state:
-                │ closed = true
-                │ reconnectFiber interrupted
-                │ failAllPending()
-                │ failAllNotificationWaiters()
-                │ subscribers.closeAll
-                │ write(CloseEvent(1000)) if handshake completed
-                │ Scope.close(scope)
-                │ Scope.close(dispatcherScope) [via runFork]
-                │ runtime.dispose()
-                ▼
-         ┌──────────────────────────────────┐
-         │         CLOSED (terminal)        │
-         │  closed = true                   │
-         │  stateRef = None                 │
-         │  reconnectFiber = null           │
-         │  No further reconnects           │
-         └──────────────────────────────────┘
+    INIT : INIT\nstateRef = None\nclosed = false
+
+    INIT --> CONNECTING : connect() called
+
+    CONNECTING : CONNECTING\nopenSocket() (10s timeout)\nstartTaskCallbackDispatcher()\nreaderFiber forked\nsendRpc(Connect) in flight
+
+    CONNECTING --> CONNECTED : HelloOk received\nstateRef = Some(ConnState)
+
+    CONNECTED : CONNECTED\nstateRef = Some(ConnState)\n_helloOk set\nclosed = false
+
+    CONNECTED --> DISCONNECTED : reader fiber exits (network error / server close)\n_helloOk = null\nfailAllPending()\nstateRef = None\nonDisconnect(closeInfo) called
+
+    DISCONNECTED : DISCONNECTED\nstateRef = None\nclosed = false (reconnectable)
+
+    DISCONNECTED --> CONNECTING : scheduleReconnect() fires\nexponential backoff (1s–30s, jitter)\nEffect.retry(Schedule) — TestClock-compatible\nconnectEffect() succeeds → onReconnect(helloOk) called
+
+    INIT --> CLOSED : close() called
+    CONNECTING --> CLOSED : close() called
+    CONNECTED --> CLOSED : close() called
+    DISCONNECTED --> CLOSED : close() called
+
+    CLOSED : CLOSED (terminal)\nclosed = true\nstateRef = None\nreconnectFiber = null\nNo further reconnects
+    CLOSED --> [*]
 ```
+
+**Annotations:**
+- `close()` actions (any state): `closed = true`, reconnectFiber interrupted, `failAllPending()`, `failAllNotificationWaiters()`, `subscribers.closeAll`, `write(CloseEvent(1000))` if handshake completed, `Scope.close(scope)`, `Scope.close(dispatcherScope)` [via runFork], `runtime.dispose()`.
 
 See also: [Connection Lifecycle](./01-connection-lifecycle.md) for the
 bootstrap sequence and reconnect arm that drive these transitions.

--- a/packages/nanoclaw-channel/ARCHITECTURE.md
+++ b/packages/nanoclaw-channel/ARCHITECTURE.md
@@ -1,0 +1,71 @@
+# Architecture — `@moltzap/nanoclaw-channel`
+
+Smoke-test channel for MoltZap. Implements the minimum-viable channel
+contract for end-to-end test coverage; **not published to npm**. Lives in
+the workspace as a local-only consumer of `@moltzap/client` so wire-shape
+regressions surface in CI before they hit real channel plugins.
+
+## Project Structure
+
+```
+packages/nanoclaw-channel/src/
+├── channels/moltzap.ts     # MoltZapChannel — the channel class (main entry)
+├── types.ts                # MoltZapChannelEnv, MoltZapChannelError
+├── test-support.ts         # ./test-support subpath
+└── __tests__/conformance/  # Smoke-test conformance harness
+```
+
+Entry point is `channels/moltzap.ts` (not `index.ts`); package main field
+points here directly.
+
+## Public Surface
+
+| Export | Purpose |
+|---|---|
+| `MoltZapChannel` | Channel class — `connect`, `disconnect`, `sendMessage`, `handleInbound` |
+| `MoltZapChannelEnv` | Config schema (apiKey, serverUrl, evalMode) |
+| `MoltZapChannelError` | Typed failure |
+| `loadMoltZapChannelEnv` | Effect-based env loader |
+| `conversationIdFromJid` / `jidFromConversationId` | JID ↔ ConversationId conversions |
+| `formatGroupBlock` / `formatCrossConvNanoclaw` | Render helpers |
+| `MOLTZAP_JID_PREFIX`, `DEFAULT_SERVER_URL`, `EVAL_GROUP_NAME_ID_CHARS` | Constants |
+
+Channel registers itself on the global `registerChannel("moltzap")` hook
+at import time (via `registerChannel` call in `channels/moltzap.ts`).
+
+## Communication Flows
+
+Detailed sequence diagrams for each flow live in `docs/architecture/`:
+
+| # | Section | Detail doc |
+|---|---------|------------|
+| 3.1 | Channel Construction + registerChannel Hook | [01-construction-and-registry.md](docs/architecture/01-construction-and-registry.md) |
+| 3.2 | connect / disconnect Lifecycle | [02-connect-disconnect-lifecycle.md](docs/architecture/02-connect-disconnect-lifecycle.md) |
+| 3.3 | Inbound Flow | [03-inbound-flow.md](docs/architecture/03-inbound-flow.md) |
+| 3.4 | Outbound sendMessage Flow | [04-outbound-send-message.md](docs/architecture/04-outbound-send-message.md) |
+| 3.5 | JID ↔ ConversationId Conversions | [05-jid-conversions.md](docs/architecture/05-jid-conversions.md) |
+| 3.6 | emitChatMetadata + ensureAutoRegistered | [06-chat-metadata-auto-register.md](docs/architecture/06-chat-metadata-auto-register.md) |
+| 3.7 | toNewMessage Projection | [07-to-new-message-projection.md](docs/architecture/07-to-new-message-projection.md) |
+
+## Dependencies
+
+**Runtime**: `effect`.
+**Internal**: `@moltzap/protocol`, `@moltzap/client`.
+**Consumers**: workspace tests only; not published. The arena repo
+historically used this as a smoke-test consumer.
+
+## Tests
+
+- `src/__tests__/conformance/` — smoke conformance harness
+- Vitest; runs as part of the workspace `pnpm test`
+
+## Glossary
+
+- **Smoke test package** — Not for production. Exists so any wire-shape
+  break in `@moltzap/protocol` or `@moltzap/client` fails CI here before
+  shipping a npm publish that would break real channel plugins.
+- **JID** — Channel-level addressing string. This package uses
+  `moltzap:<conversationId>` JIDs; `conversationIdFromJid` /
+  `jidFromConversationId` convert between the two shapes.
+- **Eval mode** — Toggle that opts into channel behaviors specific to
+  agent-evaluation pipelines (e.g., deterministic name resolution).

--- a/packages/nanoclaw-channel/docs/architecture/01-construction-and-registry.md
+++ b/packages/nanoclaw-channel/docs/architecture/01-construction-and-registry.md
@@ -16,58 +16,25 @@ phases: import time (registry registration) and instantiation time
   tests — the factory is never invoked by nanoclaw's router in this
   package.
 
-```
-  ┌─────────────────────────────────────────────────────────────────────┐
-  │  MODULE LOAD (import "channels/moltzap.ts")                         │
-  └────────────────────────────┬────────────────────────────────────────┘
-                               │
-                               │ channels/moltzap.ts → registerChannel call
-                               ▼
-              registerChannel("moltzap", factory)
-                               │
-                               │ channels/registry.ts → registeredChannelFactories.set
-                               ▼
-       registeredChannelFactories.set("moltzap", factory)
-       ┌── idempotent: if same factory ref already stored, skip ──┐
+```mermaid
+flowchart TD
+    A["MODULE LOAD\nimport &quot;channels/moltzap.ts&quot;"]
+    A -->|"channels/moltzap.ts → registerChannel call"| B["registerChannel(&quot;moltzap&quot;, factory)"]
+    B -->|"channels/registry.ts → registeredChannelFactories.set"| C["registeredChannelFactories.set(&quot;moltzap&quot;, factory)\n(idempotent: if same factory ref already stored, skip)"]
 
+    D["INSTANTIATION\n(factory called, or test calls new MoltZapChannel)"]
+    D -->|"channels/moltzap.ts → loadMoltZapChannelEnv"| E["loadMoltZapChannelEnv()\nConfig.all({ apiKey, serverUrl, evalMode })\nConfigProvider.fromEnv()\nMOLTZAP_API_KEY → Option&lt;Redacted&gt;\nMOLTZAP_SERVER_URL → string (default: wss://api.moltzap.xyz)\nMOLTZAP_EVAL_MODE → &quot;0&quot;|&quot;1&quot; (default: &quot;0&quot;)\nEffect.runSync (blocks; env is stable at load time)"]
+    E -->|"apiKey absent"| F["return null (no channel)"]
+    E -->|"apiKey present"| G["new MoltZapService({ serverUrl, agentKey: apiKey })\nnew MoltZapChannelCore({ service })\nnew MoltZapChannel(opts, core, service.ownAgentId, evalMode)"]
 
-  ┌─────────────────────────────────────────────────────────────────────┐
-  │  INSTANTIATION (factory called, or test calls new MoltZapChannel)   │
-  └────────────────────────────┬────────────────────────────────────────┘
-                               │
-                               │ channels/moltzap.ts → loadMoltZapChannelEnv
-                               ▼
-                  loadMoltZapChannelEnv()
-                  ┌─ Config.all({ apiKey, serverUrl, evalMode })
-                  │  ConfigProvider.fromEnv()
-                  │  MOLTZAP_API_KEY  → Option<Redacted>
-                  │  MOLTZAP_SERVER_URL → string (default: wss://api.moltzap.xyz)
-                  │  MOLTZAP_EVAL_MODE → "0"|"1" (default: "0")
-                  └─ Effect.runSync (blocks; env is stable at load time)
+    G --> H["MoltZapChannel CONSTRUCTOR\n(channels/moltzap.ts → constructor)"]
+    H --> I["core.onInbound(…)\nregisters callback\nthat calls handleInbound(msg)"]
+    H --> J["core.onDisconnect(…)\nEffect.runFork(\n  logWarning + annotateLogs)"]
+    H --> K["core.onReconnect(…)\nEffect.runFork(\n  logInfo + annotateLogs)"]
 
-                               │  apiKey absent → return null (no channel)
-                               │  apiKey present ↓
-                               ▼
-              new MoltZapService({ serverUrl, agentKey: apiKey })
-              new MoltZapChannelCore({ service })
-              new MoltZapChannel(opts, core, service.ownAgentId, evalMode)
-
-  ┌─────────────────────────────────────────────────────────────────────┐
-  │  MoltZapChannel CONSTRUCTOR  (channels/moltzap.ts → constructor)    │
-  └────────────────────────────┬────────────────────────────────────────┘
-                               │
-              ┌────────────────┼────────────────┐
-              │                │                │
-              ▼                ▼                ▼
-    core.onInbound(…)   core.onDisconnect(…)  core.onReconnect(…)
-    registers callback   Effect.runFork(      Effect.runFork(
-    that calls             logWarning +         logInfo +
-    handleInbound(msg)     annotateLogs)        annotateLogs)
-
-  evalMode flag (boolean):
-    false (default) → maybeAutoRegister() is a no-op
-    true            → maybeAutoRegister() calls ensureAutoRegistered()
-                      (smoke-test eval-pipeline convenience, §3.6)
+    H --> L{"evalMode flag"}
+    L -->|"false (default)"| M["maybeAutoRegister() is a no-op"]
+    L -->|"true"| N["maybeAutoRegister() calls ensureAutoRegistered()\n(smoke-test eval-pipeline convenience, §3.6)"]
 ```
 
 ---

--- a/packages/nanoclaw-channel/docs/architecture/01-construction-and-registry.md
+++ b/packages/nanoclaw-channel/docs/architecture/01-construction-and-registry.md
@@ -18,23 +18,23 @@ phases: import time (registry registration) and instantiation time
 
 ```mermaid
 flowchart TD
-    A["MODULE LOAD\nimport &quot;channels/moltzap.ts&quot;"]
+    A["MODULE LOAD<br>import &quot;channels/moltzap.ts&quot;"]
     A -->|"channels/moltzap.ts → registerChannel call"| B["registerChannel(&quot;moltzap&quot;, factory)"]
-    B -->|"channels/registry.ts → registeredChannelFactories.set"| C["registeredChannelFactories.set(&quot;moltzap&quot;, factory)\n(idempotent: if same factory ref already stored, skip)"]
+    B -->|"channels/registry.ts → registeredChannelFactories.set"| C["registeredChannelFactories.set(&quot;moltzap&quot;, factory)<br>(idempotent: if same factory ref already stored, skip)"]
 
-    D["INSTANTIATION\n(factory called, or test calls new MoltZapChannel)"]
-    D -->|"channels/moltzap.ts → loadMoltZapChannelEnv"| E["loadMoltZapChannelEnv()\nConfig.all({ apiKey, serverUrl, evalMode })\nConfigProvider.fromEnv()\nMOLTZAP_API_KEY → Option&lt;Redacted&gt;\nMOLTZAP_SERVER_URL → string (default: wss://api.moltzap.xyz)\nMOLTZAP_EVAL_MODE → &quot;0&quot;|&quot;1&quot; (default: &quot;0&quot;)\nEffect.runSync (blocks; env is stable at load time)"]
+    D["INSTANTIATION<br>(factory called, or test calls new MoltZapChannel)"]
+    D -->|"channels/moltzap.ts → loadMoltZapChannelEnv"| E["loadMoltZapChannelEnv()<br>Config.all({ apiKey, serverUrl, evalMode })<br>ConfigProvider.fromEnv()<br>MOLTZAP_API_KEY → Option&lt;Redacted&gt;<br>MOLTZAP_SERVER_URL → string (default: wss://api.moltzap.xyz)<br>MOLTZAP_EVAL_MODE → &quot;0&quot;|&quot;1&quot; (default: &quot;0&quot;)<br>Effect.runSync (blocks; env is stable at load time)"]
     E -->|"apiKey absent"| F["return null (no channel)"]
-    E -->|"apiKey present"| G["new MoltZapService({ serverUrl, agentKey: apiKey })\nnew MoltZapChannelCore({ service })\nnew MoltZapChannel(opts, core, service.ownAgentId, evalMode)"]
+    E -->|"apiKey present"| G["new MoltZapService({ serverUrl, agentKey: apiKey })<br>new MoltZapChannelCore({ service })<br>new MoltZapChannel(opts, core, service.ownAgentId, evalMode)"]
 
-    G --> H["MoltZapChannel CONSTRUCTOR\n(channels/moltzap.ts → constructor)"]
-    H --> I["core.onInbound(…)\nregisters callback\nthat calls handleInbound(msg)"]
-    H --> J["core.onDisconnect(…)\nEffect.runFork(\n  logWarning + annotateLogs)"]
-    H --> K["core.onReconnect(…)\nEffect.runFork(\n  logInfo + annotateLogs)"]
+    G --> H["MoltZapChannel CONSTRUCTOR<br>(channels/moltzap.ts → constructor)"]
+    H --> I["core.onInbound(…)<br>registers callback<br>that calls handleInbound(msg)"]
+    H --> J["core.onDisconnect(…)<br>Effect.runFork(<br>  logWarning + annotateLogs)"]
+    H --> K["core.onReconnect(…)<br>Effect.runFork(<br>  logInfo + annotateLogs)"]
 
     H --> L{"evalMode flag"}
     L -->|"false (default)"| M["maybeAutoRegister() is a no-op"]
-    L -->|"true"| N["maybeAutoRegister() calls ensureAutoRegistered()\n(smoke-test eval-pipeline convenience, §3.6)"]
+    L -->|"true"| N["maybeAutoRegister() calls ensureAutoRegistered()<br>(smoke-test eval-pipeline convenience, §3.6)"]
 ```
 
 ---

--- a/packages/nanoclaw-channel/docs/architecture/01-construction-and-registry.md
+++ b/packages/nanoclaw-channel/docs/architecture/01-construction-and-registry.md
@@ -1,0 +1,75 @@
+# Channel Construction + registerChannel Hook
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+The module-load side effect and constructor wiring happen in two distinct
+phases: import time (registry registration) and instantiation time
+(hook wiring inside `MoltZapChannel`).
+
+**What nanoclaw does NOT have here vs openclaw-channel:**
+- No persistence layer — no SQLite or event-log writes on connect.
+- No group-sync RPC — `syncGroups()` is not implemented (method absent
+  from the `Channel` interface stub in `types.ts`).
+- No `setTyping()` implementation.
+- The registry is a minimal stub (`channels/registry.ts`), not nanoclaw's
+  real channel registry; `registeredChannelFactories` is only used in
+  tests — the factory is never invoked by nanoclaw's router in this
+  package.
+
+```
+  ┌─────────────────────────────────────────────────────────────────────┐
+  │  MODULE LOAD (import "channels/moltzap.ts")                         │
+  └────────────────────────────┬────────────────────────────────────────┘
+                               │
+                               │ channels/moltzap.ts → registerChannel call
+                               ▼
+              registerChannel("moltzap", factory)
+                               │
+                               │ channels/registry.ts → registeredChannelFactories.set
+                               ▼
+       registeredChannelFactories.set("moltzap", factory)
+       ┌── idempotent: if same factory ref already stored, skip ──┐
+
+
+  ┌─────────────────────────────────────────────────────────────────────┐
+  │  INSTANTIATION (factory called, or test calls new MoltZapChannel)   │
+  └────────────────────────────┬────────────────────────────────────────┘
+                               │
+                               │ channels/moltzap.ts → loadMoltZapChannelEnv
+                               ▼
+                  loadMoltZapChannelEnv()
+                  ┌─ Config.all({ apiKey, serverUrl, evalMode })
+                  │  ConfigProvider.fromEnv()
+                  │  MOLTZAP_API_KEY  → Option<Redacted>
+                  │  MOLTZAP_SERVER_URL → string (default: wss://api.moltzap.xyz)
+                  │  MOLTZAP_EVAL_MODE → "0"|"1" (default: "0")
+                  └─ Effect.runSync (blocks; env is stable at load time)
+
+                               │  apiKey absent → return null (no channel)
+                               │  apiKey present ↓
+                               ▼
+              new MoltZapService({ serverUrl, agentKey: apiKey })
+              new MoltZapChannelCore({ service })
+              new MoltZapChannel(opts, core, service.ownAgentId, evalMode)
+
+  ┌─────────────────────────────────────────────────────────────────────┐
+  │  MoltZapChannel CONSTRUCTOR  (channels/moltzap.ts → constructor)    │
+  └────────────────────────────┬────────────────────────────────────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+              ▼                ▼                ▼
+    core.onInbound(…)   core.onDisconnect(…)  core.onReconnect(…)
+    registers callback   Effect.runFork(      Effect.runFork(
+    that calls             logWarning +         logInfo +
+    handleInbound(msg)     annotateLogs)        annotateLogs)
+
+  evalMode flag (boolean):
+    false (default) → maybeAutoRegister() is a no-op
+    true            → maybeAutoRegister() calls ensureAutoRegistered()
+                      (smoke-test eval-pipeline convenience, §3.6)
+```
+
+---
+
+Next: [02 — connect / disconnect Lifecycle](./02-connect-disconnect-lifecycle.md)

--- a/packages/nanoclaw-channel/docs/architecture/02-connect-disconnect-lifecycle.md
+++ b/packages/nanoclaw-channel/docs/architecture/02-connect-disconnect-lifecycle.md
@@ -23,15 +23,15 @@ sequenceDiagram
     Note over Caller,Core: disconnect()
     Caller->>Channel: channel.disconnect()
     Channel->>Core: Effect.runPromise(core.disconnect())
-    Note over Core: Effect never fails; resolves after WS close
+    Note over Core: Effect never fails— resolves after WS close
     Core-->>Channel: resolved
     Channel-->>Caller: resolves
     Note over Channel: channel.isConnected() → false
-    Note over Channel: disconnect does NOT clear dispatchLeasesByJid — lease entries survive across reconnects (intentional; server owns lease state; stale local entries are harmless because a second send hits the CONSUMED server path and surfaces MoltZapChannelError, §3.4)
+    Note over Channel: disconnect does NOT clear dispatchLeasesByJid — lease entries survive across reconnects (intentional— server owns lease state— stale local entries are harmless because a second send hits the CONSUMED server path and surfaces MoltZapChannelError, §3.4)
 
     Note over Caller,Core: onDisconnect / onReconnect hooks (wired in constructor)
     Core->>Channel: core detects drop → fires onDisconnect callback
-    Note over Channel: Effect.runFork(logWarning("MoltZap disconnected"))<br/>(fire-and-forget; nanoclaw router sees isConnected() → false)
+    Note over Channel: Effect.runFork(logWarning("MoltZap disconnected"))<br>(fire-and-forget— nanoclaw router sees isConnected() → false)
     Core->>Channel: core re-establishes WS → fires onReconnect callback
     Note over Channel: Effect.runFork(logInfo("MoltZap reconnected"))
 ```

--- a/packages/nanoclaw-channel/docs/architecture/02-connect-disconnect-lifecycle.md
+++ b/packages/nanoclaw-channel/docs/architecture/02-connect-disconnect-lifecycle.md
@@ -1,0 +1,64 @@
+# connect / disconnect Lifecycle
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`connect()` and `disconnect()` are Promise-boundary adapters — they wrap
+Effect values to satisfy nanoclaw's `Channel` interface (see `ownsJid` in
+`types.ts`). The channel does not own any WS socket directly; all transport
+is in `MoltZapChannelCore` (from `@moltzap/client`).
+
+```
+  Caller (nanoclaw router / test harness)
+       │
+       │ channel.connect()                    channels/moltzap.ts → connect()
+       ▼
+  Effect.runPromise(
+    this.core.connect()                       @moltzap/client
+      .pipe(
+        Effect.tap(() =>
+          Effect.logInfo("MoltZap connected")
+            .pipe(Effect.annotateLogs({ channel: "moltzap" }))
+        )
+      )
+  )
+       │
+       │ resolves when WS handshake complete
+       ▼
+  channel.isConnected() → true               (delegates to core.isConnected())
+
+
+  Caller
+       │
+       │ channel.disconnect()                 channels/moltzap.ts → disconnect()
+       ▼
+  Effect.runPromise(this.core.disconnect())
+       │
+       │ Effect never fails; resolves after WS close
+       ▼
+  channel.isConnected() → false
+
+  NOTE: disconnect does NOT clear dispatchLeasesByJid.
+        Lease entries survive across reconnects (intentional —
+        the server owns lease state; stale local entries are harmless
+        because a second send for the same lease hits the CONSUMED
+        server path and surfaces MoltZapChannelError, §3.4).
+
+  onDisconnect / onReconnect hooks (wired in constructor):
+       │ core detects drop
+       ▼
+  core fires onDisconnect callback
+       │
+       ▼  Effect.runFork(logWarning("MoltZap disconnected"))
+          (fire-and-forget; nanoclaw router sees isConnected() → false)
+
+       │ core re-establishes WS
+       ▼
+  core fires onReconnect callback
+       │
+       ▼  Effect.runFork(logInfo("MoltZap reconnected"))
+```
+
+---
+
+Previous: [01 — Channel Construction + registerChannel Hook](./01-construction-and-registry.md)
+Next: [03 — Inbound Flow](./03-inbound-flow.md)

--- a/packages/nanoclaw-channel/docs/architecture/02-connect-disconnect-lifecycle.md
+++ b/packages/nanoclaw-channel/docs/architecture/02-connect-disconnect-lifecycle.md
@@ -7,55 +7,33 @@ Effect values to satisfy nanoclaw's `Channel` interface (see `ownsJid` in
 `types.ts`). The channel does not own any WS socket directly; all transport
 is in `MoltZapChannelCore` (from `@moltzap/client`).
 
-```
-  Caller (nanoclaw router / test harness)
-       │
-       │ channel.connect()                    channels/moltzap.ts → connect()
-       ▼
-  Effect.runPromise(
-    this.core.connect()                       @moltzap/client
-      .pipe(
-        Effect.tap(() =>
-          Effect.logInfo("MoltZap connected")
-            .pipe(Effect.annotateLogs({ channel: "moltzap" }))
-        )
-      )
-  )
-       │
-       │ resolves when WS handshake complete
-       ▼
-  channel.isConnected() → true               (delegates to core.isConnected())
+```mermaid
+sequenceDiagram
+    participant Caller as Caller (nanoclaw router / test harness)
+    participant Channel as MoltZapChannel (channels/moltzap.ts)
+    participant Core as MoltZapChannelCore (@moltzap/client)
 
+    Note over Caller,Core: connect()
+    Caller->>Channel: channel.connect()
+    Channel->>Core: Effect.runPromise(core.connect())
+    Core-->>Channel: WS handshake complete
+    Channel-->>Caller: resolves
+    Note over Channel: channel.isConnected() → true (delegates to core.isConnected())
 
-  Caller
-       │
-       │ channel.disconnect()                 channels/moltzap.ts → disconnect()
-       ▼
-  Effect.runPromise(this.core.disconnect())
-       │
-       │ Effect never fails; resolves after WS close
-       ▼
-  channel.isConnected() → false
+    Note over Caller,Core: disconnect()
+    Caller->>Channel: channel.disconnect()
+    Channel->>Core: Effect.runPromise(core.disconnect())
+    Note over Core: Effect never fails; resolves after WS close
+    Core-->>Channel: resolved
+    Channel-->>Caller: resolves
+    Note over Channel: channel.isConnected() → false
+    Note over Channel: disconnect does NOT clear dispatchLeasesByJid — lease entries survive across reconnects (intentional; server owns lease state; stale local entries are harmless because a second send hits the CONSUMED server path and surfaces MoltZapChannelError, §3.4)
 
-  NOTE: disconnect does NOT clear dispatchLeasesByJid.
-        Lease entries survive across reconnects (intentional —
-        the server owns lease state; stale local entries are harmless
-        because a second send for the same lease hits the CONSUMED
-        server path and surfaces MoltZapChannelError, §3.4).
-
-  onDisconnect / onReconnect hooks (wired in constructor):
-       │ core detects drop
-       ▼
-  core fires onDisconnect callback
-       │
-       ▼  Effect.runFork(logWarning("MoltZap disconnected"))
-          (fire-and-forget; nanoclaw router sees isConnected() → false)
-
-       │ core re-establishes WS
-       ▼
-  core fires onReconnect callback
-       │
-       ▼  Effect.runFork(logInfo("MoltZap reconnected"))
+    Note over Caller,Core: onDisconnect / onReconnect hooks (wired in constructor)
+    Core->>Channel: core detects drop → fires onDisconnect callback
+    Note over Channel: Effect.runFork(logWarning("MoltZap disconnected"))<br/>(fire-and-forget; nanoclaw router sees isConnected() → false)
+    Core->>Channel: core re-establishes WS → fires onReconnect callback
+    Note over Channel: Effect.runFork(logInfo("MoltZap reconnected"))
 ```
 
 ---

--- a/packages/nanoclaw-channel/docs/architecture/03-inbound-flow.md
+++ b/packages/nanoclaw-channel/docs/architecture/03-inbound-flow.md
@@ -1,0 +1,66 @@
+# Inbound Flow
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Inbound messages arrive from `MoltZapChannelCore` as
+`EnrichedInboundMessage` objects (enriched by `@moltzap/client` with
+conversation metadata and context blocks). The channel's callback,
+registered in the constructor via `core.onInbound`, runs the full
+inbound pipeline synchronously.
+
+```
+  MoltZapChannelCore (@moltzap/client)
+       │
+       │ WS frame arrives; core decodes + enriches message
+       │ fires onInbound callback with EnrichedInboundMessage:
+       │   { id, conversationId, sender, text, createdAt,
+       │     dispatchLeaseId?, replyToId?,
+       │     conversationMeta?: { type, name, participants },
+       │     contextBlocks: { crossConversationMessages?, groupMetadata? },
+       │     isFromMe }
+       │
+       │ channels/moltzap.ts → onInbound handler (wired via core.onInbound)
+       ▼
+  Effect.sync(() => this.handleInbound(msg))
+  └── handleInbound(enriched)               channels/moltzap.ts → handleInbound
+
+         │
+         ├─1─▶ chatJid = jidFromConversationId(enriched.conversationId)
+         │        "mz:" + conversationId            (§3.5)
+         │
+         ├─2─▶ rememberDispatchLease(chatJid, enriched)
+         │        channels/moltzap.ts → rememberDispatchLease
+         │        if enriched.dispatchLeaseId:
+         │          dispatchLeasesByJid.set(chatJid, leaseId)
+         │        ┌────────────────────────────────────────────┐
+         │        │  dispatchLeasesByJid : Map<jid, leaseId>   │
+         │        │  keyed by chatJid (not conversationId)     │
+         │        │  value = LAST inbound lease for that jid   │
+         │        │  NOT cleared on send (post-cutover #533)   │
+         │        └────────────────────────────────────────────┘
+         │
+         ├─3─▶ maybeAutoRegister(chatJid, conversationId)
+         │        channels/moltzap.ts → maybeAutoRegister
+         │        evalMode=false → skip
+         │        evalMode=true  → ensureAutoRegistered()  (§3.6)
+         │
+         ├─4─▶ emitChatMetadata(chatJid, enriched)
+         │        channels/moltzap.ts → emitChatMetadata
+         │        opts.onChatMetadata({
+         │          chatJid, timestamp: enriched.createdAt,
+         │          name: enriched.conversationMeta?.name,
+         │          channel: "moltzap",
+         │          isGroup: conversationMeta?.type === "group"
+         │        })
+         │        ← nanoclaw router receives ChatMetadata BEFORE message
+         │          (test: "emitsMetadataBeforeMessage")
+         │
+         └─5─▶ opts.onMessage(chatJid, toNewMessage(chatJid, enriched))
+                  channels/moltzap.ts → toNewMessage call
+                  → NewMessage projection  (§3.7)
+```
+
+---
+
+Previous: [02 — connect / disconnect Lifecycle](./02-connect-disconnect-lifecycle.md)
+Next: [04 — Outbound sendMessage Flow](./04-outbound-send-message.md)

--- a/packages/nanoclaw-channel/docs/architecture/03-inbound-flow.md
+++ b/packages/nanoclaw-channel/docs/architecture/03-inbound-flow.md
@@ -8,56 +8,26 @@ conversation metadata and context blocks). The channel's callback,
 registered in the constructor via `core.onInbound`, runs the full
 inbound pipeline synchronously.
 
-```
-  MoltZapChannelCore (@moltzap/client)
-       │
-       │ WS frame arrives; core decodes + enriches message
-       │ fires onInbound callback with EnrichedInboundMessage:
-       │   { id, conversationId, sender, text, createdAt,
-       │     dispatchLeaseId?, replyToId?,
-       │     conversationMeta?: { type, name, participants },
-       │     contextBlocks: { crossConversationMessages?, groupMetadata? },
-       │     isFromMe }
-       │
-       │ channels/moltzap.ts → onInbound handler (wired via core.onInbound)
-       ▼
-  Effect.sync(() => this.handleInbound(msg))
-  └── handleInbound(enriched)               channels/moltzap.ts → handleInbound
+```mermaid
+sequenceDiagram
+    participant Core as MoltZapChannelCore (@moltzap/client)
+    participant Handler as handleInbound (channels/moltzap.ts)
+    participant Router as nanoclaw router
 
-         │
-         ├─1─▶ chatJid = jidFromConversationId(enriched.conversationId)
-         │        "mz:" + conversationId            (§3.5)
-         │
-         ├─2─▶ rememberDispatchLease(chatJid, enriched)
-         │        channels/moltzap.ts → rememberDispatchLease
-         │        if enriched.dispatchLeaseId:
-         │          dispatchLeasesByJid.set(chatJid, leaseId)
-         │        ┌────────────────────────────────────────────┐
-         │        │  dispatchLeasesByJid : Map<jid, leaseId>   │
-         │        │  keyed by chatJid (not conversationId)     │
-         │        │  value = LAST inbound lease for that jid   │
-         │        │  NOT cleared on send (post-cutover #533)   │
-         │        └────────────────────────────────────────────┘
-         │
-         ├─3─▶ maybeAutoRegister(chatJid, conversationId)
-         │        channels/moltzap.ts → maybeAutoRegister
-         │        evalMode=false → skip
-         │        evalMode=true  → ensureAutoRegistered()  (§3.6)
-         │
-         ├─4─▶ emitChatMetadata(chatJid, enriched)
-         │        channels/moltzap.ts → emitChatMetadata
-         │        opts.onChatMetadata({
-         │          chatJid, timestamp: enriched.createdAt,
-         │          name: enriched.conversationMeta?.name,
-         │          channel: "moltzap",
-         │          isGroup: conversationMeta?.type === "group"
-         │        })
-         │        ← nanoclaw router receives ChatMetadata BEFORE message
-         │          (test: "emitsMetadataBeforeMessage")
-         │
-         └─5─▶ opts.onMessage(chatJid, toNewMessage(chatJid, enriched))
-                  channels/moltzap.ts → toNewMessage call
-                  → NewMessage projection  (§3.7)
+    Core->>Handler: WS frame arrives; core decodes + enriches<br/>fires onInbound callback with EnrichedInboundMessage:<br/>{ id, conversationId, sender, text, createdAt,<br/>  dispatchLeaseId?, replyToId?,<br/>  conversationMeta?: { type, name, participants },<br/>  contextBlocks: { crossConversationMessages?, groupMetadata? },<br/>  isFromMe }
+    Note over Handler: Effect.sync(() =&gt; this.handleInbound(msg))
+
+    Note over Handler: Step 1 — jidFromConversationId(enriched.conversationId)<br/>chatJid = "mz:" + conversationId (§3.5)
+
+    Note over Handler: Step 2 — rememberDispatchLease(chatJid, enriched)<br/>if enriched.dispatchLeaseId:<br/>  dispatchLeasesByJid.set(chatJid, leaseId)
+
+    Note over Handler: dispatchLeasesByJid : Map&lt;jid, leaseId&gt;<br/>keyed by chatJid (not conversationId)<br/>value = LAST inbound lease for that jid<br/>NOT cleared on send (post-cutover #533)
+
+    Note over Handler: Step 3 — maybeAutoRegister(chatJid, conversationId)<br/>evalMode=false → skip<br/>evalMode=true  → ensureAutoRegistered() (§3.6)
+
+    Handler->>Router: Step 4 — opts.onChatMetadata({<br/>  chatJid, timestamp: enriched.createdAt,<br/>  name: enriched.conversationMeta?.name,<br/>  channel: "moltzap",<br/>  isGroup: conversationMeta?.type === "group"<br/>})<br/>nanoclaw router receives ChatMetadata BEFORE message<br/>(test: "emitsMetadataBeforeMessage")
+
+    Handler->>Router: Step 5 — opts.onMessage(chatJid, toNewMessage(chatJid, enriched))<br/>→ NewMessage projection (§3.7)
 ```
 
 ---

--- a/packages/nanoclaw-channel/docs/architecture/03-inbound-flow.md
+++ b/packages/nanoclaw-channel/docs/architecture/03-inbound-flow.md
@@ -14,20 +14,20 @@ sequenceDiagram
     participant Handler as handleInbound (channels/moltzap.ts)
     participant Router as nanoclaw router
 
-    Core->>Handler: WS frame arrives; core decodes + enriches<br/>fires onInbound callback with EnrichedInboundMessage:<br/>{ id, conversationId, sender, text, createdAt,<br/>  dispatchLeaseId?, replyToId?,<br/>  conversationMeta?: { type, name, participants },<br/>  contextBlocks: { crossConversationMessages?, groupMetadata? },<br/>  isFromMe }
-    Note over Handler: Effect.sync(() =&gt; this.handleInbound(msg))
+    Core->>Handler: WS frame arrives— core decodes + enriches<br>fires onInbound callback with EnrichedInboundMessage:<br>{ id, conversationId, sender, text, createdAt,<br>  dispatchLeaseId?, replyToId?,<br>  conversationMeta?: { type, name, participants },<br>  contextBlocks: { crossConversationMessages?, groupMetadata? },<br>  isFromMe }
+    Note over Handler: Effect.sync(() => this.handleInbound(msg))
 
-    Note over Handler: Step 1 — jidFromConversationId(enriched.conversationId)<br/>chatJid = "mz:" + conversationId (§3.5)
+    Note over Handler: Step 1 — jidFromConversationId(enriched.conversationId)<br>chatJid = "mz:" + conversationId (§3.5)
 
-    Note over Handler: Step 2 — rememberDispatchLease(chatJid, enriched)<br/>if enriched.dispatchLeaseId:<br/>  dispatchLeasesByJid.set(chatJid, leaseId)
+    Note over Handler: Step 2 — rememberDispatchLease(chatJid, enriched)<br>if enriched.dispatchLeaseId:<br>  dispatchLeasesByJid.set(chatJid, leaseId)
 
-    Note over Handler: dispatchLeasesByJid : Map&lt;jid, leaseId&gt;<br/>keyed by chatJid (not conversationId)<br/>value = LAST inbound lease for that jid<br/>NOT cleared on send (post-cutover #533)
+    Note over Handler: dispatchLeasesByJid : Map<jid, leaseId><br>keyed by chatJid (not conversationId)<br>value = LAST inbound lease for that jid<br>NOT cleared on send (post-cutover #533)
 
-    Note over Handler: Step 3 — maybeAutoRegister(chatJid, conversationId)<br/>evalMode=false → skip<br/>evalMode=true  → ensureAutoRegistered() (§3.6)
+    Note over Handler: Step 3 — maybeAutoRegister(chatJid, conversationId)<br>evalMode=false → skip<br>evalMode=true  → ensureAutoRegistered() (§3.6)
 
-    Handler->>Router: Step 4 — opts.onChatMetadata({<br/>  chatJid, timestamp: enriched.createdAt,<br/>  name: enriched.conversationMeta?.name,<br/>  channel: "moltzap",<br/>  isGroup: conversationMeta?.type === "group"<br/>})<br/>nanoclaw router receives ChatMetadata BEFORE message<br/>(test: "emitsMetadataBeforeMessage")
+    Handler->>Router: Step 4 — opts.onChatMetadata({<br>  chatJid, timestamp: enriched.createdAt,<br>  name: enriched.conversationMeta?.name,<br>  channel: "moltzap",<br>  isGroup: conversationMeta?.type === "group"<br>})<br>nanoclaw router receives ChatMetadata BEFORE message<br>(test: "emitsMetadataBeforeMessage")
 
-    Handler->>Router: Step 5 — opts.onMessage(chatJid, toNewMessage(chatJid, enriched))<br/>→ NewMessage projection (§3.7)
+    Handler->>Router: Step 5 — opts.onMessage(chatJid, toNewMessage(chatJid, enriched))<br>→ NewMessage projection (§3.7)
 ```
 
 ---

--- a/packages/nanoclaw-channel/docs/architecture/04-outbound-send-message.md
+++ b/packages/nanoclaw-channel/docs/architecture/04-outbound-send-message.md
@@ -6,62 +6,31 @@
 most recent dispatch lease for the JID, and calls `core.sendReply`.
 Single-use lease semantics are enforced server-side (cutover #533).
 
+```mermaid
+flowchart TD
+    A["Caller (nanoclaw router)\nchannel.sendMessage(jid, text)"]
+    A -->|"channels/moltzap.ts → sendMessage"| B["Effect.runPromise(Effect.gen(...))"]
+
+    B --> C{"ownsJid(jid)?\nchannels/moltzap.ts → ownsJid guard"}
+    C -->|"false"| D["Effect.fail(\n  MoltZapChannelError({ reason: &quot;...does not own jid: &lt;jid&gt;&quot; })\n)\n← rejects immediately; no network call"]
+    C -->|"true"| E["leaseId = dispatchLeasesByJid.get(jid)\nchannels/moltzap.ts → lease lookup"]
+
+    E -->|"present"| F["leaseOpts = { dispatchLeaseId: leaseId }"]
+    E -->|"absent"| G["leaseOpts = {}\n(unleased send; server accepts, no moderation\nobservability — valid for sends before first inbound)"]
+
+    F --> H["core.sendReply(\n  conversationIdFromJid(jid),\n  text,\n  leaseOpts\n)\nstrips &quot;mz:&quot; prefix (§3.5)"]
+    G --> H
+
+    H -->|"RpcServerError(reason=&quot;LeaseInvalid&quot;)"| I["MoltZapChannelError({ reason: &quot;lease already consumed&quot; })"]
+    H -->|"other ServiceRpcError"| J["re-raise err unchanged"]
+    H -->|"success"| K["resolves\n(dispatchLeasesByJid entry KEPT after send —\nsecond send re-uses consumed leaseId → LeaseInvalid)"]
 ```
-  Caller (nanoclaw router)
-       │
-       │ channel.sendMessage(jid, text)       channels/moltzap.ts → sendMessage
-       ▼
-  Effect.runPromise(
-    Effect.gen(this, function* () {
 
-      ── ownership guard ──────────────────────────────────────────────
-      if (!this.ownsJid(jid))                 channels/moltzap.ts → ownsJid guard
-        yield* Effect.fail(
-          new MoltZapChannelError({ reason: "...does not own jid: <jid>" })
-        )   ← rejects immediately; no network call
+**Error taxonomy:**
 
-      ── lease lookup ─────────────────────────────────────────────────
-      leaseId = dispatchLeasesByJid.get(jid)  channels/moltzap.ts → lease lookup
-        present  → { dispatchLeaseId: leaseId }
-        absent   → {}  (unleased send; server accepts, no moderation
-                        observability — valid for sends before first inbound)
-
-      ── send ─────────────────────────────────────────────────────────
-      yield* this.core.sendReply(             channels/moltzap.ts → core.sendReply
-        conversationIdFromJid(jid),           strips "mz:" prefix (§3.5)
-        text,
-        leaseOpts
-      ).pipe(
-        Effect.mapError(
-          (err: ServiceRpcError) => {
-            if err instanceof RpcServerError
-               && err.data.reason === "LeaseInvalid"
-              → new MoltZapChannelError({ reason: "lease already consumed" })
-            else
-              → re-raise err unchanged
-          }
-        )
-      )
-
-      ── NO lease eviction ────────────────────────────────────────────
-      // dispatchLeasesByJid entry is KEPT after send
-      // Second sendMessage for same jid re-sends the consumed leaseId
-      // → server returns RpcServerError(data.reason="LeaseInvalid")
-      // → mapError converts to MoltZapChannelError("lease already consumed")
-
-    })
-  )
-
-  Error taxonomy:
-  ┌────────────────────────────────────────────────────────────────────┐
-  │ MoltZapChannelError("...does not own jid...")                      │
-  │   → ownsJid() returned false (wrong channel prefix)               │
-  │ MoltZapChannelError("lease already consumed")                      │
-  │   → server returned RpcServerError(reason="LeaseInvalid")         │
-  │ ServiceRpcError (other)                                            │
-  │   → transport / auth / network errors; propagated as-is           │
-  └────────────────────────────────────────────────────────────────────┘
-```
+- `MoltZapChannelError("...does not own jid...")` — `ownsJid()` returned false (wrong channel prefix)
+- `MoltZapChannelError("lease already consumed")` — server returned `RpcServerError(reason="LeaseInvalid")`
+- `ServiceRpcError` (other) — transport / auth / network errors; propagated as-is
 
 ---
 

--- a/packages/nanoclaw-channel/docs/architecture/04-outbound-send-message.md
+++ b/packages/nanoclaw-channel/docs/architecture/04-outbound-send-message.md
@@ -1,0 +1,69 @@
+# Outbound sendMessage Flow
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`sendMessage` is the reply path. It enforces JID ownership, looks up the
+most recent dispatch lease for the JID, and calls `core.sendReply`.
+Single-use lease semantics are enforced server-side (cutover #533).
+
+```
+  Caller (nanoclaw router)
+       │
+       │ channel.sendMessage(jid, text)       channels/moltzap.ts → sendMessage
+       ▼
+  Effect.runPromise(
+    Effect.gen(this, function* () {
+
+      ── ownership guard ──────────────────────────────────────────────
+      if (!this.ownsJid(jid))                 channels/moltzap.ts → ownsJid guard
+        yield* Effect.fail(
+          new MoltZapChannelError({ reason: "...does not own jid: <jid>" })
+        )   ← rejects immediately; no network call
+
+      ── lease lookup ─────────────────────────────────────────────────
+      leaseId = dispatchLeasesByJid.get(jid)  channels/moltzap.ts → lease lookup
+        present  → { dispatchLeaseId: leaseId }
+        absent   → {}  (unleased send; server accepts, no moderation
+                        observability — valid for sends before first inbound)
+
+      ── send ─────────────────────────────────────────────────────────
+      yield* this.core.sendReply(             channels/moltzap.ts → core.sendReply
+        conversationIdFromJid(jid),           strips "mz:" prefix (§3.5)
+        text,
+        leaseOpts
+      ).pipe(
+        Effect.mapError(
+          (err: ServiceRpcError) => {
+            if err instanceof RpcServerError
+               && err.data.reason === "LeaseInvalid"
+              → new MoltZapChannelError({ reason: "lease already consumed" })
+            else
+              → re-raise err unchanged
+          }
+        )
+      )
+
+      ── NO lease eviction ────────────────────────────────────────────
+      // dispatchLeasesByJid entry is KEPT after send
+      // Second sendMessage for same jid re-sends the consumed leaseId
+      // → server returns RpcServerError(data.reason="LeaseInvalid")
+      // → mapError converts to MoltZapChannelError("lease already consumed")
+
+    })
+  )
+
+  Error taxonomy:
+  ┌────────────────────────────────────────────────────────────────────┐
+  │ MoltZapChannelError("...does not own jid...")                      │
+  │   → ownsJid() returned false (wrong channel prefix)               │
+  │ MoltZapChannelError("lease already consumed")                      │
+  │   → server returned RpcServerError(reason="LeaseInvalid")         │
+  │ ServiceRpcError (other)                                            │
+  │   → transport / auth / network errors; propagated as-is           │
+  └────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+Previous: [03 — Inbound Flow](./03-inbound-flow.md)
+Next: [05 — JID Conversions](./05-jid-conversions.md)

--- a/packages/nanoclaw-channel/docs/architecture/04-outbound-send-message.md
+++ b/packages/nanoclaw-channel/docs/architecture/04-outbound-send-message.md
@@ -8,22 +8,22 @@ Single-use lease semantics are enforced server-side (cutover #533).
 
 ```mermaid
 flowchart TD
-    A["Caller (nanoclaw router)\nchannel.sendMessage(jid, text)"]
+    A["Caller (nanoclaw router)<br>channel.sendMessage(jid, text)"]
     A -->|"channels/moltzap.ts → sendMessage"| B["Effect.runPromise(Effect.gen(...))"]
 
-    B --> C{"ownsJid(jid)?\nchannels/moltzap.ts → ownsJid guard"}
-    C -->|"false"| D["Effect.fail(\n  MoltZapChannelError({ reason: &quot;...does not own jid: &lt;jid&gt;&quot; })\n)\n← rejects immediately; no network call"]
-    C -->|"true"| E["leaseId = dispatchLeasesByJid.get(jid)\nchannels/moltzap.ts → lease lookup"]
+    B --> C{"ownsJid(jid)?<br>channels/moltzap.ts → ownsJid guard"}
+    C -->|"false"| D["Effect.fail(<br>  MoltZapChannelError({ reason: &quot;...does not own jid: &lt;jid&gt;&quot; })<br>)<br>← rejects immediately; no network call"]
+    C -->|"true"| E["leaseId = dispatchLeasesByJid.get(jid)<br>channels/moltzap.ts → lease lookup"]
 
     E -->|"present"| F["leaseOpts = { dispatchLeaseId: leaseId }"]
-    E -->|"absent"| G["leaseOpts = {}\n(unleased send; server accepts, no moderation\nobservability — valid for sends before first inbound)"]
+    E -->|"absent"| G["leaseOpts = {}<br>(unleased send; server accepts, no moderation<br>observability — valid for sends before first inbound)"]
 
-    F --> H["core.sendReply(\n  conversationIdFromJid(jid),\n  text,\n  leaseOpts\n)\nstrips &quot;mz:&quot; prefix (§3.5)"]
+    F --> H["core.sendReply(<br>  conversationIdFromJid(jid),<br>  text,<br>  leaseOpts<br>)<br>strips &quot;mz:&quot; prefix (§3.5)"]
     G --> H
 
     H -->|"RpcServerError(reason=&quot;LeaseInvalid&quot;)"| I["MoltZapChannelError({ reason: &quot;lease already consumed&quot; })"]
     H -->|"other ServiceRpcError"| J["re-raise err unchanged"]
-    H -->|"success"| K["resolves\n(dispatchLeasesByJid entry KEPT after send —\nsecond send re-uses consumed leaseId → LeaseInvalid)"]
+    H -->|"success"| K["resolves<br>(dispatchLeasesByJid entry KEPT after send —<br>second send re-uses consumed leaseId → LeaseInvalid)"]
 ```
 
 **Error taxonomy:**

--- a/packages/nanoclaw-channel/docs/architecture/05-jid-conversions.md
+++ b/packages/nanoclaw-channel/docs/architecture/05-jid-conversions.md
@@ -5,44 +5,46 @@
 The channel uses a lightweight prefix scheme. There is no registry lookup
 or validation — conversions are pure string operations.
 
+```mermaid
+flowchart TD
+    prefix["MOLTZAP_JID_PREFIX = &quot;mz:&quot;\n(channels/moltzap.ts)"]
+
+    subgraph jidFrom["jidFromConversationId(conversationId)"]
+        direction LR
+        jf1["&quot;01960000-0000-7000-8000-000000000042&quot;"]
+        jf2["&quot;mz:01960000-0000-7000-8000-000000000042&quot;"]
+        jf1 -->|"return &quot;mz:&quot; + conversationId"| jf2
+    end
+
+    subgraph convFrom["conversationIdFromJid(jid)"]
+        direction LR
+        cf1["&quot;mz:01960000-0000-7000-8000-000000000042&quot;"]
+        cf2["&quot;01960000-0000-7000-8000-000000000042&quot;"]
+        cf1 -->|"jid.slice(3)"| cf2
+    end
+
+    subgraph owns["ownsJid(jid)"]
+        direction LR
+        o1["&quot;mz:anything&quot; → true"]
+        o2["&quot;tg:1234&quot; → false"]
+        o3["&quot;wa:5551234&quot; → false"]
+        o4["&quot;conv-raw&quot; → false"]
+    end
+
+    prefix --> jidFrom
+    prefix --> convFrom
+    prefix --> owns
+
+    jidFrom -->|"call site"| cs1["handleInbound (inbound path, §3.3)"]
+    convFrom -->|"call site"| cs2["sendMessage (outbound path, §3.4)"]
+    owns -->|"call sites"| cs3["sendMessage guard + nanoclaw router dispatch"]
 ```
-  CONSTANT
-    MOLTZAP_JID_PREFIX = "mz:"                channels/moltzap.ts → MOLTZAP_JID_PREFIX
 
-  jidFromConversationId(conversationId)        channels/moltzap.ts → jidFromConversationId
-    return "mz:" + conversationId
-
-    Example:
-      "01960000-0000-7000-8000-000000000042"
-      → "mz:01960000-0000-7000-8000-000000000042"
-
-  conversationIdFromJid(jid)                   channels/moltzap.ts → conversationIdFromJid
-    return jid.slice("mz:".length)   // slice(3)
-
-    Example:
-      "mz:01960000-0000-7000-8000-000000000042"
-      → "01960000-0000-7000-8000-000000000042"
-
-  ownsJid(jid)                                 channels/moltzap.ts → ownsJid
-    return jid.startsWith("mz:")
-
-    "mz:anything"  → true
-    "tg:1234"      → false
-    "wa:5551234"   → false
-    "conv-raw"     → false
-
-  Why no regex?
-    The conversationId is a server-issued UUID. Slice is O(1), the prefix
-    is fixed, and there is no ambiguity — no other channel registered in
-    this package uses the "mz:" prefix. openclaw-channel uses the same
-    scheme; the smoke-test package intentionally mirrors it to catch
-    prefix-collision regressions.
-
-  Call sites:
-    jidFromConversationId  → handleInbound (inbound path, §3.3)
-    conversationIdFromJid  → sendMessage (outbound path, §3.4)
-    ownsJid                → sendMessage guard + nanoclaw router dispatch
-```
+**Why no regex?** The conversationId is a server-issued UUID. Slice is O(1), the prefix
+is fixed, and there is no ambiguity — no other channel registered in
+this package uses the `"mz:"` prefix. openclaw-channel uses the same
+scheme; the smoke-test package intentionally mirrors it to catch
+prefix-collision regressions.
 
 ---
 

--- a/packages/nanoclaw-channel/docs/architecture/05-jid-conversions.md
+++ b/packages/nanoclaw-channel/docs/architecture/05-jid-conversions.md
@@ -7,7 +7,7 @@ or validation — conversions are pure string operations.
 
 ```mermaid
 flowchart TD
-    prefix["MOLTZAP_JID_PREFIX = &quot;mz:&quot;\n(channels/moltzap.ts)"]
+    prefix["MOLTZAP_JID_PREFIX = &quot;mz:&quot;<br>(channels/moltzap.ts)"]
 
     subgraph jidFrom["jidFromConversationId(conversationId)"]
         direction LR

--- a/packages/nanoclaw-channel/docs/architecture/05-jid-conversions.md
+++ b/packages/nanoclaw-channel/docs/architecture/05-jid-conversions.md
@@ -1,0 +1,50 @@
+# JID ↔ ConversationId Conversions
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+The channel uses a lightweight prefix scheme. There is no registry lookup
+or validation — conversions are pure string operations.
+
+```
+  CONSTANT
+    MOLTZAP_JID_PREFIX = "mz:"                channels/moltzap.ts → MOLTZAP_JID_PREFIX
+
+  jidFromConversationId(conversationId)        channels/moltzap.ts → jidFromConversationId
+    return "mz:" + conversationId
+
+    Example:
+      "01960000-0000-7000-8000-000000000042"
+      → "mz:01960000-0000-7000-8000-000000000042"
+
+  conversationIdFromJid(jid)                   channels/moltzap.ts → conversationIdFromJid
+    return jid.slice("mz:".length)   // slice(3)
+
+    Example:
+      "mz:01960000-0000-7000-8000-000000000042"
+      → "01960000-0000-7000-8000-000000000042"
+
+  ownsJid(jid)                                 channels/moltzap.ts → ownsJid
+    return jid.startsWith("mz:")
+
+    "mz:anything"  → true
+    "tg:1234"      → false
+    "wa:5551234"   → false
+    "conv-raw"     → false
+
+  Why no regex?
+    The conversationId is a server-issued UUID. Slice is O(1), the prefix
+    is fixed, and there is no ambiguity — no other channel registered in
+    this package uses the "mz:" prefix. openclaw-channel uses the same
+    scheme; the smoke-test package intentionally mirrors it to catch
+    prefix-collision regressions.
+
+  Call sites:
+    jidFromConversationId  → handleInbound (inbound path, §3.3)
+    conversationIdFromJid  → sendMessage (outbound path, §3.4)
+    ownsJid                → sendMessage guard + nanoclaw router dispatch
+```
+
+---
+
+Previous: [04 — Outbound sendMessage Flow](./04-outbound-send-message.md)
+Next: [06 — Chat Metadata + Auto-Register](./06-chat-metadata-auto-register.md)

--- a/packages/nanoclaw-channel/docs/architecture/06-chat-metadata-auto-register.md
+++ b/packages/nanoclaw-channel/docs/architecture/06-chat-metadata-auto-register.md
@@ -7,55 +7,42 @@
 `ensureAutoRegistered` is an eval-mode-only side effect that mutates
 nanoclaw's live `registeredGroups` map.
 
+```mermaid
+sequenceDiagram
+    participant Handler as handleInbound (channels/moltzap.ts)
+    participant Router as nanoclaw router
+
+    Note over Handler: emitChatMetadata(chatJid, enriched)
+    Handler->>Router: opts.onChatMetadata({<br/>  chatJid,           e.g. "mz:&lt;uuid&gt;"<br/>  timestamp: enriched.createdAt,     ISO-8601 string<br/>  name: enriched.conversationMeta?.name,   undefined for DMs<br/>  channel: "moltzap",<br/>  isGroup: enriched.conversationMeta?.type === "group"<br/>})
+    Note over Router: indexes the chat record;<br/>subsequent message delivery uses this metadata for routing
 ```
-  emitChatMetadata(chatJid, enriched)          channels/moltzap.ts → emitChatMetadata
-       │
-       ▼  opts.onChatMetadata({
-            chatJid,                           e.g. "mz:<uuid>"
-            timestamp: enriched.createdAt,     ISO-8601 string
-            name: enriched.conversationMeta?.name,   undefined for DMs
-            channel: "moltzap",
-            isGroup: enriched.conversationMeta?.type === "group"
-          })
-       │
-       ▼  nanoclaw router indexes the chat record;
-          subsequent message delivery uses this metadata for routing
 
-  ensureAutoRegistered (evalMode=true path)    channels/moltzap.ts → ensureAutoRegistered
-       │
-       ▼  registered = opts.registeredGroups()  // live map reference
-          if registered[chatJid] exists → return immediately (idempotent)
-          else:
-            registered[chatJid] = {
-              name:    "eval-" + conversationId.slice(0, 8),
-              folder:  "eval_" + conversationId.slice(0, 8),
-              trigger: ".*",                   wildcard — fires on any text
-              added_at: new Date().toISOString(),
-              requiresTrigger: false,
-              isMain: true,
-            }
-       │
-       ▼  nanoclaw's router sees the new entry on next poll/deliver
-          (no setter call; mutates the map object nanoclaw owns)
-
-  State machine:
-    ┌──────────────┐  first inbound  ┌──────────────────────────────┐
-    │ unregistered │─────────────────▶ registered (eval-<8chars>,   │
-    │              │  evalMode=true   │ trigger=".*", isMain=true)   │
-    └──────────────┘                 └──────────────────────────────┘
-                                              │
-                                              │ subsequent inbound
-                                              ▼
-                                     registered[chatJid] exists → skip
-
-  What nanoclaw does NOT do here (smoke-test minimalism):
-    - No API call to fetch conversation membership.
-    - No persistent registration store — lives only in the in-process map.
-    - evalMode=false → registeredGroups() is never called; zero coupling
-      to nanoclaw's group system in normal (non-eval) use.
-
-  Constant: EVAL_GROUP_NAME_ID_CHARS = 8      (in channels/moltzap.ts)
+```mermaid
+flowchart TD
+    A["ensureAutoRegistered (evalMode=true path)\nchannels/moltzap.ts → ensureAutoRegistered"]
+    A --> B["registered = opts.registeredGroups()\n(live map reference)"]
+    B --> C{"registered[chatJid] exists?"}
+    C -->|"yes"| D["return immediately (idempotent)"]
+    C -->|"no"| E["registered[chatJid] = {\n  name:    &quot;eval-&quot; + conversationId.slice(0, 8),\n  folder:  &quot;eval_&quot; + conversationId.slice(0, 8),\n  trigger: &quot;.*&quot;,  (wildcard — fires on any text)\n  added_at: new Date().toISOString(),\n  requiresTrigger: false,\n  isMain: true,\n}"]
+    E --> F["nanoclaw router sees new entry on next poll/deliver\n(no setter call; mutates the map object nanoclaw owns)"]
 ```
+
+**Registration state machine:**
+
+```mermaid
+stateDiagram-v2
+    [*] --> unregistered
+
+    unregistered --> registered : first inbound (evalMode=true)\nregistered[chatJid] = { name: eval-&lt;8chars&gt;, trigger=".*", isMain=true }
+    registered --> registered : subsequent inbound\nregistered[chatJid] exists → skip
+```
+
+**What nanoclaw does NOT do here (smoke-test minimalism):**
+- No API call to fetch conversation membership.
+- No persistent registration store — lives only in the in-process map.
+- `evalMode=false` → `registeredGroups()` is never called; zero coupling to nanoclaw's group system in normal (non-eval) use.
+
+**Constant:** `EVAL_GROUP_NAME_ID_CHARS = 8` (in `channels/moltzap.ts`)
 
 ---
 

--- a/packages/nanoclaw-channel/docs/architecture/06-chat-metadata-auto-register.md
+++ b/packages/nanoclaw-channel/docs/architecture/06-chat-metadata-auto-register.md
@@ -13,18 +13,18 @@ sequenceDiagram
     participant Router as nanoclaw router
 
     Note over Handler: emitChatMetadata(chatJid, enriched)
-    Handler->>Router: opts.onChatMetadata({<br/>  chatJid,           e.g. "mz:&lt;uuid&gt;"<br/>  timestamp: enriched.createdAt,     ISO-8601 string<br/>  name: enriched.conversationMeta?.name,   undefined for DMs<br/>  channel: "moltzap",<br/>  isGroup: enriched.conversationMeta?.type === "group"<br/>})
-    Note over Router: indexes the chat record;<br/>subsequent message delivery uses this metadata for routing
+    Handler->>Router: opts.onChatMetadata({<br>  chatJid,           e.g. "mz:<uuid>"<br>  timestamp: enriched.createdAt,     ISO-8601 string<br>  name: enriched.conversationMeta?.name,   undefined for DMs<br>  channel: "moltzap",<br>  isGroup: enriched.conversationMeta?.type === "group"<br>})
+    Note over Router: indexes the chat record—<br>subsequent message delivery uses this metadata for routing
 ```
 
 ```mermaid
 flowchart TD
-    A["ensureAutoRegistered (evalMode=true path)\nchannels/moltzap.ts → ensureAutoRegistered"]
-    A --> B["registered = opts.registeredGroups()\n(live map reference)"]
+    A["ensureAutoRegistered (evalMode=true path)<br>channels/moltzap.ts → ensureAutoRegistered"]
+    A --> B["registered = opts.registeredGroups()<br>(live map reference)"]
     B --> C{"registered[chatJid] exists?"}
     C -->|"yes"| D["return immediately (idempotent)"]
-    C -->|"no"| E["registered[chatJid] = {\n  name:    &quot;eval-&quot; + conversationId.slice(0, 8),\n  folder:  &quot;eval_&quot; + conversationId.slice(0, 8),\n  trigger: &quot;.*&quot;,  (wildcard — fires on any text)\n  added_at: new Date().toISOString(),\n  requiresTrigger: false,\n  isMain: true,\n}"]
-    E --> F["nanoclaw router sees new entry on next poll/deliver\n(no setter call; mutates the map object nanoclaw owns)"]
+    C -->|"no"| E["registered[chatJid] = {<br>  name:    &quot;eval-&quot; + conversationId.slice(0, 8),<br>  folder:  &quot;eval_&quot; + conversationId.slice(0, 8),<br>  trigger: &quot;.*&quot;,  (wildcard — fires on any text)<br>  added_at: new Date().toISOString(),<br>  requiresTrigger: false,<br>  isMain: true,<br>}"]
+    E --> F["nanoclaw router sees new entry on next poll/deliver<br>(no setter call; mutates the map object nanoclaw owns)"]
 ```
 
 **Registration state machine:**
@@ -33,8 +33,18 @@ flowchart TD
 stateDiagram-v2
     [*] --> unregistered
 
-    unregistered --> registered : first inbound (evalMode=true)\nregistered[chatJid] = { name: eval-&lt;8chars&gt;, trigger=".*", isMain=true }
-    registered --> registered : subsequent inbound\nregistered[chatJid] exists → skip
+    unregistered --> registered : first inbound (evalMode=true)
+    registered --> registered : subsequent inbound — exists, skip
+```
+
+On the `unregistered → registered` transition, the channel writes:
+
+```js
+registered[chatJid] = {
+  name:    "eval-" + conversationId.slice(0, 8),
+  trigger: ".*",
+  isMain:  true,
+}
 ```
 
 **What nanoclaw does NOT do here (smoke-test minimalism):**

--- a/packages/nanoclaw-channel/docs/architecture/06-chat-metadata-auto-register.md
+++ b/packages/nanoclaw-channel/docs/architecture/06-chat-metadata-auto-register.md
@@ -1,0 +1,63 @@
+# emitChatMetadata + ensureAutoRegistered
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`emitChatMetadata` fires on every inbound message, always before
+`onMessage` (enforced by call order in `handleInbound`, §3.3).
+`ensureAutoRegistered` is an eval-mode-only side effect that mutates
+nanoclaw's live `registeredGroups` map.
+
+```
+  emitChatMetadata(chatJid, enriched)          channels/moltzap.ts → emitChatMetadata
+       │
+       ▼  opts.onChatMetadata({
+            chatJid,                           e.g. "mz:<uuid>"
+            timestamp: enriched.createdAt,     ISO-8601 string
+            name: enriched.conversationMeta?.name,   undefined for DMs
+            channel: "moltzap",
+            isGroup: enriched.conversationMeta?.type === "group"
+          })
+       │
+       ▼  nanoclaw router indexes the chat record;
+          subsequent message delivery uses this metadata for routing
+
+  ensureAutoRegistered (evalMode=true path)    channels/moltzap.ts → ensureAutoRegistered
+       │
+       ▼  registered = opts.registeredGroups()  // live map reference
+          if registered[chatJid] exists → return immediately (idempotent)
+          else:
+            registered[chatJid] = {
+              name:    "eval-" + conversationId.slice(0, 8),
+              folder:  "eval_" + conversationId.slice(0, 8),
+              trigger: ".*",                   wildcard — fires on any text
+              added_at: new Date().toISOString(),
+              requiresTrigger: false,
+              isMain: true,
+            }
+       │
+       ▼  nanoclaw's router sees the new entry on next poll/deliver
+          (no setter call; mutates the map object nanoclaw owns)
+
+  State machine:
+    ┌──────────────┐  first inbound  ┌──────────────────────────────┐
+    │ unregistered │─────────────────▶ registered (eval-<8chars>,   │
+    │              │  evalMode=true   │ trigger=".*", isMain=true)   │
+    └──────────────┘                 └──────────────────────────────┘
+                                              │
+                                              │ subsequent inbound
+                                              ▼
+                                     registered[chatJid] exists → skip
+
+  What nanoclaw does NOT do here (smoke-test minimalism):
+    - No API call to fetch conversation membership.
+    - No persistent registration store — lives only in the in-process map.
+    - evalMode=false → registeredGroups() is never called; zero coupling
+      to nanoclaw's group system in normal (non-eval) use.
+
+  Constant: EVAL_GROUP_NAME_ID_CHARS = 8      (in channels/moltzap.ts)
+```
+
+---
+
+Previous: [05 — JID Conversions](./05-jid-conversions.md)
+Next: [07 — toNewMessage Projection](./07-to-new-message-projection.md)

--- a/packages/nanoclaw-channel/docs/architecture/07-to-new-message-projection.md
+++ b/packages/nanoclaw-channel/docs/architecture/07-to-new-message-projection.md
@@ -1,0 +1,80 @@
+# toNewMessage Projection
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`toNewMessage` is a pure function that converts an `EnrichedInboundMessage`
+(the `@moltzap/client` wire shape) into a `NewMessage` (nanoclaw's stored
+message shape, defined in `types.ts`).
+
+```
+  Input: EnrichedInboundMessage  (@moltzap/client)
+    { id, conversationId, sender: { id, name? }, text,
+      createdAt, isFromMe, replyToId?,
+      contextBlocks: { crossConversationMessages?, groupMetadata? } }
+
+  Output: NewMessage  (types.ts → NewMessage)
+    { id, chat_jid, sender, sender_name, content,
+      timestamp, is_from_me, reply_to_message_id? }
+
+  Field mapping:                               channels/moltzap.ts → toNewMessage
+  ┌──────────────────────────┬───────────────────────────────────────────┐
+  │ NewMessage field         │ Source                                    │
+  ├──────────────────────────┼───────────────────────────────────────────┤
+  │ id                       │ enriched.id  (server-assigned UUID)       │
+  │ chat_jid                 │ chatJid param  ("mz:" + conversationId)   │
+  │ sender                   │ enriched.sender.id                        │
+  │ sender_name              │ enriched.sender.name ?? enriched.sender.id│
+  │ content                  │ contentFor(enriched)  ← see below         │
+  │ timestamp                │ enriched.createdAt  (ISO-8601)            │
+  │ is_from_me               │ enriched.isFromMe  (boolean)              │
+  │ reply_to_message_id      │ enriched.replyToId  (optional)            │
+  └──────────────────────────┴───────────────────────────────────────────┘
+
+  Fields NOT populated (nanoclaw interface has them, channel omits them):
+    is_bot_message            → not set (no bot-detection in MoltZap wire)
+    thread_id                 → not set (MoltZap has no threads)
+    reply_to_message_content  → not set (not carried in wire shape)
+    reply_to_sender_name      → not set
+
+  contentFor(enriched)                         channels/moltzap.ts → contentFor
+       │
+       │  Assembles context blocks in order:
+       │
+       ├─1─▶ crossConversationMessages block (if present)
+       │       formatCrossConvNanoclaw(msgs, { ownAgentId })
+       │       → "<messages>\n"
+       │           + "<message sender=\"{name}\" conversation=\"{conv}\""
+       │             + " time=\"{ts}\">{text}</message>\n" per msg
+       │           + "</messages>"
+       │       sender = "You" if senderId === ownAgentId, else senderName
+       │       ALL string fields sanitized via sanitizeForSystemReminder()
+       │       (HTML-entity-encodes <, >, &, " to prevent XML injection)
+       │
+       ├─2─▶ groupMetadata block (if conversationMeta.type === "group")
+       │       formatGroupBlock(meta)
+       │       → "<system-reminder>\n"
+       │           + "This is a group conversation.\n"
+       │           + "Group name: {name}\n"
+       │           + "Participants (N): {p1}, {p2}, ...\n"
+       │           + "</system-reminder>"
+       │       ALL strings sanitized via sanitizeForSystemReminder()
+       │
+       ├─3─▶ if no context blocks → return enriched.text verbatim
+       │
+       └─4─▶ if any blocks → blocks.join("\n\n") + "\n\n" + enriched.text
+               order: crossConv → groupMeta → rawText
+               (test: "ordersContextBlocksBeforeRawText")
+
+  Sanitization contract (sanitizeForSystemReminder from @moltzap/client):
+    Prevents XML injection through user-controlled fields.
+    Tests: "sanitizesGroupMetadata", "sanitizesCrossConversationSenderName"
+    Attack vectors closed:
+      Group name  "Evil</system-reminder><fake>"
+        → "Evil&lt;/system-reminder&gt;&lt;fake&gt;"  (1 open/close tag pair)
+      Sender name 'Mallory</messages><evil attr="x">'
+        → "Mallory&lt;/messages&gt;&lt;evil..."       (1 <messages> pair)
+```
+
+---
+
+Previous: [06 — Chat Metadata + Auto-Register](./06-chat-metadata-auto-register.md)

--- a/packages/nanoclaw-channel/docs/architecture/07-to-new-message-projection.md
+++ b/packages/nanoclaw-channel/docs/architecture/07-to-new-message-projection.md
@@ -40,21 +40,21 @@ message shape, defined in `types.ts`).
 
 ```mermaid
 flowchart TD
-    A["contentFor(enriched)\nchannels/moltzap.ts → contentFor\nAssembles context blocks in order"]
+    A["contentFor(enriched)<br>channels/moltzap.ts → contentFor<br>Assembles context blocks in order"]
 
-    A --> B{"crossConversationMessages\npresent?"}
-    B -->|"yes"| C["formatCrossConvNanoclaw(msgs, { ownAgentId })\n→ &lt;messages&gt;\n    &lt;message sender=&quot;{name}&quot; conversation=&quot;{conv}&quot; time=&quot;{ts}&quot;&gt;{text}&lt;/message&gt;\n  &lt;/messages&gt;\nsender = &quot;You&quot; if senderId === ownAgentId, else senderName\nALL string fields sanitized via sanitizeForSystemReminder()"]
-    B -->|"no"| D{"conversationMeta.type\n=== &quot;group&quot;?"}
+    A --> B{"crossConversationMessages<br>present?"}
+    B -->|"yes"| C["formatCrossConvNanoclaw(msgs, { ownAgentId })<br>→ &lt;messages&gt;<br>    &lt;message sender=&quot;{name}&quot; conversation=&quot;{conv}&quot; time=&quot;{ts}&quot;&gt;{text}&lt;/message&gt;<br>  &lt;/messages&gt;<br>sender = &quot;You&quot; if senderId === ownAgentId, else senderName<br>ALL string fields sanitized via sanitizeForSystemReminder()"]
+    B -->|"no"| D{"conversationMeta.type<br>=== &quot;group&quot;?"}
 
     C --> D
 
-    D -->|"yes"| E["formatGroupBlock(meta)\n→ &lt;system-reminder&gt;\n    This is a group conversation.\n    Group name: {name}\n    Participants (N): {p1}, {p2}, ...\n  &lt;/system-reminder&gt;\nALL strings sanitized via sanitizeForSystemReminder()"]
-    D -->|"no"| F{"any context\nblocks collected?"}
+    D -->|"yes"| E["formatGroupBlock(meta)<br>→ &lt;system-reminder&gt;<br>    This is a group conversation.<br>    Group name: {name}<br>    Participants (N): {p1}, {p2}, ...<br>  &lt;/system-reminder&gt;<br>ALL strings sanitized via sanitizeForSystemReminder()"]
+    D -->|"no"| F{"any context<br>blocks collected?"}
 
     E --> F
 
     F -->|"no"| G["return enriched.text verbatim"]
-    F -->|"yes"| H["blocks.join(&quot;\n\n&quot;) + &quot;\n\n&quot; + enriched.text\norder: crossConv → groupMeta → rawText\n(test: &quot;ordersContextBlocksBeforeRawText&quot;)"]
+    F -->|"yes"| H["blocks.join(&quot;<br><br>&quot;) + &quot;<br><br>&quot; + enriched.text<br>order: crossConv → groupMeta → rawText<br>(test: &quot;ordersContextBlocksBeforeRawText&quot;)"]
 ```
 
 **Sanitization contract** (`sanitizeForSystemReminder` from `@moltzap/client`):

--- a/packages/nanoclaw-channel/docs/architecture/07-to-new-message-projection.md
+++ b/packages/nanoclaw-channel/docs/architecture/07-to-new-message-projection.md
@@ -6,74 +6,64 @@
 (the `@moltzap/client` wire shape) into a `NewMessage` (nanoclaw's stored
 message shape, defined in `types.ts`).
 
+**Input:** `EnrichedInboundMessage` (`@moltzap/client`)
 ```
-  Input: EnrichedInboundMessage  (@moltzap/client)
-    { id, conversationId, sender: { id, name? }, text,
-      createdAt, isFromMe, replyToId?,
-      contextBlocks: { crossConversationMessages?, groupMetadata? } }
-
-  Output: NewMessage  (types.ts → NewMessage)
-    { id, chat_jid, sender, sender_name, content,
-      timestamp, is_from_me, reply_to_message_id? }
-
-  Field mapping:                               channels/moltzap.ts → toNewMessage
-  ┌──────────────────────────┬───────────────────────────────────────────┐
-  │ NewMessage field         │ Source                                    │
-  ├──────────────────────────┼───────────────────────────────────────────┤
-  │ id                       │ enriched.id  (server-assigned UUID)       │
-  │ chat_jid                 │ chatJid param  ("mz:" + conversationId)   │
-  │ sender                   │ enriched.sender.id                        │
-  │ sender_name              │ enriched.sender.name ?? enriched.sender.id│
-  │ content                  │ contentFor(enriched)  ← see below         │
-  │ timestamp                │ enriched.createdAt  (ISO-8601)            │
-  │ is_from_me               │ enriched.isFromMe  (boolean)              │
-  │ reply_to_message_id      │ enriched.replyToId  (optional)            │
-  └──────────────────────────┴───────────────────────────────────────────┘
-
-  Fields NOT populated (nanoclaw interface has them, channel omits them):
-    is_bot_message            → not set (no bot-detection in MoltZap wire)
-    thread_id                 → not set (MoltZap has no threads)
-    reply_to_message_content  → not set (not carried in wire shape)
-    reply_to_sender_name      → not set
-
-  contentFor(enriched)                         channels/moltzap.ts → contentFor
-       │
-       │  Assembles context blocks in order:
-       │
-       ├─1─▶ crossConversationMessages block (if present)
-       │       formatCrossConvNanoclaw(msgs, { ownAgentId })
-       │       → "<messages>\n"
-       │           + "<message sender=\"{name}\" conversation=\"{conv}\""
-       │             + " time=\"{ts}\">{text}</message>\n" per msg
-       │           + "</messages>"
-       │       sender = "You" if senderId === ownAgentId, else senderName
-       │       ALL string fields sanitized via sanitizeForSystemReminder()
-       │       (HTML-entity-encodes <, >, &, " to prevent XML injection)
-       │
-       ├─2─▶ groupMetadata block (if conversationMeta.type === "group")
-       │       formatGroupBlock(meta)
-       │       → "<system-reminder>\n"
-       │           + "This is a group conversation.\n"
-       │           + "Group name: {name}\n"
-       │           + "Participants (N): {p1}, {p2}, ...\n"
-       │           + "</system-reminder>"
-       │       ALL strings sanitized via sanitizeForSystemReminder()
-       │
-       ├─3─▶ if no context blocks → return enriched.text verbatim
-       │
-       └─4─▶ if any blocks → blocks.join("\n\n") + "\n\n" + enriched.text
-               order: crossConv → groupMeta → rawText
-               (test: "ordersContextBlocksBeforeRawText")
-
-  Sanitization contract (sanitizeForSystemReminder from @moltzap/client):
-    Prevents XML injection through user-controlled fields.
-    Tests: "sanitizesGroupMetadata", "sanitizesCrossConversationSenderName"
-    Attack vectors closed:
-      Group name  "Evil</system-reminder><fake>"
-        → "Evil&lt;/system-reminder&gt;&lt;fake&gt;"  (1 open/close tag pair)
-      Sender name 'Mallory</messages><evil attr="x">'
-        → "Mallory&lt;/messages&gt;&lt;evil..."       (1 <messages> pair)
+{ id, conversationId, sender: { id, name? }, text,
+  createdAt, isFromMe, replyToId?,
+  contextBlocks: { crossConversationMessages?, groupMetadata? } }
 ```
+
+**Output:** `NewMessage` (`types.ts → NewMessage`)
+```
+{ id, chat_jid, sender, sender_name, content,
+  timestamp, is_from_me, reply_to_message_id? }
+```
+
+**Field mapping** (`channels/moltzap.ts → toNewMessage`):
+
+| NewMessage field | Source |
+|---|---|
+| `id` | `enriched.id` (server-assigned UUID) |
+| `chat_jid` | `chatJid` param (`"mz:" + conversationId`) |
+| `sender` | `enriched.sender.id` |
+| `sender_name` | `enriched.sender.name ?? enriched.sender.id` |
+| `content` | `contentFor(enriched)` ← see below |
+| `timestamp` | `enriched.createdAt` (ISO-8601) |
+| `is_from_me` | `enriched.isFromMe` (boolean) |
+| `reply_to_message_id` | `enriched.replyToId` (optional) |
+
+**Fields NOT populated** (nanoclaw interface has them, channel omits them):
+- `is_bot_message` — not set (no bot-detection in MoltZap wire)
+- `thread_id` — not set (MoltZap has no threads)
+- `reply_to_message_content` — not set (not carried in wire shape)
+- `reply_to_sender_name` — not set
+
+```mermaid
+flowchart TD
+    A["contentFor(enriched)\nchannels/moltzap.ts → contentFor\nAssembles context blocks in order"]
+
+    A --> B{"crossConversationMessages\npresent?"}
+    B -->|"yes"| C["formatCrossConvNanoclaw(msgs, { ownAgentId })\n→ &lt;messages&gt;\n    &lt;message sender=&quot;{name}&quot; conversation=&quot;{conv}&quot; time=&quot;{ts}&quot;&gt;{text}&lt;/message&gt;\n  &lt;/messages&gt;\nsender = &quot;You&quot; if senderId === ownAgentId, else senderName\nALL string fields sanitized via sanitizeForSystemReminder()"]
+    B -->|"no"| D{"conversationMeta.type\n=== &quot;group&quot;?"}
+
+    C --> D
+
+    D -->|"yes"| E["formatGroupBlock(meta)\n→ &lt;system-reminder&gt;\n    This is a group conversation.\n    Group name: {name}\n    Participants (N): {p1}, {p2}, ...\n  &lt;/system-reminder&gt;\nALL strings sanitized via sanitizeForSystemReminder()"]
+    D -->|"no"| F{"any context\nblocks collected?"}
+
+    E --> F
+
+    F -->|"no"| G["return enriched.text verbatim"]
+    F -->|"yes"| H["blocks.join(&quot;\n\n&quot;) + &quot;\n\n&quot; + enriched.text\norder: crossConv → groupMeta → rawText\n(test: &quot;ordersContextBlocksBeforeRawText&quot;)"]
+```
+
+**Sanitization contract** (`sanitizeForSystemReminder` from `@moltzap/client`):
+Prevents XML injection through user-controlled fields.
+Tests: `"sanitizesGroupMetadata"`, `"sanitizesCrossConversationSenderName"`
+
+Attack vectors closed:
+- Group name `"Evil</system-reminder><fake>"` → `"Evil&lt;/system-reminder&gt;&lt;fake&gt;"` (1 open/close tag pair)
+- Sender name `'Mallory</messages><evil attr="x">'` → `"Mallory&lt;/messages&gt;&lt;evil..."` (1 `<messages>` pair)
 
 ---
 

--- a/packages/openclaw-channel/ARCHITECTURE.md
+++ b/packages/openclaw-channel/ARCHITECTURE.md
@@ -1,0 +1,78 @@
+# Architecture — `@moltzap/openclaw-channel`
+
+OpenClaw plugin that bridges MoltZap's wire protocol into OpenClaw's
+plugin shape. OpenClaw's interface (`startAccount`, `sendText`, `deliver`,
+`listPeers`, `listGroups`) is Promise-based; internally this package uses
+Effect and only pays `Effect.runPromise` at the plugin surface.
+
+## 1. Project Structure
+
+```
+packages/openclaw-channel/src/
+├── openclaw-entry.ts       # createMoltzapChannelPlugin — the public plugin
+├── mapping.ts              # Notification → OpenClaw event extractors
+├── context-log.ts          # Per-message context-log writer
+├── format-cross-conv.ts    # Cross-conv block formatter
+├── test-utils/             # container-core (Docker harness)
+├── test-support.ts         # Re-export for the ./test-support subpath
+└── __tests__/conformance/  # Channel conformance harness
+```
+
+## 2. Public Surface
+
+| Export | Purpose |
+|---|---|
+| `moltzapChannelPlugin` / `MoltzapChannelPlugin` | The default plugin instance |
+| `createMoltzapChannelPlugin` | Factory for custom-configured variants |
+| `MoltZapAccount`, `OpenClawConfig` | Account + plugin config schemas |
+| `OpenClawTargetResolved`, `OpenClawTargetRejected`, `OpenClawTargetResolveResult` | Target-resolution typed results |
+| `OpenClawSendTextSuccess`, `OpenClawSendTextFailure` | Outbound send result tags |
+| `OpenClawDeliver`, `OpenClawLogger`, `OpenClawReplyDispatcher` | Adapter shapes for OpenClaw runtime |
+| `OpenClawStartAccountContext`, `OpenClawStopAccountContext` | Lifecycle context |
+| `MoltZapClientNotConnectedError` | Typed failure |
+| `isMoltZapTarget`, `readOpenClawContextLogDir`, `adaptOpenClawLogger` | Utilities |
+
+Subpath exports: `./test-utils` (Docker-backed integration harness),
+`./test-support` (lighter test helpers).
+
+## 3. Communication Flows
+
+| Section | Detail doc |
+|---|---|
+| `startAccount` lifecycle (connect, abort, reconnect handlers) | [01-start-account-lifecycle.md](docs/architecture/01-start-account-lifecycle.md) |
+| Outbound `sendText` — Effect ↔ Promise boundary | [02-outbound-send-text.md](docs/architecture/02-outbound-send-text.md) |
+| Inbound `onInbound` callback — full Effect chain | [03-inbound-on-inbound.md](docs/architecture/03-inbound-on-inbound.md) |
+| Notification extractors (`mapping.ts`) — 5 arms | [04-notification-extractors.md](docs/architecture/04-notification-extractors.md) |
+| `deliver()` error handling — RpcServerError discrimination (PR #587) | [05-deliver-error-handling.md](docs/architecture/05-deliver-error-handling.md) |
+| `stopAccount` lifecycle (teardown, race notes) | [06-stop-account-lifecycle.md](docs/architecture/06-stop-account-lifecycle.md) |
+| `resolveTarget` format and error shape (two callers) | [07-resolve-target.md](docs/architecture/07-resolve-target.md) |
+
+## 4. Dependencies
+
+**Runtime**: `effect`, `@effect/platform[-node]`.
+**Internal**: `@moltzap/protocol`, `@moltzap/client`.
+**Peer**: `openclaw` (the host runtime).
+**Consumers**: OpenClaw plugin installations (`openclaw plugin install`).
+
+## 5. Tests
+
+- `src/__tests__/conformance/` — conformance harness
+- `src/test-utils/container-core.ts` — Docker container fixtures
+- Co-located `*.test.ts` for `context-log`, `format-cross-conv`,
+  `openclaw-entry` (multiple variants)
+- Vitest; integration test config at `vitest.integration.config.ts`
+
+## 6. Glossary
+
+- **OpenClaw** — The external runtime this plugin targets. Imposes a
+  Promise-based plugin contract.
+- **Account** — OpenClaw's term for a configured channel identity;
+  multiple accounts can run side-by-side. Each maps to one MoltZap
+  agent (apiKey + agentName + serverUrl).
+- **Target** — An outbound send destination, either `agent:<id>` or
+  `conv:<id>`. `isMoltZapTarget` is the type guard.
+- **Context log** — Per-message JSONL dump of the full enriched inbound
+  payload (system reminder, cross-conv block, etc.), written to a
+  configurable directory for debugging/training data capture.
+- **Dispatch lease** — Single-use admission token from MoltZap server;
+  this package threads it through OpenClaw's `deliver` → reply flow.

--- a/packages/openclaw-channel/CLAUDE.md
+++ b/packages/openclaw-channel/CLAUDE.md
@@ -2,6 +2,8 @@
 
 OpenClaw gateway channel plugin that bridges MoltZap messages into the OpenClaw agent framework.
 
+See `ARCHITECTURE.md` (and `docs/architecture/*.md`) for flow diagrams: startAccount lifecycle, Effect↔Promise boundary on outbound `sendText`, the inbound `onInbound` handler body, notification extractors, deliver error handling, stopAccount, target resolution. Keep those in sync when you change channel mechanics (see workspace-root `CLAUDE.md` for the doc-maintenance rules).
+
 ## Key Files
 - `src/openclaw-entry.ts` — Main plugin: gateway startAccount, descriptor-backed notification routing, wraps `MoltZapChannelCore` from `@moltzap/client` for inbound enrichment + dispatch-chain ordering, projects EnrichedInboundMessage into OpenClaw's DispatchContext, deliver callback sends reply via `core.sendReply`.
 - `src/mapping.ts` — Notification extractors for the non-message MoltZap notifications (delivery, conversation lifecycle, contact notifications, presence).

--- a/packages/openclaw-channel/docs/architecture/01-start-account-lifecycle.md
+++ b/packages/openclaw-channel/docs/architecture/01-start-account-lifecycle.md
@@ -9,34 +9,34 @@ sequenceDiagram
     participant Svc as MoltZapService
     participant Core as MoltZapChannelCore
 
-    OC->>Entry: gateway.startAccount(ctx)<br/>ctx = { accountId, account, abortSignal,<br/>         log, setStatus, channelRuntime }
+    OC->>Entry: gateway.startAccount(ctx)<br>ctx = { accountId, account, abortSignal,<br>         log, setStatus, channelRuntime }
 
-    Entry->>Entry: Guard: account.apiKey && account.serverUrl<br/>missing? log.error + return Promise.resolve()
+    Entry->>Entry: Guard: account.apiKey && account.serverUrl<br>missing? log.error + return Promise.resolve()
 
-    Entry->>Entry: adaptOpenClawLogger(log.*)<br/>(reorders structured-log args to match OpenClaw's shape)
+    Entry->>Entry: adaptOpenClawLogger(log.*)<br>(reorders structured-log args to match OpenClaw's shape)
 
-    Entry->>Svc: new MoltZapService({ serverUrl, agentKey, logger })<br/>(WsClient + socket-server wrapper; entry into @moltzap/client)
+    Entry->>Svc: new MoltZapService({ serverUrl, agentKey, logger })<br>(WsClient + socket-server wrapper— entry into @moltzap/client)
 
-    Entry->>Core: new MoltZapChannelCore({ service, logger })<br/>(registers internal listeners; forks consumerFiber)
+    Entry->>Core: new MoltZapChannelCore({ service, logger })<br>(registers internal listeners— forks consumerFiber)
 
-    Entry->>Core: core.onInbound(handler)<br/>handler body is the Effect.gen block<br/>→ see 03-inbound-on-inbound.md
+    Entry->>Core: core.onInbound(handler)<br>handler body is the Effect.gen block<br>→ see 03-inbound-on-inbound.md
 
-    Entry->>Svc: service.on("rawNotification", …)<br/>sync dispatcher → mapping extractors<br/>→ see 04-notification-extractors.md
+    Entry->>Svc: service.on("rawNotification", …)<br>sync dispatcher → mapping extractors<br>→ see 04-notification-extractors.md
 
-    Entry->>Core: core.onDisconnect(() => { … })<br/>log.warn + setStatus({ connected:false, lastDisconnect:{at:now} })
+    Entry->>Core: core.onDisconnect(() => { … })<br>log.warn + setStatus({ connected:false, lastDisconnect:{at:now} })
 
-    Entry->>Core: core.onReconnect(() => { … })<br/>log.info + setStatus({ connected:true, lastConnectedAt:now })
+    Entry->>Core: core.onReconnect(() => { … })<br>log.info + setStatus({ connected:true, lastConnectedAt:now })
 
     Entry->>Entry: activeClients.set(accountId, service)
 
     alt aborted already?
-        Entry->>Core: Effect.runPromise(core.disconnect()<br/>  .tap(() => activeClients.delete(accountId)))
+        Entry->>Core: Effect.runPromise(core.disconnect()<br>  .tap(() => activeClients.delete(accountId)))
         Note over Entry: short-circuit — return that Promise immediately
     else not yet aborted
-        Entry->>Entry: abortSignal.addEventListener("abort", { once }, …)<br/>handler: Effect.runPromise(core.disconnect())<br/>         activeClients.delete(accountId)
+        Entry->>Entry: abortSignal.addEventListener("abort", { once }, …)<br>handler: Effect.runPromise(core.disconnect())<br>         activeClients.delete(accountId)
         Note over Entry,OC: Effect.runPromise — Effect↔Promise boundary
-        Entry->>Core: core.connect()<br/>  .tap(() => startSocketServer, log.info, setStatus)<br/>  .zipRight(waitForAbort(abortSignal))<br/>  .catchAll(err => log.error + Effect.fail(err))
-        Entry-->>OC: Promise (long-lived lifecycle promise)<br/>resolves only when AbortSignal fires
+        Entry->>Core: core.connect()<br>  .tap(() => startSocketServer, log.info, setStatus)<br>  .zipRight(waitForAbort(abortSignal))<br>  .catchAll(err => log.error + Effect.fail(err))
+        Entry-->>OC: Promise (long-lived lifecycle promise)<br>resolves only when AbortSignal fires
     end
 ```
 

--- a/packages/openclaw-channel/docs/architecture/01-start-account-lifecycle.md
+++ b/packages/openclaw-channel/docs/architecture/01-start-account-lifecycle.md
@@ -2,105 +2,65 @@
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 
+```mermaid
+sequenceDiagram
+    participant OC as OpenClaw runtime
+    participant Entry as openclaw-entry.ts
+    participant Svc as MoltZapService
+    participant Core as MoltZapChannelCore
+
+    OC->>Entry: gateway.startAccount(ctx)<br/>ctx = { accountId, account, abortSignal,<br/>         log, setStatus, channelRuntime }
+
+    Entry->>Entry: Guard: account.apiKey && account.serverUrl<br/>missing? log.error + return Promise.resolve()
+
+    Entry->>Entry: adaptOpenClawLogger(log.*)<br/>(reorders structured-log args to match OpenClaw's shape)
+
+    Entry->>Svc: new MoltZapService({ serverUrl, agentKey, logger })<br/>(WsClient + socket-server wrapper; entry into @moltzap/client)
+
+    Entry->>Core: new MoltZapChannelCore({ service, logger })<br/>(registers internal listeners; forks consumerFiber)
+
+    Entry->>Core: core.onInbound(handler)<br/>handler body is the Effect.gen block<br/>→ see 03-inbound-on-inbound.md
+
+    Entry->>Svc: service.on("rawNotification", …)<br/>sync dispatcher → mapping extractors<br/>→ see 04-notification-extractors.md
+
+    Entry->>Core: core.onDisconnect(() => { … })<br/>log.warn + setStatus({ connected:false, lastDisconnect:{at:now} })
+
+    Entry->>Core: core.onReconnect(() => { … })<br/>log.info + setStatus({ connected:true, lastConnectedAt:now })
+
+    Entry->>Entry: activeClients.set(accountId, service)
+
+    alt aborted already?
+        Entry->>Core: Effect.runPromise(core.disconnect()<br/>  .tap(() => activeClients.delete(accountId)))
+        Note over Entry: short-circuit — return that Promise immediately
+    else not yet aborted
+        Entry->>Entry: abortSignal.addEventListener("abort", { once }, …)<br/>handler: Effect.runPromise(core.disconnect())<br/>         activeClients.delete(accountId)
+        Note over Entry,OC: Effect.runPromise — Effect↔Promise boundary
+        Entry->>Core: core.connect()<br/>  .tap(() => startSocketServer, log.info, setStatus)<br/>  .zipRight(waitForAbort(abortSignal))<br/>  .catchAll(err => log.error + Effect.fail(err))
+        Entry-->>OC: Promise (long-lived lifecycle promise)<br/>resolves only when AbortSignal fires
+    end
 ```
-OpenClaw runtime
-      │
-      │  gateway.startAccount(ctx)
-      │  ctx = { accountId, account, abortSignal,
-      │           log, setStatus, channelRuntime }
-      │
-      ▼
-┌─────────────────────────────────────────────────────────┐
-│  Guard: account.apiKey && account.serverUrl              │
-│  → missing? log.error + return Promise.resolve()         │
-└─────────────────────────────────────────────────────────┘
-      │
-      ▼
-  adaptOpenClawLogger(log.*)
-  (reorders structured-log args to match OpenClaw's shape)
-      │
-      ▼
-  new MoltZapService({ serverUrl, agentKey, logger })
-  (WsClient + socket-server wrapper; entry into @moltzap/client)
-      │
-      ▼
-  new MoltZapChannelCore({ service, logger })
-  (registers internal listeners; forks consumerFiber)
-      │
-      ├─ core.onInbound(handler)
-      │    handler body is the huge Effect.gen block (§3.3)
-      │    → see 03-inbound-on-inbound.md
-      │
-      ├─ service.on("rawNotification", …)
-      │    sync dispatcher → mapping extractors
-      │    → see 04-notification-extractors.md
-      │
-      ├─ core.onDisconnect(() => { … })
-      │    log.warn + setStatus({ connected:false,
-      │                           lastDisconnect:{at:now} })
-      │
-      └─ core.onReconnect(() => { … })
-           log.info + setStatus({ connected:true,
-                                  lastConnectedAt:now })
-      │
-      ▼
-  activeClients.set(accountId, service)   (in `openclaw-entry.ts`)
-      │
-      ├─[aborted already?]
-      │    Effect.runPromise(
-      │      core.disconnect()
-      │        .tap(() => activeClients.delete(accountId))
-      │    )
-      │    → return that Promise (short-circuit)
-      │
-      └─[not yet aborted]
-           │
-           abortSignal.addEventListener("abort", { once }, …)
-           handler: Effect.runPromise(core.disconnect())
-                    activeClients.delete(accountId)
-           │
-           ▼
-        Effect.runPromise(
-          core.connect()                    ← Effect boundary
-            .tap(() =>
-              service.startSocketServer()
-              log.info("connected as …")
-              setStatus({ connected:true, … })
-            )
-            .zipRight(waitForAbort(abortSignal))
-            .catchAll(err =>
-              log.error("connection failed: …")
-              Effect.fail(err)
-            )
-        )
-        ──────────────────────────────────────────────────►
-        Promise returned to OpenClaw runtime.
-        Promise resolves only when AbortSignal fires.
-        (This is a long-lived "lifecycle" promise, not a
-         one-shot async action.)
 
-Abort handling detail
-─────────────────────
-  Two code paths cover the abort race:
+**Abort handling detail**
 
-  Path A — signal already aborted when startAccount runs
-    Effect.runPromise(core.disconnect() + delete) returned immediately;
-    the long-lived promise is never started.
+Two code paths cover the abort race:
 
-  Path B — signal fires after startAccount is running
-    "abort" listener calls:
-      void Effect.runPromise(core.disconnect())
-      activeClients.delete(accountId)
-    The zipRight(waitForAbort(abortSignal)) branch in the running
-    promise then resolves (waitForAbort registers one "abort" listener;
-    if already aborted, resumes synchronously).
+- **Path A** — signal already aborted when `startAccount` runs:
+  `Effect.runPromise(core.disconnect() + delete)` returned immediately;
+  the long-lived promise is never started.
 
-  waitForAbort internals (in `openclaw-entry.ts → waitForAbort`):
-    Effect.async<void>(resume => {
-      if (signal.aborted) { resume(Effect.void); return; }
-      signal.addEventListener("abort", () => resume(Effect.void),
-                              { once: true });
-    })
+- **Path B** — signal fires after `startAccount` is running:
+  "abort" listener calls `void Effect.runPromise(core.disconnect())` and
+  `activeClients.delete(accountId)`. The `zipRight(waitForAbort(abortSignal))`
+  branch in the running promise then resolves (`waitForAbort` registers one
+  "abort" listener; if already aborted, resumes synchronously).
+
+`waitForAbort` internals (in `openclaw-entry.ts → waitForAbort`):
+```ts
+Effect.async<void>(resume => {
+  if (signal.aborted) { resume(Effect.void); return; }
+  signal.addEventListener("abort", () => resume(Effect.void),
+                          { once: true });
+})
 ```
 
 ---

--- a/packages/openclaw-channel/docs/architecture/01-start-account-lifecycle.md
+++ b/packages/openclaw-channel/docs/architecture/01-start-account-lifecycle.md
@@ -1,0 +1,111 @@
+# `startAccount` Lifecycle
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+```
+OpenClaw runtime
+      │
+      │  gateway.startAccount(ctx)
+      │  ctx = { accountId, account, abortSignal,
+      │           log, setStatus, channelRuntime }
+      │
+      ▼
+┌─────────────────────────────────────────────────────────┐
+│  Guard: account.apiKey && account.serverUrl              │
+│  → missing? log.error + return Promise.resolve()         │
+└─────────────────────────────────────────────────────────┘
+      │
+      ▼
+  adaptOpenClawLogger(log.*)
+  (reorders structured-log args to match OpenClaw's shape)
+      │
+      ▼
+  new MoltZapService({ serverUrl, agentKey, logger })
+  (WsClient + socket-server wrapper; entry into @moltzap/client)
+      │
+      ▼
+  new MoltZapChannelCore({ service, logger })
+  (registers internal listeners; forks consumerFiber)
+      │
+      ├─ core.onInbound(handler)
+      │    handler body is the huge Effect.gen block (§3.3)
+      │    → see 03-inbound-on-inbound.md
+      │
+      ├─ service.on("rawNotification", …)
+      │    sync dispatcher → mapping extractors
+      │    → see 04-notification-extractors.md
+      │
+      ├─ core.onDisconnect(() => { … })
+      │    log.warn + setStatus({ connected:false,
+      │                           lastDisconnect:{at:now} })
+      │
+      └─ core.onReconnect(() => { … })
+           log.info + setStatus({ connected:true,
+                                  lastConnectedAt:now })
+      │
+      ▼
+  activeClients.set(accountId, service)   (in `openclaw-entry.ts`)
+      │
+      ├─[aborted already?]
+      │    Effect.runPromise(
+      │      core.disconnect()
+      │        .tap(() => activeClients.delete(accountId))
+      │    )
+      │    → return that Promise (short-circuit)
+      │
+      └─[not yet aborted]
+           │
+           abortSignal.addEventListener("abort", { once }, …)
+           handler: Effect.runPromise(core.disconnect())
+                    activeClients.delete(accountId)
+           │
+           ▼
+        Effect.runPromise(
+          core.connect()                    ← Effect boundary
+            .tap(() =>
+              service.startSocketServer()
+              log.info("connected as …")
+              setStatus({ connected:true, … })
+            )
+            .zipRight(waitForAbort(abortSignal))
+            .catchAll(err =>
+              log.error("connection failed: …")
+              Effect.fail(err)
+            )
+        )
+        ──────────────────────────────────────────────────►
+        Promise returned to OpenClaw runtime.
+        Promise resolves only when AbortSignal fires.
+        (This is a long-lived "lifecycle" promise, not a
+         one-shot async action.)
+
+Abort handling detail
+─────────────────────
+  Two code paths cover the abort race:
+
+  Path A — signal already aborted when startAccount runs
+    Effect.runPromise(core.disconnect() + delete) returned immediately;
+    the long-lived promise is never started.
+
+  Path B — signal fires after startAccount is running
+    "abort" listener calls:
+      void Effect.runPromise(core.disconnect())
+      activeClients.delete(accountId)
+    The zipRight(waitForAbort(abortSignal)) branch in the running
+    promise then resolves (waitForAbort registers one "abort" listener;
+    if already aborted, resumes synchronously).
+
+  waitForAbort internals (in `openclaw-entry.ts → waitForAbort`):
+    Effect.async<void>(resume => {
+      if (signal.aborted) { resume(Effect.void); return; }
+      signal.addEventListener("abort", () => resume(Effect.void),
+                              { once: true });
+    })
+```
+
+---
+
+See also:
+- [06-stop-account-lifecycle.md](06-stop-account-lifecycle.md) — teardown counterpart
+- [03-inbound-on-inbound.md](03-inbound-on-inbound.md) — the onInbound handler registered here
+- [04-notification-extractors.md](04-notification-extractors.md) — the rawNotification dispatcher registered here

--- a/packages/openclaw-channel/docs/architecture/02-outbound-send-text.md
+++ b/packages/openclaw-channel/docs/architecture/02-outbound-send-text.md
@@ -1,0 +1,67 @@
+# Outbound `sendText` — Promise Boundary
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+```
+OpenClaw runtime
+      │
+      │  outbound.sendText(ctx)
+      │  ctx = { cfg, to, text, accountId?, replyToId? }
+      │
+      ▼
+┌──────────────────────────── Effect world ───────────────────────────────┐
+│                                                                          │
+│  Effect.gen(function* () {          (in `openclaw-entry.ts → sendText`) │
+│    accountId = ctx.accountId ?? "default"                               │
+│                                                                          │
+│    service = activeClients.get(accountId)                               │
+│    if (!service)                                                         │
+│      yield* Effect.fail(                                                 │
+│        new MoltZapClientNotConnectedError({ accountId })                │
+│      )                                                                   │
+│                                                                          │
+│    ┌── branch: ctx.to starts with "agent:" ───────────────────────────┤ │
+│    │   agentName = to.slice("agent:".length)                             │
+│    │   yield* service.sendToAgent(agentName, text,                       │
+│    │                              { replyTo: ctx.replyToId })            │
+│    └──────────────────────────────────────────────────────────────────  │
+│    ┌── branch: ctx.to starts with "conv:" (or plain id)  ─────────────┤ │
+│    │   conversationId = to starts with "conv:"                           │
+│    │                    ? to.slice("conv:".length) : to                  │
+│    │   yield* service.send(conversationId, text,                         │
+│    │                       { replyTo: ctx.replyToId })                   │
+│    └──────────────────────────────────────────────────────────────────  │
+│                                                                          │
+│    return new OpenClawSendTextSuccess()                                  │
+│                                                                          │
+│  }).pipe(                                                                │
+│    Effect.withSpan("createMoltzapChannelPlugin.sendText"),               │
+│    Effect.match({                                                        │
+│      onSuccess: ok  => ok,          ← OpenClawSendTextSuccess           │
+│      onFailure: err => new OpenClawSendTextFailure({                     │
+│                          error: err instanceof Error                     │
+│                            ? err : new Error(String(err))               │
+│                        })           ← wraps ALL failures                 │
+│    })                                                                    │
+│  )                                                                       │
+│                                                                          │
+└────────────────── Effect.runPromise(effect) ─────────────────────────── ┘
+      │
+      ▼   ◄── Promise boundary: Effect.runPromise called once
+      Promise<OpenClawSendTextSuccess | OpenClawSendTextFailure>
+      returned to OpenClaw runtime
+
+Key invariants:
+  • Effect.match collapses the error channel — runPromise never rejects.
+  • MoltZapClientNotConnectedError is the only typed failure; all others
+    (ServiceRpcError from service.send) propagate through Effect.match's
+    onFailure arm and become OpenClawSendTextFailure.
+  • The "conv:" strip + fallback-to-plain-id is backward compat for
+    callers that pass a raw conversation UUID.
+```
+
+---
+
+See also:
+- [07-resolve-target.md](07-resolve-target.md) — `outbound.resolveTarget` validation runs before sendText
+- [05-deliver-error-handling.md](05-deliver-error-handling.md) — the deliver callback that sends replies via the inbound path

--- a/packages/openclaw-channel/docs/architecture/02-outbound-send-text.md
+++ b/packages/openclaw-channel/docs/architecture/02-outbound-send-text.md
@@ -2,63 +2,44 @@
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 
-```
-OpenClaw runtime
-      │
-      │  outbound.sendText(ctx)
-      │  ctx = { cfg, to, text, accountId?, replyToId? }
-      │
-      ▼
-┌──────────────────────────── Effect world ───────────────────────────────┐
-│                                                                          │
-│  Effect.gen(function* () {          (in `openclaw-entry.ts → sendText`) │
-│    accountId = ctx.accountId ?? "default"                               │
-│                                                                          │
-│    service = activeClients.get(accountId)                               │
-│    if (!service)                                                         │
-│      yield* Effect.fail(                                                 │
-│        new MoltZapClientNotConnectedError({ accountId })                │
-│      )                                                                   │
-│                                                                          │
-│    ┌── branch: ctx.to starts with "agent:" ───────────────────────────┤ │
-│    │   agentName = to.slice("agent:".length)                             │
-│    │   yield* service.sendToAgent(agentName, text,                       │
-│    │                              { replyTo: ctx.replyToId })            │
-│    └──────────────────────────────────────────────────────────────────  │
-│    ┌── branch: ctx.to starts with "conv:" (or plain id)  ─────────────┤ │
-│    │   conversationId = to starts with "conv:"                           │
-│    │                    ? to.slice("conv:".length) : to                  │
-│    │   yield* service.send(conversationId, text,                         │
-│    │                       { replyTo: ctx.replyToId })                   │
-│    └──────────────────────────────────────────────────────────────────  │
-│                                                                          │
-│    return new OpenClawSendTextSuccess()                                  │
-│                                                                          │
-│  }).pipe(                                                                │
-│    Effect.withSpan("createMoltzapChannelPlugin.sendText"),               │
-│    Effect.match({                                                        │
-│      onSuccess: ok  => ok,          ← OpenClawSendTextSuccess           │
-│      onFailure: err => new OpenClawSendTextFailure({                     │
-│                          error: err instanceof Error                     │
-│                            ? err : new Error(String(err))               │
-│                        })           ← wraps ALL failures                 │
-│    })                                                                    │
-│  )                                                                       │
-│                                                                          │
-└────────────────── Effect.runPromise(effect) ─────────────────────────── ┘
-      │
-      ▼   ◄── Promise boundary: Effect.runPromise called once
-      Promise<OpenClawSendTextSuccess | OpenClawSendTextFailure>
-      returned to OpenClaw runtime
+```mermaid
+sequenceDiagram
+    participant OC as OpenClaw runtime
+    participant Entry as openclaw-entry.ts sendText
+    participant Clients as activeClients Map
+    participant Svc as MoltZapService
 
-Key invariants:
-  • Effect.match collapses the error channel — runPromise never rejects.
-  • MoltZapClientNotConnectedError is the only typed failure; all others
-    (ServiceRpcError from service.send) propagate through Effect.match's
-    onFailure arm and become OpenClawSendTextFailure.
-  • The "conv:" strip + fallback-to-plain-id is backward compat for
-    callers that pass a raw conversation UUID.
+    OC->>Entry: outbound.sendText(ctx)<br/>ctx = { cfg, to, text, accountId?, replyToId? }
+
+    Note over Entry: Effect.gen — inside Effect world
+    Entry->>Entry: accountId = ctx.accountId ?? "default"
+    Entry->>Clients: activeClients.get(accountId)
+
+    alt service not found
+        Entry->>Entry: yield* Effect.fail(new MoltZapClientNotConnectedError({ accountId }))
+    else ctx.to starts with "agent:"
+        Entry->>Entry: agentName = to.slice("agent:".length)
+        Entry->>Svc: service.sendToAgent(agentName, text, { replyTo: ctx.replyToId })
+    else ctx.to starts with "conv:" or plain id
+        Entry->>Entry: conversationId = to.startsWith("conv:") ? to.slice("conv:".length) : to
+        Entry->>Svc: service.send(conversationId, text, { replyTo: ctx.replyToId })
+    end
+
+    Entry->>Entry: return new OpenClawSendTextSuccess()
+
+    Note over Entry: .pipe(Effect.withSpan(...), Effect.match({<br/>  onSuccess: ok => ok,<br/>  onFailure: err => new OpenClawSendTextFailure({ error })<br/>}))
+
+    Note over Entry,OC: Effect.runPromise — Effect↔Promise boundary
+    Entry-->>OC: Promise&lt;OpenClawSendTextSuccess | OpenClawSendTextFailure&gt;<br/>(never rejects — error channel collapsed by Effect.match)
 ```
+
+**Key invariants:**
+- `Effect.match` collapses the error channel — `runPromise` never rejects.
+- `MoltZapClientNotConnectedError` is the only typed failure; all others
+  (`ServiceRpcError` from `service.send`) propagate through `Effect.match`'s
+  `onFailure` arm and become `OpenClawSendTextFailure`.
+- The `"conv:"` strip + fallback-to-plain-id is backward compat for
+  callers that pass a raw conversation UUID.
 
 ---
 

--- a/packages/openclaw-channel/docs/architecture/02-outbound-send-text.md
+++ b/packages/openclaw-channel/docs/architecture/02-outbound-send-text.md
@@ -9,7 +9,7 @@ sequenceDiagram
     participant Clients as activeClients Map
     participant Svc as MoltZapService
 
-    OC->>Entry: outbound.sendText(ctx)<br/>ctx = { cfg, to, text, accountId?, replyToId? }
+    OC->>Entry: outbound.sendText(ctx)<br>ctx = { cfg, to, text, accountId?, replyToId? }
 
     Note over Entry: Effect.gen — inside Effect world
     Entry->>Entry: accountId = ctx.accountId ?? "default"
@@ -27,10 +27,10 @@ sequenceDiagram
 
     Entry->>Entry: return new OpenClawSendTextSuccess()
 
-    Note over Entry: .pipe(Effect.withSpan(...), Effect.match({<br/>  onSuccess: ok => ok,<br/>  onFailure: err => new OpenClawSendTextFailure({ error })<br/>}))
+    Note over Entry: .pipe(Effect.withSpan(...), Effect.match({<br>  onSuccess: ok => ok,<br>  onFailure: err => new OpenClawSendTextFailure({ error })<br>}))
 
     Note over Entry,OC: Effect.runPromise — Effect↔Promise boundary
-    Entry-->>OC: Promise&lt;OpenClawSendTextSuccess | OpenClawSendTextFailure&gt;<br/>(never rejects — error channel collapsed by Effect.match)
+    Entry-->>OC: Promise<OpenClawSendTextSuccess | OpenClawSendTextFailure><br>(never rejects — error channel collapsed by Effect.match)
 ```
 
 **Key invariants:**

--- a/packages/openclaw-channel/docs/architecture/03-inbound-on-inbound.md
+++ b/packages/openclaw-channel/docs/architecture/03-inbound-on-inbound.md
@@ -1,0 +1,191 @@
+# Inbound `onInbound` Callback — Full Effect Chain
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+```
+MoltZap server
+      │  WebSocket frame
+      ▼
+  MoltZapService "message" event       (channel-core.ts → consumerFiber)
+      │
+      ▼  Queue.unsafeOffer(inboundQueue, work)
+         work = { message, attempt:0, receivedAtMs, clock }
+      │
+      ▼  consumerFiber (Effect.forever loop)
+         Queue.take → dispatchInboundWork(work)
+         │
+         ▼  takeDispatchCandidate(work)
+            (re-order: if parked messages for same conv,
+             take oldest parked, re-queue incoming)
+         │
+         ▼  dispatchAdmission(work)
+            (dispatch/request RPC → await dispatchRelease verdict)
+            decision = grant | deny | hold
+         │
+         ├─[deny]  log + return (message dropped)
+         ├─[hold]  parkDispatchWork(work) + return
+         └─[grant]
+               │
+               ▼  dispatchWithLease(messages, leaseId)
+                  sets leaseIdInFlight = leaseId
+               │
+               ▼  dispatchInboundEffect(messages)
+                  enrichChannelMessage(service, msgs)
+                  → resolveAgentName, getConversation,
+                    peekFullMessages (cross-conv)
+                  enriched = EnrichedInboundMessage
+                  if leaseIdInFlight → attach dispatchLeaseId
+                  │
+                  ▼  inboundHandler(enriched)   ◄──────────────────────┐
+                                                                         │
+──────────── BOUNDARY: enters openclaw-entry.ts handler ──────────────  │
+                                                                         │
+  Effect.gen(function* () {           (openclaw-entry.ts → onInbound)   │
+    chatType = enriched.conversationMeta?.type …                         │
+    fromId   = `agent:${enriched.sender.id}`                             │
+    log.info("MoltZap: inbound from …")                                  │
+    setStatus({ accountId, lastInboundAt, lastEventAt })                 │
+                                                                         │
+    crossConvBlock = formatCrossConvOpenClaw(                            │
+      enriched.contextBlocks.crossConversationMessages,                  │
+      { ownAgentId: service.ownAgentId ?? "" }                          │
+    )                                                                    │
+    bodyForAgent = crossConvBlock                                        │
+      ? `${crossConvBlock}\n\n${enriched.text}`                          │
+      : enriched.text                                                    │
+                                                                         │
+    yield* writeContextLogOrWarn(log, {                                  │
+      logDir: contextLogDir,   ← MOLTZAP_OPENCLAW_CONTEXT_LOG_DIR env   │
+      accountId, accountAgentName, ownAgentId,                           │
+      conversationId, conversationName, conversationType,                 │
+      from: fromId, to: account.agentName,                               │
+      body: enriched.text, bodyForAgent,                                  │
+      crossConversationMessages                                           │
+    })                                                                    │
+    (errors from writeOpenClawContextLog caught →                        │
+     log.warn only; never fails the handler)                             │
+                                                                         │
+    dispatch = ctx.channelRuntime?.reply                                 │
+                ?.dispatchReplyWithBufferedBlockDispatcher                │
+    if (!dispatch) { log.warn; return; }                                 │
+                                                                         │
+    groupSubject = enriched.conversationMeta?.name                       │
+    groupMembers = (type==="group")                                      │
+      ? participants.join(",") : undefined                               │
+                                                                         │
+    ┌── deliver closure (per-message, single-use lease) ─────────────── ┤
+    │   let consumedLeaseAt: number | null = null                         │
+    │                                                                     │
+    │   deliver(payload, info?) =>                                        │
+    │     if info.kind !== "final" → Promise.resolve(true)  (no-op)      │
+    │     text = payload.text ?? payload.body                             │
+    │     if !text → Promise.resolve(true)                                │
+    │     if consumedLeaseAt !== null →                                   │
+    │       log.warn("duplicate-reply rejected …")                        │
+    │       return Promise.resolve(false)    ◄── OpenclawDuplicateReply  │
+    │                                                                     │
+    │     [first final delivery]                                          │
+    │     deliverEffect =                                                 │
+    │       core.sendReply(enriched.conversationId, text)                 │
+    │         .tap(() => {                                                 │
+    │           consumedLeaseAt = Date.now()     ← stamp lease consumed  │
+    │           log.info("MoltZap: outbound reply to …")                  │
+    │         })                                                           │
+    │         .map(() => true)                                            │
+    │         .catchTag("RpcServerError", err =>                          │
+    │           if err.code === TaskClosedError.code  (-32020)           │
+    │             log.warn("task closed, dropping without retry")         │
+    │             return true   ← signal consumed; do NOT retry          │
+    │           else                                                      │
+    │             log.error("failed to send reply: …")                   │
+    │             return false  ← retry-eligible                          │
+    │         )                                                           │
+    │         .catchAll(err =>                                            │
+    │           log.error("failed to send reply: …")                      │
+    │           return false                                              │
+    │         )                                                           │
+    │                                                                     │
+    │     return Effect.runPromise(deliverEffect)  ◄── Promise boundary  │
+    └──────────────────────────────────────────────────────────────────  │
+                                                                         │
+    result = yield* Effect.tryPromise({                                  │
+      try: () => dispatch({                                              │
+        ctx: {                                                            │
+          Body, BodyForAgent, From, To,                                  │
+          SessionKey: `agent:main:moltzap:${chatType}:${convId}`,        │
+          AccountId, Provider: "moltzap", Surface: "moltzap",            │
+          OriginatingChannel: "moltzap",                                  │
+          OriginatingTo: enriched.conversationId,                        │
+          ChatType, GroupSubject?, GroupMembers?,                         │
+          ConversationLabel?, SenderName                                  │
+        },                                                                │
+        cfg: ctx.cfg,                                                    │
+        dispatcherOptions: { deliver }  ← the closure above              │
+      }),                                                                 │
+      catch: err => err,                                                  │
+    }).pipe(                                                              │
+      Effect.catchAll(err =>                                             │
+        log.error("MoltZap: dispatch error: …")                          │
+        return null                                                       │
+      )                                                                   │
+    )                                                                     │
+                                                                         │
+    log.info("dispatch finished …")                                      │
+    if result && !result.queuedFinal                                     │
+      log.debug("completed without final reply")                          │
+  }).pipe(                                                               │
+    Effect.withSpan("createMoltzapChannelPlugin.inboundDispatch")        │
+  )  ───────────────────────────────────────────────────────────────────┘
+      │
+      ▼  back in consumerFiber (channel-core.ts)
+         .catchAllCause(cause => logInboundFailure(work, cause))
+         loop: Queue.take → next message
+```
+
+**Context-log writer detail** (`src/context-log.ts`):
+
+```
+writeContextLogOrWarn(log, input)   (openclaw-entry.ts → writeContextLogOrWarn)
+  writeOpenClawContextLog(input)    (context-log.ts → writeOpenClawContextLog)
+    if !input.logDir → Effect.void  (no-op)
+    Effect.gen:
+      fileSystem = yield* FileSystem.FileSystem
+      stateDir from OPENCLAW_STATE_DIR env
+      entry = OpenClawContextLogEntry {
+        schemaVersion:1, recordedAt, pid, cwd,
+        stateDir?, accountId, accountAgentName?,
+        ownAgentId?, conversationId, conversationName?,
+        conversationType, from, to, body, bodyForAgent,
+        crossConversationMessageCount,
+        crossConversationMessages
+      }
+      yield* fileSystem.makeDirectory(logDir, {recursive:true})
+      file = contextLogPath(logDir, accountAgentName)
+             → "<logDir>/<agent>.<stateName>.<pid>.contexts.jsonl"
+             stateName = basename(OPENCLAW_STATE_DIR) | "pid-<pid>"
+      yield* fileSystem.writeFileString(file, JSON.stringify(entry)+"\n",
+                                        {flag:"a"})
+    .provide(NodePath.layer, NodeFileSystem.layer)
+  .catchAll(err → logContextLogWriteFailure(log, err))
+  (never propagates; context-log failure is warn-only)
+```
+
+**Cross-conv formatter** (`src/format-cross-conv.ts`):
+
+```
+formatCrossConvOpenClaw(messages, { ownAgentId })
+  if messages.length === 0 → null
+  items = messages.map(m => {
+    conversation: m.conversationName ?? `DM with @${m.senderName}`
+    sender: m.senderId === ownAgentId ? "You" : m.senderName
+    text: m.text
+    timestamp: m.timestamp
+  })
+  return "Messages (untrusted metadata):\n```json\n<indent-2>\n```"
+```
+
+---
+
+See also:
+- [05-deliver-error-handling.md](05-deliver-error-handling.md) — detailed breakdown of the deliver closure error paths
+- [01-start-account-lifecycle.md](01-start-account-lifecycle.md) — where `core.onInbound(handler)` is registered

--- a/packages/openclaw-channel/docs/architecture/03-inbound-on-inbound.md
+++ b/packages/openclaw-channel/docs/architecture/03-inbound-on-inbound.md
@@ -2,186 +2,127 @@
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 
+## Part 1 — Consumer Fiber Path (channel-core.ts)
+
+```mermaid
+sequenceDiagram
+    participant WS as MoltZap server (WebSocket)
+    participant Svc as MoltZapService
+    participant Q as inboundQueue
+    participant CF as consumerFiber (Effect.forever)
+    participant DA as dispatchAdmission
+
+    WS->>Svc: WebSocket frame ("message" event)
+    Svc->>Q: Queue.unsafeOffer(inboundQueue, work)<br/>work = { message, attempt:0, receivedAtMs, clock }
+
+    loop Effect.forever
+        CF->>Q: Queue.take
+        CF->>CF: takeDispatchCandidate(work)<br/>(re-order: if parked messages for same conv,<br/> take oldest parked, re-queue incoming)
+        CF->>DA: dispatchAdmission(work)<br/>(dispatch/request RPC → await dispatchRelease verdict)
+
+        alt deny
+            DA-->>CF: log + return (message dropped)
+        else hold
+            DA-->>CF: parkDispatchWork(work) + return
+        else grant
+            CF->>CF: dispatchWithLease(messages, leaseId)<br/>sets leaseIdInFlight = leaseId
+            CF->>CF: dispatchInboundEffect(messages)<br/>enrichChannelMessage(service, msgs)<br/>→ resolveAgentName, getConversation,<br/>  peekFullMessages (cross-conv)<br/>enriched = EnrichedInboundMessage<br/>if leaseIdInFlight → attach dispatchLeaseId
+            CF->>CF: inboundHandler(enriched)
+            Note over CF: → see Part 2 (openclaw-entry.ts handler)
+            CF->>CF: .catchAllCause(cause => logInboundFailure(work, cause))
+        end
+    end
 ```
-MoltZap server
-      │  WebSocket frame
-      ▼
-  MoltZapService "message" event       (channel-core.ts → consumerFiber)
-      │
-      ▼  Queue.unsafeOffer(inboundQueue, work)
-         work = { message, attempt:0, receivedAtMs, clock }
-      │
-      ▼  consumerFiber (Effect.forever loop)
-         Queue.take → dispatchInboundWork(work)
-         │
-         ▼  takeDispatchCandidate(work)
-            (re-order: if parked messages for same conv,
-             take oldest parked, re-queue incoming)
-         │
-         ▼  dispatchAdmission(work)
-            (dispatch/request RPC → await dispatchRelease verdict)
-            decision = grant | deny | hold
-         │
-         ├─[deny]  log + return (message dropped)
-         ├─[hold]  parkDispatchWork(work) + return
-         └─[grant]
-               │
-               ▼  dispatchWithLease(messages, leaseId)
-                  sets leaseIdInFlight = leaseId
-               │
-               ▼  dispatchInboundEffect(messages)
-                  enrichChannelMessage(service, msgs)
-                  → resolveAgentName, getConversation,
-                    peekFullMessages (cross-conv)
-                  enriched = EnrichedInboundMessage
-                  if leaseIdInFlight → attach dispatchLeaseId
-                  │
-                  ▼  inboundHandler(enriched)   ◄──────────────────────┐
-                                                                         │
-──────────── BOUNDARY: enters openclaw-entry.ts handler ──────────────  │
-                                                                         │
-  Effect.gen(function* () {           (openclaw-entry.ts → onInbound)   │
-    chatType = enriched.conversationMeta?.type …                         │
-    fromId   = `agent:${enriched.sender.id}`                             │
-    log.info("MoltZap: inbound from …")                                  │
-    setStatus({ accountId, lastInboundAt, lastEventAt })                 │
-                                                                         │
-    crossConvBlock = formatCrossConvOpenClaw(                            │
-      enriched.contextBlocks.crossConversationMessages,                  │
-      { ownAgentId: service.ownAgentId ?? "" }                          │
-    )                                                                    │
-    bodyForAgent = crossConvBlock                                        │
-      ? `${crossConvBlock}\n\n${enriched.text}`                          │
-      : enriched.text                                                    │
-                                                                         │
-    yield* writeContextLogOrWarn(log, {                                  │
-      logDir: contextLogDir,   ← MOLTZAP_OPENCLAW_CONTEXT_LOG_DIR env   │
-      accountId, accountAgentName, ownAgentId,                           │
-      conversationId, conversationName, conversationType,                 │
-      from: fromId, to: account.agentName,                               │
-      body: enriched.text, bodyForAgent,                                  │
-      crossConversationMessages                                           │
-    })                                                                    │
-    (errors from writeOpenClawContextLog caught →                        │
-     log.warn only; never fails the handler)                             │
-                                                                         │
-    dispatch = ctx.channelRuntime?.reply                                 │
-                ?.dispatchReplyWithBufferedBlockDispatcher                │
-    if (!dispatch) { log.warn; return; }                                 │
-                                                                         │
-    groupSubject = enriched.conversationMeta?.name                       │
-    groupMembers = (type==="group")                                      │
-      ? participants.join(",") : undefined                               │
-                                                                         │
-    ┌── deliver closure (per-message, single-use lease) ─────────────── ┤
-    │   let consumedLeaseAt: number | null = null                         │
-    │                                                                     │
-    │   deliver(payload, info?) =>                                        │
-    │     if info.kind !== "final" → Promise.resolve(true)  (no-op)      │
-    │     text = payload.text ?? payload.body                             │
-    │     if !text → Promise.resolve(true)                                │
-    │     if consumedLeaseAt !== null →                                   │
-    │       log.warn("duplicate-reply rejected …")                        │
-    │       return Promise.resolve(false)    ◄── OpenclawDuplicateReply  │
-    │                                                                     │
-    │     [first final delivery]                                          │
-    │     deliverEffect =                                                 │
-    │       core.sendReply(enriched.conversationId, text)                 │
-    │         .tap(() => {                                                 │
-    │           consumedLeaseAt = Date.now()     ← stamp lease consumed  │
-    │           log.info("MoltZap: outbound reply to …")                  │
-    │         })                                                           │
-    │         .map(() => true)                                            │
-    │         .catchTag("RpcServerError", err =>                          │
-    │           if err.code === TaskClosedError.code  (-32020)           │
-    │             log.warn("task closed, dropping without retry")         │
-    │             return true   ← signal consumed; do NOT retry          │
-    │           else                                                      │
-    │             log.error("failed to send reply: …")                   │
-    │             return false  ← retry-eligible                          │
-    │         )                                                           │
-    │         .catchAll(err =>                                            │
-    │           log.error("failed to send reply: …")                      │
-    │           return false                                              │
-    │         )                                                           │
-    │                                                                     │
-    │     return Effect.runPromise(deliverEffect)  ◄── Promise boundary  │
-    └──────────────────────────────────────────────────────────────────  │
-                                                                         │
-    result = yield* Effect.tryPromise({                                  │
-      try: () => dispatch({                                              │
-        ctx: {                                                            │
-          Body, BodyForAgent, From, To,                                  │
-          SessionKey: `agent:main:moltzap:${chatType}:${convId}`,        │
-          AccountId, Provider: "moltzap", Surface: "moltzap",            │
-          OriginatingChannel: "moltzap",                                  │
-          OriginatingTo: enriched.conversationId,                        │
-          ChatType, GroupSubject?, GroupMembers?,                         │
-          ConversationLabel?, SenderName                                  │
-        },                                                                │
-        cfg: ctx.cfg,                                                    │
-        dispatcherOptions: { deliver }  ← the closure above              │
-      }),                                                                 │
-      catch: err => err,                                                  │
-    }).pipe(                                                              │
-      Effect.catchAll(err =>                                             │
-        log.error("MoltZap: dispatch error: …")                          │
-        return null                                                       │
-      )                                                                   │
-    )                                                                     │
-                                                                         │
-    log.info("dispatch finished …")                                      │
-    if result && !result.queuedFinal                                     │
-      log.debug("completed without final reply")                          │
-  }).pipe(                                                               │
-    Effect.withSpan("createMoltzapChannelPlugin.inboundDispatch")        │
-  )  ───────────────────────────────────────────────────────────────────┘
-      │
-      ▼  back in consumerFiber (channel-core.ts)
-         .catchAllCause(cause => logInboundFailure(work, cause))
-         loop: Queue.take → next message
+
+## Part 2 — Inbound Handler (openclaw-entry.ts)
+
+```mermaid
+sequenceDiagram
+    participant CF as consumerFiber
+    participant H as onInbound handler (Effect.gen)
+    participant CL as writeContextLogOrWarn
+    participant D as deliver closure
+
+    CF->>H: inboundHandler(enriched)
+
+    Note over H: Effect.gen — inside Effect world
+
+    H->>H: chatType = enriched.conversationMeta?.type<br/>fromId = "agent:${enriched.sender.id}"<br/>log.info("MoltZap: inbound from …")<br/>setStatus({ accountId, lastInboundAt, lastEventAt })
+
+    H->>H: crossConvBlock = formatCrossConvOpenClaw(<br/>  enriched.contextBlocks.crossConversationMessages,<br/>  { ownAgentId: service.ownAgentId ?? "" }<br/>)<br/>bodyForAgent = crossConvBlock<br/>  ? crossConvBlock + "\n\n" + enriched.text<br/>  : enriched.text
+
+    H->>CL: yield* writeContextLogOrWarn(log, {<br/>  logDir: contextLogDir (MOLTZAP_OPENCLAW_CONTEXT_LOG_DIR),<br/>  accountId, accountAgentName, ownAgentId,<br/>  conversationId, conversationName, conversationType,<br/>  from, to, body, bodyForAgent, crossConversationMessages<br/>})
+    Note over CL: errors caught → log.warn only; never fails the handler
+
+    H->>H: dispatch = ctx.channelRuntime?.reply<br/>          ?.dispatchReplyWithBufferedBlockDispatcher
+    alt dispatch not available
+        H->>H: log.warn + return
+    else dispatch available
+        H->>H: groupSubject = enriched.conversationMeta?.name<br/>groupMembers = (type==="group") ? participants.join(",") : undefined
+        H->>H: build deliver closure (see Part 3)
+        H->>H: yield* Effect.tryPromise({ try: () => dispatch({<br/>  ctx: { Body, BodyForAgent, From, To,<br/>    SessionKey, AccountId, Provider, Surface,<br/>    OriginatingChannel, OriginatingTo,<br/>    ChatType, GroupSubject?, GroupMembers?,<br/>    ConversationLabel?, SenderName },<br/>  cfg: ctx.cfg,<br/>  dispatcherOptions: { deliver }<br/>}), catch: err => err }).pipe(<br/>  Effect.catchAll(err => log.error + null)<br/>)
+        H->>H: log.info("dispatch finished …")<br/>if result &amp;&amp; !result.queuedFinal → log.debug
+    end
+
+    Note over H,CF: Effect.withSpan("createMoltzapChannelPlugin.inboundDispatch")
+    H-->>CF: Effect completes → consumerFiber loops
+```
+
+## Part 3 — Deliver Closure (per-message, single-use lease)
+
+```mermaid
+flowchart TD
+    A["deliver(payload, info?)"] --> B{"info.kind !== 'final'?"}
+    B -->|yes| C["Promise.resolve(true) — no-op"]
+    B -->|no| D{"text = payload.text ?? payload.body\ntext empty?"}
+    D -->|yes| E["Promise.resolve(true)"]
+    D -->|no| F{"consumedLeaseAt !== null?"}
+    F -->|yes| G["log.warn('duplicate-reply rejected …')\nPromise.resolve(false) — OpenclawDuplicateReply"]
+    F -->|no — first final delivery| H["build deliverEffect:\ncore.sendReply(enriched.conversationId, text)"]
+
+    H --> I["tap: consumedLeaseAt = Date.now()\nlog.info('MoltZap: outbound reply to …')"]
+    I --> J[".map(() => true)"]
+    J --> K{".catchTag('RpcServerError')"}
+    K -->|"err.code === TaskClosedError.code (-32020)"| L["log.warn('task closed, dropping without retry')\nreturn true — signal consumed; do NOT retry"]
+    K -->|other RpcServerError| M["log.error('failed to send reply: …')\nreturn false — retry-eligible"]
+    J --> N{".catchAll(err)"}
+    N --> O["log.error('failed to send reply: …')\nreturn false"]
+
+    L --> P["Effect.runPromise(deliverEffect)"]
+    M --> P
+    O --> P
+    J --> P
+
+    P --> Q["Promise&lt;boolean&gt; → OpenClaw runtime\ntrue = delivered / terminal-consumed\nfalse = retry eligible"]
+
+    style P fill:#f0f0f0,stroke:#999
+    style Q fill:#e8f4e8,stroke:#4a8
 ```
 
 **Context-log writer detail** (`src/context-log.ts`):
 
-```
-writeContextLogOrWarn(log, input)   (openclaw-entry.ts → writeContextLogOrWarn)
-  writeOpenClawContextLog(input)    (context-log.ts → writeOpenClawContextLog)
-    if !input.logDir → Effect.void  (no-op)
-    Effect.gen:
-      fileSystem = yield* FileSystem.FileSystem
-      stateDir from OPENCLAW_STATE_DIR env
-      entry = OpenClawContextLogEntry {
-        schemaVersion:1, recordedAt, pid, cwd,
-        stateDir?, accountId, accountAgentName?,
-        ownAgentId?, conversationId, conversationName?,
-        conversationType, from, to, body, bodyForAgent,
-        crossConversationMessageCount,
-        crossConversationMessages
-      }
-      yield* fileSystem.makeDirectory(logDir, {recursive:true})
-      file = contextLogPath(logDir, accountAgentName)
-             → "<logDir>/<agent>.<stateName>.<pid>.contexts.jsonl"
-             stateName = basename(OPENCLAW_STATE_DIR) | "pid-<pid>"
-      yield* fileSystem.writeFileString(file, JSON.stringify(entry)+"\n",
-                                        {flag:"a"})
-    .provide(NodePath.layer, NodeFileSystem.layer)
-  .catchAll(err → logContextLogWriteFailure(log, err))
-  (never propagates; context-log failure is warn-only)
+```mermaid
+flowchart LR
+    A["writeContextLogOrWarn(log, input)\nopenclaw-entry.ts"] --> B["writeOpenClawContextLog(input)\ncontext-log.ts"]
+    B --> C{"input.logDir set?"}
+    C -->|no| D["Effect.void — no-op"]
+    C -->|yes| E["Effect.gen:\nyield* FileSystem.FileSystem\nstateDir from OPENCLAW_STATE_DIR"]
+    E --> F["build OpenClawContextLogEntry {\n  schemaVersion:1, recordedAt, pid, cwd,\n  stateDir?, accountId, accountAgentName?,\n  ownAgentId?, conversationId, conversationName?,\n  conversationType, from, to, body, bodyForAgent,\n  crossConversationMessageCount,\n  crossConversationMessages\n}"]
+    F --> G["yield* fileSystem.makeDirectory(logDir, {recursive:true})"]
+    G --> H["file = contextLogPath(logDir, accountAgentName)\n→ logDir/agent.stateName.pid.contexts.jsonl\nstateName = basename(OPENCLAW_STATE_DIR) | 'pid-&lt;pid&gt;'"]
+    H --> I["yield* fileSystem.writeFileString(file,\n  JSON.stringify(entry)+newline, {flag:'a'})"]
+    I --> J[".provide(NodePath.layer, NodeFileSystem.layer)"]
+    B --> K[".catchAll(err → logContextLogWriteFailure(log, err))\nnever propagates; context-log failure is warn-only"]
 ```
 
 **Cross-conv formatter** (`src/format-cross-conv.ts`):
 
-```
-formatCrossConvOpenClaw(messages, { ownAgentId })
-  if messages.length === 0 → null
-  items = messages.map(m => {
-    conversation: m.conversationName ?? `DM with @${m.senderName}`
-    sender: m.senderId === ownAgentId ? "You" : m.senderName
-    text: m.text
-    timestamp: m.timestamp
-  })
-  return "Messages (untrusted metadata):\n```json\n<indent-2>\n```"
+```mermaid
+flowchart LR
+    A["formatCrossConvOpenClaw(messages, { ownAgentId })"] --> B{"messages.length === 0?"}
+    B -->|yes| C["return null"]
+    B -->|no| D["items = messages.map(m => {\n  conversation: m.conversationName ?? 'DM with @' + m.senderName\n  sender: m.senderId === ownAgentId ? 'You' : m.senderName\n  text: m.text\n  timestamp: m.timestamp\n})"]
+    D --> E["return formatted string:\n'Messages (untrusted metadata):\\njson block with 2-space indent'"]
 ```
 
 ---

--- a/packages/openclaw-channel/docs/architecture/03-inbound-on-inbound.md
+++ b/packages/openclaw-channel/docs/architecture/03-inbound-on-inbound.md
@@ -13,20 +13,20 @@ sequenceDiagram
     participant DA as dispatchAdmission
 
     WS->>Svc: WebSocket frame ("message" event)
-    Svc->>Q: Queue.unsafeOffer(inboundQueue, work)<br/>work = { message, attempt:0, receivedAtMs, clock }
+    Svc->>Q: Queue.unsafeOffer(inboundQueue, work)<br>work = { message, attempt:0, receivedAtMs, clock }
 
     loop Effect.forever
         CF->>Q: Queue.take
-        CF->>CF: takeDispatchCandidate(work)<br/>(re-order: if parked messages for same conv,<br/> take oldest parked, re-queue incoming)
-        CF->>DA: dispatchAdmission(work)<br/>(dispatch/request RPC → await dispatchRelease verdict)
+        CF->>CF: takeDispatchCandidate(work)<br>(re-order: if parked messages for same conv,<br> take oldest parked, re-queue incoming)
+        CF->>DA: dispatchAdmission(work)<br>(dispatch/request RPC → await dispatchRelease verdict)
 
         alt deny
             DA-->>CF: log + return (message dropped)
         else hold
             DA-->>CF: parkDispatchWork(work) + return
         else grant
-            CF->>CF: dispatchWithLease(messages, leaseId)<br/>sets leaseIdInFlight = leaseId
-            CF->>CF: dispatchInboundEffect(messages)<br/>enrichChannelMessage(service, msgs)<br/>→ resolveAgentName, getConversation,<br/>  peekFullMessages (cross-conv)<br/>enriched = EnrichedInboundMessage<br/>if leaseIdInFlight → attach dispatchLeaseId
+            CF->>CF: dispatchWithLease(messages, leaseId)<br>sets leaseIdInFlight = leaseId
+            CF->>CF: dispatchInboundEffect(messages)<br>enrichChannelMessage(service, msgs)<br>→ resolveAgentName, getConversation,<br>  peekFullMessages (cross-conv)<br>enriched = EnrichedInboundMessage<br>if leaseIdInFlight → attach dispatchLeaseId
             CF->>CF: inboundHandler(enriched)
             Note over CF: → see Part 2 (openclaw-entry.ts handler)
             CF->>CF: .catchAllCause(cause => logInboundFailure(work, cause))
@@ -47,21 +47,21 @@ sequenceDiagram
 
     Note over H: Effect.gen — inside Effect world
 
-    H->>H: chatType = enriched.conversationMeta?.type<br/>fromId = "agent:${enriched.sender.id}"<br/>log.info("MoltZap: inbound from …")<br/>setStatus({ accountId, lastInboundAt, lastEventAt })
+    H->>H: chatType = enriched.conversationMeta?.type<br>fromId = "agent:${enriched.sender.id}"<br>log.info("MoltZap: inbound from …")<br>setStatus({ accountId, lastInboundAt, lastEventAt })
 
-    H->>H: crossConvBlock = formatCrossConvOpenClaw(<br/>  enriched.contextBlocks.crossConversationMessages,<br/>  { ownAgentId: service.ownAgentId ?? "" }<br/>)<br/>bodyForAgent = crossConvBlock<br/>  ? crossConvBlock + "\n\n" + enriched.text<br/>  : enriched.text
+    H->>H: crossConvBlock = formatCrossConvOpenClaw(<br>  enriched.contextBlocks.crossConversationMessages,<br>  { ownAgentId: service.ownAgentId ?? "" }<br>)<br>bodyForAgent = crossConvBlock<br>  ? crossConvBlock + "\n\n" + enriched.text<br>  : enriched.text
 
-    H->>CL: yield* writeContextLogOrWarn(log, {<br/>  logDir: contextLogDir (MOLTZAP_OPENCLAW_CONTEXT_LOG_DIR),<br/>  accountId, accountAgentName, ownAgentId,<br/>  conversationId, conversationName, conversationType,<br/>  from, to, body, bodyForAgent, crossConversationMessages<br/>})
-    Note over CL: errors caught → log.warn only; never fails the handler
+    H->>CL: yield* writeContextLogOrWarn(log, {<br>  logDir: contextLogDir (MOLTZAP_OPENCLAW_CONTEXT_LOG_DIR),<br>  accountId, accountAgentName, ownAgentId,<br>  conversationId, conversationName, conversationType,<br>  from, to, body, bodyForAgent, crossConversationMessages<br>})
+    Note over CL: errors caught → log.warn only— never fails the handler
 
-    H->>H: dispatch = ctx.channelRuntime?.reply<br/>          ?.dispatchReplyWithBufferedBlockDispatcher
+    H->>H: dispatch = ctx.channelRuntime?.reply<br>          ?.dispatchReplyWithBufferedBlockDispatcher
     alt dispatch not available
         H->>H: log.warn + return
     else dispatch available
-        H->>H: groupSubject = enriched.conversationMeta?.name<br/>groupMembers = (type==="group") ? participants.join(",") : undefined
+        H->>H: groupSubject = enriched.conversationMeta?.name<br>groupMembers = (type==="group") ? participants.join(",") : undefined
         H->>H: build deliver closure (see Part 3)
-        H->>H: yield* Effect.tryPromise({ try: () => dispatch({<br/>  ctx: { Body, BodyForAgent, From, To,<br/>    SessionKey, AccountId, Provider, Surface,<br/>    OriginatingChannel, OriginatingTo,<br/>    ChatType, GroupSubject?, GroupMembers?,<br/>    ConversationLabel?, SenderName },<br/>  cfg: ctx.cfg,<br/>  dispatcherOptions: { deliver }<br/>}), catch: err => err }).pipe(<br/>  Effect.catchAll(err => log.error + null)<br/>)
-        H->>H: log.info("dispatch finished …")<br/>if result &amp;&amp; !result.queuedFinal → log.debug
+        H->>H: yield* Effect.tryPromise({ try: () => dispatch({<br>  ctx: { Body, BodyForAgent, From, To,<br>    SessionKey, AccountId, Provider, Surface,<br>    OriginatingChannel, OriginatingTo,<br>    ChatType, GroupSubject?, GroupMembers?,<br>    ConversationLabel?, SenderName },<br>  cfg: ctx.cfg,<br>  dispatcherOptions: { deliver }<br>}), catch: err => err }).pipe(<br>  Effect.catchAll(err => log.error + null)<br>)
+        H->>H: log.info("dispatch finished …")<br>if result &amp—&amp— !result.queuedFinal → log.debug
     end
 
     Note over H,CF: Effect.withSpan("createMoltzapChannelPlugin.inboundDispatch")
@@ -74,26 +74,26 @@ sequenceDiagram
 flowchart TD
     A["deliver(payload, info?)"] --> B{"info.kind !== 'final'?"}
     B -->|yes| C["Promise.resolve(true) — no-op"]
-    B -->|no| D{"text = payload.text ?? payload.body\ntext empty?"}
+    B -->|no| D{"text = payload.text ?? payload.body<br>text empty?"}
     D -->|yes| E["Promise.resolve(true)"]
     D -->|no| F{"consumedLeaseAt !== null?"}
-    F -->|yes| G["log.warn('duplicate-reply rejected …')\nPromise.resolve(false) — OpenclawDuplicateReply"]
-    F -->|no — first final delivery| H["build deliverEffect:\ncore.sendReply(enriched.conversationId, text)"]
+    F -->|yes| G["log.warn('duplicate-reply rejected …')<br>Promise.resolve(false) — OpenclawDuplicateReply"]
+    F -->|no — first final delivery| H["build deliverEffect:<br>core.sendReply(enriched.conversationId, text)"]
 
-    H --> I["tap: consumedLeaseAt = Date.now()\nlog.info('MoltZap: outbound reply to …')"]
+    H --> I["tap: consumedLeaseAt = Date.now()<br>log.info('MoltZap: outbound reply to …')"]
     I --> J[".map(() => true)"]
     J --> K{".catchTag('RpcServerError')"}
-    K -->|"err.code === TaskClosedError.code (-32020)"| L["log.warn('task closed, dropping without retry')\nreturn true — signal consumed; do NOT retry"]
-    K -->|other RpcServerError| M["log.error('failed to send reply: …')\nreturn false — retry-eligible"]
+    K -->|"err.code === TaskClosedError.code (-32020)"| L["log.warn('task closed, dropping without retry')<br>return true — signal consumed; do NOT retry"]
+    K -->|other RpcServerError| M["log.error('failed to send reply: …')<br>return false — retry-eligible"]
     J --> N{".catchAll(err)"}
-    N --> O["log.error('failed to send reply: …')\nreturn false"]
+    N --> O["log.error('failed to send reply: …')<br>return false"]
 
     L --> P["Effect.runPromise(deliverEffect)"]
     M --> P
     O --> P
     J --> P
 
-    P --> Q["Promise&lt;boolean&gt; → OpenClaw runtime\ntrue = delivered / terminal-consumed\nfalse = retry eligible"]
+    P --> Q["Promise&lt;boolean&gt; → OpenClaw runtime<br>true = delivered / terminal-consumed<br>false = retry eligible"]
 
     style P fill:#f0f0f0,stroke:#999
     style Q fill:#e8f4e8,stroke:#4a8
@@ -103,16 +103,16 @@ flowchart TD
 
 ```mermaid
 flowchart LR
-    A["writeContextLogOrWarn(log, input)\nopenclaw-entry.ts"] --> B["writeOpenClawContextLog(input)\ncontext-log.ts"]
+    A["writeContextLogOrWarn(log, input)<br>openclaw-entry.ts"] --> B["writeOpenClawContextLog(input)<br>context-log.ts"]
     B --> C{"input.logDir set?"}
     C -->|no| D["Effect.void — no-op"]
-    C -->|yes| E["Effect.gen:\nyield* FileSystem.FileSystem\nstateDir from OPENCLAW_STATE_DIR"]
-    E --> F["build OpenClawContextLogEntry {\n  schemaVersion:1, recordedAt, pid, cwd,\n  stateDir?, accountId, accountAgentName?,\n  ownAgentId?, conversationId, conversationName?,\n  conversationType, from, to, body, bodyForAgent,\n  crossConversationMessageCount,\n  crossConversationMessages\n}"]
+    C -->|yes| E["Effect.gen:<br>yield* FileSystem.FileSystem<br>stateDir from OPENCLAW_STATE_DIR"]
+    E --> F["build OpenClawContextLogEntry {<br>  schemaVersion:1, recordedAt, pid, cwd,<br>  stateDir?, accountId, accountAgentName?,<br>  ownAgentId?, conversationId, conversationName?,<br>  conversationType, from, to, body, bodyForAgent,<br>  crossConversationMessageCount,<br>  crossConversationMessages<br>}"]
     F --> G["yield* fileSystem.makeDirectory(logDir, {recursive:true})"]
-    G --> H["file = contextLogPath(logDir, accountAgentName)\n→ logDir/agent.stateName.pid.contexts.jsonl\nstateName = basename(OPENCLAW_STATE_DIR) | 'pid-&lt;pid&gt;'"]
-    H --> I["yield* fileSystem.writeFileString(file,\n  JSON.stringify(entry)+newline, {flag:'a'})"]
+    G --> H["file = contextLogPath(logDir, accountAgentName)<br>→ logDir/agent.stateName.pid.contexts.jsonl<br>stateName = basename(OPENCLAW_STATE_DIR) | 'pid-&lt;pid&gt;'"]
+    H --> I["yield* fileSystem.writeFileString(file,<br>  JSON.stringify(entry)+newline, {flag:'a'})"]
     I --> J[".provide(NodePath.layer, NodeFileSystem.layer)"]
-    B --> K[".catchAll(err → logContextLogWriteFailure(log, err))\nnever propagates; context-log failure is warn-only"]
+    B --> K[".catchAll(err → logContextLogWriteFailure(log, err))<br>never propagates; context-log failure is warn-only"]
 ```
 
 **Cross-conv formatter** (`src/format-cross-conv.ts`):
@@ -121,8 +121,8 @@ flowchart LR
 flowchart LR
     A["formatCrossConvOpenClaw(messages, { ownAgentId })"] --> B{"messages.length === 0?"}
     B -->|yes| C["return null"]
-    B -->|no| D["items = messages.map(m => {\n  conversation: m.conversationName ?? 'DM with @' + m.senderName\n  sender: m.senderId === ownAgentId ? 'You' : m.senderName\n  text: m.text\n  timestamp: m.timestamp\n})"]
-    D --> E["return formatted string:\n'Messages (untrusted metadata):\\njson block with 2-space indent'"]
+    B -->|no| D["items = messages.map(m => {<br>  conversation: m.conversationName ?? 'DM with @' + m.senderName<br>  sender: m.senderId === ownAgentId ? 'You' : m.senderName<br>  text: m.text<br>  timestamp: m.timestamp<br>})"]
+    D --> E["return formatted string:<br>'Messages (untrusted metadata):\<br>json block with 2-space indent'"]
 ```
 
 ---

--- a/packages/openclaw-channel/docs/architecture/03-inbound-on-inbound.md
+++ b/packages/openclaw-channel/docs/architecture/03-inbound-on-inbound.md
@@ -2,39 +2,18 @@
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 
-## Part 1 — Consumer Fiber Path (channel-core.ts)
+The inbound flow has two phases: the channel-core consumer fiber (lives
+in `@moltzap/client`) drains the WS inbound queue, runs dispatch
+admission, enriches the message, then invokes the registered
+`onInbound` handler. This package is just the handler — everything
+above it belongs to `@moltzap/client`. For the full consumer-fiber +
+dispatch-admission mechanics, see
+[`client/03-inbound-dispatch.md`](../../../client/docs/architecture/03-inbound-dispatch.md).
 
-```mermaid
-sequenceDiagram
-    participant WS as MoltZap server (WebSocket)
-    participant Svc as MoltZapService
-    participant Q as inboundQueue
-    participant CF as consumerFiber (Effect.forever)
-    participant DA as dispatchAdmission
+What follows covers only the openclaw-channel handler body (the Effect
+the channel registers via `core.onInbound(handler)`).
 
-    WS->>Svc: WebSocket frame ("message" event)
-    Svc->>Q: Queue.unsafeOffer(inboundQueue, work)<br>work = { message, attempt:0, receivedAtMs, clock }
-
-    loop Effect.forever
-        CF->>Q: Queue.take
-        CF->>CF: takeDispatchCandidate(work)<br>(re-order: if parked messages for same conv,<br> take oldest parked, re-queue incoming)
-        CF->>DA: dispatchAdmission(work)<br>(dispatch/request RPC → await dispatchRelease verdict)
-
-        alt deny
-            DA-->>CF: log + return (message dropped)
-        else hold
-            DA-->>CF: parkDispatchWork(work) + return
-        else grant
-            CF->>CF: dispatchWithLease(messages, leaseId)<br>sets leaseIdInFlight = leaseId
-            CF->>CF: dispatchInboundEffect(messages)<br>enrichChannelMessage(service, msgs)<br>→ resolveAgentName, getConversation,<br>  peekFullMessages (cross-conv)<br>enriched = EnrichedInboundMessage<br>if leaseIdInFlight → attach dispatchLeaseId
-            CF->>CF: inboundHandler(enriched)
-            Note over CF: → see Part 2 (openclaw-entry.ts handler)
-            CF->>CF: .catchAllCause(cause => logInboundFailure(work, cause))
-        end
-    end
-```
-
-## Part 2 — Inbound Handler (openclaw-entry.ts)
+## Part 1 — Inbound Handler (openclaw-entry.ts)
 
 ```mermaid
 sequenceDiagram
@@ -59,7 +38,7 @@ sequenceDiagram
         H->>H: log.warn + return
     else dispatch available
         H->>H: groupSubject = enriched.conversationMeta?.name<br>groupMembers = (type==="group") ? participants.join(",") : undefined
-        H->>H: build deliver closure (see Part 3)
+        H->>H: build deliver closure (see Part 2)
         H->>H: yield* Effect.tryPromise({ try: () => dispatch({<br>  ctx: { Body, BodyForAgent, From, To,<br>    SessionKey, AccountId, Provider, Surface,<br>    OriginatingChannel, OriginatingTo,<br>    ChatType, GroupSubject?, GroupMembers?,<br>    ConversationLabel?, SenderName },<br>  cfg: ctx.cfg,<br>  dispatcherOptions: { deliver }<br>}), catch: err => err }).pipe(<br>  Effect.catchAll(err => log.error + null)<br>)
         H->>H: log.info("dispatch finished …")<br>if result &amp—&amp— !result.queuedFinal → log.debug
     end
@@ -68,7 +47,7 @@ sequenceDiagram
     H-->>CF: Effect completes → consumerFiber loops
 ```
 
-## Part 3 — Deliver Closure (per-message, single-use lease)
+## Part 2 — Deliver Closure (per-message, single-use lease)
 
 ```mermaid
 flowchart TD

--- a/packages/openclaw-channel/docs/architecture/04-notification-extractors.md
+++ b/packages/openclaw-channel/docs/architecture/04-notification-extractors.md
@@ -10,71 +10,65 @@ preserved below from the last source revision).
 
 Each extractor follows the same pattern:
 
-```
-extractXxx(frame: NotificationFrame): Result | null
-  decodedNotification(frame)          ← Effect.runSync, returns Option
-    decodeServerInbound(frame)
-    flatMap: tag === "Notification" ? succeed : fail(NotANotificationFrameError)
-    .option
-  Option.match:
-    onNone → null
-    onSome → isFor(notification, XxxNotificationDefinition)
-             ? notification.params.xxx : null
+```mermaid
+flowchart LR
+    A["extractXxx(frame: NotificationFrame)"] --> B["decodedNotification(frame)\nEffect.runSync → Option"]
+    B --> C["decodeServerInbound(frame)\nflatMap: tag === 'Notification'\n  ? succeed : fail(NotANotificationFrameError)\n.option"]
+    C --> D{"Option.match"}
+    D -->|onNone| E["return null"]
+    D -->|onSome| F{"isFor(notification,\nXxxNotificationDefinition)?"}
+    F -->|no| E
+    F -->|yes| G["return notification.params.xxx"]
 ```
 
 **arm 1 — conversationCreated**
 
-```
-extractConversationCreated(event)
-  ← ConversationCreatedNotificationDefinition
-  → { conversation: { id, type, name? } } | null
-  on match:
-    log.debug("conversation created ${id}")
-    setStatus({ accountId, lastEventAt: Date.now() })
+```mermaid
+flowchart LR
+    A["extractConversationCreated(event)\n← ConversationCreatedNotificationDefinition"] --> B{"match?"}
+    B -->|no| C["return null"]
+    B -->|yes| D["{ conversation: { id, type, name? } }"]
+    D --> E["log.debug('conversation created id')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 **arm 2 — conversationUpdated**
 
-```
-extractConversationUpdated(event)
-  ← ConversationUpdatedNotificationDefinition
-  → { conversation: { id, type, name? } } | null
-  on match:
-    log.debug("conversation updated ${id}")
-    setStatus({ accountId, lastEventAt: Date.now() })
+```mermaid
+flowchart LR
+    A["extractConversationUpdated(event)\n← ConversationUpdatedNotificationDefinition"] --> B{"match?"}
+    B -->|no| C["return null"]
+    B -->|yes| D["{ conversation: { id, type, name? } }"]
+    D --> E["log.debug('conversation updated id')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 **arm 3 — contactRequest**
 
-```
-extractContactRequest(event)
-  ← ContactRequestNotificationDefinition
-  → { contact: { id, contactUserId } } | null
-  on match:
-    log.debug("contact request from ${contactUserId}")
-    setStatus({ accountId, lastEventAt: Date.now() })
+```mermaid
+flowchart LR
+    A["extractContactRequest(event)\n← ContactRequestNotificationDefinition"] --> B{"match?"}
+    B -->|no| C["return null"]
+    B -->|yes| D["{ contact: { id, contactUserId } }"]
+    D --> E["log.debug('contact request from contactUserId')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 **arm 4 — contactAccepted**
 
-```
-extractContactAccepted(event)
-  ← ContactAcceptedNotificationDefinition
-  → { contact: { id, contactUserId } } | null
-  on match:
-    log.debug("contact accepted ${id}")
-    setStatus({ accountId, lastEventAt: Date.now() })
+```mermaid
+flowchart LR
+    A["extractContactAccepted(event)\n← ContactAcceptedNotificationDefinition"] --> B{"match?"}
+    B -->|no| C["return null"]
+    B -->|yes| D["{ contact: { id, contactUserId } }"]
+    D --> E["log.debug('contact accepted id')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 **arm 5 — presenceChanged**
 
-```
-extractPresenceChanged(event)
-  ← PresenceChangedNotificationDefinition
-  → { agentId: string, status: string } | null
-  on match:
-    log.debug("${agentId} is now ${status}")
-    setStatus({ accountId, lastEventAt: Date.now() })
+```mermaid
+flowchart LR
+    A["extractPresenceChanged(event)\n← PresenceChangedNotificationDefinition"] --> B{"match?"}
+    B -->|no| C["return null"]
+    B -->|yes| D["{ agentId: string, status: string }"]
+    D --> E["log.debug('agentId is now status')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 All five arms are tried in order for every rawNotification frame. The

--- a/packages/openclaw-channel/docs/architecture/04-notification-extractors.md
+++ b/packages/openclaw-channel/docs/architecture/04-notification-extractors.md
@@ -12,11 +12,11 @@ Each extractor follows the same pattern:
 
 ```mermaid
 flowchart LR
-    A["extractXxx(frame: NotificationFrame)"] --> B["decodedNotification(frame)\nEffect.runSync → Option"]
-    B --> C["decodeServerInbound(frame)\nflatMap: tag === 'Notification'\n  ? succeed : fail(NotANotificationFrameError)\n.option"]
+    A["extractXxx(frame: NotificationFrame)"] --> B["decodedNotification(frame)<br>Effect.runSync → Option"]
+    B --> C["decodeServerInbound(frame)<br>flatMap: tag === 'Notification'<br>  ? succeed : fail(NotANotificationFrameError)<br>.option"]
     C --> D{"Option.match"}
     D -->|onNone| E["return null"]
-    D -->|onSome| F{"isFor(notification,\nXxxNotificationDefinition)?"}
+    D -->|onSome| F{"isFor(notification,<br>XxxNotificationDefinition)?"}
     F -->|no| E
     F -->|yes| G["return notification.params.xxx"]
 ```
@@ -25,50 +25,50 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-    A["extractConversationCreated(event)\n← ConversationCreatedNotificationDefinition"] --> B{"match?"}
+    A["extractConversationCreated(event)<br>← ConversationCreatedNotificationDefinition"] --> B{"match?"}
     B -->|no| C["return null"]
     B -->|yes| D["{ conversation: { id, type, name? } }"]
-    D --> E["log.debug('conversation created id')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
+    D --> E["log.debug('conversation created id')<br>setStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 **arm 2 — conversationUpdated**
 
 ```mermaid
 flowchart LR
-    A["extractConversationUpdated(event)\n← ConversationUpdatedNotificationDefinition"] --> B{"match?"}
+    A["extractConversationUpdated(event)<br>← ConversationUpdatedNotificationDefinition"] --> B{"match?"}
     B -->|no| C["return null"]
     B -->|yes| D["{ conversation: { id, type, name? } }"]
-    D --> E["log.debug('conversation updated id')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
+    D --> E["log.debug('conversation updated id')<br>setStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 **arm 3 — contactRequest**
 
 ```mermaid
 flowchart LR
-    A["extractContactRequest(event)\n← ContactRequestNotificationDefinition"] --> B{"match?"}
+    A["extractContactRequest(event)<br>← ContactRequestNotificationDefinition"] --> B{"match?"}
     B -->|no| C["return null"]
     B -->|yes| D["{ contact: { id, contactUserId } }"]
-    D --> E["log.debug('contact request from contactUserId')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
+    D --> E["log.debug('contact request from contactUserId')<br>setStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 **arm 4 — contactAccepted**
 
 ```mermaid
 flowchart LR
-    A["extractContactAccepted(event)\n← ContactAcceptedNotificationDefinition"] --> B{"match?"}
+    A["extractContactAccepted(event)<br>← ContactAcceptedNotificationDefinition"] --> B{"match?"}
     B -->|no| C["return null"]
     B -->|yes| D["{ contact: { id, contactUserId } }"]
-    D --> E["log.debug('contact accepted id')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
+    D --> E["log.debug('contact accepted id')<br>setStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 **arm 5 — presenceChanged**
 
 ```mermaid
 flowchart LR
-    A["extractPresenceChanged(event)\n← PresenceChangedNotificationDefinition"] --> B{"match?"}
+    A["extractPresenceChanged(event)<br>← PresenceChangedNotificationDefinition"] --> B{"match?"}
     B -->|no| C["return null"]
     B -->|yes| D["{ agentId: string, status: string }"]
-    D --> E["log.debug('agentId is now status')\nsetStatus({ accountId, lastEventAt: Date.now() })"]
+    D --> E["log.debug('agentId is now status')<br>setStatus({ accountId, lastEventAt: Date.now() })"]
 ```
 
 All five arms are tried in order for every rawNotification frame. The

--- a/packages/openclaw-channel/docs/architecture/04-notification-extractors.md
+++ b/packages/openclaw-channel/docs/architecture/04-notification-extractors.md
@@ -1,0 +1,89 @@
+# Notification Extractors (`mapping.ts`)
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+The `service.on("rawNotification", …)` handler (registered in `openclaw-entry.ts →
+startAccount`) runs a sequential dispatch chain. Each arm calls a pure extractor from
+`src/mapping.ts` (now deleted; logic lives in the compiled dist —
+the source was deleted in commit dabad82 but the extractor shapes are
+preserved below from the last source revision).
+
+Each extractor follows the same pattern:
+
+```
+extractXxx(frame: NotificationFrame): Result | null
+  decodedNotification(frame)          ← Effect.runSync, returns Option
+    decodeServerInbound(frame)
+    flatMap: tag === "Notification" ? succeed : fail(NotANotificationFrameError)
+    .option
+  Option.match:
+    onNone → null
+    onSome → isFor(notification, XxxNotificationDefinition)
+             ? notification.params.xxx : null
+```
+
+**arm 1 — conversationCreated**
+
+```
+extractConversationCreated(event)
+  ← ConversationCreatedNotificationDefinition
+  → { conversation: { id, type, name? } } | null
+  on match:
+    log.debug("conversation created ${id}")
+    setStatus({ accountId, lastEventAt: Date.now() })
+```
+
+**arm 2 — conversationUpdated**
+
+```
+extractConversationUpdated(event)
+  ← ConversationUpdatedNotificationDefinition
+  → { conversation: { id, type, name? } } | null
+  on match:
+    log.debug("conversation updated ${id}")
+    setStatus({ accountId, lastEventAt: Date.now() })
+```
+
+**arm 3 — contactRequest**
+
+```
+extractContactRequest(event)
+  ← ContactRequestNotificationDefinition
+  → { contact: { id, contactUserId } } | null
+  on match:
+    log.debug("contact request from ${contactUserId}")
+    setStatus({ accountId, lastEventAt: Date.now() })
+```
+
+**arm 4 — contactAccepted**
+
+```
+extractContactAccepted(event)
+  ← ContactAcceptedNotificationDefinition
+  → { contact: { id, contactUserId } } | null
+  on match:
+    log.debug("contact accepted ${id}")
+    setStatus({ accountId, lastEventAt: Date.now() })
+```
+
+**arm 5 — presenceChanged**
+
+```
+extractPresenceChanged(event)
+  ← PresenceChangedNotificationDefinition
+  → { agentId: string, status: string } | null
+  on match:
+    log.debug("${agentId} is now ${status}")
+    setStatus({ accountId, lastEventAt: Date.now() })
+```
+
+All five arms are tried in order for every rawNotification frame. The
+first matching arm executes, calls `return`, and subsequent arms are
+skipped. The rawNotification handler is sync — it does NOT enter the
+Effect runtime. setStatus is a direct call into OpenClaw's status API.
+
+---
+
+See also:
+- [01-start-account-lifecycle.md](01-start-account-lifecycle.md) — where `service.on("rawNotification", …)` is registered
+- [03-inbound-on-inbound.md](03-inbound-on-inbound.md) — the separate inbound message path (messages/received, not notifications)

--- a/packages/openclaw-channel/docs/architecture/05-deliver-error-handling.md
+++ b/packages/openclaw-channel/docs/architecture/05-deliver-error-handling.md
@@ -1,0 +1,72 @@
+# `deliver()` Error Handling — RpcServerError Discrimination
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+This is load-bearing. The wrong return value here causes OpenClaw to
+retry (or not retry) the reply delivery. The code lives inside the
+per-message `deliver` closure in `openclaw-entry.ts → onInbound, deliver`.
+
+```
+core.sendReply(conversationId, text)
+  (calls service.send with dispatchLeaseId, in `openclaw-entry.ts → sendReply`)
+
+       ┌─ SUCCESS ──────────────────────────────────────────────┐
+       │  .tap(() => {                                           │
+       │    consumedLeaseAt = Date.now()  ← lease now consumed  │
+       │    log.info("outbound reply to …: ${text[:80]}")       │
+       │  })                                                     │
+       │  .map(() => true)  ← deliver returns true (delivered)  │
+       └─────────────────────────────────────────────────────── ┘
+
+       ┌─ FAILURE path 1: RpcServerError ──────────────────────────────┐
+       │  .catchTag("RpcServerError", (err: RpcServerError) =>          │
+       │                                                                │
+       │    if err.code === TaskClosedError.code               (-32020) │
+       │    ┌── TERMINAL: Task is closed ────────────────────────────── │
+       │    │   log.warn({ conversationId, code, msg },                 │
+       │    │             "send rejected — task closed, dropping")      │
+       │    │   return true                                              │
+       │    │   ─────────────────────────────────────────────────────── │
+       │    │   WHY true? The lease is consumed on the server side.     │
+       │    │   Returning true tells OpenClaw "delivered" so it does    │
+       │    │   NOT retry. Retrying would create a new orphan send.     │
+       │    │   This was the PR #587 fix: previously returned false,    │
+       │    │   causing infinite retry loops on closed tasks.           │
+       │    └─────────────────────────────────────────────────────────  │
+       │    else                                                         │
+       │    ┌── RETRY-ELIGIBLE: other RpcServerError ─────────────────  │
+       │    │   log.error("failed to send reply: …")                    │
+       │    │   return false                                             │
+       │    │   ─────────────────────────────────────────────────────── │
+       │    │   WHY false? Non-terminal server error (e.g. rate limit,  │
+       │    │   transient server fault). OpenClaw may retry.            │
+       │    └─────────────────────────────────────────────────────────  │
+       └────────────────────────────────────────────────────────────── ┘
+
+       ┌─ FAILURE path 2: any other error ─────────────────────────────┐
+       │  .catchAll(err =>                                              │
+       │    log.error("failed to send reply: …")                        │
+       │    return false                                                 │
+       │  )                                                             │
+       │  (network drops, Effect runtime errors, etc.)                  │
+       └────────────────────────────────────────────────────────────── ┘
+
+       ▼
+  Effect.runPromise(deliverEffect)
+  ────────────────── Promise boundary ───────────────────────────────────
+  Promise<boolean> → OpenClaw runtime
+    true  = "delivered or terminal-consumed; do not retry"
+    false = "delivery failed; retry eligible"
+
+TaskClosedError.code:
+  Defined in @moltzap/protocol/task.
+  Wire value: -32020.
+  Meaning: the server-side task context for this conversation is closed;
+  no further messages can be sent. Terminal; must not retry.
+```
+
+---
+
+See also:
+- [03-inbound-on-inbound.md](03-inbound-on-inbound.md) — the full Effect chain in which the deliver closure lives
+- [02-outbound-send-text.md](02-outbound-send-text.md) — the separate outbound sendText path (not reply delivery)

--- a/packages/openclaw-channel/docs/architecture/05-deliver-error-handling.md
+++ b/packages/openclaw-channel/docs/architecture/05-deliver-error-handling.md
@@ -8,28 +8,28 @@ per-message `deliver` closure in `openclaw-entry.ts → onInbound, deliver`.
 
 ```mermaid
 flowchart TD
-    A["core.sendReply(conversationId, text)\n(calls service.send with dispatchLeaseId,\nopenclaw-entry.ts → sendReply)"]
+    A["core.sendReply(conversationId, text)<br>(calls service.send with dispatchLeaseId,<br>openclaw-entry.ts → sendReply)"]
 
     A --> B{"Outcome"}
 
-    B -->|SUCCESS| C[".tap(() => {\n  consumedLeaseAt = Date.now()\n  log.info('outbound reply to …: text[:80]')\n})\n.map(() => true)"]
+    B -->|SUCCESS| C[".tap(() => {<br>  consumedLeaseAt = Date.now()<br>  log.info('outbound reply to …: text[:80]')<br>})<br>.map(() => true)"]
 
-    B -->|"FAILURE: RpcServerError\n.catchTag('RpcServerError')"| D{"err.code ===\nTaskClosedError.code\n(-32020)?"}
+    B -->|"FAILURE: RpcServerError<br>.catchTag('RpcServerError')"| D{"err.code ===<br>TaskClosedError.code<br>(-32020)?"}
 
-    D -->|yes — TERMINAL| E["log.warn({ conversationId, code, msg },\n'send rejected — task closed, dropping')\nreturn true"]
-    E --> F["WHY true? Lease is consumed server-side.\nReturning true tells OpenClaw 'delivered'\nso it does NOT retry. Retrying would create\na new orphan send.\n(PR #587 fix: previously returned false,\ncausing infinite retry loops on closed tasks.)"]
+    D -->|yes — TERMINAL| E["log.warn({ conversationId, code, msg },<br>'send rejected — task closed, dropping')<br>return true"]
+    E --> F["WHY true? Lease is consumed server-side.<br>Returning true tells OpenClaw 'delivered'<br>so it does NOT retry. Retrying would create<br>a new orphan send.<br>(PR #587 fix: previously returned false,<br>causing infinite retry loops on closed tasks.)"]
 
-    D -->|no — RETRY-ELIGIBLE| G["log.error('failed to send reply: …')\nreturn false"]
-    G --> H["WHY false? Non-terminal server error\n(e.g. rate limit, transient server fault).\nOpenClaw may retry."]
+    D -->|no — RETRY-ELIGIBLE| G["log.error('failed to send reply: …')<br>return false"]
+    G --> H["WHY false? Non-terminal server error<br>(e.g. rate limit, transient server fault).<br>OpenClaw may retry."]
 
-    B -->|"FAILURE: any other error\n.catchAll(err)"| I["log.error('failed to send reply: …')\nreturn false\n(network drops, Effect runtime errors, etc.)"]
+    B -->|"FAILURE: any other error<br>.catchAll(err)"| I["log.error('failed to send reply: …')<br>return false<br>(network drops, Effect runtime errors, etc.)"]
 
-    C --> J["Effect.runPromise(deliverEffect)\n— Effect↔Promise boundary —"]
+    C --> J["Effect.runPromise(deliverEffect)<br>— Effect↔Promise boundary —"]
     F --> J
     H --> J
     I --> J
 
-    J --> K["Promise&lt;boolean&gt; → OpenClaw runtime\ntrue  = delivered or terminal-consumed; do not retry\nfalse = delivery failed; retry eligible"]
+    J --> K["Promise&lt;boolean&gt; → OpenClaw runtime<br>true  = delivered or terminal-consumed; do not retry<br>false = delivery failed; retry eligible"]
 
     style E fill:#fff3cd,stroke:#d4a
     style G fill:#fde,stroke:#d44

--- a/packages/openclaw-channel/docs/architecture/05-deliver-error-handling.md
+++ b/packages/openclaw-channel/docs/architecture/05-deliver-error-handling.md
@@ -6,64 +6,40 @@ This is load-bearing. The wrong return value here causes OpenClaw to
 retry (or not retry) the reply delivery. The code lives inside the
 per-message `deliver` closure in `openclaw-entry.ts → onInbound, deliver`.
 
+```mermaid
+flowchart TD
+    A["core.sendReply(conversationId, text)\n(calls service.send with dispatchLeaseId,\nopenclaw-entry.ts → sendReply)"]
+
+    A --> B{"Outcome"}
+
+    B -->|SUCCESS| C[".tap(() => {\n  consumedLeaseAt = Date.now()\n  log.info('outbound reply to …: text[:80]')\n})\n.map(() => true)"]
+
+    B -->|"FAILURE: RpcServerError\n.catchTag('RpcServerError')"| D{"err.code ===\nTaskClosedError.code\n(-32020)?"}
+
+    D -->|yes — TERMINAL| E["log.warn({ conversationId, code, msg },\n'send rejected — task closed, dropping')\nreturn true"]
+    E --> F["WHY true? Lease is consumed server-side.\nReturning true tells OpenClaw 'delivered'\nso it does NOT retry. Retrying would create\na new orphan send.\n(PR #587 fix: previously returned false,\ncausing infinite retry loops on closed tasks.)"]
+
+    D -->|no — RETRY-ELIGIBLE| G["log.error('failed to send reply: …')\nreturn false"]
+    G --> H["WHY false? Non-terminal server error\n(e.g. rate limit, transient server fault).\nOpenClaw may retry."]
+
+    B -->|"FAILURE: any other error\n.catchAll(err)"| I["log.error('failed to send reply: …')\nreturn false\n(network drops, Effect runtime errors, etc.)"]
+
+    C --> J["Effect.runPromise(deliverEffect)\n— Effect↔Promise boundary —"]
+    F --> J
+    H --> J
+    I --> J
+
+    J --> K["Promise&lt;boolean&gt; → OpenClaw runtime\ntrue  = delivered or terminal-consumed; do not retry\nfalse = delivery failed; retry eligible"]
+
+    style E fill:#fff3cd,stroke:#d4a
+    style G fill:#fde,stroke:#d44
+    style I fill:#fde,stroke:#d44
+    style C fill:#dfd,stroke:#4a4
 ```
-core.sendReply(conversationId, text)
-  (calls service.send with dispatchLeaseId, in `openclaw-entry.ts → sendReply`)
 
-       ┌─ SUCCESS ──────────────────────────────────────────────┐
-       │  .tap(() => {                                           │
-       │    consumedLeaseAt = Date.now()  ← lease now consumed  │
-       │    log.info("outbound reply to …: ${text[:80]}")       │
-       │  })                                                     │
-       │  .map(() => true)  ← deliver returns true (delivered)  │
-       └─────────────────────────────────────────────────────── ┘
+**Annotations:**
 
-       ┌─ FAILURE path 1: RpcServerError ──────────────────────────────┐
-       │  .catchTag("RpcServerError", (err: RpcServerError) =>          │
-       │                                                                │
-       │    if err.code === TaskClosedError.code               (-32020) │
-       │    ┌── TERMINAL: Task is closed ────────────────────────────── │
-       │    │   log.warn({ conversationId, code, msg },                 │
-       │    │             "send rejected — task closed, dropping")      │
-       │    │   return true                                              │
-       │    │   ─────────────────────────────────────────────────────── │
-       │    │   WHY true? The lease is consumed on the server side.     │
-       │    │   Returning true tells OpenClaw "delivered" so it does    │
-       │    │   NOT retry. Retrying would create a new orphan send.     │
-       │    │   This was the PR #587 fix: previously returned false,    │
-       │    │   causing infinite retry loops on closed tasks.           │
-       │    └─────────────────────────────────────────────────────────  │
-       │    else                                                         │
-       │    ┌── RETRY-ELIGIBLE: other RpcServerError ─────────────────  │
-       │    │   log.error("failed to send reply: …")                    │
-       │    │   return false                                             │
-       │    │   ─────────────────────────────────────────────────────── │
-       │    │   WHY false? Non-terminal server error (e.g. rate limit,  │
-       │    │   transient server fault). OpenClaw may retry.            │
-       │    └─────────────────────────────────────────────────────────  │
-       └────────────────────────────────────────────────────────────── ┘
-
-       ┌─ FAILURE path 2: any other error ─────────────────────────────┐
-       │  .catchAll(err =>                                              │
-       │    log.error("failed to send reply: …")                        │
-       │    return false                                                 │
-       │  )                                                             │
-       │  (network drops, Effect runtime errors, etc.)                  │
-       └────────────────────────────────────────────────────────────── ┘
-
-       ▼
-  Effect.runPromise(deliverEffect)
-  ────────────────── Promise boundary ───────────────────────────────────
-  Promise<boolean> → OpenClaw runtime
-    true  = "delivered or terminal-consumed; do not retry"
-    false = "delivery failed; retry eligible"
-
-TaskClosedError.code:
-  Defined in @moltzap/protocol/task.
-  Wire value: -32020.
-  Meaning: the server-side task context for this conversation is closed;
-  no further messages can be sent. Terminal; must not retry.
-```
+- `TaskClosedError.code`: Defined in `@moltzap/protocol/task`. Wire value: `-32020`. Meaning: the server-side task context for this conversation is closed; no further messages can be sent. Terminal; must not retry.
 
 ---
 

--- a/packages/openclaw-channel/docs/architecture/06-stop-account-lifecycle.md
+++ b/packages/openclaw-channel/docs/architecture/06-stop-account-lifecycle.md
@@ -1,0 +1,67 @@
+# `stopAccount` Lifecycle
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+```
+OpenClaw runtime
+      │
+      │  gateway.stopAccount(ctx)
+      │  ctx = { accountId, log? }
+      │
+      ▼
+  service = activeClients.get(ctx.accountId)   (in `openclaw-entry.ts`)
+      │
+      ├─[service found]
+      │   ctx.log?.info?.("MoltZap: stopping")
+      │   service.close()          ← MoltZapService.close()
+      │   activeClients.delete(ctx.accountId)
+      │
+      └─[service not found]
+          (no-op; idempotent)
+      │
+      ▼
+  return Promise.resolve()        ← always resolves immediately
+```
+
+**What `service.close()` tears down:**
+
+`MoltZapService.close()` is defined in `@moltzap/client/src/service.ts`.
+It closes the underlying WebSocket transport. The WsClient event loop
+fires a "disconnect" event, which:
+- sets `core.connected = false`
+- calls all `disconnectHandlers` registered via `core.onDisconnect`
+  (in `openclaw-entry.ts → startAccount, onDisconnect`: log.warn + setStatus)
+
+`MoltZapChannelCore` itself is NOT explicitly torn down by `stopAccount`.
+The consumer fiber (`consumerFiber`) is interrupted only by
+`core.disconnect()`, which is NOT called in `stopAccount`. This means:
+
+```
+Race: stopAccount vs in-flight inbound
+───────────────────────────────────────
+  1. stopAccount calls service.close()
+  2. WS closes; no new "message" events fired
+  3. consumerFiber is still alive but inboundQueue will drain
+     to empty and then block on Queue.take forever
+  4. activeClients entry is deleted → future sendText for this
+     accountId will receive MoltZapClientNotConnectedError
+  5. Existing in-flight inbound handler (if in the middle of
+     dispatchReplyWithBufferedBlockDispatcher) continues to run
+     because service.close() doesn't interrupt the Effect fiber
+
+Idempotency:
+  Multiple stopAccount calls for the same accountId:
+  - First call: service found, close() + delete → safe
+  - Subsequent calls: service not found, no-op → safe
+  No mutex needed; JavaScript event loop is single-threaded.
+
+Contrast with abort path (§3.1 Path B):
+  abortSignal handler calls Effect.runPromise(core.disconnect()),
+  which calls Fiber.interrupt(consumerFiber) in addition to
+  service.close(). stopAccount does NOT interrupt the fiber.
+```
+
+---
+
+See also:
+- [01-start-account-lifecycle.md](01-start-account-lifecycle.md) — the startup counterpart, and the abort path that does interrupt the fiber

--- a/packages/openclaw-channel/docs/architecture/06-stop-account-lifecycle.md
+++ b/packages/openclaw-channel/docs/architecture/06-stop-account-lifecycle.md
@@ -9,16 +9,16 @@ sequenceDiagram
     participant Clients as activeClients Map
     participant Svc as MoltZapService
 
-    OC->>Entry: gateway.stopAccount(ctx)<br/>ctx = { accountId, log? }
+    OC->>Entry: gateway.stopAccount(ctx)<br>ctx = { accountId, log? }
     Entry->>Clients: activeClients.get(ctx.accountId)
 
     alt service found
         Entry->>Entry: ctx.log?.info?.("MoltZap: stopping")
         Entry->>Svc: service.close() — MoltZapService.close()
-        Note over Svc: closes WebSocket transport;<br/>WsClient fires "disconnect" event →<br/>core.connected = false;<br/>disconnectHandlers called (log.warn + setStatus)
+        Note over Svc: closes WebSocket transport—<br>WsClient fires "disconnect" event →<br>core.connected = false—<br>disconnectHandlers called (log.warn + setStatus)
         Entry->>Clients: activeClients.delete(ctx.accountId)
     else service not found
-        Note over Entry: no-op; idempotent
+        Note over Entry: no-op— idempotent
     end
 
     Entry-->>OC: return Promise.resolve() — always resolves immediately
@@ -40,19 +40,19 @@ The consumer fiber (`consumerFiber`) is interrupted only by
 ```mermaid
 flowchart TD
     A["stopAccount calls service.close()"] --> B["WS closes — no new 'message' events fired"]
-    B --> C["consumerFiber is still alive\ninboundQueue drains to empty\nthen blocks on Queue.take forever"]
-    B --> D["activeClients entry deleted\nfuture sendText for this accountId\nreceives MoltZapClientNotConnectedError"]
-    B --> E["Existing in-flight inbound handler continues to run\nservice.close() does NOT interrupt the Effect fiber"]
+    B --> C["consumerFiber is still alive<br>inboundQueue drains to empty<br>then blocks on Queue.take forever"]
+    B --> D["activeClients entry deleted<br>future sendText for this accountId<br>receives MoltZapClientNotConnectedError"]
+    B --> E["Existing in-flight inbound handler continues to run<br>service.close() does NOT interrupt the Effect fiber"]
 
     subgraph Idempotency
-        F["First stopAccount call\nservice found → close() + delete"] --> G["Safe"]
-        H["Subsequent stopAccount calls\nservice not found → no-op"] --> I["Safe"]
-        J["No mutex needed\nJavaScript event loop is single-threaded"]
+        F["First stopAccount call<br>service found → close() + delete"] --> G["Safe"]
+        H["Subsequent stopAccount calls<br>service not found → no-op"] --> I["Safe"]
+        J["No mutex needed<br>JavaScript event loop is single-threaded"]
     end
 
     subgraph Contrast ["Contrast with abort path (§3.1 Path B)"]
-        K["abortSignal handler calls\nEffect.runPromise(core.disconnect())"] --> L["Fiber.interrupt(consumerFiber)\n+ service.close()"]
-        M["stopAccount does NOT\ninterrupt the fiber"]
+        K["abortSignal handler calls<br>Effect.runPromise(core.disconnect())"] --> L["Fiber.interrupt(consumerFiber)<br>+ service.close()"]
+        M["stopAccount does NOT<br>interrupt the fiber"]
     end
 ```
 

--- a/packages/openclaw-channel/docs/architecture/06-stop-account-lifecycle.md
+++ b/packages/openclaw-channel/docs/architecture/06-stop-account-lifecycle.md
@@ -2,25 +2,26 @@
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 
-```
-OpenClaw runtime
-      │
-      │  gateway.stopAccount(ctx)
-      │  ctx = { accountId, log? }
-      │
-      ▼
-  service = activeClients.get(ctx.accountId)   (in `openclaw-entry.ts`)
-      │
-      ├─[service found]
-      │   ctx.log?.info?.("MoltZap: stopping")
-      │   service.close()          ← MoltZapService.close()
-      │   activeClients.delete(ctx.accountId)
-      │
-      └─[service not found]
-          (no-op; idempotent)
-      │
-      ▼
-  return Promise.resolve()        ← always resolves immediately
+```mermaid
+sequenceDiagram
+    participant OC as OpenClaw runtime
+    participant Entry as openclaw-entry.ts
+    participant Clients as activeClients Map
+    participant Svc as MoltZapService
+
+    OC->>Entry: gateway.stopAccount(ctx)<br/>ctx = { accountId, log? }
+    Entry->>Clients: activeClients.get(ctx.accountId)
+
+    alt service found
+        Entry->>Entry: ctx.log?.info?.("MoltZap: stopping")
+        Entry->>Svc: service.close() — MoltZapService.close()
+        Note over Svc: closes WebSocket transport;<br/>WsClient fires "disconnect" event →<br/>core.connected = false;<br/>disconnectHandlers called (log.warn + setStatus)
+        Entry->>Clients: activeClients.delete(ctx.accountId)
+    else service not found
+        Note over Entry: no-op; idempotent
+    end
+
+    Entry-->>OC: return Promise.resolve() — always resolves immediately
 ```
 
 **What `service.close()` tears down:**
@@ -36,29 +37,23 @@ fires a "disconnect" event, which:
 The consumer fiber (`consumerFiber`) is interrupted only by
 `core.disconnect()`, which is NOT called in `stopAccount`. This means:
 
-```
-Race: stopAccount vs in-flight inbound
-───────────────────────────────────────
-  1. stopAccount calls service.close()
-  2. WS closes; no new "message" events fired
-  3. consumerFiber is still alive but inboundQueue will drain
-     to empty and then block on Queue.take forever
-  4. activeClients entry is deleted → future sendText for this
-     accountId will receive MoltZapClientNotConnectedError
-  5. Existing in-flight inbound handler (if in the middle of
-     dispatchReplyWithBufferedBlockDispatcher) continues to run
-     because service.close() doesn't interrupt the Effect fiber
+```mermaid
+flowchart TD
+    A["stopAccount calls service.close()"] --> B["WS closes — no new 'message' events fired"]
+    B --> C["consumerFiber is still alive\ninboundQueue drains to empty\nthen blocks on Queue.take forever"]
+    B --> D["activeClients entry deleted\nfuture sendText for this accountId\nreceives MoltZapClientNotConnectedError"]
+    B --> E["Existing in-flight inbound handler continues to run\nservice.close() does NOT interrupt the Effect fiber"]
 
-Idempotency:
-  Multiple stopAccount calls for the same accountId:
-  - First call: service found, close() + delete → safe
-  - Subsequent calls: service not found, no-op → safe
-  No mutex needed; JavaScript event loop is single-threaded.
+    subgraph Idempotency
+        F["First stopAccount call\nservice found → close() + delete"] --> G["Safe"]
+        H["Subsequent stopAccount calls\nservice not found → no-op"] --> I["Safe"]
+        J["No mutex needed\nJavaScript event loop is single-threaded"]
+    end
 
-Contrast with abort path (§3.1 Path B):
-  abortSignal handler calls Effect.runPromise(core.disconnect()),
-  which calls Fiber.interrupt(consumerFiber) in addition to
-  service.close(). stopAccount does NOT interrupt the fiber.
+    subgraph Contrast ["Contrast with abort path (§3.1 Path B)"]
+        K["abortSignal handler calls\nEffect.runPromise(core.disconnect())"] --> L["Fiber.interrupt(consumerFiber)\n+ service.close()"]
+        M["stopAccount does NOT\ninterrupt the fiber"]
+    end
 ```
 
 ---

--- a/packages/openclaw-channel/docs/architecture/07-resolve-target.md
+++ b/packages/openclaw-channel/docs/architecture/07-resolve-target.md
@@ -11,12 +11,12 @@ Signature: `resolveTarget(params) → Promise<Result | null>`
 
 ```mermaid
 flowchart TD
-    A["resolveTarget(params)\nparams.normalized"] --> B{"isMoltZapTarget(normalized)?\nMOLTZAP_TARGET_RE = /^(agent|conv):.+$/"}
-    B -->|no match| C["return null\nnot our namespace;\nOpenClaw tries next resolver"]
+    A["resolveTarget(params)<br>params.normalized"] --> B{"isMoltZapTarget(normalized)?<br>MOLTZAP_TARGET_RE = /^(agent|conv):.+$/"}
+    B -->|no match| C["return null<br>not our namespace;<br>OpenClaw tries next resolver"]
     B -->|match| D{"normalized starts with 'conv:'?"}
     D -->|yes| E["kind = 'group'"]
     D -->|no| F["kind = 'user'"]
-    E --> G["Promise.resolve({\n  to: normalized,\n  kind,\n  display: normalized.split(':').slice(1).join(':'),\n  source: 'normalized'\n})\nNo server round-trip; pure string parse."]
+    E --> G["Promise.resolve({<br>  to: normalized,<br>  kind,<br>  display: normalized.split(':').slice(1).join(':'),<br>  source: 'normalized'<br>})<br>No server round-trip; pure string parse."]
     F --> G
 ```
 
@@ -27,11 +27,11 @@ Signature: `resolveTarget(params) → OpenClawTargetResolveResult` (synchronous 
 
 ```mermaid
 flowchart TD
-    A["resolveTarget(params)\nparams.to (after trim)"] --> B{"empty string?"}
-    B -->|yes| C["return new OpenClawTargetRejected({\n  error: new Error('MoltZap: target is required')\n})"]
-    B -->|no| D{"contains ':'\nAND fails isMoltZapTarget?\ne.g. 'slack:alice', 'http://example.com'"}
-    D -->|yes| E["return new OpenClawTargetRejected({\n  error: new Error(\n    'MoltZap: unsupported target format &lt;to&gt;'\n    + ' — use agent:&lt;name&gt; or conv:&lt;id&gt;'\n  )\n})"]
-    D -->|no| F["passes isMoltZapTarget\nOR contains no ':'\n(plain UUID — backward compat path)"]
+    A["resolveTarget(params)<br>params.to (after trim)"] --> B{"empty string?"}
+    B -->|yes| C["return new OpenClawTargetRejected({<br>  error: new Error('MoltZap: target is required')<br>})"]
+    B -->|no| D{"contains ':'<br>AND fails isMoltZapTarget?<br>e.g. 'slack:alice', 'http://example.com'"}
+    D -->|yes| E["return new OpenClawTargetRejected({<br>  error: new Error(<br>    'MoltZap: unsupported target format &lt;to&gt;'<br>    + ' — use agent:&lt;name&gt; or conv:&lt;id&gt;'<br>  )<br>})"]
+    D -->|no| F["passes isMoltZapTarget<br>OR contains no ':'<br>(plain UUID — backward compat path)"]
     F --> G["return new OpenClawTargetResolved({ to })"]
 ```
 

--- a/packages/openclaw-channel/docs/architecture/07-resolve-target.md
+++ b/packages/openclaw-channel/docs/architecture/07-resolve-target.md
@@ -6,70 +6,49 @@
 
 **A. `messaging.targetResolver.resolveTarget` (directory resolver)**
 
-```
-Called by: OpenClaw's address-book pipeline
-           (wired in `openclaw-entry.ts → messaging.targetResolver`)
-Signature: resolveTarget(params) → Promise<Result | null>
+Called by: OpenClaw's address-book pipeline (wired in `openclaw-entry.ts → messaging.targetResolver`).
+Signature: `resolveTarget(params) → Promise<Result | null>`
 
-params.normalized → isMoltZapTarget(normalized)?
-  returns null     ← not our namespace; OpenClaw tries next resolver
-
-  MOLTZAP_TARGET_RE = /^(agent|conv):.+$/   (in `openclaw-entry.ts`)
-  matches: "agent:anything" or "conv:anything"
-
-  on match → Promise.resolve({
-    to:      normalized,
-    kind:    conv:* → "group" | otherwise → "user",
-    display: normalized.split(":").slice(1).join(":"),
-              e.g. "agent:alice" → display "alice"
-              e.g. "conv:abc-123" → display "abc-123"
-    source:  "normalized"
-  })
-  No server round-trip; pure string parse.
+```mermaid
+flowchart TD
+    A["resolveTarget(params)\nparams.normalized"] --> B{"isMoltZapTarget(normalized)?\nMOLTZAP_TARGET_RE = /^(agent|conv):.+$/"}
+    B -->|no match| C["return null\nnot our namespace;\nOpenClaw tries next resolver"]
+    B -->|match| D{"normalized starts with 'conv:'?"}
+    D -->|yes| E["kind = 'group'"]
+    D -->|no| F["kind = 'user'"]
+    E --> G["Promise.resolve({\n  to: normalized,\n  kind,\n  display: normalized.split(':').slice(1).join(':'),\n  source: 'normalized'\n})\nNo server round-trip; pure string parse."]
+    F --> G
 ```
 
 **B. `outbound.resolveTarget` (send-time validation)**
 
+Called by: OpenClaw before calling `outbound.sendText` (wired in `openclaw-entry.ts → outbound.resolveTarget`).
+Signature: `resolveTarget(params) → OpenClawTargetResolveResult` (synchronous — no Promise)
+
+```mermaid
+flowchart TD
+    A["resolveTarget(params)\nparams.to (after trim)"] --> B{"empty string?"}
+    B -->|yes| C["return new OpenClawTargetRejected({\n  error: new Error('MoltZap: target is required')\n})"]
+    B -->|no| D{"contains ':'\nAND fails isMoltZapTarget?\ne.g. 'slack:alice', 'http://example.com'"}
+    D -->|yes| E["return new OpenClawTargetRejected({\n  error: new Error(\n    'MoltZap: unsupported target format &lt;to&gt;'\n    + ' — use agent:&lt;name&gt; or conv:&lt;id&gt;'\n  )\n})"]
+    D -->|no| F["passes isMoltZapTarget\nOR contains no ':'\n(plain UUID — backward compat path)"]
+    F --> G["return new OpenClawTargetResolved({ to })"]
 ```
-Called by: OpenClaw before calling outbound.sendText
-           (wired in `openclaw-entry.ts → outbound.resolveTarget`)
-Signature: resolveTarget(params) → OpenClawTargetResolveResult
-           (synchronous — no Promise)
 
-params.to (after trim):
-  ┌─ empty string ────────────────────────────────────────────────────┐
-  │  return new OpenClawTargetRejected({                               │
-  │    error: new Error("MoltZap: target is required")                 │
-  │  })                                                                │
-  └──────────────────────────────────────────────────────────────────┘
+**Normalization table:**
 
-  ┌─ contains ":" but fails isMoltZapTarget ──────────────────────────┐
-  │  e.g. "slack:alice", "http://example.com"                          │
-  │  return new OpenClawTargetRejected({                               │
-  │    error: new Error(                                               │
-  │      `MoltZap: unsupported target format "${to}"                   │
-  │       — use agent:<name> or conv:<id>`)                           │
-  │  })                                                                │
-  └──────────────────────────────────────────────────────────────────┘
+| Input | resolveTarget result | sendText branch |
+|---|---|---|
+| `"agent:alice"` | resolved, kind `"user"` | `agent:` path → `sendToAgent` |
+| `"conv:abc-123"` | resolved, kind `"group"` | `conv:` → slice prefix → `send` |
+| `"abc-123"` | resolved (no colon → no rejection) | plain-id path → `send` |
 
-  ┌─ passes isMoltZapTarget OR contains no ":" ────────────────────────┐
-  │  (plain UUID without prefix — backward compat path)               │
-  │  return new OpenClawTargetResolved({ to })                         │
-  └──────────────────────────────────────────────────────────────────┘
+**Error shape:**
 
-Normalization table:
-  "agent:alice"      → resolved, kind "user"   in targetResolver
-                     → sendText branches agent: path
-  "conv:abc-123"     → resolved, kind "group"  in targetResolver
-                     → sendText branches conv: → slice prefix
-  "abc-123"          → resolved (no colon → no rejection)
-                     → sendText falls to plain-id path
+- `OpenClawTargetResolved` — `{ _tag: "OpenClawTargetResolved", ok:true, to }`
+- `OpenClawTargetRejected` — `{ _tag: "OpenClawTargetRejected", ok:false, error }`
 
-Error shape:
-  OpenClawTargetResolved  { _tag: "OpenClawTargetResolved",  ok:true,  to }
-  OpenClawTargetRejected  { _tag: "OpenClawTargetRejected",  ok:false, error }
-  Both extend Data.TaggedClass (effect Data module).
-```
+Both extend `Data.TaggedClass` (effect Data module).
 
 ---
 

--- a/packages/openclaw-channel/docs/architecture/07-resolve-target.md
+++ b/packages/openclaw-channel/docs/architecture/07-resolve-target.md
@@ -1,0 +1,77 @@
+# `resolveTarget` Format and Error Shape
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`resolveTarget` appears in two distinct places with different callers:
+
+**A. `messaging.targetResolver.resolveTarget` (directory resolver)**
+
+```
+Called by: OpenClaw's address-book pipeline
+           (wired in `openclaw-entry.ts → messaging.targetResolver`)
+Signature: resolveTarget(params) → Promise<Result | null>
+
+params.normalized → isMoltZapTarget(normalized)?
+  returns null     ← not our namespace; OpenClaw tries next resolver
+
+  MOLTZAP_TARGET_RE = /^(agent|conv):.+$/   (in `openclaw-entry.ts`)
+  matches: "agent:anything" or "conv:anything"
+
+  on match → Promise.resolve({
+    to:      normalized,
+    kind:    conv:* → "group" | otherwise → "user",
+    display: normalized.split(":").slice(1).join(":"),
+              e.g. "agent:alice" → display "alice"
+              e.g. "conv:abc-123" → display "abc-123"
+    source:  "normalized"
+  })
+  No server round-trip; pure string parse.
+```
+
+**B. `outbound.resolveTarget` (send-time validation)**
+
+```
+Called by: OpenClaw before calling outbound.sendText
+           (wired in `openclaw-entry.ts → outbound.resolveTarget`)
+Signature: resolveTarget(params) → OpenClawTargetResolveResult
+           (synchronous — no Promise)
+
+params.to (after trim):
+  ┌─ empty string ────────────────────────────────────────────────────┐
+  │  return new OpenClawTargetRejected({                               │
+  │    error: new Error("MoltZap: target is required")                 │
+  │  })                                                                │
+  └──────────────────────────────────────────────────────────────────┘
+
+  ┌─ contains ":" but fails isMoltZapTarget ──────────────────────────┐
+  │  e.g. "slack:alice", "http://example.com"                          │
+  │  return new OpenClawTargetRejected({                               │
+  │    error: new Error(                                               │
+  │      `MoltZap: unsupported target format "${to}"                   │
+  │       — use agent:<name> or conv:<id>`)                           │
+  │  })                                                                │
+  └──────────────────────────────────────────────────────────────────┘
+
+  ┌─ passes isMoltZapTarget OR contains no ":" ────────────────────────┐
+  │  (plain UUID without prefix — backward compat path)               │
+  │  return new OpenClawTargetResolved({ to })                         │
+  └──────────────────────────────────────────────────────────────────┘
+
+Normalization table:
+  "agent:alice"      → resolved, kind "user"   in targetResolver
+                     → sendText branches agent: path
+  "conv:abc-123"     → resolved, kind "group"  in targetResolver
+                     → sendText branches conv: → slice prefix
+  "abc-123"          → resolved (no colon → no rejection)
+                     → sendText falls to plain-id path
+
+Error shape:
+  OpenClawTargetResolved  { _tag: "OpenClawTargetResolved",  ok:true,  to }
+  OpenClawTargetRejected  { _tag: "OpenClawTargetRejected",  ok:false, error }
+  Both extend Data.TaggedClass (effect Data module).
+```
+
+---
+
+See also:
+- [02-outbound-send-text.md](02-outbound-send-text.md) — sendText routing after resolveTarget succeeds

--- a/packages/protocol/ARCHITECTURE.md
+++ b/packages/protocol/ARCHITECTURE.md
@@ -1,0 +1,111 @@
+# Architecture — `@moltzap/protocol`
+
+Wire-level protocol surface for MoltZap. Pure types, schemas, RPC method
+definitions, and the runtime JSON-RPC server/client implementations. No
+transport, no I/O — every other package depends on this one.
+
+## 1. Project Structure
+
+```
+packages/protocol/src/
+├── schema-primitives.ts    # brandedId, brandedString, stringEnum, DateTimeString
+├── version.ts              # PROTOCOL_VERSION
+├── rpc-registry.ts         # Aggregated method + notification tables; decoders
+│
+├── transport/              # Wire-frame layer (no domain semantics)
+│   ├── wire.ts                # Ajv, JSON-RPC frame schemas, encoders, decodeFrame
+│   ├── method.ts              # defineRpc, defineNotification, RpcDefinition
+│   ├── wire-errors.ts         # Tagged-error registry, JSON_RPC_RESERVED_CODES
+│   ├── rpc-errors.ts          # NotConnectedError, RpcServerError
+│   ├── rpc-groups.ts          # decodeRpcRequest, decodeNotification over a method group
+│   ├── json-rpc-server.ts     # makeJsonRpcServer, handler(), handleJsonRpcRequest
+│   └── json-rpc-client.ts     # makeJsonRpcClient, pending-call map, call/resolve
+│
+├── identity/               # Agents, users, sessions, attestation, contact policy
+├── network/                # Ping, presence, connection liveness, actor-model types
+├── task/                   # Conversations, messages, dispatch, TM authority
+├── app/                    # AppHost RPCs (apps/register, dispatch/*, hooks)
+│
+├── testing/                # Conformance suite, arbitraries, toxics, divergence proofs
+│   ├── conformance/           # Property-based suite (executable + runner)
+│   ├── arbitraries/           # fast-check generators
+│   ├── models/                # Reference state machines
+│   └── toxics/                # Toxiproxy fault-injection adapters
+│
+└── index.ts                # Public barrel: `export * from "./{layer}/index.js"`
+```
+
+Each domain layer (`identity`, `network`, `task`, `app`) has a self-contained
+`index.ts` re-exporting its public surface; the root barrel composes them.
+
+## 2. Public Surface
+
+| Export | Layer | Purpose |
+|---|---|---|
+| `PROTOCOL_VERSION` | root | Wire-format version constant |
+| `rpcMethods` | rpc-registry | All C↔S request methods (frozen array) |
+| `notificationDefinitions` | rpc-registry | All S↔C notifications |
+| `taskCallbackMethods` | rpc-registry | Subset: methods the server calls *into* the client |
+| `decodeServerInbound` / `decodeClientInbound` | rpc-registry | Tagged-union frame decoders, fail-closed |
+| `defineRpc` / `defineNotification` | transport/method | Descriptor factories used by domain layers |
+| `makeJsonRpcServer` / `makeJsonRpcClient` | transport | Runtime endpoints |
+| `Agent*`, `User*`, `Session*` | identity | Identity primitives + auth flows |
+| `Conversation*`, `Message*`, `TmDecision*` | task | Task-layer state |
+| `Dispatch*`, `App*`, `Hook*` | app | AppHost surface |
+| Tagged errors (`HookBlockedError`, `TaskClosedError`, …) | various | Auto-registered into `RegisteredTaggedError` union |
+
+Subpath exports (`./transport`, `./identity`, `./network`, `./task`, `./app`,
+`./testing`) let consumers pull only the layer they need.
+
+## 3. Communication Flows
+
+| Topic | Document |
+|---|---|
+| How wire methods are defined and validated | [01 — Method-definition pipeline](docs/architecture/01-method-definition.md) |
+| Decoding inbound frames (both sides) | [02 — Frame decode pipeline](docs/architecture/02-frame-decode.md) |
+| Server-side request handling | [03 — Server request handling](docs/architecture/03-server-request-handling.md) |
+| Client-side RPC call lifecycle | [04 — Client call lifecycle](docs/architecture/04-client-call-lifecycle.md) |
+| Notification fan-out | [05 — Notification fan-out](docs/architecture/05-notification-fanout.md) |
+| End-to-end `messages/send` walk-through | [06 — End-to-end messages/send](docs/architecture/06-end-to-end-messages-send.md) |
+| Server-initiated callbacks (e.g. dispatch/authorize) | [07 — Server-initiated callbacks](docs/architecture/07-server-initiated-callback.md) |
+| Tagged error registry mechanics | [08 — Tagged error registry](docs/architecture/08-tagged-error-registry.md) |
+| Layer DAG enforcement | [09 — Layer DAG](docs/architecture/09-layer-dag.md) |
+| Conformance suite mechanics | [10 — Conformance suite](docs/architecture/10-conformance-suite.md) |
+
+## 4. Dependencies
+
+**Runtime**: `effect`, `@effect/platform`, `@sinclair/typebox`, `ajv`,
+`ajv-formats`.
+**Internal**: none — protocol is the root of the workspace dependency DAG.
+**Consumers**: every other package in `packages/`, plus the arena repo via
+submodule + workspace link.
+
+## 5. Tests
+
+- `src/testing/__tests__/` — direct unit tests for protocol-package code.
+- `src/testing/conformance/__divergence_proofs__/` — divergence proofs.
+- Consumed by `packages/server/src/__tests__/conformance/` (in-process)
+  and `packages/client/src/__tests__/conformance/` (over the wire).
+
+## 6. Glossary
+
+- **TM (Task Manager)** — Authority for a task's conversation set.
+  Default-TM (UUID-bound) for ordinary DMs/groups; app-bound TM for
+  app-moderated tasks.
+- **AppHost** — Server-side dispatcher that routes app callbacks
+  (`dispatch/authorize`, hook RPCs) to the registered moderator.
+- **Descriptor** — A frozen `RpcDefinition` or `NotificationDefinition`
+  produced by `defineRpc` / `defineNotification`. Carries the schema,
+  validators, and frame encoders for one wire method.
+- **Conformance suite** — Property-based tests over the wire protocol.
+  Lives in `src/testing/conformance/`; consumed by server, client, and
+  external repos.
+- **Divergence proof** — Executable test that asserts the conformance
+  property *would fail* if the implementation intentionally regresses.
+- **Task-callback method** — An RPC the *server* calls *into* a client.
+  Restricted subset of `rpcMethods`; the client's `decodeServerInbound`
+  rejects any other method shape as `MalformedFrameError`.
+- **Registered tagged error** — A `Data.TaggedError` class with a
+  `static readonly code` self-registered via `registerErrorClass` at
+  module load. Allows the client to reconstruct a typed error instance
+  from a wire `code` for `Effect.catchTag(...)` use.

--- a/packages/protocol/CLAUDE.md
+++ b/packages/protocol/CLAUDE.md
@@ -2,6 +2,8 @@
 
 TypeBox schema definitions, descriptor-backed RPC/notification definitions, and AJV validators for the MoltZap JSON-RPC protocol. Source of truth for all wire message types.
 
+See `ARCHITECTURE.md` (and `docs/architecture/*.md`) for flow diagrams: method-definition pipeline, frame decode, server/client lifecycle, tagged error registry, layer DAG, conformance suite. Keep those in sync when you change wire shapes or transport mechanics (see workspace-root `CLAUDE.md` for the doc-maintenance rules).
+
 ## Key Files
 - `src/identity/` — Identity layer: agent/contact RPC descriptors, schemas, notification definitions
 - `src/network/` — Network layer: connect/ping/presence RPC descriptors, endpoint actor-model types

--- a/packages/protocol/docs/architecture/01-method-definition.md
+++ b/packages/protocol/docs/architecture/01-method-definition.md
@@ -8,13 +8,13 @@ identical schema semantics:
 
 ```mermaid
 flowchart TD
-    A["domain layer\n(e.g. task/methods.ts)"]
+    A["domain layer<br>(e.g. task/methods.ts)"]
     B["defineRpc({ name, params, result })"]
-    C["ajv.compile(params)\n→ validateParams predicate"]
-    D["ajv.compile(result)\n→ validateResult predicate"]
+    C["ajv.compile(params)<br>→ validateParams predicate"]
+    D["ajv.compile(result)<br>→ validateResult predicate"]
     E["RpcDefinition&lt;Name, P, R&gt;"]
     F["pushed into per-layer *RpcMethods const"]
-    G["aggregated into rpcMethods\nunion typed as AnyRpcDefinition"]
+    G["aggregated into rpcMethods<br>union typed as AnyRpcDefinition"]
 
     A --> B
     B --> C

--- a/packages/protocol/docs/architecture/01-method-definition.md
+++ b/packages/protocol/docs/architecture/01-method-definition.md
@@ -1,0 +1,40 @@
+# 01 — Method-definition pipeline
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Every wire method is born at module-load time by a single `defineRpc` call.
+The factory compiles AJV validators eagerly so every wire boundary uses
+identical schema semantics:
+
+```text
+            domain layer (e.g. task/methods.ts)
+                       │
+                       ▼  defineRpc({ name, params, result })       transport/method.ts → defineRpc
+                       │
+       ┌───────────────┴────────────────────────────┐
+       ▼                                            ▼
+  ajv.compile(params)                          ajv.compile(result)
+  → validateParams predicate                   → validateResult predicate
+       │                                            │
+       └────────────┬───────────────────────────────┘
+                    ▼
+            RpcDefinition<Name, P, R> {
+              name (branded)                                method.ts → RpcDefinition type
+              paramsSchema / resultSchema (TypeBox)
+              validateParams / validateResult (Ajv)
+              encodeRequest(id, params) → RequestFrame      wire.ts → encodeRequest
+              encodeResponse(id, result) → ResponseFrame    wire.ts → encodeResponse
+            }
+                    │
+                    ▼
+       pushed into per-layer `*RpcMethods` const
+                    │
+                    ▼
+       aggregated into `rpcMethods` (rpc-registry.ts → rpcMethods)
+       union typed as `AnyRpcDefinition` (rpc-registry.ts → AnyRpcDefinition)
+```
+
+`defineNotification` is the same pipeline minus the result schema and minus
+the response encoder. Method names are branded `JsonRpcMethod<"the.name">`
+so a runtime string can never accidentally type-fit a method position
+(wire.ts → JsonRpcMethod branded type).

--- a/packages/protocol/docs/architecture/01-method-definition.md
+++ b/packages/protocol/docs/architecture/01-method-definition.md
@@ -6,33 +6,30 @@ Every wire method is born at module-load time by a single `defineRpc` call.
 The factory compiles AJV validators eagerly so every wire boundary uses
 identical schema semantics:
 
-```text
-            domain layer (e.g. task/methods.ts)
-                       │
-                       ▼  defineRpc({ name, params, result })       transport/method.ts → defineRpc
-                       │
-       ┌───────────────┴────────────────────────────┐
-       ▼                                            ▼
-  ajv.compile(params)                          ajv.compile(result)
-  → validateParams predicate                   → validateResult predicate
-       │                                            │
-       └────────────┬───────────────────────────────┘
-                    ▼
-            RpcDefinition<Name, P, R> {
-              name (branded)                                method.ts → RpcDefinition type
-              paramsSchema / resultSchema (TypeBox)
-              validateParams / validateResult (Ajv)
-              encodeRequest(id, params) → RequestFrame      wire.ts → encodeRequest
-              encodeResponse(id, result) → ResponseFrame    wire.ts → encodeResponse
-            }
-                    │
-                    ▼
-       pushed into per-layer `*RpcMethods` const
-                    │
-                    ▼
-       aggregated into `rpcMethods` (rpc-registry.ts → rpcMethods)
-       union typed as `AnyRpcDefinition` (rpc-registry.ts → AnyRpcDefinition)
+```mermaid
+flowchart TD
+    A["domain layer\n(e.g. task/methods.ts)"]
+    B["defineRpc({ name, params, result })"]
+    C["ajv.compile(params)\n→ validateParams predicate"]
+    D["ajv.compile(result)\n→ validateResult predicate"]
+    E["RpcDefinition&lt;Name, P, R&gt;"]
+    F["pushed into per-layer *RpcMethods const"]
+    G["aggregated into rpcMethods\nunion typed as AnyRpcDefinition"]
+
+    A --> B
+    B --> C
+    B --> D
+    C --> E
+    D --> E
+    E --> F
+    F --> G
 ```
+
+**Annotations:**
+
+- `defineRpc` — `transport/method.ts → defineRpc`
+- `RpcDefinition` type — `method.ts → RpcDefinition type`; fields: `name` (branded), `paramsSchema` / `resultSchema` (TypeBox), `validateParams` / `validateResult` (Ajv), `encodeRequest(id, params) → RequestFrame` (`wire.ts → encodeRequest`), `encodeResponse(id, result) → ResponseFrame` (`wire.ts → encodeResponse`)
+- `rpcMethods` / `AnyRpcDefinition` — `rpc-registry.ts → rpcMethods`, `rpc-registry.ts → AnyRpcDefinition`
 
 `defineNotification` is the same pipeline minus the result schema and minus
 the response encoder. Method names are branded `JsonRpcMethod<"the.name">`

--- a/packages/protocol/docs/architecture/02-frame-decode.md
+++ b/packages/protocol/docs/architecture/02-frame-decode.md
@@ -1,0 +1,58 @@
+# 02 — Frame decode pipeline
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+The single decode entry point is `decodeFrame` (wire.ts); the two
+direction-typed wrappers in `rpc-registry.ts` narrow what *kind* of frame
+is admissible on which side:
+
+```text
+raw socket payload
+       │
+       ▼  JSON.parse  (caller's responsibility — wire layer takes `unknown`)
+       │
+       ▼
+decodeFrame(parsed)                                                   wire.ts → decodeFrame
+       │
+   ┌───┴────────────────────┬─────────────────────────────┐
+   ▼                        ▼                             ▼
+validateRequestFrame   validateResponseFrame      validateNotificationFrame
+   │                        │                             │
+{_tag:"Request"}        {_tag:"Response"}            {_tag:"Notification"}
+   │                        │                             │
+   └────────────────┬───────┴─────────────────────────────┘
+                    │  (all three pre-validated by Ajv against the
+                    │   generic JSON-RPC envelope schemas)
+                    │
+       ┌────────────┴────────────┐
+       ▼                         ▼
+decodeServerInbound        decodeClientInbound        rpc-registry.ts → decodeServerInbound / decodeClientInbound
+(used by client)           (used by server)
+       │                         │
+   for Request:              for Request:
+     decodeRpcRequest(           decodeRpcRequest(
+       taskCallbackMethods)        rpcMethods)
+     → ServerRequest             → ClientRequest
+   for Response:             for Response:
+     decodeResponseFrame         decodeResponseFrame
+     → ResponseSuccess           → ResponseSuccess
+       | ResponseError             | ResponseError
+   for Notification:         for Notification:
+     decodeNotification          decodeNotification
+       (notificationDefs)          (notificationDefs)
+     → Notification              → Notification
+       │                         │
+       ▼                         ▼
+DecodedServerInbound       DecodedClientInbound
+(discriminated union)      (discriminated union)
+```
+
+Both wrappers **fail closed with `MalformedFrameError`** on any mismatch —
+including a response frame whose `id` is `null` (rpc-registry.ts →
+`decodeClientInbound`, null-id guard), since a null id has no pending call
+to resolve.
+
+Client-inbound `Request` frames are restricted to `taskCallbackMethods`
+(the subset the server is allowed to call back into the client — e.g.
+`dispatch/authorize`). Server-inbound `Request` frames cover the full
+`rpcMethods` set.

--- a/packages/protocol/docs/architecture/02-frame-decode.md
+++ b/packages/protocol/docs/architecture/02-frame-decode.md
@@ -6,46 +6,47 @@ The single decode entry point is `decodeFrame` (wire.ts); the two
 direction-typed wrappers in `rpc-registry.ts` narrow what *kind* of frame
 is admissible on which side:
 
-```text
-raw socket payload
-       │
-       ▼  JSON.parse  (caller's responsibility — wire layer takes `unknown`)
-       │
-       ▼
-decodeFrame(parsed)                                                   wire.ts → decodeFrame
-       │
-   ┌───┴────────────────────┬─────────────────────────────┐
-   ▼                        ▼                             ▼
-validateRequestFrame   validateResponseFrame      validateNotificationFrame
-   │                        │                             │
-{_tag:"Request"}        {_tag:"Response"}            {_tag:"Notification"}
-   │                        │                             │
-   └────────────────┬───────┴─────────────────────────────┘
-                    │  (all three pre-validated by Ajv against the
-                    │   generic JSON-RPC envelope schemas)
-                    │
-       ┌────────────┴────────────┐
-       ▼                         ▼
-decodeServerInbound        decodeClientInbound        rpc-registry.ts → decodeServerInbound / decodeClientInbound
-(used by client)           (used by server)
-       │                         │
-   for Request:              for Request:
-     decodeRpcRequest(           decodeRpcRequest(
-       taskCallbackMethods)        rpcMethods)
-     → ServerRequest             → ClientRequest
-   for Response:             for Response:
-     decodeResponseFrame         decodeResponseFrame
-     → ResponseSuccess           → ResponseSuccess
-       | ResponseError             | ResponseError
-   for Notification:         for Notification:
-     decodeNotification          decodeNotification
-       (notificationDefs)          (notificationDefs)
-     → Notification              → Notification
-       │                         │
-       ▼                         ▼
-DecodedServerInbound       DecodedClientInbound
-(discriminated union)      (discriminated union)
+```mermaid
+flowchart TD
+    RAW["raw socket payload"]
+    PARSE["JSON.parse\n(caller's responsibility — wire layer takes unknown)"]
+    DECODE["decodeFrame(parsed)"]
+    VRQ["validateRequestFrame\n→ {_tag: &quot;Request&quot;}"]
+    VRS["validateResponseFrame\n→ {_tag: &quot;Response&quot;}"]
+    VNF["validateNotificationFrame\n→ {_tag: &quot;Notification&quot;}"]
+    NOTE["all three pre-validated by Ajv\nagainst generic JSON-RPC envelope schemas"]
+    DSI["decodeServerInbound\n(used by client)"]
+    DCI["decodeClientInbound\n(used by server)"]
+    OUT_S["DecodedServerInbound\n(discriminated union)"]
+    OUT_C["DecodedClientInbound\n(discriminated union)"]
+
+    RAW --> PARSE --> DECODE
+    DECODE --> VRQ
+    DECODE --> VRS
+    DECODE --> VNF
+    VRQ --> NOTE
+    VRS --> NOTE
+    VNF --> NOTE
+    NOTE --> DSI
+    NOTE --> DCI
+    DSI --> OUT_S
+    DCI --> OUT_C
 ```
+
+**Annotations:**
+
+- `decodeFrame` — `wire.ts → decodeFrame`
+- `decodeServerInbound` / `decodeClientInbound` — `rpc-registry.ts → decodeServerInbound / decodeClientInbound`
+
+For `decodeServerInbound` (used by client):
+- Request frames: `decodeRpcRequest(taskCallbackMethods)` → `ServerRequest`
+- Response frames: `decodeResponseFrame` → `ResponseSuccess | ResponseError`
+- Notification frames: `decodeNotification(notificationDefs)` → `Notification`
+
+For `decodeClientInbound` (used by server):
+- Request frames: `decodeRpcRequest(rpcMethods)` → `ClientRequest`
+- Response frames: `decodeResponseFrame` → `ResponseSuccess | ResponseError`
+- Notification frames: `decodeNotification(notificationDefs)` → `Notification`
 
 Both wrappers **fail closed with `MalformedFrameError`** on any mismatch —
 including a response frame whose `id` is `null` (rpc-registry.ts →

--- a/packages/protocol/docs/architecture/02-frame-decode.md
+++ b/packages/protocol/docs/architecture/02-frame-decode.md
@@ -9,16 +9,16 @@ is admissible on which side:
 ```mermaid
 flowchart TD
     RAW["raw socket payload"]
-    PARSE["JSON.parse\n(caller's responsibility — wire layer takes unknown)"]
+    PARSE["JSON.parse<br>(caller's responsibility — wire layer takes unknown)"]
     DECODE["decodeFrame(parsed)"]
-    VRQ["validateRequestFrame\n→ {_tag: &quot;Request&quot;}"]
-    VRS["validateResponseFrame\n→ {_tag: &quot;Response&quot;}"]
-    VNF["validateNotificationFrame\n→ {_tag: &quot;Notification&quot;}"]
-    NOTE["all three pre-validated by Ajv\nagainst generic JSON-RPC envelope schemas"]
-    DSI["decodeServerInbound\n(used by client)"]
-    DCI["decodeClientInbound\n(used by server)"]
-    OUT_S["DecodedServerInbound\n(discriminated union)"]
-    OUT_C["DecodedClientInbound\n(discriminated union)"]
+    VRQ["validateRequestFrame<br>→ {_tag: &quot;Request&quot;}"]
+    VRS["validateResponseFrame<br>→ {_tag: &quot;Response&quot;}"]
+    VNF["validateNotificationFrame<br>→ {_tag: &quot;Notification&quot;}"]
+    NOTE["all three pre-validated by Ajv<br>against generic JSON-RPC envelope schemas"]
+    DSI["decodeServerInbound<br>(used by client)"]
+    DCI["decodeClientInbound<br>(used by server)"]
+    OUT_S["DecodedServerInbound<br>(discriminated union)"]
+    OUT_C["DecodedClientInbound<br>(discriminated union)"]
 
     RAW --> PARSE --> DECODE
     DECODE --> VRQ

--- a/packages/protocol/docs/architecture/03-server-request-handling.md
+++ b/packages/protocol/docs/architecture/03-server-request-handling.md
@@ -1,0 +1,52 @@
+# 03 — Server request handling
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`makeJsonRpcServer` builds a method→handler map at construction time and
+serves through a single `handle(frame, ctx)` entry point:
+
+```text
+ResponseFrame ← makeJsonRpcServer.handle(frame, ctx)            json-rpc-server.ts → handle
+                       │
+                       ▼
+            handlerByMethod.get(frame.method)
+                       │
+              ┌────────┴─────────────┐
+              │ undefined            │ RpcHandler
+              ▼                      ▼
+       methodNotFoundResponse   decodeRpcParams(handler.definition, frame.params)
+       code: -32601                       │
+              │                  ┌────────┴─────────────┐
+              │                  │ Failure              │ Success
+              │                  ▼                      ▼
+              │           invalidParamsResponse    handler.handle(params, ctx)
+              │           code: -32602                  │
+              │                  │              ┌──────┴───────────────┐
+              │                  │              │ Exit.isSuccess       │ Exit.isFailure
+              │                  │              ▼                      ▼
+              │                  │       successResponse           failureResponse(cause)
+              │                  │       logInfo + result               │
+              │                  │              │              wireErrorFromInstance(failure)
+              │                  │              │                       │
+              │                  │              │              ┌────────┴────────┐
+              │                  │              │              │ tagged-error    │ generic cause
+              │                  │              │              ▼                 ▼
+              │                  │              │      knownWireErrorResponse  internalErrorResponse
+              │                  │              │      logWarning + code         logError + cause
+              │                  │              │      from registry             code: -32603
+              └────────┬─────────┴──────────────┴───────────────┴─────────────────┘
+                       ▼
+                  ResponseFrame
+```
+
+Tagged error mapping (in `json-rpc-server.ts → wireErrorFromInstance`): the
+server uses `isRegisteredErrorInstance` to check whether the failure carries
+a `static readonly code`/`message` set by `registerErrorClass`. If so, the
+class's code + the instance's message + the instance's `data` ride the wire.
+Anything else collapses to `InternalError` (-32603) with `Cause.pretty(cause)`
+logged but **not** sent to the client.
+
+Handlers are bound via the `handler(definition, fn)` factory (in
+`json-rpc-server.ts → handler`). The cast erases descriptor-typed params to
+`unknown` for storage; runtime `decodeRpcParams` produces the `ParamsOf<D>`
+shape, so the erasure is safe.

--- a/packages/protocol/docs/architecture/03-server-request-handling.md
+++ b/packages/protocol/docs/architecture/03-server-request-handling.md
@@ -5,38 +5,34 @@
 `makeJsonRpcServer` builds a method→handler map at construction time and
 serves through a single `handle(frame, ctx)` entry point:
 
-```text
-ResponseFrame ← makeJsonRpcServer.handle(frame, ctx)            json-rpc-server.ts → handle
-                       │
-                       ▼
-            handlerByMethod.get(frame.method)
-                       │
-              ┌────────┴─────────────┐
-              │ undefined            │ RpcHandler
-              ▼                      ▼
-       methodNotFoundResponse   decodeRpcParams(handler.definition, frame.params)
-       code: -32601                       │
-              │                  ┌────────┴─────────────┐
-              │                  │ Failure              │ Success
-              │                  ▼                      ▼
-              │           invalidParamsResponse    handler.handle(params, ctx)
-              │           code: -32602                  │
-              │                  │              ┌──────┴───────────────┐
-              │                  │              │ Exit.isSuccess       │ Exit.isFailure
-              │                  │              ▼                      ▼
-              │                  │       successResponse           failureResponse(cause)
-              │                  │       logInfo + result               │
-              │                  │              │              wireErrorFromInstance(failure)
-              │                  │              │                       │
-              │                  │              │              ┌────────┴────────┐
-              │                  │              │              │ tagged-error    │ generic cause
-              │                  │              │              ▼                 ▼
-              │                  │              │      knownWireErrorResponse  internalErrorResponse
-              │                  │              │      logWarning + code         logError + cause
-              │                  │              │      from registry             code: -32603
-              └────────┬─────────┴──────────────┴───────────────┴─────────────────┘
-                       ▼
-                  ResponseFrame
+```mermaid
+flowchart TD
+    ENTRY["makeJsonRpcServer.handle(frame, ctx)"]
+    LOOKUP["handlerByMethod.get(frame.method)"]
+    NOT_FOUND["methodNotFoundResponse\ncode: -32601"]
+    DECODE_PARAMS["decodeRpcParams(handler.definition, frame.params)"]
+    INVALID_PARAMS["invalidParamsResponse\ncode: -32602"]
+    HANDLE["handler.handle(params, ctx)"]
+    SUCCESS_RSP["successResponse\nlogInfo + result"]
+    FAILURE["failureResponse(cause)\nwireErrorFromInstance(failure)"]
+    TAGGED["knownWireErrorResponse\nlogWarning + code (from registry)"]
+    INTERNAL["internalErrorResponse\nlogError + cause\ncode: -32603"]
+    OUT["ResponseFrame"]
+
+    ENTRY --> LOOKUP
+    LOOKUP -->|"undefined"| NOT_FOUND
+    LOOKUP -->|"RpcHandler"| DECODE_PARAMS
+    DECODE_PARAMS -->|"Failure"| INVALID_PARAMS
+    DECODE_PARAMS -->|"Success"| HANDLE
+    HANDLE -->|"Exit.isSuccess"| SUCCESS_RSP
+    HANDLE -->|"Exit.isFailure"| FAILURE
+    FAILURE -->|"tagged-error"| TAGGED
+    FAILURE -->|"generic cause"| INTERNAL
+    NOT_FOUND --> OUT
+    INVALID_PARAMS --> OUT
+    SUCCESS_RSP --> OUT
+    TAGGED --> OUT
+    INTERNAL --> OUT
 ```
 
 Tagged error mapping (in `json-rpc-server.ts → wireErrorFromInstance`): the

--- a/packages/protocol/docs/architecture/03-server-request-handling.md
+++ b/packages/protocol/docs/architecture/03-server-request-handling.md
@@ -9,14 +9,14 @@ serves through a single `handle(frame, ctx)` entry point:
 flowchart TD
     ENTRY["makeJsonRpcServer.handle(frame, ctx)"]
     LOOKUP["handlerByMethod.get(frame.method)"]
-    NOT_FOUND["methodNotFoundResponse\ncode: -32601"]
+    NOT_FOUND["methodNotFoundResponse<br>code: -32601"]
     DECODE_PARAMS["decodeRpcParams(handler.definition, frame.params)"]
-    INVALID_PARAMS["invalidParamsResponse\ncode: -32602"]
+    INVALID_PARAMS["invalidParamsResponse<br>code: -32602"]
     HANDLE["handler.handle(params, ctx)"]
-    SUCCESS_RSP["successResponse\nlogInfo + result"]
-    FAILURE["failureResponse(cause)\nwireErrorFromInstance(failure)"]
-    TAGGED["knownWireErrorResponse\nlogWarning + code (from registry)"]
-    INTERNAL["internalErrorResponse\nlogError + cause\ncode: -32603"]
+    SUCCESS_RSP["successResponse<br>logInfo + result"]
+    FAILURE["failureResponse(cause)<br>wireErrorFromInstance(failure)"]
+    TAGGED["knownWireErrorResponse<br>logWarning + code (from registry)"]
+    INTERNAL["internalErrorResponse<br>logError + cause<br>code: -32603"]
     OUT["ResponseFrame"]
 
     ENTRY --> LOOKUP

--- a/packages/protocol/docs/architecture/04-client-call-lifecycle.md
+++ b/packages/protocol/docs/architecture/04-client-call-lifecycle.md
@@ -10,18 +10,18 @@ hung Deferred (in `json-rpc-client.ts → failAllPending`).
 flowchart TD
     CALLER["caller"]
     CALL["call(definition, params)"]
-    COUNTER["counterRef.modify(n → [n+1, n+1])\ngenerates idPrefix-next JsonRpcId"]
+    COUNTER["counterRef.modify(n → [n+1, n+1])<br>generates idPrefix-next JsonRpcId"]
     FRAME["requestFrame(id, definition, params) → RequestFrame"]
     DEFERRED["Deferred.make&lt;unknown, RpcCallError&gt;()"]
-    PENDING["pendingRef.update(set(id, {method, definition, deferred}))\npending map insert BEFORE write (#310 contract)"]
+    PENDING["pendingRef.update(set(id, {method, definition, deferred}))<br>pending map insert BEFORE write (#310 contract)"]
     WRITE["config.write(JSON.stringify(frame))"]
     WRITE_OK["proceed to Deferred.await"]
-    WRITE_FAIL["Deferred.fail(NotConnectedError)\nEffect.fail bubbles, ensuring() removes from map"]
-    AWAIT["Deferred.await(deferred)\n(unblocked by resolve(frame) when matching inbound arrives)"]
+    WRITE_FAIL["Deferred.fail(NotConnectedError)<br>Effect.fail bubbles, ensuring() removes from map"]
+    AWAIT["Deferred.await(deferred)<br>(unblocked by resolve(frame) when matching inbound arrives)"]
     DECODE_RESULT["decodeRpcResult(definition, result)"]
     RESULT_OK["ResultOf&lt;D&gt;"]
-    RESULT_ERR["RpcServerError\ncode: -32603\n\"Invalid result for method: …\""]
-    ENSURE["ensuring(pendingRef.remove(id))\nruns on success, failure, OR interrupt (#310 contract)"]
+    RESULT_ERR["RpcServerError<br>code: -32603<br>\"Invalid result for method: …\""]
+    ENSURE["ensuring(pendingRef.remove(id))<br>runs on success, failure, OR interrupt (#310 contract)"]
 
     CALLER --> CALL --> COUNTER --> FRAME --> DEFERRED --> PENDING --> WRITE
     WRITE -->|"ok"| WRITE_OK --> AWAIT
@@ -41,13 +41,13 @@ flowchart TD
     ARRIVE["ResponseFrame arrives at the transport"]
     RESOLVE["client.resolve(frame)"]
     NULL_CHECK{"frame.id === null?"}
-    DROP_NULL["return false\n(drop; nothing to settle)"]
-    TAKE["pendingRef.modify(takePendingEntry(frame.id))\natomic Get-then-Remove"]
+    DROP_NULL["return false<br>(drop; nothing to settle)"]
+    TAKE["pendingRef.modify(takePendingEntry(frame.id))<br>atomic Get-then-Remove"]
     OPTION{"Option.match"}
-    NONE["return false\n(late frame, deferred already cleaned up)"]
+    NONE["return false<br>(late frame, deferred already cleaned up)"]
     COMPLETE["completePendingFrame"]
-    ERROR_ARM["frame.error\n→ Deferred.fail(wireErrorToRpcCallError)\nerrorClassFor(code) → tagged-class ctor;\nelse RpcServerError fallback"]
-    SUCCESS_ARM["frame.result\n→ Deferred.succeed(result)"]
+    ERROR_ARM["frame.error<br>→ Deferred.fail(wireErrorToRpcCallError)<br>errorClassFor(code) → tagged-class ctor;<br>else RpcServerError fallback"]
+    SUCCESS_ARM["frame.result<br>→ Deferred.succeed(result)"]
 
     ARRIVE --> RESOLVE --> NULL_CHECK
     NULL_CHECK -->|"yes"| DROP_NULL

--- a/packages/protocol/docs/architecture/04-client-call-lifecycle.md
+++ b/packages/protocol/docs/architecture/04-client-call-lifecycle.md
@@ -1,0 +1,75 @@
+# 04 — Client call lifecycle
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`makeJsonRpcClient` is **scope-bound**: closing the scope runs
+`failAllPending(NotConnectedError)` so no caller is ever orphaned on a
+hung Deferred (in `json-rpc-client.ts → failAllPending`).
+
+```text
+caller
+   │
+   ▼  call(definition, params)                                  json-rpc-client.ts → call
+   │
+   ▼  counterRef.modify(n → [n+1, n+1])
+   │       generates `${idPrefix}-${next}` JsonRpcId
+   │
+   ▼  requestFrame(id, definition, params) → RequestFrame
+   │
+   ▼  Deferred.make<unknown, RpcCallError>()
+   │
+   ▼  pendingRef.update(set(id, {method, definition, deferred}))
+   │       ─── pending map insert BEFORE write (#310 contract)
+   │
+   ▼  config.write(JSON.stringify(frame))
+   │       │
+   │       ├─ ok        →  proceed to Deferred.await
+   │       │
+   │       └─ failure   →  Deferred.fail(NotConnectedError);
+   │                       Effect.fail bubbles, ensuring() removes from map
+   │
+   ▼  Deferred.await(deferred)
+   │       ↑
+   │       │  ── unblocked by `resolve(frame)` when matching inbound arrives
+   │       │
+   │       ▼  decodeRpcResult(definition, result)
+   │             │
+   │             ├─ success → ResultOf<D>
+   │             │
+   │             └─ RpcResultDecodeError → RpcServerError
+   │                                       code: -32603,
+   │                                       "Invalid result for method: …"
+   │
+   └─ ensuring(pendingRef.remove(id))  ── runs on success, failure, OR interrupt
+                                          (Issue #310 contract)
+```
+
+Inbound response routing (in `json-rpc-client.ts → resolve`):
+
+```text
+ResponseFrame arrives at the transport
+   │
+   ▼  client.resolve(frame)
+   │
+   ▼  frame.id === null  →  return false (drop; nothing to settle)
+   │
+   ▼  pendingRef.modify(takePendingEntry(frame.id))
+   │       atomic Get-then-Remove
+   │
+   ▼  Option.match
+        │
+        ├─ None  →  return false   ── late frame, deferred already cleaned up
+        │
+        └─ Some(entry)  →  completePendingFrame
+                              │
+                              ├─ frame.error  →  Deferred.fail(wireErrorToRpcCallError)
+                              │                      │
+                              │                      └─ errorClassFor(code) → tagged-class
+                              │                          ctor; else RpcServerError fallback
+                              │
+                              └─ frame.result →  Deferred.succeed(result)
+```
+
+The pending-map uses atomic `Ref.modify` for both insert and take, so two
+inbound responses with the same id (server bug) at worst resolve once and
+then race-lose harmlessly (second take sees `None`).

--- a/packages/protocol/docs/architecture/04-client-call-lifecycle.md
+++ b/packages/protocol/docs/architecture/04-client-call-lifecycle.md
@@ -6,68 +6,56 @@
 `failAllPending(NotConnectedError)` so no caller is ever orphaned on a
 hung Deferred (in `json-rpc-client.ts → failAllPending`).
 
-```text
-caller
-   │
-   ▼  call(definition, params)                                  json-rpc-client.ts → call
-   │
-   ▼  counterRef.modify(n → [n+1, n+1])
-   │       generates `${idPrefix}-${next}` JsonRpcId
-   │
-   ▼  requestFrame(id, definition, params) → RequestFrame
-   │
-   ▼  Deferred.make<unknown, RpcCallError>()
-   │
-   ▼  pendingRef.update(set(id, {method, definition, deferred}))
-   │       ─── pending map insert BEFORE write (#310 contract)
-   │
-   ▼  config.write(JSON.stringify(frame))
-   │       │
-   │       ├─ ok        →  proceed to Deferred.await
-   │       │
-   │       └─ failure   →  Deferred.fail(NotConnectedError);
-   │                       Effect.fail bubbles, ensuring() removes from map
-   │
-   ▼  Deferred.await(deferred)
-   │       ↑
-   │       │  ── unblocked by `resolve(frame)` when matching inbound arrives
-   │       │
-   │       ▼  decodeRpcResult(definition, result)
-   │             │
-   │             ├─ success → ResultOf<D>
-   │             │
-   │             └─ RpcResultDecodeError → RpcServerError
-   │                                       code: -32603,
-   │                                       "Invalid result for method: …"
-   │
-   └─ ensuring(pendingRef.remove(id))  ── runs on success, failure, OR interrupt
-                                          (Issue #310 contract)
+```mermaid
+flowchart TD
+    CALLER["caller"]
+    CALL["call(definition, params)"]
+    COUNTER["counterRef.modify(n → [n+1, n+1])\ngenerates idPrefix-next JsonRpcId"]
+    FRAME["requestFrame(id, definition, params) → RequestFrame"]
+    DEFERRED["Deferred.make&lt;unknown, RpcCallError&gt;()"]
+    PENDING["pendingRef.update(set(id, {method, definition, deferred}))\npending map insert BEFORE write (#310 contract)"]
+    WRITE["config.write(JSON.stringify(frame))"]
+    WRITE_OK["proceed to Deferred.await"]
+    WRITE_FAIL["Deferred.fail(NotConnectedError)\nEffect.fail bubbles, ensuring() removes from map"]
+    AWAIT["Deferred.await(deferred)\n(unblocked by resolve(frame) when matching inbound arrives)"]
+    DECODE_RESULT["decodeRpcResult(definition, result)"]
+    RESULT_OK["ResultOf&lt;D&gt;"]
+    RESULT_ERR["RpcServerError\ncode: -32603\n\"Invalid result for method: …\""]
+    ENSURE["ensuring(pendingRef.remove(id))\nruns on success, failure, OR interrupt (#310 contract)"]
+
+    CALLER --> CALL --> COUNTER --> FRAME --> DEFERRED --> PENDING --> WRITE
+    WRITE -->|"ok"| WRITE_OK --> AWAIT
+    WRITE -->|"failure"| WRITE_FAIL
+    AWAIT --> DECODE_RESULT
+    DECODE_RESULT -->|"success"| RESULT_OK
+    DECODE_RESULT -->|"RpcResultDecodeError"| RESULT_ERR
+    RESULT_OK --> ENSURE
+    RESULT_ERR --> ENSURE
+    WRITE_FAIL --> ENSURE
 ```
 
 Inbound response routing (in `json-rpc-client.ts → resolve`):
 
-```text
-ResponseFrame arrives at the transport
-   │
-   ▼  client.resolve(frame)
-   │
-   ▼  frame.id === null  →  return false (drop; nothing to settle)
-   │
-   ▼  pendingRef.modify(takePendingEntry(frame.id))
-   │       atomic Get-then-Remove
-   │
-   ▼  Option.match
-        │
-        ├─ None  →  return false   ── late frame, deferred already cleaned up
-        │
-        └─ Some(entry)  →  completePendingFrame
-                              │
-                              ├─ frame.error  →  Deferred.fail(wireErrorToRpcCallError)
-                              │                      │
-                              │                      └─ errorClassFor(code) → tagged-class
-                              │                          ctor; else RpcServerError fallback
-                              │
-                              └─ frame.result →  Deferred.succeed(result)
+```mermaid
+flowchart TD
+    ARRIVE["ResponseFrame arrives at the transport"]
+    RESOLVE["client.resolve(frame)"]
+    NULL_CHECK{"frame.id === null?"}
+    DROP_NULL["return false\n(drop; nothing to settle)"]
+    TAKE["pendingRef.modify(takePendingEntry(frame.id))\natomic Get-then-Remove"]
+    OPTION{"Option.match"}
+    NONE["return false\n(late frame, deferred already cleaned up)"]
+    COMPLETE["completePendingFrame"]
+    ERROR_ARM["frame.error\n→ Deferred.fail(wireErrorToRpcCallError)\nerrorClassFor(code) → tagged-class ctor;\nelse RpcServerError fallback"]
+    SUCCESS_ARM["frame.result\n→ Deferred.succeed(result)"]
+
+    ARRIVE --> RESOLVE --> NULL_CHECK
+    NULL_CHECK -->|"yes"| DROP_NULL
+    NULL_CHECK -->|"no"| TAKE --> OPTION
+    OPTION -->|"None"| NONE
+    OPTION -->|"Some(entry)"| COMPLETE
+    COMPLETE -->|"frame.error"| ERROR_ARM
+    COMPLETE -->|"frame.result"| SUCCESS_ARM
 ```
 
 The pending-map uses atomic `Ref.modify` for both insert and take, so two

--- a/packages/protocol/docs/architecture/05-notification-fanout.md
+++ b/packages/protocol/docs/architecture/05-notification-fanout.md
@@ -6,25 +6,18 @@ Notifications are fire-and-forget (no id, no response). The transport-side
 runtimes don't track them — clients subscribe externally via per-method
 handlers:
 
-```text
-emitter (server or client)
-   │
-   ▼  Notification.encode(params) → NotificationFrame              transport/method.ts → encode
-   │       {jsonrpc, method, params}
-   │
-   ▼  socket.write(JSON.stringify(frame))
-                            │
-                            ▼  wire
-                            │
-                            ▼
-receiver
-   │
-   ▼  decode{Server,Client}Inbound  →  {_tag: "Notification", definition, params}
-   │
-   ▼  subscriber dispatcher  (lives in consumer package, not here)
-   │       e.g. `@moltzap/client/runtime/subscribers.ts`
-   │
-   ▼  matching SubscriberHandler(params)
+```mermaid
+flowchart LR
+    EMITTER["emitter\n(server or client)"]
+    ENCODE["Notification.encode(params)\n→ NotificationFrame\n{jsonrpc, method, params}"]
+    WRITE["socket.write(JSON.stringify(frame))"]
+    WIRE["wire"]
+    RECEIVER["receiver"]
+    DECODE["decode{Server,Client}Inbound\n→ {_tag: &quot;Notification&quot;, definition, params}"]
+    DISPATCH["subscriber dispatcher\n(lives in consumer package)\ne.g. @moltzap/client/runtime/subscribers.ts"]
+    HANDLER["matching SubscriberHandler(params)"]
+
+    EMITTER --> ENCODE --> WRITE --> WIRE --> RECEIVER --> DECODE --> DISPATCH --> HANDLER
 ```
 
 The notification descriptor's role at this layer is purely encode/decode +

--- a/packages/protocol/docs/architecture/05-notification-fanout.md
+++ b/packages/protocol/docs/architecture/05-notification-fanout.md
@@ -1,0 +1,31 @@
+# 05 — Notification fan-out
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Notifications are fire-and-forget (no id, no response). The transport-side
+runtimes don't track them — clients subscribe externally via per-method
+handlers:
+
+```text
+emitter (server or client)
+   │
+   ▼  Notification.encode(params) → NotificationFrame              transport/method.ts → encode
+   │       {jsonrpc, method, params}
+   │
+   ▼  socket.write(JSON.stringify(frame))
+                            │
+                            ▼  wire
+                            │
+                            ▼
+receiver
+   │
+   ▼  decode{Server,Client}Inbound  →  {_tag: "Notification", definition, params}
+   │
+   ▼  subscriber dispatcher  (lives in consumer package, not here)
+   │       e.g. `@moltzap/client/runtime/subscribers.ts`
+   │
+   ▼  matching SubscriberHandler(params)
+```
+
+The notification descriptor's role at this layer is purely encode/decode +
+schema validation. Routing semantics live in consumers.

--- a/packages/protocol/docs/architecture/05-notification-fanout.md
+++ b/packages/protocol/docs/architecture/05-notification-fanout.md
@@ -8,13 +8,13 @@ handlers:
 
 ```mermaid
 flowchart LR
-    EMITTER["emitter\n(server or client)"]
-    ENCODE["Notification.encode(params)\n→ NotificationFrame\n{jsonrpc, method, params}"]
+    EMITTER["emitter<br>(server or client)"]
+    ENCODE["Notification.encode(params)<br>→ NotificationFrame<br>{jsonrpc, method, params}"]
     WRITE["socket.write(JSON.stringify(frame))"]
     WIRE["wire"]
     RECEIVER["receiver"]
-    DECODE["decode{Server,Client}Inbound\n→ {_tag: &quot;Notification&quot;, definition, params}"]
-    DISPATCH["subscriber dispatcher\n(lives in consumer package)\ne.g. @moltzap/client/runtime/subscribers.ts"]
+    DECODE["decode{Server,Client}Inbound<br>→ {_tag: &quot;Notification&quot;, definition, params}"]
+    DISPATCH["subscriber dispatcher<br>(lives in consumer package)<br>e.g. @moltzap/client/runtime/subscribers.ts"]
     HANDLER["matching SubscriberHandler(params)"]
 
     EMITTER --> ENCODE --> WRITE --> WIRE --> RECEIVER --> DECODE --> DISPATCH --> HANDLER

--- a/packages/protocol/docs/architecture/06-end-to-end-messages-send.md
+++ b/packages/protocol/docs/architecture/06-end-to-end-messages-send.md
@@ -1,0 +1,60 @@
+# 06 — End-to-end `messages/send`
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Concrete walk-through of one method, end to end:
+
+```text
+CLIENT                                              SERVER
+──────                                              ──────
+caller
+  │  service.send({...})
+  ▼
+MoltZapWsClient.call(MessagesSend, params)
+  │
+  ▼  json-rpc-client.ts → call
+  │
+  │  next id = "wsclient-42"
+  │  frame = {jsonrpc:"2.0", id:"wsclient-42",
+  │           method:"messages/send", params:{...}}
+  │  insert pending[wsclient-42] = {Deferred}
+  │  write(JSON.stringify(frame))
+  │  await Deferred
+  │                                                 ─── WS frame ──▶
+  │                                                                 decodeClientInbound(json)
+  │                                                                   → {_tag: "ClientRequest",
+  │                                                                      definition: MessagesSend,
+  │                                                                      params}
+  │                                                                 makeJsonRpcServer.handle(frame, ctx)
+  │                                                                   ▼ json-rpc-server.ts → handle
+  │                                                                 handlerByMethod.get("messages/send")
+  │                                                                   ▼
+  │                                                                 decodeRpcParams → ParamsOf<MessagesSend>
+  │                                                                   ▼
+  │                                                                 messageHandlers["messages/send"]
+  │                                                                   .handle(params, dispatchCtx)
+  │                                                                   ▼
+  │                                                                 MessageService.send(...)
+  │                                                                   ▼
+  │                                                                 Exit.isSuccess → result
+  │                                                                   ▼
+  │                                                                 successResponse(frame, ms, result)
+  │                                                                   ▼ logInfo "RPC request completed"
+  │                                                <── WS frame ──   responseFrame(id, {result})
+  │
+  ▼  socket onmessage → decodeServerInbound → ResponseSuccess
+  │
+  ▼  client.resolve(frame)
+  │  → pendingRef.modify(take("wsclient-42"))
+  │  → Deferred.succeed(result)
+  │
+  ▼  await unblocks
+  │  decodeRpcResult(MessagesSend, result)
+  │
+  ▼  ResultOf<MessagesSend> returned to caller
+```
+
+On the error arm, the server returns `{error: {code, message, data}}`,
+`completePendingFrame` calls `wireErrorToRpcCallError`, and the caller
+sees a `Deferred.fail` with either a `RegisteredTaggedError` (if the wire
+code is in the registry) or `RpcServerError` (anything else).

--- a/packages/protocol/docs/architecture/06-end-to-end-messages-send.md
+++ b/packages/protocol/docs/architecture/06-end-to-end-messages-send.md
@@ -4,54 +4,19 @@
 
 Concrete walk-through of one method, end to end:
 
-```text
-CLIENT                                              SERVER
-──────                                              ──────
-caller
-  │  service.send({...})
-  ▼
-MoltZapWsClient.call(MessagesSend, params)
-  │
-  ▼  json-rpc-client.ts → call
-  │
-  │  next id = "wsclient-42"
-  │  frame = {jsonrpc:"2.0", id:"wsclient-42",
-  │           method:"messages/send", params:{...}}
-  │  insert pending[wsclient-42] = {Deferred}
-  │  write(JSON.stringify(frame))
-  │  await Deferred
-  │                                                 ─── WS frame ──▶
-  │                                                                 decodeClientInbound(json)
-  │                                                                   → {_tag: "ClientRequest",
-  │                                                                      definition: MessagesSend,
-  │                                                                      params}
-  │                                                                 makeJsonRpcServer.handle(frame, ctx)
-  │                                                                   ▼ json-rpc-server.ts → handle
-  │                                                                 handlerByMethod.get("messages/send")
-  │                                                                   ▼
-  │                                                                 decodeRpcParams → ParamsOf<MessagesSend>
-  │                                                                   ▼
-  │                                                                 messageHandlers["messages/send"]
-  │                                                                   .handle(params, dispatchCtx)
-  │                                                                   ▼
-  │                                                                 MessageService.send(...)
-  │                                                                   ▼
-  │                                                                 Exit.isSuccess → result
-  │                                                                   ▼
-  │                                                                 successResponse(frame, ms, result)
-  │                                                                   ▼ logInfo "RPC request completed"
-  │                                                <── WS frame ──   responseFrame(id, {result})
-  │
-  ▼  socket onmessage → decodeServerInbound → ResponseSuccess
-  │
-  ▼  client.resolve(frame)
-  │  → pendingRef.modify(take("wsclient-42"))
-  │  → Deferred.succeed(result)
-  │
-  ▼  await unblocks
-  │  decodeRpcResult(MessagesSend, result)
-  │
-  ▼  ResultOf<MessagesSend> returned to caller
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Client as "MoltZapWsClient<br/>(json-rpc-client.ts → call)"
+    participant Server as "makeJsonRpcServer<br/>(json-rpc-server.ts → handle)"
+
+    Caller->>Client: service.send({...})
+    Note over Client: next id = "wsclient-42"<br/>frame = {jsonrpc:"2.0", id:"wsclient-42",<br/>method:"messages/send", params:{...}}<br/>insert pending[wsclient-42] = {Deferred}<br/>write(JSON.stringify(frame))<br/>await Deferred
+    Client->>Server: WS frame (messages/send, id: wsclient-42)
+    Note over Server: decodeClientInbound(json)<br/>→ {_tag: "ClientRequest", definition: MessagesSend, params}<br/>handlerByMethod.get("messages/send")<br/>decodeRpcParams → ParamsOf&lt;MessagesSend&gt;<br/>messageHandlers["messages/send"].handle(params, dispatchCtx)<br/>MessageService.send(...)<br/>Exit.isSuccess → result<br/>successResponse — logInfo "RPC request completed"
+    Server-->>Client: WS frame (responseFrame id: wsclient-42, {result})
+    Note over Client: socket onmessage → decodeServerInbound → ResponseSuccess<br/>client.resolve(frame)<br/>pendingRef.modify(take("wsclient-42"))<br/>Deferred.succeed(result)<br/>await unblocks<br/>decodeRpcResult(MessagesSend, result)
+    Client-->>Caller: ResultOf&lt;MessagesSend&gt;
 ```
 
 On the error arm, the server returns `{error: {code, message, data}}`,

--- a/packages/protocol/docs/architecture/06-end-to-end-messages-send.md
+++ b/packages/protocol/docs/architecture/06-end-to-end-messages-send.md
@@ -7,16 +7,16 @@ Concrete walk-through of one method, end to end:
 ```mermaid
 sequenceDiagram
     participant Caller
-    participant Client as "MoltZapWsClient<br/>(json-rpc-client.ts → call)"
-    participant Server as "makeJsonRpcServer<br/>(json-rpc-server.ts → handle)"
+    participant Client as "MoltZapWsClient
+    participant Server as "makeJsonRpcServer
 
     Caller->>Client: service.send({...})
-    Note over Client: next id = "wsclient-42"<br/>frame = {jsonrpc:"2.0", id:"wsclient-42",<br/>method:"messages/send", params:{...}}<br/>insert pending[wsclient-42] = {Deferred}<br/>write(JSON.stringify(frame))<br/>await Deferred
+    Note over Client: next id = "wsclient-42"<br>frame = {jsonrpc:"2.0", id:"wsclient-42",<br>method:"messages/send", params:{...}}<br>insert pending[wsclient-42] = {Deferred}<br>write(JSON.stringify(frame))<br>await Deferred
     Client->>Server: WS frame (messages/send, id: wsclient-42)
-    Note over Server: decodeClientInbound(json)<br/>→ {_tag: "ClientRequest", definition: MessagesSend, params}<br/>handlerByMethod.get("messages/send")<br/>decodeRpcParams → ParamsOf&lt;MessagesSend&gt;<br/>messageHandlers["messages/send"].handle(params, dispatchCtx)<br/>MessageService.send(...)<br/>Exit.isSuccess → result<br/>successResponse — logInfo "RPC request completed"
+    Note over Server: decodeClientInbound(json)<br>→ {_tag: "ClientRequest", definition: MessagesSend, params}<br>handlerByMethod.get("messages/send")<br>decodeRpcParams → ParamsOf<MessagesSend><br>messageHandlers["messages/send"].handle(params, dispatchCtx)<br>MessageService.send(...)<br>Exit.isSuccess → result<br>successResponse — logInfo "RPC request completed"
     Server-->>Client: WS frame (responseFrame id: wsclient-42, {result})
-    Note over Client: socket onmessage → decodeServerInbound → ResponseSuccess<br/>client.resolve(frame)<br/>pendingRef.modify(take("wsclient-42"))<br/>Deferred.succeed(result)<br/>await unblocks<br/>decodeRpcResult(MessagesSend, result)
-    Client-->>Caller: ResultOf&lt;MessagesSend&gt;
+    Note over Client: socket onmessage → decodeServerInbound → ResponseSuccess<br>client.resolve(frame)<br>pendingRef.modify(take("wsclient-42"))<br>Deferred.succeed(result)<br>await unblocks<br>decodeRpcResult(MessagesSend, result)
+    Client-->>Caller: ResultOf<MessagesSend>
 ```
 
 On the error arm, the server returns `{error: {code, message, data}}`,

--- a/packages/protocol/docs/architecture/07-server-initiated-callback.md
+++ b/packages/protocol/docs/architecture/07-server-initiated-callback.md
@@ -1,0 +1,44 @@
+# 07 — Server-initiated callback: `dispatch/authorize`
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Same client/server runtime, reversed roles. The server holds a `JsonRpcClient`
+instance per moderator connection (lives in `@moltzap/server-core`); the
+client holds a `JsonRpcServer` wired with `taskCallbackHandlers`.
+
+```text
+SERVER (forked fiber)                               CLIENT (moderator)
+─────────────────────                               ──────────────────
+AppHost.runAuthorizeDispatch
+  │
+  ▼  perConnectionClient.call(
+       DispatchAuthorize, {dispatchId, …})
+  │  pending["server-7"] = Deferred
+  │  await
+  │                                                 ─── WS frame ──▶
+  │                                                                 decodeServerInbound(json)
+  │                                                                   → {_tag: "ServerRequest",
+  │                                                                      definition: DispatchAuthorize,
+  │                                                                      params}
+  │                                                                 client-side JsonRpcServer.handle
+  │                                                                   ▼
+  │                                                                 taskCallbackHandlers
+  │                                                                   ["dispatch/authorize"]
+  │                                                                   .handle(params, ctx)
+  │                                                                   ▼
+  │                                                                 moderator app code emits verdict
+  │                                                                 → {decision: "grant" | "deny" | "hold"}
+  │                                                                   ▼
+  │                                                <── WS frame ──   responseFrame(id, {result: verdict})
+  │
+  ▼  serverside.resolve(frame)
+  │  → Deferred.succeed(verdict)
+  │
+  ▼  back into AppHost: emit dispatch/release{verdict}
+     to the original recipient connection
+```
+
+`taskCallbackMethods` is the **strict subset** of `rpcMethods` allowed
+in this direction; `decodeServerInbound` rejects any other method as
+`MalformedFrameError`, so a misconfigured server can't smuggle a
+non-callback request through the client's inbound path.

--- a/packages/protocol/docs/architecture/07-server-initiated-callback.md
+++ b/packages/protocol/docs/architecture/07-server-initiated-callback.md
@@ -6,36 +6,16 @@ Same client/server runtime, reversed roles. The server holds a `JsonRpcClient`
 instance per moderator connection (lives in `@moltzap/server-core`); the
 client holds a `JsonRpcServer` wired with `taskCallbackHandlers`.
 
-```text
-SERVER (forked fiber)                               CLIENT (moderator)
-─────────────────────                               ──────────────────
-AppHost.runAuthorizeDispatch
-  │
-  ▼  perConnectionClient.call(
-       DispatchAuthorize, {dispatchId, …})
-  │  pending["server-7"] = Deferred
-  │  await
-  │                                                 ─── WS frame ──▶
-  │                                                                 decodeServerInbound(json)
-  │                                                                   → {_tag: "ServerRequest",
-  │                                                                      definition: DispatchAuthorize,
-  │                                                                      params}
-  │                                                                 client-side JsonRpcServer.handle
-  │                                                                   ▼
-  │                                                                 taskCallbackHandlers
-  │                                                                   ["dispatch/authorize"]
-  │                                                                   .handle(params, ctx)
-  │                                                                   ▼
-  │                                                                 moderator app code emits verdict
-  │                                                                 → {decision: "grant" | "deny" | "hold"}
-  │                                                                   ▼
-  │                                                <── WS frame ──   responseFrame(id, {result: verdict})
-  │
-  ▼  serverside.resolve(frame)
-  │  → Deferred.succeed(verdict)
-  │
-  ▼  back into AppHost: emit dispatch/release{verdict}
-     to the original recipient connection
+```mermaid
+sequenceDiagram
+    participant Server as "SERVER (forked fiber)<br/>AppHost.runAuthorizeDispatch"
+    participant Client as "CLIENT (moderator)<br/>client-side JsonRpcServer"
+
+    Note over Server: perConnectionClient.call(DispatchAuthorize, {dispatchId, …})<br/>pending["server-7"] = Deferred<br/>await
+    Server->>Client: WS frame (dispatch/authorize, id: server-7)
+    Note over Client: decodeServerInbound(json)<br/>→ {_tag: "ServerRequest", definition: DispatchAuthorize, params}<br/>taskCallbackHandlers["dispatch/authorize"].handle(params, ctx)<br/>moderator app code emits verdict<br/>→ {decision: "grant" | "deny" | "hold"}
+    Client-->>Server: WS frame (responseFrame id: server-7, {result: verdict})
+    Note over Server: serverside.resolve(frame)<br/>Deferred.succeed(verdict)<br/>emit dispatch/release{verdict} to original recipient connection
 ```
 
 `taskCallbackMethods` is the **strict subset** of `rpcMethods` allowed

--- a/packages/protocol/docs/architecture/07-server-initiated-callback.md
+++ b/packages/protocol/docs/architecture/07-server-initiated-callback.md
@@ -8,14 +8,14 @@ client holds a `JsonRpcServer` wired with `taskCallbackHandlers`.
 
 ```mermaid
 sequenceDiagram
-    participant Server as "SERVER (forked fiber)<br/>AppHost.runAuthorizeDispatch"
-    participant Client as "CLIENT (moderator)<br/>client-side JsonRpcServer"
+    participant Server as "SERVER (forked fiber)
+    participant Client as "CLIENT (moderator)
 
-    Note over Server: perConnectionClient.call(DispatchAuthorize, {dispatchId, …})<br/>pending["server-7"] = Deferred<br/>await
+    Note over Server: perConnectionClient.call(DispatchAuthorize, {dispatchId, …})<br>pending["server-7"] = Deferred<br>await
     Server->>Client: WS frame (dispatch/authorize, id: server-7)
-    Note over Client: decodeServerInbound(json)<br/>→ {_tag: "ServerRequest", definition: DispatchAuthorize, params}<br/>taskCallbackHandlers["dispatch/authorize"].handle(params, ctx)<br/>moderator app code emits verdict<br/>→ {decision: "grant" | "deny" | "hold"}
+    Note over Client: decodeServerInbound(json)<br>→ {_tag: "ServerRequest", definition: DispatchAuthorize, params}<br>taskCallbackHandlers["dispatch/authorize"].handle(params, ctx)<br>moderator app code emits verdict<br>→ {decision: "grant" | "deny" | "hold"}
     Client-->>Server: WS frame (responseFrame id: server-7, {result: verdict})
-    Note over Server: serverside.resolve(frame)<br/>Deferred.succeed(verdict)<br/>emit dispatch/release{verdict} to original recipient connection
+    Note over Server: serverside.resolve(frame)<br>Deferred.succeed(verdict)<br>emit dispatch/release{verdict} to original recipient connection
 ```
 
 `taskCallbackMethods` is the **strict subset** of `rpcMethods` allowed

--- a/packages/protocol/docs/architecture/08-tagged-error-registry.md
+++ b/packages/protocol/docs/architecture/08-tagged-error-registry.md
@@ -2,40 +2,30 @@
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 
-```text
-module load order
-   │
-   ▼  class HookBlockedError extends Data.TaggedError("HookBlocked")<{...}> {
-   │      static readonly code = -32019
-   │      static readonly message = "Hook blocked"
-   │    }
-   │    registerErrorClass(HookBlockedError)            wire-errors.ts → registerErrorClass
-   │       │
-   │       └─→ map.set(-32019, HookBlockedError)
-   │
-   ▼  every domain layer registers its tagged-error classes at load time
-   │
-   ▼  rpc-registry.ts → RegisteredTaggedError union
-   │    type RegisteredTaggedError =
-   │      | UnauthorizedError | ForbiddenError | NotFoundError | …
-   │      | HookBlockedError | TaskClosedError | …
-   │    (must be hand-kept in sync with registry; type system can't enumerate
-   │     the static-side registry into a union)
-   │
-   ▼  client side: wireErrorToRpcCallError            json-rpc-client.ts → wireErrorToRpcCallError
-   │    errorClassFor(code) → registered class | undefined
-   │      │
-   │      ├─ class → new cls({data}) → RegisteredTaggedError instance
-   │      │           caller can Effect.catchTag("HookBlocked", …)
-   │      │
-   │      └─ undefined → new RpcServerError({code, message, data})
-   │                       caller catches by "RpcServerError" tag + branches on code
-   │
-   ▼  server side: wireErrorFromInstance              json-rpc-server.ts → wireErrorFromInstance
-        isRegisteredErrorInstance(value)?
-          ▼
-        wireErrorPayload(cls, message, data) → wire `error` sub-object
+```mermaid
+flowchart TD
+    LOAD["module load order"]
+    REGISTER["class HookBlockedError extends Data.TaggedError(...)\nstatic readonly code = -32019\nstatic readonly message = &quot;Hook blocked&quot;\nregisterErrorClass(HookBlockedError)\n→ map.set(-32019, HookBlockedError)"]
+    ALL_LAYERS["every domain layer registers its\ntagged-error classes at load time"]
+    UNION["RegisteredTaggedError union\ntype RegisteredTaggedError =\n  UnauthorizedError | ForbiddenError | NotFoundError | …\n  | HookBlockedError | TaskClosedError | …"]
+    CLIENT["client side: wireErrorToRpcCallError\nerrorClassFor(code) → registered class | undefined"]
+    CLASS_FOUND["new cls({data}) → RegisteredTaggedError instance\ncaller can Effect.catchTag(&quot;HookBlocked&quot;, …)"]
+    CLASS_NOT_FOUND["new RpcServerError({code, message, data})\ncaller catches by &quot;RpcServerError&quot; tag + branches on code"]
+    SERVER["server side: wireErrorFromInstance\nisRegisteredErrorInstance(value)?\n→ wireErrorPayload(cls, message, data)\n→ wire error sub-object"]
+
+    LOAD --> REGISTER --> ALL_LAYERS --> UNION
+    UNION --> CLIENT
+    CLIENT -->|"class found"| CLASS_FOUND
+    CLIENT -->|"undefined"| CLASS_NOT_FOUND
+    UNION --> SERVER
 ```
+
+**Annotations:**
+
+- `registerErrorClass` — `wire-errors.ts → registerErrorClass`
+- `RegisteredTaggedError` union — `rpc-registry.ts → RegisteredTaggedError`; must be hand-kept in sync with registry; type system cannot enumerate the static-side registry into a union
+- `wireErrorToRpcCallError` — `json-rpc-client.ts → wireErrorToRpcCallError`
+- `wireErrorFromInstance` — `json-rpc-server.ts → wireErrorFromInstance`
 
 `JSON_RPC_RESERVED_CODES` (in `json-rpc-server.ts`) covers only
 the JSON-RPC 2.0 spec codes (-32700 ParseError, -32600 InvalidRequest,

--- a/packages/protocol/docs/architecture/08-tagged-error-registry.md
+++ b/packages/protocol/docs/architecture/08-tagged-error-registry.md
@@ -5,13 +5,13 @@
 ```mermaid
 flowchart TD
     LOAD["module load order"]
-    REGISTER["class HookBlockedError extends Data.TaggedError(...)\nstatic readonly code = -32019\nstatic readonly message = &quot;Hook blocked&quot;\nregisterErrorClass(HookBlockedError)\n→ map.set(-32019, HookBlockedError)"]
-    ALL_LAYERS["every domain layer registers its\ntagged-error classes at load time"]
-    UNION["RegisteredTaggedError union\ntype RegisteredTaggedError =\n  UnauthorizedError | ForbiddenError | NotFoundError | …\n  | HookBlockedError | TaskClosedError | …"]
-    CLIENT["client side: wireErrorToRpcCallError\nerrorClassFor(code) → registered class | undefined"]
-    CLASS_FOUND["new cls({data}) → RegisteredTaggedError instance\ncaller can Effect.catchTag(&quot;HookBlocked&quot;, …)"]
-    CLASS_NOT_FOUND["new RpcServerError({code, message, data})\ncaller catches by &quot;RpcServerError&quot; tag + branches on code"]
-    SERVER["server side: wireErrorFromInstance\nisRegisteredErrorInstance(value)?\n→ wireErrorPayload(cls, message, data)\n→ wire error sub-object"]
+    REGISTER["class HookBlockedError extends Data.TaggedError(...)<br>static readonly code = -32019<br>static readonly message = &quot;Hook blocked&quot;<br>registerErrorClass(HookBlockedError)<br>→ map.set(-32019, HookBlockedError)"]
+    ALL_LAYERS["every domain layer registers its<br>tagged-error classes at load time"]
+    UNION["RegisteredTaggedError union<br>type RegisteredTaggedError =<br>  UnauthorizedError | ForbiddenError | NotFoundError | …<br>  | HookBlockedError | TaskClosedError | …"]
+    CLIENT["client side: wireErrorToRpcCallError<br>errorClassFor(code) → registered class | undefined"]
+    CLASS_FOUND["new cls({data}) → RegisteredTaggedError instance<br>caller can Effect.catchTag(&quot;HookBlocked&quot;, …)"]
+    CLASS_NOT_FOUND["new RpcServerError({code, message, data})<br>caller catches by &quot;RpcServerError&quot; tag + branches on code"]
+    SERVER["server side: wireErrorFromInstance<br>isRegisteredErrorInstance(value)?<br>→ wireErrorPayload(cls, message, data)<br>→ wire error sub-object"]
 
     LOAD --> REGISTER --> ALL_LAYERS --> UNION
     UNION --> CLIENT

--- a/packages/protocol/docs/architecture/08-tagged-error-registry.md
+++ b/packages/protocol/docs/architecture/08-tagged-error-registry.md
@@ -1,0 +1,43 @@
+# 08 — Tagged error registry
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+```text
+module load order
+   │
+   ▼  class HookBlockedError extends Data.TaggedError("HookBlocked")<{...}> {
+   │      static readonly code = -32019
+   │      static readonly message = "Hook blocked"
+   │    }
+   │    registerErrorClass(HookBlockedError)            wire-errors.ts → registerErrorClass
+   │       │
+   │       └─→ map.set(-32019, HookBlockedError)
+   │
+   ▼  every domain layer registers its tagged-error classes at load time
+   │
+   ▼  rpc-registry.ts → RegisteredTaggedError union
+   │    type RegisteredTaggedError =
+   │      | UnauthorizedError | ForbiddenError | NotFoundError | …
+   │      | HookBlockedError | TaskClosedError | …
+   │    (must be hand-kept in sync with registry; type system can't enumerate
+   │     the static-side registry into a union)
+   │
+   ▼  client side: wireErrorToRpcCallError            json-rpc-client.ts → wireErrorToRpcCallError
+   │    errorClassFor(code) → registered class | undefined
+   │      │
+   │      ├─ class → new cls({data}) → RegisteredTaggedError instance
+   │      │           caller can Effect.catchTag("HookBlocked", …)
+   │      │
+   │      └─ undefined → new RpcServerError({code, message, data})
+   │                       caller catches by "RpcServerError" tag + branches on code
+   │
+   ▼  server side: wireErrorFromInstance              json-rpc-server.ts → wireErrorFromInstance
+        isRegisteredErrorInstance(value)?
+          ▼
+        wireErrorPayload(cls, message, data) → wire `error` sub-object
+```
+
+`JSON_RPC_RESERVED_CODES` (in `json-rpc-server.ts`) covers only
+the JSON-RPC 2.0 spec codes (-32700 ParseError, -32600 InvalidRequest,
+-32601 MethodNotFound, -32602 InvalidParams, -32603 InternalError). Domain
+codes are in the registry, not in a central table.

--- a/packages/protocol/docs/architecture/09-layer-dag.md
+++ b/packages/protocol/docs/architecture/09-layer-dag.md
@@ -5,12 +5,24 @@
 Source layout enforces a directed DAG. Each layer's `methods.ts` may import
 from layers below; never above:
 
-```text
-  app/        ← uses task + identity + transport
-  task/       ← uses identity + transport
-  network/    ← uses identity + transport
-  identity/   ← uses transport
-  transport/  ← uses schema-primitives only
+```mermaid
+flowchart TD
+    APP["app/"]
+    TASK["task/"]
+    NETWORK["network/"]
+    IDENTITY["identity/"]
+    TRANSPORT["transport/"]
+    PRIMITIVES["schema-primitives"]
+
+    APP --> TASK
+    APP --> IDENTITY
+    APP --> TRANSPORT
+    TASK --> IDENTITY
+    TASK --> TRANSPORT
+    NETWORK --> IDENTITY
+    NETWORK --> TRANSPORT
+    IDENTITY --> TRANSPORT
+    TRANSPORT --> PRIMITIVES
 ```
 
 A method defined in `task` may reference `identity` types (e.g. `AgentId`)

--- a/packages/protocol/docs/architecture/09-layer-dag.md
+++ b/packages/protocol/docs/architecture/09-layer-dag.md
@@ -1,0 +1,19 @@
+# 09 — Layer DAG
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Source layout enforces a directed DAG. Each layer's `methods.ts` may import
+from layers below; never above:
+
+```text
+  app/        ← uses task + identity + transport
+  task/       ← uses identity + transport
+  network/    ← uses identity + transport
+  identity/   ← uses transport
+  transport/  ← uses schema-primitives only
+```
+
+A method defined in `task` may reference `identity` types (e.g. `AgentId`)
+but never the other way. The Tag-allowlist hierarchy in
+`server/src/rpc/layer-tags.ts` mirrors this, so handler bodies can only
+pull services from layers at-or-below the method's home layer.

--- a/packages/protocol/docs/architecture/10-conformance-suite.md
+++ b/packages/protocol/docs/architecture/10-conformance-suite.md
@@ -9,10 +9,10 @@ that *intentionally fails* the property to prove the assertion has teeth.
 ```mermaid
 flowchart TD
     PROP["src/testing/conformance/{layer}/&lt;property&gt;.ts"]
-    BODY["property body\nEffect that asserts the invariant"]
+    BODY["property body<br>Effect that asserts the invariant"]
     PROOFS["__divergence_proofs__/&lt;property&gt;.proofs.test.ts"]
-    REGISTER["register&lt;PropertyName&gt;\nserver intentionally violates the invariant;\nproperty must fail"]
-    VITEST["vitest runs the proof\nfailure of failure = pass"]
+    REGISTER["register&lt;PropertyName&gt;<br>server intentionally violates the invariant;<br>property must fail"]
+    VITEST["vitest runs the proof<br>failure of failure = pass"]
 
     PROP --> BODY
     PROP --> PROOFS

--- a/packages/protocol/docs/architecture/10-conformance-suite.md
+++ b/packages/protocol/docs/architecture/10-conformance-suite.md
@@ -1,0 +1,24 @@
+# 10 — Conformance suite
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`testing/conformance/` defines properties any compliant client/server pair
+must satisfy. Each property ships an **executable** (a divergence proof)
+that *intentionally fails* the property to prove the assertion has teeth.
+
+```text
+src/testing/conformance/{layer}/<property>.ts
+   │
+   ├─ property body — Effect that asserts the invariant
+   │
+   └─ __divergence_proofs__/<property>.proofs.test.ts
+        │
+        ├─ register<PropertyName>  ── server intentionally violates the
+        │                              invariant; property must fail
+        │
+        └─ vitest runs the proof; failure of failure = pass
+```
+
+External consumers (e.g. `moltzap-arena`) drop a ~20-line vitest wrapper
+matching the AC22 template (see `packages/protocol/CLAUDE.md`) and the
+suite runs against their real WS client.

--- a/packages/protocol/docs/architecture/10-conformance-suite.md
+++ b/packages/protocol/docs/architecture/10-conformance-suite.md
@@ -6,17 +6,18 @@
 must satisfy. Each property ships an **executable** (a divergence proof)
 that *intentionally fails* the property to prove the assertion has teeth.
 
-```text
-src/testing/conformance/{layer}/<property>.ts
-   │
-   ├─ property body — Effect that asserts the invariant
-   │
-   └─ __divergence_proofs__/<property>.proofs.test.ts
-        │
-        ├─ register<PropertyName>  ── server intentionally violates the
-        │                              invariant; property must fail
-        │
-        └─ vitest runs the proof; failure of failure = pass
+```mermaid
+flowchart TD
+    PROP["src/testing/conformance/{layer}/&lt;property&gt;.ts"]
+    BODY["property body\nEffect that asserts the invariant"]
+    PROOFS["__divergence_proofs__/&lt;property&gt;.proofs.test.ts"]
+    REGISTER["register&lt;PropertyName&gt;\nserver intentionally violates the invariant;\nproperty must fail"]
+    VITEST["vitest runs the proof\nfailure of failure = pass"]
+
+    PROP --> BODY
+    PROP --> PROOFS
+    PROOFS --> REGISTER
+    PROOFS --> VITEST
 ```
 
 External consumers (e.g. `moltzap-arena`) drop a ~20-line vitest wrapper

--- a/packages/runtimes/ARCHITECTURE.md
+++ b/packages/runtimes/ARCHITECTURE.md
@@ -1,0 +1,76 @@
+# Architecture — `@moltzap/runtimes`
+
+Process-launch and lifecycle orchestration for MoltZap "trace-capture agents":
+spawning external runtimes (OpenClaw, Nanoclaw, Claude Code) as child
+processes, waiting for ready, supervising fleets, propagating shutdown.
+
+This package is the bridge between server-side orchestration code and the
+external runtime binaries. It does not speak the wire protocol; it spawns
+processes that do.
+
+## Project Structure
+
+```
+packages/runtimes/src/
+├── runtime.ts                  # RuntimeKind, RuntimeAgentSpec base types
+├── fleet.ts                    # launchRuntimeFleet, startup interruption
+├── openclaw-adapter.ts         # OpenClawAdapter + workspace variant
+├── nanoclaw-adapter.ts         # NanoclawAdapter
+├── claude-code-adapter.ts      # ClaudeCodeAdapter + workspace variant
+├── await-agent-ready.ts        # awaitAgentReadyByPolling
+└── errors.ts                   # SpawnFailed, RuntimeExitedBeforeReady,
+                                  RuntimeReadyTimedOut, RuntimeLaunchFailed
+```
+
+Single-tier source layout — no subdirectories. Each adapter is a peer.
+
+## Public Surface
+
+| Export | Shape | Purpose |
+|---|---|---|
+| `OpenClawAdapter` / `NanoclawAdapter` / `ClaudeCodeAdapter` | Adapter | Spawn + supervise a single agent runtime |
+| `createWorkspace{OpenClaw,ClaudeCode}Adapter` | Factory | Workspace-aware variants that resolve binary paths |
+| `startRuntimeAgent` | Effect | Start one runtime + wait for ready |
+| `launchRuntimeFleet` / `launchRuntimeFleetWithProcessSignals` | Effect | Start many, propagate SIGINT/SIGTERM |
+| `awaitAgentReadyByPolling` | Effect | Generic readiness probe |
+| `RuntimeKind` / `RuntimeAgentSpec` / `RuntimeFleet` / `RuntimeStartOptions` | Type | Inputs to fleet APIs |
+| `SpawnFailed`, `RuntimeExitedBeforeReady`, `RuntimeReadyTimedOut`, `RuntimeFleetStartupInterrupted` | TaggedError | Typed failure channel |
+
+## Communication Flows
+
+Detailed subsections covering startup sequencing, fleet supervision,
+per-adapter mechanics, workspace path resolution, shutdown propagation,
+and the typed error taxonomy:
+
+| # | Topic | Detail doc |
+|---|---|---|
+| 3.1 | Single-runtime startup sequence | [01-single-runtime-startup.md](docs/architecture/01-single-runtime-startup.md) |
+| 3.2 | Fleet launch sequence | [02-fleet-launch.md](docs/architecture/02-fleet-launch.md) |
+| 3.3 | Per-adapter spawn details (OpenClaw / Nanoclaw / ClaudeCode) | [03-per-adapter-spawn.md](docs/architecture/03-per-adapter-spawn.md) |
+| 3.4 | Workspace adapter — binary path resolution | [04-workspace-path-resolution.md](docs/architecture/04-workspace-path-resolution.md) |
+| 3.5 | Shutdown propagation | [05-shutdown-propagation.md](docs/architecture/05-shutdown-propagation.md) |
+| 3.6 | Error matrix | [06-error-matrix.md](docs/architecture/06-error-matrix.md) |
+| 3.7 | Per-process state machine | [07-process-state-machine.md](docs/architecture/07-process-state-machine.md) |
+
+## Dependencies
+
+**Runtime**: `effect`, `@effect/platform[-node]`, `openclaw` (external CLI
+binary referenced for its plugin protocol).
+**Internal**: `@moltzap/protocol`, `@moltzap/claude-code-channel`.
+**Consumers**: orchestration scripts in `scripts/`, arena agent-launcher.
+
+## Tests
+
+Co-located unit tests only (single-tier `src/`). No conformance harness —
+runtime supervision is observed via integration tests in the consumers.
+
+## Glossary
+
+- **Runtime** — An external agent process (OpenClaw / Nanoclaw / Claude Code)
+  that connects back to a moltzap server via WS and presents an agent identity.
+- **Adapter** — Per-runtime wrapper that knows how to spawn its binary, parse
+  its readiness signal, and propagate signals on shutdown.
+- **Fleet** — A coordinated multi-agent launch; if any agent fails startup
+  the whole fleet aborts with `RuntimeFleetStartupInterrupted`.
+- **Workspace adapter** — Variant that resolves binary paths relative to a
+  monorepo workspace (vs. PATH-based resolution).

--- a/packages/runtimes/docs/architecture/01-single-runtime-startup.md
+++ b/packages/runtimes/docs/architecture/01-single-runtime-startup.md
@@ -8,76 +8,50 @@
 `startPendingRuntimeAgent`, which wires a finalizer-guarded scope around the
 spawn + readiness check so that any failure path tears down automatically.
 
-```text
-caller
-  │
-  │  startRuntimeAgent(options: RuntimeStartOptions)        fleet.ts → startRuntimeAgent
-  │    Effect.scoped(startPendingRuntimeAgent(options))
-  │    Effect.withSpan("startRuntimeAgent")
-  │
-  ▼
-startPendingRuntimeAgent                                    fleet.ts → startPendingRuntimeAgent
-  │
-  ├─ createRuntime(options)                                 fleet.ts → createRuntime
-  │    switch options.kind
-  │      "openclaw"    → createWorkspaceOpenClawAdapter()   openclaw-adapter.ts → createWorkspaceOpenClawAdapter
-  │      "nanoclaw"    → new NanoclawAdapter()              nanoclaw-adapter.ts → NanoclawAdapter
-  │      "claude-code" → createWorkspaceClaudeCodeAdapter() claude-code-adapter.ts → createWorkspaceClaudeCodeAdapter
-  │
-  ├─ Effect.withEarlyRelease(scope)
-  │    Effect.addFinalizer(cleanupArmed
-  │      ? runtime.teardown() : Effect.void)
-  │    runtime.spawn(spawnInput)
-  │      ┌── [on error] ──────────────────────────────┐
-  │      │   SpawnFailed { agentName, cause, message } │  errors.ts → SpawnFailed
-  │      │   finalizer fires → runtime.teardown()      │
-  │      └────────────────────────────────────────────┘
-  │
-  ├─ runtime.waitUntilReady(readyTimeoutMs)
-  │    Effect.race(
-  │      server.awaitAgentReady(agentId, timeoutMs),        runtime.ts → awaitAgentReady
-  │      processExitLoop(processExit)                       adapter-readiness.ts → processExitLoop
-  │    )
-  │    .flatMap(promoteTimeoutIfProcessExited)              adapter-readiness.ts → promoteTimeoutIfProcessExited
-  │    .tap(outcome →
-  │          outcome._tag === "Ready" ? void : teardown())
-  │
-  │    ReadyOutcome._tag = "Ready"
-  │      └─ return PendingRuntimeAgent { runtime, releaseStartupCleanup }
-  │
-  │    ReadyOutcome._tag = "Timeout"
-  │      └─ teardown() then fail:
-  │         RuntimeReadyTimedOut { agentName, timeoutMs }   errors.ts → RuntimeReadyTimedOut
-  │
-  │    ReadyOutcome._tag = "ProcessExited"
-  │      └─ teardown() then fail:
-  │         RuntimeExitedBeforeReady                        errors.ts → RuntimeExitedBeforeReady
-  │           { agentName, exitCode, stderr }
-  │
-  └─ releaseStartupCleanup
-       Effect.sync(() => cleanupArmed = false)
-       Effect.zipRight(closeStartupScope)
-       (disarms the scope finalizer — runtime now caller-owned)
+```mermaid
+flowchart TD
+    A["caller\nstartRuntimeAgent(options: RuntimeStartOptions)\nfleet.ts → startRuntimeAgent\nEffect.scoped(startPendingRuntimeAgent)\nEffect.withSpan(&quot;startRuntimeAgent&quot;)"]
+    B["startPendingRuntimeAgent\nfleet.ts → startPendingRuntimeAgent"]
+    C["createRuntime(options)\nfleet.ts → createRuntime"]
+    D1["&quot;openclaw&quot; →\ncreateWorkspaceOpenClawAdapter()\nopenclaw-adapter.ts"]
+    D2["&quot;nanoclaw&quot; →\nnew NanoclawAdapter()\nnanoclaw-adapter.ts"]
+    D3["&quot;claude-code&quot; →\ncreateWorkspaceClaudeCodeAdapter()\nclaude-code-adapter.ts"]
+    E["Effect.withEarlyRelease(scope)\nEffect.addFinalizer(cleanupArmed\n? runtime.teardown() : Effect.void)\nruntime.spawn(spawnInput)"]
+    SF["SpawnFailed { agentName, cause, message }\nerrors.ts → SpawnFailed\nfinalizer fires → runtime.teardown()"]
+    F["runtime.waitUntilReady(readyTimeoutMs)\nEffect.race(\n  server.awaitAgentReady(agentId, timeoutMs),\n  processExitLoop(processExit)\n)\n.flatMap(promoteTimeoutIfProcessExited)\n.tap(outcome → outcome._tag === &quot;Ready&quot; ? void : teardown())"]
+    G1["ReadyOutcome._tag = &quot;Ready&quot;\n→ return PendingRuntimeAgent\n{ runtime, releaseStartupCleanup }"]
+    G2["ReadyOutcome._tag = &quot;Timeout&quot;\n→ teardown() then fail:\nRuntimeReadyTimedOut { agentName, timeoutMs }\nerrors.ts → RuntimeReadyTimedOut"]
+    G3["ReadyOutcome._tag = &quot;ProcessExited&quot;\n→ teardown() then fail:\nRuntimeExitedBeforeReady\n{ agentName, exitCode, stderr }\nerrors.ts → RuntimeExitedBeforeReady"]
+    H["releaseStartupCleanup\nEffect.sync(() =&gt; cleanupArmed = false)\nEffect.zipRight(closeStartupScope)\n(disarms scope finalizer — runtime now caller-owned)"]
+
+    A --> B
+    B --> C
+    C --> D1
+    C --> D2
+    C --> D3
+    D1 & D2 & D3 --> E
+    E -->|"spawn error"| SF
+    E --> F
+    F --> G1
+    F --> G2
+    F --> G3
+    G1 --> H
 ```
 
 ## Readiness Polling Detail (`adapter-readiness.ts`)
 
-```text
-processExitLoop                                             adapter-readiness.ts → processExitLoop
-  └─ Effect.iterate(null, {
-       while: state === null,
-       body: Effect.sleep("250 millis")
-               .zipRight(processExitTick)
-     })
+```mermaid
+flowchart TD
+    PEL["processExitLoop\nadapter-readiness.ts → processExitLoop\nEffect.iterate(null, {\n  while: state === null,\n  body: Effect.sleep(&quot;250 millis&quot;)\n          .zipRight(processExitTick)\n})"]
+    PET["processExitTick\nadapter-readiness.ts → processExitTick\npollExitCode()  — Fiber.poll on exitFiber"]
+    PEN["Option.None → null\n(process still running)"]
+    PES["Option.Some(code) →\nReadyOutcome { _tag: &quot;ProcessExited&quot;, exitCode, stderr }"]
+    PT["promoteTimeoutIfProcessExited\nadapter-readiness.ts → promoteTimeoutIfProcessExited\nIf outcome._tag is &quot;Timeout&quot;, runs one\nfinal processExitTick to catch exits that\nlanded in the last 250 ms tick window"]
 
-processExitTick                                             adapter-readiness.ts → processExitTick
-  └─ pollExitCode()           (Fiber.poll on exitFiber)
-       Option.None → null     (process still running)
-       Option.Some(code) → ReadyOutcome { _tag: "ProcessExited", exitCode, stderr }
-
-promoteTimeoutIfProcessExited                               adapter-readiness.ts → promoteTimeoutIfProcessExited
-  If outcome._tag is "Timeout", runs one final processExitTick
-  to catch exits that landed in the last 250 ms tick window.
+    PEL --> PET
+    PET --> PEN
+    PET --> PES
+    PES --> PT
 ```
 
 `awaitAgentReadyByPolling` is the default `RuntimeServerHandle.awaitAgentReady`

--- a/packages/runtimes/docs/architecture/01-single-runtime-startup.md
+++ b/packages/runtimes/docs/architecture/01-single-runtime-startup.md
@@ -10,19 +10,19 @@ spawn + readiness check so that any failure path tears down automatically.
 
 ```mermaid
 flowchart TD
-    A["caller\nstartRuntimeAgent(options: RuntimeStartOptions)\nfleet.ts → startRuntimeAgent\nEffect.scoped(startPendingRuntimeAgent)\nEffect.withSpan(&quot;startRuntimeAgent&quot;)"]
-    B["startPendingRuntimeAgent\nfleet.ts → startPendingRuntimeAgent"]
-    C["createRuntime(options)\nfleet.ts → createRuntime"]
-    D1["&quot;openclaw&quot; →\ncreateWorkspaceOpenClawAdapter()\nopenclaw-adapter.ts"]
-    D2["&quot;nanoclaw&quot; →\nnew NanoclawAdapter()\nnanoclaw-adapter.ts"]
-    D3["&quot;claude-code&quot; →\ncreateWorkspaceClaudeCodeAdapter()\nclaude-code-adapter.ts"]
-    E["Effect.withEarlyRelease(scope)\nEffect.addFinalizer(cleanupArmed\n? runtime.teardown() : Effect.void)\nruntime.spawn(spawnInput)"]
-    SF["SpawnFailed { agentName, cause, message }\nerrors.ts → SpawnFailed\nfinalizer fires → runtime.teardown()"]
-    F["runtime.waitUntilReady(readyTimeoutMs)\nEffect.race(\n  server.awaitAgentReady(agentId, timeoutMs),\n  processExitLoop(processExit)\n)\n.flatMap(promoteTimeoutIfProcessExited)\n.tap(outcome → outcome._tag === &quot;Ready&quot; ? void : teardown())"]
-    G1["ReadyOutcome._tag = &quot;Ready&quot;\n→ return PendingRuntimeAgent\n{ runtime, releaseStartupCleanup }"]
-    G2["ReadyOutcome._tag = &quot;Timeout&quot;\n→ teardown() then fail:\nRuntimeReadyTimedOut { agentName, timeoutMs }\nerrors.ts → RuntimeReadyTimedOut"]
-    G3["ReadyOutcome._tag = &quot;ProcessExited&quot;\n→ teardown() then fail:\nRuntimeExitedBeforeReady\n{ agentName, exitCode, stderr }\nerrors.ts → RuntimeExitedBeforeReady"]
-    H["releaseStartupCleanup\nEffect.sync(() =&gt; cleanupArmed = false)\nEffect.zipRight(closeStartupScope)\n(disarms scope finalizer — runtime now caller-owned)"]
+    A["caller<br>startRuntimeAgent(options: RuntimeStartOptions)<br>fleet.ts → startRuntimeAgent<br>Effect.scoped(startPendingRuntimeAgent)<br>Effect.withSpan(&quot;startRuntimeAgent&quot;)"]
+    B["startPendingRuntimeAgent<br>fleet.ts → startPendingRuntimeAgent"]
+    C["createRuntime(options)<br>fleet.ts → createRuntime"]
+    D1["&quot;openclaw&quot; →<br>createWorkspaceOpenClawAdapter()<br>openclaw-adapter.ts"]
+    D2["&quot;nanoclaw&quot; →<br>new NanoclawAdapter()<br>nanoclaw-adapter.ts"]
+    D3["&quot;claude-code&quot; →<br>createWorkspaceClaudeCodeAdapter()<br>claude-code-adapter.ts"]
+    E["Effect.withEarlyRelease(scope)<br>Effect.addFinalizer(cleanupArmed<br>? runtime.teardown() : Effect.void)<br>runtime.spawn(spawnInput)"]
+    SF["SpawnFailed { agentName, cause, message }<br>errors.ts → SpawnFailed<br>finalizer fires → runtime.teardown()"]
+    F["runtime.waitUntilReady(readyTimeoutMs)<br>Effect.race(<br>  server.awaitAgentReady(agentId, timeoutMs),<br>  processExitLoop(processExit)<br>)<br>.flatMap(promoteTimeoutIfProcessExited)<br>.tap(outcome → outcome._tag === &quot;Ready&quot; ? void : teardown())"]
+    G1["ReadyOutcome._tag = &quot;Ready&quot;<br>→ return PendingRuntimeAgent<br>{ runtime, releaseStartupCleanup }"]
+    G2["ReadyOutcome._tag = &quot;Timeout&quot;<br>→ teardown() then fail:<br>RuntimeReadyTimedOut { agentName, timeoutMs }<br>errors.ts → RuntimeReadyTimedOut"]
+    G3["ReadyOutcome._tag = &quot;ProcessExited&quot;<br>→ teardown() then fail:<br>RuntimeExitedBeforeReady<br>{ agentName, exitCode, stderr }<br>errors.ts → RuntimeExitedBeforeReady"]
+    H["releaseStartupCleanup<br>Effect.sync(() =&gt; cleanupArmed = false)<br>Effect.zipRight(closeStartupScope)<br>(disarms scope finalizer — runtime now caller-owned)"]
 
     A --> B
     B --> C
@@ -42,11 +42,11 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    PEL["processExitLoop\nadapter-readiness.ts → processExitLoop\nEffect.iterate(null, {\n  while: state === null,\n  body: Effect.sleep(&quot;250 millis&quot;)\n          .zipRight(processExitTick)\n})"]
-    PET["processExitTick\nadapter-readiness.ts → processExitTick\npollExitCode()  — Fiber.poll on exitFiber"]
-    PEN["Option.None → null\n(process still running)"]
-    PES["Option.Some(code) →\nReadyOutcome { _tag: &quot;ProcessExited&quot;, exitCode, stderr }"]
-    PT["promoteTimeoutIfProcessExited\nadapter-readiness.ts → promoteTimeoutIfProcessExited\nIf outcome._tag is &quot;Timeout&quot;, runs one\nfinal processExitTick to catch exits that\nlanded in the last 250 ms tick window"]
+    PEL["processExitLoop<br>adapter-readiness.ts → processExitLoop<br>Effect.iterate(null, {<br>  while: state === null,<br>  body: Effect.sleep(&quot;250 millis&quot;)<br>          .zipRight(processExitTick)<br>})"]
+    PET["processExitTick<br>adapter-readiness.ts → processExitTick<br>pollExitCode()  — Fiber.poll on exitFiber"]
+    PEN["Option.None → null<br>(process still running)"]
+    PES["Option.Some(code) →<br>ReadyOutcome { _tag: &quot;ProcessExited&quot;, exitCode, stderr }"]
+    PT["promoteTimeoutIfProcessExited<br>adapter-readiness.ts → promoteTimeoutIfProcessExited<br>If outcome._tag is &quot;Timeout&quot;, runs one<br>final processExitTick to catch exits that<br>landed in the last 250 ms tick window"]
 
     PEL --> PET
     PET --> PEN

--- a/packages/runtimes/docs/architecture/01-single-runtime-startup.md
+++ b/packages/runtimes/docs/architecture/01-single-runtime-startup.md
@@ -1,0 +1,94 @@
+# Single-Runtime Startup Sequence
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+## Overview
+
+`startRuntimeAgent` is the entry point for launching one agent. It delegates to
+`startPendingRuntimeAgent`, which wires a finalizer-guarded scope around the
+spawn + readiness check so that any failure path tears down automatically.
+
+```text
+caller
+  │
+  │  startRuntimeAgent(options: RuntimeStartOptions)        fleet.ts → startRuntimeAgent
+  │    Effect.scoped(startPendingRuntimeAgent(options))
+  │    Effect.withSpan("startRuntimeAgent")
+  │
+  ▼
+startPendingRuntimeAgent                                    fleet.ts → startPendingRuntimeAgent
+  │
+  ├─ createRuntime(options)                                 fleet.ts → createRuntime
+  │    switch options.kind
+  │      "openclaw"    → createWorkspaceOpenClawAdapter()   openclaw-adapter.ts → createWorkspaceOpenClawAdapter
+  │      "nanoclaw"    → new NanoclawAdapter()              nanoclaw-adapter.ts → NanoclawAdapter
+  │      "claude-code" → createWorkspaceClaudeCodeAdapter() claude-code-adapter.ts → createWorkspaceClaudeCodeAdapter
+  │
+  ├─ Effect.withEarlyRelease(scope)
+  │    Effect.addFinalizer(cleanupArmed
+  │      ? runtime.teardown() : Effect.void)
+  │    runtime.spawn(spawnInput)
+  │      ┌── [on error] ──────────────────────────────┐
+  │      │   SpawnFailed { agentName, cause, message } │  errors.ts → SpawnFailed
+  │      │   finalizer fires → runtime.teardown()      │
+  │      └────────────────────────────────────────────┘
+  │
+  ├─ runtime.waitUntilReady(readyTimeoutMs)
+  │    Effect.race(
+  │      server.awaitAgentReady(agentId, timeoutMs),        runtime.ts → awaitAgentReady
+  │      processExitLoop(processExit)                       adapter-readiness.ts → processExitLoop
+  │    )
+  │    .flatMap(promoteTimeoutIfProcessExited)              adapter-readiness.ts → promoteTimeoutIfProcessExited
+  │    .tap(outcome →
+  │          outcome._tag === "Ready" ? void : teardown())
+  │
+  │    ReadyOutcome._tag = "Ready"
+  │      └─ return PendingRuntimeAgent { runtime, releaseStartupCleanup }
+  │
+  │    ReadyOutcome._tag = "Timeout"
+  │      └─ teardown() then fail:
+  │         RuntimeReadyTimedOut { agentName, timeoutMs }   errors.ts → RuntimeReadyTimedOut
+  │
+  │    ReadyOutcome._tag = "ProcessExited"
+  │      └─ teardown() then fail:
+  │         RuntimeExitedBeforeReady                        errors.ts → RuntimeExitedBeforeReady
+  │           { agentName, exitCode, stderr }
+  │
+  └─ releaseStartupCleanup
+       Effect.sync(() => cleanupArmed = false)
+       Effect.zipRight(closeStartupScope)
+       (disarms the scope finalizer — runtime now caller-owned)
+```
+
+## Readiness Polling Detail (`adapter-readiness.ts`)
+
+```text
+processExitLoop                                             adapter-readiness.ts → processExitLoop
+  └─ Effect.iterate(null, {
+       while: state === null,
+       body: Effect.sleep("250 millis")
+               .zipRight(processExitTick)
+     })
+
+processExitTick                                             adapter-readiness.ts → processExitTick
+  └─ pollExitCode()           (Fiber.poll on exitFiber)
+       Option.None → null     (process still running)
+       Option.Some(code) → ReadyOutcome { _tag: "ProcessExited", exitCode, stderr }
+
+promoteTimeoutIfProcessExited                               adapter-readiness.ts → promoteTimeoutIfProcessExited
+  If outcome._tag is "Timeout", runs one final processExitTick
+  to catch exits that landed in the last 250 ms tick window.
+```
+
+`awaitAgentReadyByPolling` is the default `RuntimeServerHandle.awaitAgentReady`
+implementation for in-process callers (in `await-agent-ready.ts`). It polls
+`connections.getByAgent(agentId)` every 500 ms until at least one connection
+has `auth !== null`. Out-of-process callers replace it with a WebSocket presence
+subscription (see the `@example` block in `await-agent-ready.ts`).
+
+## See Also
+
+- [Fleet Launch](./02-fleet-launch.md)
+- [Per-Adapter Spawn Details](./03-per-adapter-spawn.md)
+- [Error Matrix](./06-error-matrix.md)
+- [Process State Machine](./07-process-state-machine.md)

--- a/packages/runtimes/docs/architecture/02-fleet-launch.md
+++ b/packages/runtimes/docs/architecture/02-fleet-launch.md
@@ -10,38 +10,38 @@ OS-signal handlers.
 
 ```mermaid
 flowchart TD
-    FL["launchRuntimeFleet(options)\nfleet.ts → launchRuntimeFleet\nEffect.scoped(...)\nEffect.withSpan(&quot;launchRuntimeFleet&quot;)\n\nstartedAgents: StartedRuntimeAgent[]\n\nEffect.forEach(options.agents, startFleetAgent,\n  { concurrency: options.concurrency ?? 1 })"]
+    FL["launchRuntimeFleet(options)<br>fleet.ts → launchRuntimeFleet<br>Effect.scoped(...)<br>Effect.withSpan(&quot;launchRuntimeFleet&quot;)<br><br>startedAgents: StartedRuntimeAgent[]<br><br>Effect.forEach(options.agents, startFleetAgent,<br>  { concurrency: options.concurrency ?? 1 })"]
 
     subgraph Sequential["Sequential by default (concurrency: 1)"]
-        A0["startFleetAgent — Agent 0\nfleet.ts → startFleetAgent"]
-        A1["startFleetAgent — Agent 1\n(starts after 0 succeeds)"]
-        AN["startFleetAgent — Agent N\n(starts after 1 succeeds)"]
+        A0["startFleetAgent — Agent 0<br>fleet.ts → startFleetAgent"]
+        A1["startFleetAgent — Agent 1<br>(starts after 0 succeeds)"]
+        AN["startFleetAgent — Agent N<br>(starts after 1 succeeds)"]
         A0 --> A1 --> AN
     end
 
     FL --> Sequential
 
-    Sequential -->|"onExit finalizer\n(Exit.isSuccess → void\nelse → teardownStartedAgents\nin REVERSE insertion order\nfleet.ts → teardownStartedAgents)"| OUTCOME
+    Sequential -->|"onExit finalizer<br>(Exit.isSuccess → void<br>else → teardownStartedAgents<br>in REVERSE insertion order<br>fleet.ts → teardownStartedAgents)"| OUTCOME
 
     OUTCOME{"outcome?"}
 
-    OUTCOME -->|"ONE agent fails"| FAIL["startPendingRuntimeAgent fails\nwith RuntimeLaunchFailed\nEffect.forEach short-circuits\nonExit finalizer tears down all\nstartedAgents so far\nCaller receives first error"]
+    OUTCOME -->|"ONE agent fails"| FAIL["startPendingRuntimeAgent fails<br>with RuntimeLaunchFailed<br>Effect.forEach short-circuits<br>onExit finalizer tears down all<br>startedAgents so far<br>Caller receives first error"]
 
-    OUTCOME -->|"All agents succeed"| SUCCESS["toRuntimeFleet(started)\nfleet.ts → toRuntimeFleet\n→ RuntimeFleet {\n  agents: [{ name, agentId }, ...],\n  stopAll: () =&gt; teardownStartedAgents(started),\n  getLogs: (name) =&gt; runtime.getLogs(0).text\n}"]
+    OUTCOME -->|"All agents succeed"| SUCCESS["toRuntimeFleet(started)<br>fleet.ts → toRuntimeFleet<br>→ RuntimeFleet {<br>  agents: [{ name, agentId }, ...],<br>  stopAll: () =&gt; teardownStartedAgents(started),<br>  getLogs: (name) =&gt; runtime.getLogs(0).text<br>}"]
 ```
 
 ## Signal-Handler Variant
 
 ```mermaid
 flowchart TD
-    LRFPS["launchRuntimeFleetWithProcessSignals(options)\nfleet.ts → launchRuntimeFleetWithProcessSignals"]
+    LRFPS["launchRuntimeFleetWithProcessSignals(options)<br>fleet.ts → launchRuntimeFleetWithProcessSignals"]
     FORK["Effect.runFork(launchRuntimeFleet(options)) → fiber"]
-    SIGNALS["installProcessSignalHandlers(\n  signals ?? [&quot;SIGINT&quot;, &quot;SIGTERM&quot;],\n  shutdownSignal, fiber\n)\nfleet.ts → installProcessSignalHandlers\n\nEach signal: process.on(signal, handler)\nFirst signal to fire:\n  shutdownSignal.value = signal\n  Effect.runFork(Fiber.interrupt(fiber))"]
-    OBS["observeFleetLaunchFiber(fiber, ...)\nfleet.ts → observeFleetLaunchFiber\n\nfiber.addObserver(exit =&gt; {\n  cleanup()  ← process.off() all handlers\n  ...route by exit shape (see below)\n})"]
-    OK["Exit.isSuccess\n→ resume(Effect.succeed(fleet))"]
-    INT["shutdownSignal.value !== null &amp;&amp; interrupted\n→ resume(interruptedStartup(signal))\nRuntimeFleetStartupInterrupted { signal }\nfleet.ts → RuntimeFleetStartupInterrupted"]
-    ERR["else\n→ resume(Effect.failCause(exit.cause))"]
-    CLEANUP["Returns Effect.async cleanup:\ncleanup() + Fiber.interrupt(fiber)\n(Effect-level cancellation of outer effect)"]
+    SIGNALS["installProcessSignalHandlers(<br>  signals ?? [&quot;SIGINT&quot;, &quot;SIGTERM&quot;],<br>  shutdownSignal, fiber<br>)<br>fleet.ts → installProcessSignalHandlers<br><br>Each signal: process.on(signal, handler)<br>First signal to fire:<br>  shutdownSignal.value = signal<br>  Effect.runFork(Fiber.interrupt(fiber))"]
+    OBS["observeFleetLaunchFiber(fiber, ...)<br>fleet.ts → observeFleetLaunchFiber<br><br>fiber.addObserver(exit =&gt; {<br>  cleanup()  ← process.off() all handlers<br>  ...route by exit shape (see below)<br>})"]
+    OK["Exit.isSuccess<br>→ resume(Effect.succeed(fleet))"]
+    INT["shutdownSignal.value !== null &amp;&amp; interrupted<br>→ resume(interruptedStartup(signal))<br>RuntimeFleetStartupInterrupted { signal }<br>fleet.ts → RuntimeFleetStartupInterrupted"]
+    ERR["else<br>→ resume(Effect.failCause(exit.cause))"]
+    CLEANUP["Returns Effect.async cleanup:<br>cleanup() + Fiber.interrupt(fiber)<br>(Effect-level cancellation of outer effect)"]
 
     LRFPS --> FORK --> SIGNALS --> OBS
     OBS --> OK

--- a/packages/runtimes/docs/architecture/02-fleet-launch.md
+++ b/packages/runtimes/docs/architecture/02-fleet-launch.md
@@ -8,78 +8,46 @@
 (`concurrency: 1`). `launchRuntimeFleetWithProcessSignals` wraps it with
 OS-signal handlers.
 
-```text
-                    launchRuntimeFleet(options)              fleet.ts → launchRuntimeFleet
-                      Effect.scoped(...)
-                      Effect.withSpan("launchRuntimeFleet")
-                           │
-                           │  startedAgents: StartedRuntimeAgent[]
-                           │
-                           ▼
-                    Effect.forEach(options.agents, startFleetAgent,
-                      { concurrency: options.concurrency ?? 1 })
+```mermaid
+flowchart TD
+    FL["launchRuntimeFleet(options)\nfleet.ts → launchRuntimeFleet\nEffect.scoped(...)\nEffect.withSpan(&quot;launchRuntimeFleet&quot;)\n\nstartedAgents: StartedRuntimeAgent[]\n\nEffect.forEach(options.agents, startFleetAgent,\n  { concurrency: options.concurrency ?? 1 })"]
 
-              ┌────────────────────────────────────────────────────────┐
-              │   Agent 0           Agent 1           Agent N          │
-              │  startFleetAgent   startFleetAgent   startFleetAgent   │ fleet.ts → startFleetAgent
-              │   (sequential by   (starts after 0   (starts after 1  │
-              │    default)         succeeds)          succeeds)        │
-              └────────────────────────────────────────────────────────┘
-                           │
-                 .pipe(Effect.onExit(exit =>
-                   Exit.isSuccess(exit) ? void
-                   : teardownStartedAgents(startedAgents)
-                 ))
-                 Teardown on failure is sequential in REVERSE
-                 insertion order.                         fleet.ts → teardownStartedAgents
+    subgraph Sequential["Sequential by default (concurrency: 1)"]
+        A0["startFleetAgent — Agent 0\nfleet.ts → startFleetAgent"]
+        A1["startFleetAgent — Agent 1\n(starts after 0 succeeds)"]
+        AN["startFleetAgent — Agent N\n(starts after 1 succeeds)"]
+        A0 --> A1 --> AN
+    end
 
-              ┌─ ONE agent fails ─────────────────────────────────────┐
-              │  startPendingRuntimeAgent fails with RuntimeLaunchFailed│
-              │  Effect.forEach short-circuits                          │
-              │  onExit finalizer tears down all startedAgents so far  │
-              │  Caller receives the first RuntimeLaunchFailed error    │
-              └────────────────────────────────────────────────────────┘
+    FL --> Sequential
 
-              ┌─ All agents succeed ───────────────────────────────────┐
-              │  toRuntimeFleet(started) → RuntimeFleet {              │ fleet.ts → toRuntimeFleet
-              │    agents: [{ name, agentId }, ...],                   │
-              │    stopAll: () => teardownStartedAgents(started),      │
-              │    getLogs: (name) => runtime.getLogs(0).text          │
-              │  }                                                      │
-              └────────────────────────────────────────────────────────┘
+    Sequential -->|"onExit finalizer\n(Exit.isSuccess → void\nelse → teardownStartedAgents\nin REVERSE insertion order\nfleet.ts → teardownStartedAgents)"| OUTCOME
+
+    OUTCOME{"outcome?"}
+
+    OUTCOME -->|"ONE agent fails"| FAIL["startPendingRuntimeAgent fails\nwith RuntimeLaunchFailed\nEffect.forEach short-circuits\nonExit finalizer tears down all\nstartedAgents so far\nCaller receives first error"]
+
+    OUTCOME -->|"All agents succeed"| SUCCESS["toRuntimeFleet(started)\nfleet.ts → toRuntimeFleet\n→ RuntimeFleet {\n  agents: [{ name, agentId }, ...],\n  stopAll: () =&gt; teardownStartedAgents(started),\n  getLogs: (name) =&gt; runtime.getLogs(0).text\n}"]
 ```
 
 ## Signal-Handler Variant
 
-```text
-launchRuntimeFleetWithProcessSignals(options)               fleet.ts → launchRuntimeFleetWithProcessSignals
-  │
-  ├─ Effect.runFork(launchRuntimeFleet(options)) → fiber
-  │
-  ├─ installProcessSignalHandlers(                          fleet.ts → installProcessSignalHandlers
-  │    signals ?? ["SIGINT","SIGTERM"],
-  │    shutdownSignal,
-  │    fiber
-  │  )
-  │   Each signal installs process.on(signal, handler)
-  │   First signal to fire:
-  │     shutdownSignal.value = signal
-  │     Effect.runFork(Fiber.interrupt(fiber))
-  │
-  ├─ observeFleetLaunchFiber(fiber, ...)                    fleet.ts → observeFleetLaunchFiber
-  │   fiber.addObserver(exit => {
-  │     cleanup()  ← process.off() for all handlers
-  │     if Exit.isSuccess → resume(Effect.succeed(fleet))
-  │     if shutdownSignal.value !== null && interrupted
-  │       → resume(interruptedStartup(signal))
-  │         RuntimeFleetStartupInterrupted { signal }       fleet.ts → RuntimeFleetStartupInterrupted
-  │     else
-  │       → resume(Effect.failCause(exit.cause))
-  │   })
-  │
-  └─ Returns Effect.async cleanup:
-       cleanup() + Fiber.interrupt(fiber)
-       (for Effect-level cancellation of the outer effect)
+```mermaid
+flowchart TD
+    LRFPS["launchRuntimeFleetWithProcessSignals(options)\nfleet.ts → launchRuntimeFleetWithProcessSignals"]
+    FORK["Effect.runFork(launchRuntimeFleet(options)) → fiber"]
+    SIGNALS["installProcessSignalHandlers(\n  signals ?? [&quot;SIGINT&quot;, &quot;SIGTERM&quot;],\n  shutdownSignal, fiber\n)\nfleet.ts → installProcessSignalHandlers\n\nEach signal: process.on(signal, handler)\nFirst signal to fire:\n  shutdownSignal.value = signal\n  Effect.runFork(Fiber.interrupt(fiber))"]
+    OBS["observeFleetLaunchFiber(fiber, ...)\nfleet.ts → observeFleetLaunchFiber\n\nfiber.addObserver(exit =&gt; {\n  cleanup()  ← process.off() all handlers\n  ...route by exit shape (see below)\n})"]
+    OK["Exit.isSuccess\n→ resume(Effect.succeed(fleet))"]
+    INT["shutdownSignal.value !== null &amp;&amp; interrupted\n→ resume(interruptedStartup(signal))\nRuntimeFleetStartupInterrupted { signal }\nfleet.ts → RuntimeFleetStartupInterrupted"]
+    ERR["else\n→ resume(Effect.failCause(exit.cause))"]
+    CLEANUP["Returns Effect.async cleanup:\ncleanup() + Fiber.interrupt(fiber)\n(Effect-level cancellation of outer effect)"]
+
+    LRFPS --> FORK --> SIGNALS --> OBS
+    OBS --> OK
+    OBS --> INT
+    OBS --> ERR
+    LRFPS --> CLEANUP
 ```
 
 `RuntimeFleetStartupInterrupted` is the only error type that is **not** in

--- a/packages/runtimes/docs/architecture/02-fleet-launch.md
+++ b/packages/runtimes/docs/architecture/02-fleet-launch.md
@@ -1,0 +1,93 @@
+# Fleet Launch Sequence
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+## Overview
+
+`launchRuntimeFleet` launches N agents, by default sequentially
+(`concurrency: 1`). `launchRuntimeFleetWithProcessSignals` wraps it with
+OS-signal handlers.
+
+```text
+                    launchRuntimeFleet(options)              fleet.ts → launchRuntimeFleet
+                      Effect.scoped(...)
+                      Effect.withSpan("launchRuntimeFleet")
+                           │
+                           │  startedAgents: StartedRuntimeAgent[]
+                           │
+                           ▼
+                    Effect.forEach(options.agents, startFleetAgent,
+                      { concurrency: options.concurrency ?? 1 })
+
+              ┌────────────────────────────────────────────────────────┐
+              │   Agent 0           Agent 1           Agent N          │
+              │  startFleetAgent   startFleetAgent   startFleetAgent   │ fleet.ts → startFleetAgent
+              │   (sequential by   (starts after 0   (starts after 1  │
+              │    default)         succeeds)          succeeds)        │
+              └────────────────────────────────────────────────────────┘
+                           │
+                 .pipe(Effect.onExit(exit =>
+                   Exit.isSuccess(exit) ? void
+                   : teardownStartedAgents(startedAgents)
+                 ))
+                 Teardown on failure is sequential in REVERSE
+                 insertion order.                         fleet.ts → teardownStartedAgents
+
+              ┌─ ONE agent fails ─────────────────────────────────────┐
+              │  startPendingRuntimeAgent fails with RuntimeLaunchFailed│
+              │  Effect.forEach short-circuits                          │
+              │  onExit finalizer tears down all startedAgents so far  │
+              │  Caller receives the first RuntimeLaunchFailed error    │
+              └────────────────────────────────────────────────────────┘
+
+              ┌─ All agents succeed ───────────────────────────────────┐
+              │  toRuntimeFleet(started) → RuntimeFleet {              │ fleet.ts → toRuntimeFleet
+              │    agents: [{ name, agentId }, ...],                   │
+              │    stopAll: () => teardownStartedAgents(started),      │
+              │    getLogs: (name) => runtime.getLogs(0).text          │
+              │  }                                                      │
+              └────────────────────────────────────────────────────────┘
+```
+
+## Signal-Handler Variant
+
+```text
+launchRuntimeFleetWithProcessSignals(options)               fleet.ts → launchRuntimeFleetWithProcessSignals
+  │
+  ├─ Effect.runFork(launchRuntimeFleet(options)) → fiber
+  │
+  ├─ installProcessSignalHandlers(                          fleet.ts → installProcessSignalHandlers
+  │    signals ?? ["SIGINT","SIGTERM"],
+  │    shutdownSignal,
+  │    fiber
+  │  )
+  │   Each signal installs process.on(signal, handler)
+  │   First signal to fire:
+  │     shutdownSignal.value = signal
+  │     Effect.runFork(Fiber.interrupt(fiber))
+  │
+  ├─ observeFleetLaunchFiber(fiber, ...)                    fleet.ts → observeFleetLaunchFiber
+  │   fiber.addObserver(exit => {
+  │     cleanup()  ← process.off() for all handlers
+  │     if Exit.isSuccess → resume(Effect.succeed(fleet))
+  │     if shutdownSignal.value !== null && interrupted
+  │       → resume(interruptedStartup(signal))
+  │         RuntimeFleetStartupInterrupted { signal }       fleet.ts → RuntimeFleetStartupInterrupted
+  │     else
+  │       → resume(Effect.failCause(exit.cause))
+  │   })
+  │
+  └─ Returns Effect.async cleanup:
+       cleanup() + Fiber.interrupt(fiber)
+       (for Effect-level cancellation of the outer effect)
+```
+
+`RuntimeFleetStartupInterrupted` is the only error type that is **not** in
+`errors.ts`; it is local to `fleet.ts` because it only arises in the signals
+variant and carries the interrupting `Signal` value.
+
+## See Also
+
+- [Single-Runtime Startup](./01-single-runtime-startup.md)
+- [Shutdown Propagation](./05-shutdown-propagation.md)
+- [Error Matrix](./06-error-matrix.md)

--- a/packages/runtimes/docs/architecture/03-per-adapter-spawn.md
+++ b/packages/runtimes/docs/architecture/03-per-adapter-spawn.md
@@ -4,63 +4,28 @@
 
 ## 3.1 OpenClaw Adapter (`openclaw-adapter.ts`)
 
-```text
-OpenClawAdapter.spawn(input)                               openclaw-adapter.ts → OpenClawAdapter.spawn
+```mermaid
+flowchart TD
+    OCS["OpenClawAdapter.spawn(input)\nopenclaw-adapter.ts → OpenClawAdapter.spawn"]
+    OC1["1. allocateFreePort()\nNodeSocketServer.make({ host: &quot;127.0.0.1&quot;, port: 0 })\nReads ephemeral port; scope closed immediately\n— port number recorded for openclaw.json config"]
+    OC2["2. prepareOpenClawStateDir(deps, input)\nmakeTempDirectory({ prefix: &quot;openclaw-&lt;agentName&gt;-&quot; })\nwriteOpenClawConfig(stateDir, ...)\nseedWorkspaceFiles(stateDir, input.workspaceFiles)\ninstallChannelPlugin(stateDir, channelDistDir, repoRoot)"]
+    OC3["3. buildOpenClawProcessPlan(openclawBin, port)\nIf openclawBin.endsWith(&quot;.mjs&quot;):\n  command=&quot;node&quot; args=[openclawBin, &quot;gateway&quot;, &quot;run&quot;, ...]\nElse:\n  command=openclawBin args=[&quot;gateway&quot;, &quot;run&quot;, ...]"]
+    OC4["4. spawnOpenClawProcess(command, args, cwd=stateDir)\nenv: OPENCLAW_STATE_DIR, OPENCLAW_CONFIG_PATH\nScope.make() → Command.start() → Scope.extend(scope)\nexitFiber = proc.exitCode.forkIn(scope)\nstdout + stderr fibers → logBuffer.value"]
+    OC5["5. this.state = { process, stateDir, logBuffer,\n   spawnInput, tornDown: false }"]
+    OCR["Readiness — OpenClawAdapter.waitUntilReady\nRace:\n  server.awaitAgentReady(agentId, timeoutMs)\n  processExitLoop({ pollExitCode: () =&gt; Fiber.poll(exitFiber),\n                    stderr: () =&gt; logBuffer.value })\nReadiness signal: server-side WS authentication event\nInbound marker: &quot;inbound from agent:&quot;"]
 
-  1. allocateFreePort()                                    openclaw-adapter.ts → allocateFreePort
-       NodeSocketServer.make({ host: "127.0.0.1", port: 0 })
-       Reads ephemeral port from server.address.port
-       Scope is immediately closed — port is released, but its
-       number is recorded for use in the openclaw.json config.
-
-  2. prepareOpenClawStateDir(deps, input)                  openclaw-adapter.ts → prepareOpenClawStateDir
-       makeTempDirectory({ prefix: "openclaw-<agentName>-" })
-       writeOpenClawConfig(stateDir, ...)                  openclaw-adapter.ts → writeOpenClawConfig
-         writes stateDir/openclaw.json  (OpenClawConfig)
-         config shape:
-           agents.defaults.model.primary = modelId ?? "openai-codex/gpt-5.4"
-           agents.defaults.workspace = stateDir/workspace
-           channels.moltzap.accounts[0] = { apiKey, serverUrl, agentName }
-           gateway.mode = "local"
-           gateway.auth.token = "runtime-<timestamp_base36>"
-       seedWorkspaceFiles(stateDir, input.workspaceFiles)  openclaw-adapter.ts → seedWorkspaceFiles
-       installChannelPlugin(stateDir, channelDistDir,       openclaw-adapter.ts → installChannelPlugin
-                            repoRoot)
-         resolves `effect` dep via resolveChannelDependency
-         installs openclaw-channel as plugin via
-           openclaw.plugin.json manifest
-
-  3. buildOpenClawProcessPlan(openclawBin, port)           openclaw-adapter.ts → buildOpenClawProcessPlan
-       If openclawBin.endsWith(".mjs"):
-         command = "node"  args = [openclawBin, "gateway",
-           "run", "--allow-unconfigured", "--port", port]
-       Else:
-         command = openclawBin  args = ["gateway", "run",
-           "--allow-unconfigured", "--port", port]
-
-  4. spawnOpenClawProcess(command, args, cwd=stateDir,     openclaw-adapter.ts → spawnOpenClawProcess
-       env = {
-         OPENCLAW_STATE_DIR: stateDir,
-         OPENCLAW_CONFIG_PATH: stateDir/openclaw.json
-       })
-       Scope.make() → Command.start() → Scope.extend(scope)
-       exitFiber = proc.exitCode.forkIn(scope)
-       stdout + stderr fibers → logBuffer.value
-
-  5. this.state = { process, stateDir, logBuffer,
-                    spawnInput, tornDown: false }
-
-Readiness (OpenClawAdapter.waitUntilReady):             openclaw-adapter.ts → OpenClawAdapter.waitUntilReady
-  Race:
-    server.awaitAgentReady(agentId, timeoutMs)
-      (openclaw's moltzap channel authenticates on WS connect)
-    processExitLoop({ pollExitCode: () => Fiber.poll(exitFiber),
-                      stderr: () => logBuffer.value })
-  Binary: "openclaw" (native) or "node <openclaw.mjs>" (mjs)
-  Readiness signal: server-side WS authentication event
-    (NOT a stdout pattern — openclaw dials moltzap on startup)
-  Inbound marker: "inbound from agent:"              openclaw-adapter.ts → inbound log marker
+    OCS --> OC1 --> OC2 --> OC3 --> OC4 --> OC5 --> OCR
 ```
+
+**Annotations:**
+- `allocateFreePort` — `openclaw-adapter.ts → allocateFreePort`
+- `prepareOpenClawStateDir` — `openclaw-adapter.ts → prepareOpenClawStateDir`
+- `writeOpenClawConfig` — `openclaw-adapter.ts → writeOpenClawConfig`; writes `stateDir/openclaw.json` with model, workspace, moltzap channel account, gateway mode/auth
+- `seedWorkspaceFiles` — `openclaw-adapter.ts → seedWorkspaceFiles`
+- `installChannelPlugin` — `openclaw-adapter.ts → installChannelPlugin`; resolves `effect` dep via `resolveChannelDependency`; installs via `openclaw.plugin.json`
+- `buildOpenClawProcessPlan` — `openclaw-adapter.ts → buildOpenClawProcessPlan`
+- `spawnOpenClawProcess` — `openclaw-adapter.ts → spawnOpenClawProcess`
+- `OpenClawAdapter.waitUntilReady` — `openclaw-adapter.ts → OpenClawAdapter.waitUntilReady`; inbound marker `openclaw-adapter.ts → inbound log marker`
 
 ## 3.2 Nanoclaw Adapter (`nanoclaw-adapter.ts` + `nanoclaw-process.ts`)
 
@@ -68,148 +33,75 @@ Nanoclaw is unique: it runs agent subprocesses **inside Docker containers**
 via the OneCLI gateway. The adapter has a two-phase startup: first ensure the
 runtime cache is installed, then launch.
 
-```text
-NanoclawAdapter.spawn(input)                           nanoclaw-adapter.ts → NanoclawAdapter.spawn
+```mermaid
+flowchart TD
+    NS["NanoclawAdapter.spawn(input)\nnanoclaw-adapter.ts → NanoclawAdapter.spawn"]
 
-  Phase 1 — ensureNanoclawRuntimeInstalledEffect()     nanoclaw-process.ts → ensureNanoclawRuntimeInstalledEffect
-    Checks ~/.cache/moltzap-runtimes/nanoclaw/<sha12>/.ready
-    If .ready exists:
-      syncChannelFileIntoCache()                        nanoclaw-process.ts → syncChannelFileIntoCache
-        diffs packages/nanoclaw-channel/src/channels/moltzap.ts
-        diffs packages/client/dist/channel-core.js
-        if either drifted: overwrite cache + npm run build
-    Else (cold install):
-      preflightDocker()                                 nanoclaw-process.ts → preflightDocker
-        execEffect("docker info", timeout=5000ms)
-      downloadTarball(NANOCLAW_URL, tmpDir)             nanoclaw-process.ts → downloadTarball
-        curl -fsSL <github tarball> -o nanoclaw.tar.gz
-        tar -xzf ... --strip-components=1
-        NANOCLAW_SHA = qwibitai/nanoclaw@934f063...     nanoclaw-process.ts → NANOCLAW_SHA
-      copyChannelFileIntoCache(tmpDir)                  nanoclaw-process.ts → copyChannelFileIntoCache
-      appendMoltzapBarrelImport(tmpDir)                 nanoclaw-process.ts → appendMoltzapBarrelImport
-      copySharedSkillIntoCache(tmpDir)                  nanoclaw-process.ts → copySharedSkillIntoCache
-      buildNanoclawRuntimeCache(tmpDir)                 nanoclaw-process.ts → buildNanoclawRuntimeCache
-        npm install @moltzap/client@latest (120s)
-        npm install (300s)
-        npm run build (120s)
-        bash container/build.sh (300s)
-      promoteRuntimeCache(tmpDir → NANOCLAW_RUNTIME_CACHE)
+    subgraph Phase1["Phase 1 — ensureNanoclawRuntimeInstalledEffect\nnanoclaw-process.ts → ensureNanoclawRuntimeInstalledEffect"]
+        P1C{"~/.cache/.../nanoclaw/&lt;sha12&gt;/.ready\nexists?"}
+        P1WARM["syncChannelFileIntoCache()\ndiff nanoclaw-channel moltzap.ts\ndiff client dist/channel-core.js\nif either drifted: overwrite + npm run build"]
+        P1COLD["preflightDocker()\nexecEffect(&quot;docker info&quot;, timeout=5000ms)"]
+        P1DL["downloadTarball(NANOCLAW_URL, tmpDir)\ncurl -fsSL &lt;github tarball&gt;\nNANOCLAW_SHA = qwibitai/nanoclaw@934f063..."]
+        P1COPY["copyChannelFileIntoCache(tmpDir)\nappendMoltzapBarrelImport(tmpDir)\ncopySharedSkillIntoCache(tmpDir)"]
+        P1BUILD["buildNanoclawRuntimeCache(tmpDir)\nnpm install @moltzap/client@latest (120s)\nnpm install (300s)\nnpm run build (120s)\nbash container/build.sh (300s)"]
+        P1PROMOTE["promoteRuntimeCache(tmpDir → NANOCLAW_RUNTIME_CACHE)"]
 
-  Phase 2 — startNanoclawRuntimeEffect(opts)           nanoclaw-process.ts → startNanoclawRuntimeEffect
-    createNanoclawDataDir()  (mktemp prefix=moltzap-nanoclaw-runtime-)
-    ensureOnecliRunning()                               nanoclaw-process.ts → ensureOnecliRunning
-      probe http://127.0.0.1:10254 (timeout=2s)
-      if unreachable: docker compose -p onecli up -d --wait
-      probe up to 20×500ms
-    writeRuntimeWorkspaceFiles(workspaceFiles)
-      → NANOCLAW_RUNTIME_CACHE/container/skills/<path>
+        P1C -->|".ready exists (warm)"| P1WARM
+        P1C -->|"cold install"| P1COLD --> P1DL --> P1COPY --> P1BUILD --> P1PROMOTE
+    end
 
-    startNanoclawProcess(opts, dataDir, capturedLogs)   nanoclaw-process.ts → startNanoclawProcess
-      command: "node dist/index.js"
-      cwd: NANOCLAW_RUNTIME_CACHE
-      env = {
-        MOLTZAP_API_KEY: apiKey,
-        MOLTZAP_SERVER_URL: <http-normalized>,
-        MOLTZAP_EVAL_MODE: "1",
-        DATA_DIR: dataDir,
-        CONTAINER_RUNTIME: "docker",
-        ONECLI_URL: "http://127.0.0.1:10254",
-        LOG_LEVEL: "info"
-      }
+    subgraph Phase2["Phase 2 — startNanoclawRuntimeEffect\nnanoclaw-process.ts → startNanoclawRuntimeEffect"]
+        P2DIR["createNanoclawDataDir()\nmktemp prefix=moltzap-nanoclaw-runtime-"]
+        P2OC["ensureOnecliRunning()\nprobe http://127.0.0.1:10254 (timeout=2s)\nif unreachable: docker compose -p onecli up -d --wait\nprobe up to 20×500ms"]
+        P2WS["writeRuntimeWorkspaceFiles(workspaceFiles)\n→ NANOCLAW_RUNTIME_CACHE/container/skills/&lt;path&gt;"]
+        P2SP["startNanoclawProcess(opts, dataDir, capturedLogs)\ncommand: &quot;node dist/index.js&quot;\ncwd: NANOCLAW_RUNTIME_CACHE\nenv: MOLTZAP_API_KEY, MOLTZAP_SERVER_URL,\n  MOLTZAP_EVAL_MODE=&quot;1&quot;, DATA_DIR,\n  CONTAINER_RUNTIME=&quot;docker&quot;,\n  ONECLI_URL=&quot;http://127.0.0.1:10254&quot;,\n  LOG_LEVEL=&quot;info&quot;"]
+        P2WAIT["waitForNanoclawConnection(exitFiber, capturedLogs)\nRace (timeout=60s):\n  waitForConnectedMarker: poll 200ms,\n    scan capturedLogs for CONNECTED_MARKER\n    /\\[info\\].*MoltZap connected|MoltZap connected/\n  failIfProcessExitsBeforeConnect: Fiber.join(exitFiber)"]
 
-    waitForNanoclawConnection(exitFiber, capturedLogs)  nanoclaw-process.ts → waitForNanoclawConnection
-      Race (timeout=60s):
-        waitForConnectedMarker: poll every 200ms,
-          scan capturedLogs for CONNECTED_MARKER regex     nanoclaw-process.ts → CONNECTED_MARKER
-          /\[info\].*MoltZap connected|MoltZap connected/
-        failIfProcessExitsBeforeConnect: Fiber.join(exitFiber)
+        P2DIR --> P2OC --> P2WS --> P2SP --> P2WAIT
+    end
 
-  this.state = { handle, spawnInput, tornDown: false }
+    P2STATE["this.state = { handle, spawnInput, tornDown: false }"]
+    NCR["Readiness — NanoclawAdapter.waitUntilReady\nTWO gates:\n1. Inner: waitForNanoclawConnection (stdout marker)\n2. Outer: server.awaitAgentReady (server WS auth)\n\nOuter race:\n  server.awaitAgentReady(agentId, timeoutMs)\n  processExitLoop({ pollExitCode: () =&gt; Fiber.poll(handle.exitFiber),\n                    stderr: () =&gt; getNanoclawRuntimeLogs(handle) })\nInbound marker: &quot;New messages&quot;"]
 
-Readiness (NanoclawAdapter.waitUntilReady):             nanoclaw-adapter.ts → NanoclawAdapter.waitUntilReady
-  Note: nanoclaw has TWO readiness gates:
-    1. Inner: waitForNanoclawConnection (stdout marker,
-              inside startNanoclawRuntimeEffect)
-    2. Outer: server.awaitAgentReady (server WS auth,
-              inside waitUntilReady)
-  Outer race:
-    server.awaitAgentReady(agentId, timeoutMs)
-    processExitLoop({ pollExitCode: () =>
-      Fiber.poll(handle.exitFiber), stderr: () =>
-      getNanoclawRuntimeLogs(handle) })
-  Binary: "node dist/index.js" in NANOCLAW_RUNTIME_CACHE
-  Inbound marker: "New messages"                        nanoclaw-adapter.ts → inbound log marker
+    NS --> Phase1
+    Phase1 --> Phase2
+    Phase2 --> P2STATE --> NCR
 ```
+
+**Annotations:**
+- `ensureNanoclawRuntimeInstalledEffect` — `nanoclaw-process.ts → ensureNanoclawRuntimeInstalledEffect`
+- `syncChannelFileIntoCache` — `nanoclaw-process.ts → syncChannelFileIntoCache`
+- `preflightDocker` — `nanoclaw-process.ts → preflightDocker`
+- `downloadTarball` — `nanoclaw-process.ts → downloadTarball`; `NANOCLAW_SHA` — `nanoclaw-process.ts → NANOCLAW_SHA`
+- `copyChannelFileIntoCache`, `appendMoltzapBarrelImport`, `copySharedSkillIntoCache` — `nanoclaw-process.ts`
+- `buildNanoclawRuntimeCache` — `nanoclaw-process.ts → buildNanoclawRuntimeCache`
+- `startNanoclawRuntimeEffect` — `nanoclaw-process.ts → startNanoclawRuntimeEffect`
+- `ensureOnecliRunning` — `nanoclaw-process.ts → ensureOnecliRunning`
+- `startNanoclawProcess` — `nanoclaw-process.ts → startNanoclawProcess`
+- `waitForNanoclawConnection` — `nanoclaw-process.ts → waitForNanoclawConnection`; `CONNECTED_MARKER` — `nanoclaw-process.ts → CONNECTED_MARKER`
+- `NanoclawAdapter.waitUntilReady` — `nanoclaw-adapter.ts → NanoclawAdapter.waitUntilReady`; inbound marker — `nanoclaw-adapter.ts → inbound log marker`
 
 ## 3.3 ClaudeCode Adapter (`claude-code-adapter.ts`)
 
-```text
-ClaudeCodeAdapter.spawn(input)                         claude-code-adapter.ts → ClaudeCodeAdapter.spawn
+```mermaid
+flowchart TD
+    CCS["ClaudeCodeAdapter.spawn(input)\nclaude-code-adapter.ts → ClaudeCodeAdapter.spawn"]
+    CC1["1. prepareClaudeCodeStateDir(deps, input)\nmakeTempDirectory({ prefix: &quot;claude-code-&lt;agentName&gt;-&quot; })\nseedWorkspaceFiles(stateDir, input.workspaceFiles)\ninstallClaudeCodeChannelPlugin(deps, stateDir)\n  resolves @modelcontextprotocol/sdk + effect deps\n  via resolveChannelDependency (parent node_modules walk)\n  no openclaw.plugin.json — cc-channel has no OpenClaw manifest\n  returns extDir (channel path inside stateDir)"]
+    CC2["2. writeClaudeCodeMcpConfig(opts)\nserverUrl: strip /ws, ws→http, wss→https\nchannelServerName = &quot;@moltzap/claude-code-channel/&lt;agentName&gt;&quot;\nwrites stateDir/mcp-config.json:\n  { mcpServers: { moltzap: {\n    command: &quot;node&quot;,\n    args: [extDir/dist/cli.js],\n    env: { MOLTZAP_API_KEY, MOLTZAP_SERVER_URL,\n           MOLTZAP_SERVER_NAME: channelServerName }\n  }}}"]
+    CC3["3. spawnConfiguredClaude(deps, stateDir, mcpConfigPath, logBuffer)\nbuildClaudeArgs: --strict-mcp-config\n  --mcp-config &lt;mcpConfigPath&gt;\n  --print --input-format stream-json\n  --output-format stream-json --verbose\n  --dangerously-skip-permissions\n  --add-dir &lt;stateDir/workspace&gt;\nspawnClaudeProcess(claudeBin, args,\n  cwd=stateDir, env={ CLAUDE_CODE_HOME: stateDir },\n  stdin=&quot;inherit&quot;)\nScope.make() → Command.start() → Scope.extend(scope)\nexitFiber = proc.exitCode.forkIn(scope)\nstdout + stderr fibers → logBuffer.value"]
+    CC4["4. this.state = { process, stateDir, spawnInput,\n   logBuffer, tornDown: false }"]
+    CCR["Readiness — ClaudeCodeAdapter.waitUntilReady\nRace:\n  server.awaitAgentReady(agentId, timeoutMs)\n    (cc-channel's MCP stdio server authenticates on start)\n  processExitLoop({ pollExitCode: () =&gt; pollClaudeExitCode(proc),\n                    stderr: () =&gt; logBuffer.value })\nBinary: claudeBin (&quot;claude&quot; CLI, @anthropic-ai/claude-code)\nClaude spawns cc-channel as MCP stdio child automatically\n  (SIGTERM on claude propagates to cc-channel naturally —\n   no process-group kill needed, unlike openclaw)\nReadiness signal: server-side WS authentication event\nInbound marker: &quot;notifications/claude/channel&quot;\n  (cc-channel sends MCP notifications/claude/channel\n   per inbound message; visible in --verbose output)"]
 
-  1. prepareClaudeCodeStateDir(deps, input)            claude-code-adapter.ts → prepareClaudeCodeStateDir
-       makeTempDirectory({ prefix: "claude-code-<agentName>-" })
-       seedWorkspaceFiles(stateDir, input.workspaceFiles)
-       installClaudeCodeChannelPlugin(deps, stateDir)   claude-code-adapter.ts → installClaudeCodeChannelPlugin
-         resolves @modelcontextprotocol/sdk and effect deps
-         via resolveChannelDependency (parent node_modules walk)
-         installs claude-code-channel (no openclaw.plugin.json —
-         cc-channel has no OpenClaw manifest equivalent)
-         returns extDir (path to channel inside stateDir)
-
-  2. writeClaudeCodeMcpConfig(opts)                    claude-code-process.ts → writeClaudeCodeMcpConfig
-       serverUrl normalized: strip /ws, ws→http, wss→https
-       channelServerName = "@moltzap/claude-code-channel/<agentName>"
-       writes stateDir/mcp-config.json:
-         { mcpServers: {
-             moltzap: {
-               command: "node",
-               args: [extDir/dist/cli.js],
-               env: {
-                 MOLTZAP_API_KEY: apiKey,
-                 MOLTZAP_SERVER_URL: serverUrl,
-                 MOLTZAP_SERVER_NAME: channelServerName
-               }
-             }
-           }
-         }
-       returns configPath
-
-  3. spawnConfiguredClaude(deps, stateDir, mcpConfigPath, logBuffer)
-       buildClaudeArgs(path, stateDir, mcpConfigPath):    claude-code-adapter.ts → buildClaudeArgs
-         "--strict-mcp-config"
-         "--mcp-config"  <mcpConfigPath>
-         "--print"
-         "--input-format" "stream-json"
-         "--output-format" "stream-json"
-         "--verbose"
-         "--dangerously-skip-permissions"
-         "--add-dir" <stateDir/workspace>
-       spawnClaudeProcess(claudeBin, args,                claude-code-adapter.ts → spawnClaudeProcess
-         cwd=stateDir,
-         env={ CLAUDE_CODE_HOME: stateDir },
-         stdin="inherit")
-       Scope.make() → Command.start() → Scope.extend(scope)
-       exitFiber = proc.exitCode.forkIn(scope)
-       stdout + stderr fibers → logBuffer.value
-
-  4. this.state = { process, stateDir, spawnInput,
-                    logBuffer, tornDown: false }
-
-Readiness (ClaudeCodeAdapter.waitUntilReady):          claude-code-adapter.ts → ClaudeCodeAdapter.waitUntilReady
-  Race:
-    server.awaitAgentReady(agentId, timeoutMs)
-      (cc-channel's MCP stdio server authenticates on start)
-    processExitLoop({ pollExitCode: () =>
-      pollClaudeExitCode(proc), stderr: () => logBuffer.value })
-  Binary: claudeBin ("claude" CLI, @anthropic-ai/claude-code)
-  Claude spawns cc-channel as MCP stdio child automatically
-    (SIGTERM on claude propagates to cc-channel naturally —
-     no process-group kill needed, unlike openclaw)
-  Readiness signal: server-side WS authentication event
-  Inbound marker: "notifications/claude/channel"        claude-code-adapter.ts → inbound log marker
-    (cc-channel sends MCP notifications/claude/channel
-     for each inbound message; visible in --verbose output)
+    CCS --> CC1 --> CC2 --> CC3 --> CC4 --> CCR
 ```
+
+**Annotations:**
+- `prepareClaudeCodeStateDir` — `claude-code-adapter.ts → prepareClaudeCodeStateDir`
+- `installClaudeCodeChannelPlugin` — `claude-code-adapter.ts → installClaudeCodeChannelPlugin`
+- `writeClaudeCodeMcpConfig` — `claude-code-process.ts → writeClaudeCodeMcpConfig`
+- `buildClaudeArgs` — `claude-code-adapter.ts → buildClaudeArgs`
+- `spawnClaudeProcess` — `claude-code-adapter.ts → spawnClaudeProcess`
+- `ClaudeCodeAdapter.waitUntilReady` — `claude-code-adapter.ts → ClaudeCodeAdapter.waitUntilReady`; inbound marker — `claude-code-adapter.ts → inbound log marker`
 
 ## See Also
 

--- a/packages/runtimes/docs/architecture/03-per-adapter-spawn.md
+++ b/packages/runtimes/docs/architecture/03-per-adapter-spawn.md
@@ -6,13 +6,13 @@
 
 ```mermaid
 flowchart TD
-    OCS["OpenClawAdapter.spawn(input)\nopenclaw-adapter.ts → OpenClawAdapter.spawn"]
-    OC1["1. allocateFreePort()\nNodeSocketServer.make({ host: &quot;127.0.0.1&quot;, port: 0 })\nReads ephemeral port; scope closed immediately\n— port number recorded for openclaw.json config"]
-    OC2["2. prepareOpenClawStateDir(deps, input)\nmakeTempDirectory({ prefix: &quot;openclaw-&lt;agentName&gt;-&quot; })\nwriteOpenClawConfig(stateDir, ...)\nseedWorkspaceFiles(stateDir, input.workspaceFiles)\ninstallChannelPlugin(stateDir, channelDistDir, repoRoot)"]
-    OC3["3. buildOpenClawProcessPlan(openclawBin, port)\nIf openclawBin.endsWith(&quot;.mjs&quot;):\n  command=&quot;node&quot; args=[openclawBin, &quot;gateway&quot;, &quot;run&quot;, ...]\nElse:\n  command=openclawBin args=[&quot;gateway&quot;, &quot;run&quot;, ...]"]
-    OC4["4. spawnOpenClawProcess(command, args, cwd=stateDir)\nenv: OPENCLAW_STATE_DIR, OPENCLAW_CONFIG_PATH\nScope.make() → Command.start() → Scope.extend(scope)\nexitFiber = proc.exitCode.forkIn(scope)\nstdout + stderr fibers → logBuffer.value"]
-    OC5["5. this.state = { process, stateDir, logBuffer,\n   spawnInput, tornDown: false }"]
-    OCR["Readiness — OpenClawAdapter.waitUntilReady\nRace:\n  server.awaitAgentReady(agentId, timeoutMs)\n  processExitLoop({ pollExitCode: () =&gt; Fiber.poll(exitFiber),\n                    stderr: () =&gt; logBuffer.value })\nReadiness signal: server-side WS authentication event\nInbound marker: &quot;inbound from agent:&quot;"]
+    OCS["OpenClawAdapter.spawn(input)<br>openclaw-adapter.ts → OpenClawAdapter.spawn"]
+    OC1["1. allocateFreePort()<br>NodeSocketServer.make({ host: &quot;127.0.0.1&quot;, port: 0 })<br>Reads ephemeral port; scope closed immediately<br>— port number recorded for openclaw.json config"]
+    OC2["2. prepareOpenClawStateDir(deps, input)<br>makeTempDirectory({ prefix: &quot;openclaw-&lt;agentName&gt;-&quot; })<br>writeOpenClawConfig(stateDir, ...)<br>seedWorkspaceFiles(stateDir, input.workspaceFiles)<br>installChannelPlugin(stateDir, channelDistDir, repoRoot)"]
+    OC3["3. buildOpenClawProcessPlan(openclawBin, port)<br>If openclawBin.endsWith(&quot;.mjs&quot;):<br>  command=&quot;node&quot; args=[openclawBin, &quot;gateway&quot;, &quot;run&quot;, ...]<br>Else:<br>  command=openclawBin args=[&quot;gateway&quot;, &quot;run&quot;, ...]"]
+    OC4["4. spawnOpenClawProcess(command, args, cwd=stateDir)<br>env: OPENCLAW_STATE_DIR, OPENCLAW_CONFIG_PATH<br>Scope.make() → Command.start() → Scope.extend(scope)<br>exitFiber = proc.exitCode.forkIn(scope)<br>stdout + stderr fibers → logBuffer.value"]
+    OC5["5. this.state = { process, stateDir, logBuffer,<br>   spawnInput, tornDown: false }"]
+    OCR["Readiness — OpenClawAdapter.waitUntilReady<br>Race:<br>  server.awaitAgentReady(agentId, timeoutMs)<br>  processExitLoop({ pollExitCode: () =&gt; Fiber.poll(exitFiber),<br>                    stderr: () =&gt; logBuffer.value })<br>Readiness signal: server-side WS authentication event<br>Inbound marker: &quot;inbound from agent:&quot;"]
 
     OCS --> OC1 --> OC2 --> OC3 --> OC4 --> OC5 --> OCR
 ```
@@ -35,33 +35,33 @@ runtime cache is installed, then launch.
 
 ```mermaid
 flowchart TD
-    NS["NanoclawAdapter.spawn(input)\nnanoclaw-adapter.ts → NanoclawAdapter.spawn"]
+    NS["NanoclawAdapter.spawn(input)<br>nanoclaw-adapter.ts → NanoclawAdapter.spawn"]
 
-    subgraph Phase1["Phase 1 — ensureNanoclawRuntimeInstalledEffect\nnanoclaw-process.ts → ensureNanoclawRuntimeInstalledEffect"]
-        P1C{"~/.cache/.../nanoclaw/&lt;sha12&gt;/.ready\nexists?"}
-        P1WARM["syncChannelFileIntoCache()\ndiff nanoclaw-channel moltzap.ts\ndiff client dist/channel-core.js\nif either drifted: overwrite + npm run build"]
-        P1COLD["preflightDocker()\nexecEffect(&quot;docker info&quot;, timeout=5000ms)"]
-        P1DL["downloadTarball(NANOCLAW_URL, tmpDir)\ncurl -fsSL &lt;github tarball&gt;\nNANOCLAW_SHA = qwibitai/nanoclaw@934f063..."]
-        P1COPY["copyChannelFileIntoCache(tmpDir)\nappendMoltzapBarrelImport(tmpDir)\ncopySharedSkillIntoCache(tmpDir)"]
-        P1BUILD["buildNanoclawRuntimeCache(tmpDir)\nnpm install @moltzap/client@latest (120s)\nnpm install (300s)\nnpm run build (120s)\nbash container/build.sh (300s)"]
+    subgraph Phase1["Phase 1 — ensureNanoclawRuntimeInstalledEffect<br>nanoclaw-process.ts → ensureNanoclawRuntimeInstalledEffect"]
+        P1C{"~/.cache/.../nanoclaw/&lt;sha12&gt;/.ready<br>exists?"}
+        P1WARM["syncChannelFileIntoCache()<br>diff nanoclaw-channel moltzap.ts<br>diff client dist/channel-core.js<br>if either drifted: overwrite + npm run build"]
+        P1COLD["preflightDocker()<br>execEffect(&quot;docker info&quot;, timeout=5000ms)"]
+        P1DL["downloadTarball(NANOCLAW_URL, tmpDir)<br>curl -fsSL &lt;github tarball&gt;<br>NANOCLAW_SHA = qwibitai/nanoclaw@934f063..."]
+        P1COPY["copyChannelFileIntoCache(tmpDir)<br>appendMoltzapBarrelImport(tmpDir)<br>copySharedSkillIntoCache(tmpDir)"]
+        P1BUILD["buildNanoclawRuntimeCache(tmpDir)<br>npm install @moltzap/client@latest (120s)<br>npm install (300s)<br>npm run build (120s)<br>bash container/build.sh (300s)"]
         P1PROMOTE["promoteRuntimeCache(tmpDir → NANOCLAW_RUNTIME_CACHE)"]
 
         P1C -->|".ready exists (warm)"| P1WARM
         P1C -->|"cold install"| P1COLD --> P1DL --> P1COPY --> P1BUILD --> P1PROMOTE
     end
 
-    subgraph Phase2["Phase 2 — startNanoclawRuntimeEffect\nnanoclaw-process.ts → startNanoclawRuntimeEffect"]
-        P2DIR["createNanoclawDataDir()\nmktemp prefix=moltzap-nanoclaw-runtime-"]
-        P2OC["ensureOnecliRunning()\nprobe http://127.0.0.1:10254 (timeout=2s)\nif unreachable: docker compose -p onecli up -d --wait\nprobe up to 20×500ms"]
-        P2WS["writeRuntimeWorkspaceFiles(workspaceFiles)\n→ NANOCLAW_RUNTIME_CACHE/container/skills/&lt;path&gt;"]
-        P2SP["startNanoclawProcess(opts, dataDir, capturedLogs)\ncommand: &quot;node dist/index.js&quot;\ncwd: NANOCLAW_RUNTIME_CACHE\nenv: MOLTZAP_API_KEY, MOLTZAP_SERVER_URL,\n  MOLTZAP_EVAL_MODE=&quot;1&quot;, DATA_DIR,\n  CONTAINER_RUNTIME=&quot;docker&quot;,\n  ONECLI_URL=&quot;http://127.0.0.1:10254&quot;,\n  LOG_LEVEL=&quot;info&quot;"]
-        P2WAIT["waitForNanoclawConnection(exitFiber, capturedLogs)\nRace (timeout=60s):\n  waitForConnectedMarker: poll 200ms,\n    scan capturedLogs for CONNECTED_MARKER\n    /\\[info\\].*MoltZap connected|MoltZap connected/\n  failIfProcessExitsBeforeConnect: Fiber.join(exitFiber)"]
+    subgraph Phase2["Phase 2 — startNanoclawRuntimeEffect<br>nanoclaw-process.ts → startNanoclawRuntimeEffect"]
+        P2DIR["createNanoclawDataDir()<br>mktemp prefix=moltzap-nanoclaw-runtime-"]
+        P2OC["ensureOnecliRunning()<br>probe http://127.0.0.1:10254 (timeout=2s)<br>if unreachable: docker compose -p onecli up -d --wait<br>probe up to 20×500ms"]
+        P2WS["writeRuntimeWorkspaceFiles(workspaceFiles)<br>→ NANOCLAW_RUNTIME_CACHE/container/skills/&lt;path&gt;"]
+        P2SP["startNanoclawProcess(opts, dataDir, capturedLogs)<br>command: &quot;node dist/index.js&quot;<br>cwd: NANOCLAW_RUNTIME_CACHE<br>env: MOLTZAP_API_KEY, MOLTZAP_SERVER_URL,<br>  MOLTZAP_EVAL_MODE=&quot;1&quot;, DATA_DIR,<br>  CONTAINER_RUNTIME=&quot;docker&quot;,<br>  ONECLI_URL=&quot;http://127.0.0.1:10254&quot;,<br>  LOG_LEVEL=&quot;info&quot;"]
+        P2WAIT["waitForNanoclawConnection(exitFiber, capturedLogs)<br>Race (timeout=60s):<br>  waitForConnectedMarker: poll 200ms,<br>    scan capturedLogs for CONNECTED_MARKER<br>    /\\[info\\].*MoltZap connected|MoltZap connected/<br>  failIfProcessExitsBeforeConnect: Fiber.join(exitFiber)"]
 
         P2DIR --> P2OC --> P2WS --> P2SP --> P2WAIT
     end
 
     P2STATE["this.state = { handle, spawnInput, tornDown: false }"]
-    NCR["Readiness — NanoclawAdapter.waitUntilReady\nTWO gates:\n1. Inner: waitForNanoclawConnection (stdout marker)\n2. Outer: server.awaitAgentReady (server WS auth)\n\nOuter race:\n  server.awaitAgentReady(agentId, timeoutMs)\n  processExitLoop({ pollExitCode: () =&gt; Fiber.poll(handle.exitFiber),\n                    stderr: () =&gt; getNanoclawRuntimeLogs(handle) })\nInbound marker: &quot;New messages&quot;"]
+    NCR["Readiness — NanoclawAdapter.waitUntilReady<br>TWO gates:<br>1. Inner: waitForNanoclawConnection (stdout marker)<br>2. Outer: server.awaitAgentReady (server WS auth)<br><br>Outer race:<br>  server.awaitAgentReady(agentId, timeoutMs)<br>  processExitLoop({ pollExitCode: () =&gt; Fiber.poll(handle.exitFiber),<br>                    stderr: () =&gt; getNanoclawRuntimeLogs(handle) })<br>Inbound marker: &quot;New messages&quot;"]
 
     NS --> Phase1
     Phase1 --> Phase2
@@ -85,12 +85,12 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    CCS["ClaudeCodeAdapter.spawn(input)\nclaude-code-adapter.ts → ClaudeCodeAdapter.spawn"]
-    CC1["1. prepareClaudeCodeStateDir(deps, input)\nmakeTempDirectory({ prefix: &quot;claude-code-&lt;agentName&gt;-&quot; })\nseedWorkspaceFiles(stateDir, input.workspaceFiles)\ninstallClaudeCodeChannelPlugin(deps, stateDir)\n  resolves @modelcontextprotocol/sdk + effect deps\n  via resolveChannelDependency (parent node_modules walk)\n  no openclaw.plugin.json — cc-channel has no OpenClaw manifest\n  returns extDir (channel path inside stateDir)"]
-    CC2["2. writeClaudeCodeMcpConfig(opts)\nserverUrl: strip /ws, ws→http, wss→https\nchannelServerName = &quot;@moltzap/claude-code-channel/&lt;agentName&gt;&quot;\nwrites stateDir/mcp-config.json:\n  { mcpServers: { moltzap: {\n    command: &quot;node&quot;,\n    args: [extDir/dist/cli.js],\n    env: { MOLTZAP_API_KEY, MOLTZAP_SERVER_URL,\n           MOLTZAP_SERVER_NAME: channelServerName }\n  }}}"]
-    CC3["3. spawnConfiguredClaude(deps, stateDir, mcpConfigPath, logBuffer)\nbuildClaudeArgs: --strict-mcp-config\n  --mcp-config &lt;mcpConfigPath&gt;\n  --print --input-format stream-json\n  --output-format stream-json --verbose\n  --dangerously-skip-permissions\n  --add-dir &lt;stateDir/workspace&gt;\nspawnClaudeProcess(claudeBin, args,\n  cwd=stateDir, env={ CLAUDE_CODE_HOME: stateDir },\n  stdin=&quot;inherit&quot;)\nScope.make() → Command.start() → Scope.extend(scope)\nexitFiber = proc.exitCode.forkIn(scope)\nstdout + stderr fibers → logBuffer.value"]
-    CC4["4. this.state = { process, stateDir, spawnInput,\n   logBuffer, tornDown: false }"]
-    CCR["Readiness — ClaudeCodeAdapter.waitUntilReady\nRace:\n  server.awaitAgentReady(agentId, timeoutMs)\n    (cc-channel's MCP stdio server authenticates on start)\n  processExitLoop({ pollExitCode: () =&gt; pollClaudeExitCode(proc),\n                    stderr: () =&gt; logBuffer.value })\nBinary: claudeBin (&quot;claude&quot; CLI, @anthropic-ai/claude-code)\nClaude spawns cc-channel as MCP stdio child automatically\n  (SIGTERM on claude propagates to cc-channel naturally —\n   no process-group kill needed, unlike openclaw)\nReadiness signal: server-side WS authentication event\nInbound marker: &quot;notifications/claude/channel&quot;\n  (cc-channel sends MCP notifications/claude/channel\n   per inbound message; visible in --verbose output)"]
+    CCS["ClaudeCodeAdapter.spawn(input)<br>claude-code-adapter.ts → ClaudeCodeAdapter.spawn"]
+    CC1["1. prepareClaudeCodeStateDir(deps, input)<br>makeTempDirectory({ prefix: &quot;claude-code-&lt;agentName&gt;-&quot; })<br>seedWorkspaceFiles(stateDir, input.workspaceFiles)<br>installClaudeCodeChannelPlugin(deps, stateDir)<br>  resolves @modelcontextprotocol/sdk + effect deps<br>  via resolveChannelDependency (parent node_modules walk)<br>  no openclaw.plugin.json — cc-channel has no OpenClaw manifest<br>  returns extDir (channel path inside stateDir)"]
+    CC2["2. writeClaudeCodeMcpConfig(opts)<br>serverUrl: strip /ws, ws→http, wss→https<br>channelServerName = &quot;@moltzap/claude-code-channel/&lt;agentName&gt;&quot;<br>writes stateDir/mcp-config.json:<br>  { mcpServers: { moltzap: {<br>    command: &quot;node&quot;,<br>    args: [extDir/dist/cli.js],<br>    env: { MOLTZAP_API_KEY, MOLTZAP_SERVER_URL,<br>           MOLTZAP_SERVER_NAME: channelServerName }<br>  }}}"]
+    CC3["3. spawnConfiguredClaude(deps, stateDir, mcpConfigPath, logBuffer)<br>buildClaudeArgs: --strict-mcp-config<br>  --mcp-config &lt;mcpConfigPath&gt;<br>  --print --input-format stream-json<br>  --output-format stream-json --verbose<br>  --dangerously-skip-permissions<br>  --add-dir &lt;stateDir/workspace&gt;<br>spawnClaudeProcess(claudeBin, args,<br>  cwd=stateDir, env={ CLAUDE_CODE_HOME: stateDir },<br>  stdin=&quot;inherit&quot;)<br>Scope.make() → Command.start() → Scope.extend(scope)<br>exitFiber = proc.exitCode.forkIn(scope)<br>stdout + stderr fibers → logBuffer.value"]
+    CC4["4. this.state = { process, stateDir, spawnInput,<br>   logBuffer, tornDown: false }"]
+    CCR["Readiness — ClaudeCodeAdapter.waitUntilReady<br>Race:<br>  server.awaitAgentReady(agentId, timeoutMs)<br>    (cc-channel's MCP stdio server authenticates on start)<br>  processExitLoop({ pollExitCode: () =&gt; pollClaudeExitCode(proc),<br>                    stderr: () =&gt; logBuffer.value })<br>Binary: claudeBin (&quot;claude&quot; CLI, @anthropic-ai/claude-code)<br>Claude spawns cc-channel as MCP stdio child automatically<br>  (SIGTERM on claude propagates to cc-channel naturally —<br>   no process-group kill needed, unlike openclaw)<br>Readiness signal: server-side WS authentication event<br>Inbound marker: &quot;notifications/claude/channel&quot;<br>  (cc-channel sends MCP notifications/claude/channel<br>   per inbound message; visible in --verbose output)"]
 
     CCS --> CC1 --> CC2 --> CC3 --> CC4 --> CCR
 ```

--- a/packages/runtimes/docs/architecture/03-per-adapter-spawn.md
+++ b/packages/runtimes/docs/architecture/03-per-adapter-spawn.md
@@ -1,0 +1,219 @@
+# Per-Adapter Spawn Details
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+## 3.1 OpenClaw Adapter (`openclaw-adapter.ts`)
+
+```text
+OpenClawAdapter.spawn(input)                               openclaw-adapter.ts → OpenClawAdapter.spawn
+
+  1. allocateFreePort()                                    openclaw-adapter.ts → allocateFreePort
+       NodeSocketServer.make({ host: "127.0.0.1", port: 0 })
+       Reads ephemeral port from server.address.port
+       Scope is immediately closed — port is released, but its
+       number is recorded for use in the openclaw.json config.
+
+  2. prepareOpenClawStateDir(deps, input)                  openclaw-adapter.ts → prepareOpenClawStateDir
+       makeTempDirectory({ prefix: "openclaw-<agentName>-" })
+       writeOpenClawConfig(stateDir, ...)                  openclaw-adapter.ts → writeOpenClawConfig
+         writes stateDir/openclaw.json  (OpenClawConfig)
+         config shape:
+           agents.defaults.model.primary = modelId ?? "openai-codex/gpt-5.4"
+           agents.defaults.workspace = stateDir/workspace
+           channels.moltzap.accounts[0] = { apiKey, serverUrl, agentName }
+           gateway.mode = "local"
+           gateway.auth.token = "runtime-<timestamp_base36>"
+       seedWorkspaceFiles(stateDir, input.workspaceFiles)  openclaw-adapter.ts → seedWorkspaceFiles
+       installChannelPlugin(stateDir, channelDistDir,       openclaw-adapter.ts → installChannelPlugin
+                            repoRoot)
+         resolves `effect` dep via resolveChannelDependency
+         installs openclaw-channel as plugin via
+           openclaw.plugin.json manifest
+
+  3. buildOpenClawProcessPlan(openclawBin, port)           openclaw-adapter.ts → buildOpenClawProcessPlan
+       If openclawBin.endsWith(".mjs"):
+         command = "node"  args = [openclawBin, "gateway",
+           "run", "--allow-unconfigured", "--port", port]
+       Else:
+         command = openclawBin  args = ["gateway", "run",
+           "--allow-unconfigured", "--port", port]
+
+  4. spawnOpenClawProcess(command, args, cwd=stateDir,     openclaw-adapter.ts → spawnOpenClawProcess
+       env = {
+         OPENCLAW_STATE_DIR: stateDir,
+         OPENCLAW_CONFIG_PATH: stateDir/openclaw.json
+       })
+       Scope.make() → Command.start() → Scope.extend(scope)
+       exitFiber = proc.exitCode.forkIn(scope)
+       stdout + stderr fibers → logBuffer.value
+
+  5. this.state = { process, stateDir, logBuffer,
+                    spawnInput, tornDown: false }
+
+Readiness (OpenClawAdapter.waitUntilReady):             openclaw-adapter.ts → OpenClawAdapter.waitUntilReady
+  Race:
+    server.awaitAgentReady(agentId, timeoutMs)
+      (openclaw's moltzap channel authenticates on WS connect)
+    processExitLoop({ pollExitCode: () => Fiber.poll(exitFiber),
+                      stderr: () => logBuffer.value })
+  Binary: "openclaw" (native) or "node <openclaw.mjs>" (mjs)
+  Readiness signal: server-side WS authentication event
+    (NOT a stdout pattern — openclaw dials moltzap on startup)
+  Inbound marker: "inbound from agent:"              openclaw-adapter.ts → inbound log marker
+```
+
+## 3.2 Nanoclaw Adapter (`nanoclaw-adapter.ts` + `nanoclaw-process.ts`)
+
+Nanoclaw is unique: it runs agent subprocesses **inside Docker containers**
+via the OneCLI gateway. The adapter has a two-phase startup: first ensure the
+runtime cache is installed, then launch.
+
+```text
+NanoclawAdapter.spawn(input)                           nanoclaw-adapter.ts → NanoclawAdapter.spawn
+
+  Phase 1 — ensureNanoclawRuntimeInstalledEffect()     nanoclaw-process.ts → ensureNanoclawRuntimeInstalledEffect
+    Checks ~/.cache/moltzap-runtimes/nanoclaw/<sha12>/.ready
+    If .ready exists:
+      syncChannelFileIntoCache()                        nanoclaw-process.ts → syncChannelFileIntoCache
+        diffs packages/nanoclaw-channel/src/channels/moltzap.ts
+        diffs packages/client/dist/channel-core.js
+        if either drifted: overwrite cache + npm run build
+    Else (cold install):
+      preflightDocker()                                 nanoclaw-process.ts → preflightDocker
+        execEffect("docker info", timeout=5000ms)
+      downloadTarball(NANOCLAW_URL, tmpDir)             nanoclaw-process.ts → downloadTarball
+        curl -fsSL <github tarball> -o nanoclaw.tar.gz
+        tar -xzf ... --strip-components=1
+        NANOCLAW_SHA = qwibitai/nanoclaw@934f063...     nanoclaw-process.ts → NANOCLAW_SHA
+      copyChannelFileIntoCache(tmpDir)                  nanoclaw-process.ts → copyChannelFileIntoCache
+      appendMoltzapBarrelImport(tmpDir)                 nanoclaw-process.ts → appendMoltzapBarrelImport
+      copySharedSkillIntoCache(tmpDir)                  nanoclaw-process.ts → copySharedSkillIntoCache
+      buildNanoclawRuntimeCache(tmpDir)                 nanoclaw-process.ts → buildNanoclawRuntimeCache
+        npm install @moltzap/client@latest (120s)
+        npm install (300s)
+        npm run build (120s)
+        bash container/build.sh (300s)
+      promoteRuntimeCache(tmpDir → NANOCLAW_RUNTIME_CACHE)
+
+  Phase 2 — startNanoclawRuntimeEffect(opts)           nanoclaw-process.ts → startNanoclawRuntimeEffect
+    createNanoclawDataDir()  (mktemp prefix=moltzap-nanoclaw-runtime-)
+    ensureOnecliRunning()                               nanoclaw-process.ts → ensureOnecliRunning
+      probe http://127.0.0.1:10254 (timeout=2s)
+      if unreachable: docker compose -p onecli up -d --wait
+      probe up to 20×500ms
+    writeRuntimeWorkspaceFiles(workspaceFiles)
+      → NANOCLAW_RUNTIME_CACHE/container/skills/<path>
+
+    startNanoclawProcess(opts, dataDir, capturedLogs)   nanoclaw-process.ts → startNanoclawProcess
+      command: "node dist/index.js"
+      cwd: NANOCLAW_RUNTIME_CACHE
+      env = {
+        MOLTZAP_API_KEY: apiKey,
+        MOLTZAP_SERVER_URL: <http-normalized>,
+        MOLTZAP_EVAL_MODE: "1",
+        DATA_DIR: dataDir,
+        CONTAINER_RUNTIME: "docker",
+        ONECLI_URL: "http://127.0.0.1:10254",
+        LOG_LEVEL: "info"
+      }
+
+    waitForNanoclawConnection(exitFiber, capturedLogs)  nanoclaw-process.ts → waitForNanoclawConnection
+      Race (timeout=60s):
+        waitForConnectedMarker: poll every 200ms,
+          scan capturedLogs for CONNECTED_MARKER regex     nanoclaw-process.ts → CONNECTED_MARKER
+          /\[info\].*MoltZap connected|MoltZap connected/
+        failIfProcessExitsBeforeConnect: Fiber.join(exitFiber)
+
+  this.state = { handle, spawnInput, tornDown: false }
+
+Readiness (NanoclawAdapter.waitUntilReady):             nanoclaw-adapter.ts → NanoclawAdapter.waitUntilReady
+  Note: nanoclaw has TWO readiness gates:
+    1. Inner: waitForNanoclawConnection (stdout marker,
+              inside startNanoclawRuntimeEffect)
+    2. Outer: server.awaitAgentReady (server WS auth,
+              inside waitUntilReady)
+  Outer race:
+    server.awaitAgentReady(agentId, timeoutMs)
+    processExitLoop({ pollExitCode: () =>
+      Fiber.poll(handle.exitFiber), stderr: () =>
+      getNanoclawRuntimeLogs(handle) })
+  Binary: "node dist/index.js" in NANOCLAW_RUNTIME_CACHE
+  Inbound marker: "New messages"                        nanoclaw-adapter.ts → inbound log marker
+```
+
+## 3.3 ClaudeCode Adapter (`claude-code-adapter.ts`)
+
+```text
+ClaudeCodeAdapter.spawn(input)                         claude-code-adapter.ts → ClaudeCodeAdapter.spawn
+
+  1. prepareClaudeCodeStateDir(deps, input)            claude-code-adapter.ts → prepareClaudeCodeStateDir
+       makeTempDirectory({ prefix: "claude-code-<agentName>-" })
+       seedWorkspaceFiles(stateDir, input.workspaceFiles)
+       installClaudeCodeChannelPlugin(deps, stateDir)   claude-code-adapter.ts → installClaudeCodeChannelPlugin
+         resolves @modelcontextprotocol/sdk and effect deps
+         via resolveChannelDependency (parent node_modules walk)
+         installs claude-code-channel (no openclaw.plugin.json —
+         cc-channel has no OpenClaw manifest equivalent)
+         returns extDir (path to channel inside stateDir)
+
+  2. writeClaudeCodeMcpConfig(opts)                    claude-code-process.ts → writeClaudeCodeMcpConfig
+       serverUrl normalized: strip /ws, ws→http, wss→https
+       channelServerName = "@moltzap/claude-code-channel/<agentName>"
+       writes stateDir/mcp-config.json:
+         { mcpServers: {
+             moltzap: {
+               command: "node",
+               args: [extDir/dist/cli.js],
+               env: {
+                 MOLTZAP_API_KEY: apiKey,
+                 MOLTZAP_SERVER_URL: serverUrl,
+                 MOLTZAP_SERVER_NAME: channelServerName
+               }
+             }
+           }
+         }
+       returns configPath
+
+  3. spawnConfiguredClaude(deps, stateDir, mcpConfigPath, logBuffer)
+       buildClaudeArgs(path, stateDir, mcpConfigPath):    claude-code-adapter.ts → buildClaudeArgs
+         "--strict-mcp-config"
+         "--mcp-config"  <mcpConfigPath>
+         "--print"
+         "--input-format" "stream-json"
+         "--output-format" "stream-json"
+         "--verbose"
+         "--dangerously-skip-permissions"
+         "--add-dir" <stateDir/workspace>
+       spawnClaudeProcess(claudeBin, args,                claude-code-adapter.ts → spawnClaudeProcess
+         cwd=stateDir,
+         env={ CLAUDE_CODE_HOME: stateDir },
+         stdin="inherit")
+       Scope.make() → Command.start() → Scope.extend(scope)
+       exitFiber = proc.exitCode.forkIn(scope)
+       stdout + stderr fibers → logBuffer.value
+
+  4. this.state = { process, stateDir, spawnInput,
+                    logBuffer, tornDown: false }
+
+Readiness (ClaudeCodeAdapter.waitUntilReady):          claude-code-adapter.ts → ClaudeCodeAdapter.waitUntilReady
+  Race:
+    server.awaitAgentReady(agentId, timeoutMs)
+      (cc-channel's MCP stdio server authenticates on start)
+    processExitLoop({ pollExitCode: () =>
+      pollClaudeExitCode(proc), stderr: () => logBuffer.value })
+  Binary: claudeBin ("claude" CLI, @anthropic-ai/claude-code)
+  Claude spawns cc-channel as MCP stdio child automatically
+    (SIGTERM on claude propagates to cc-channel naturally —
+     no process-group kill needed, unlike openclaw)
+  Readiness signal: server-side WS authentication event
+  Inbound marker: "notifications/claude/channel"        claude-code-adapter.ts → inbound log marker
+    (cc-channel sends MCP notifications/claude/channel
+     for each inbound message; visible in --verbose output)
+```
+
+## See Also
+
+- [Single-Runtime Startup](./01-single-runtime-startup.md)
+- [Workspace Path Resolution](./04-workspace-path-resolution.md)
+- [Shutdown Propagation](./05-shutdown-propagation.md)
+- [Process State Machine](./07-process-state-machine.md)

--- a/packages/runtimes/docs/architecture/04-workspace-path-resolution.md
+++ b/packages/runtimes/docs/architecture/04-workspace-path-resolution.md
@@ -1,0 +1,85 @@
+# Workspace Adapter — Binary Path Resolution
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+## Overview
+
+Both OpenClaw and ClaudeCode have `createWorkspace*` factory functions that
+resolve the binary and channel dist paths from the monorepo layout at module
+load time (synchronously via `Effect.runSync`).
+
+## OpenClaw (`openclaw-adapter.ts → createWorkspaceOpenClawAdapter`)
+
+```text
+createWorkspaceOpenClawAdapter(input)                  openclaw-adapter.ts → createWorkspaceOpenClawAdapter
+  │
+  ├─ resolveWorkspacePackageRoot()                     openclaw-adapter.ts → resolveWorkspacePackageRoot
+  │    Walk import.meta.url ancestors until a segment
+  │    named "packages" is found → join("packages/runtimes")
+  │    (Result: absolute path to packages/runtimes/)
+  │
+  ├─ repoRoot = input.repoRoot
+  │             ?? path.dirname(path.dirname(packageRoot))
+  │             (Result: monorepo root — two dirs up from packages/runtimes)
+  │
+  ├─ openclawBin = input.openclawBin
+  │                ?? resolveWorkspaceOpenClawBin(...)   package-resolution.ts → resolveWorkspaceOpenClawBin
+  │                     resolveWorkspaceBin({
+  │                       binName: "openclaw",
+  │                       packageName: "openclaw",
+  │                       packageRoot: resolveOpenClawPackageRoot()
+  │                     })
+  │                   Strategy (package-resolution.ts → resolveWorkspaceBin):
+  │                     1. createRequire(packages/runtimes/package.json)
+  │                        .resolve("openclaw")  → resolvedFile
+  │                     2. packageRootFromResolvedFile(resolvedFile)
+  │                        (walks resolved path backward to find
+  │                         the "openclaw" segment → package root)
+  │                     3. packageBinTarget(root, "openclaw", "openclaw")
+  │                        reads package.json "bin" → absolute path to bin
+  │                     Fallback: dependency packageRoot directly
+  │
+  ├─ channelDistDir = input.channelDistDir
+  │                   ?? path.join(repoRoot,
+  │                        "packages/openclaw-channel/dist")
+  │
+  └─ returns new OpenClawAdapter({ server, openclawBin,
+                                   channelDistDir, repoRoot })
+```
+
+## ClaudeCode (`claude-code-adapter.ts → createWorkspaceClaudeCodeAdapter`)
+
+```text
+createWorkspaceClaudeCodeAdapter(input)                claude-code-adapter.ts → createWorkspaceClaudeCodeAdapter
+  │  (mirrors OpenClaw pattern)
+  │
+  ├─ claudeBin = input.claudeBin
+  │              ?? resolveWorkspaceClaudeBin(...)       package-resolution.ts → resolveWorkspaceClaudeBin
+  │                   resolveWorkspaceBin({
+  │                     binName: "claude",
+  │                     packageName: "@anthropic-ai/claude-code"
+  │                   })
+  │                   resolveClaudeCodePackageRoot():    package-resolution.ts → resolveClaudeCodePackageRoot
+  │                     imports package.json via static import assertion
+  │                     requireFromHere.resolve("@anthropic-ai/claude-code/package.json")
+  │                     → dirname is the package root
+  │
+  └─ channelDistDir = input.channelDistDir
+                      ?? resolveClaudeCodeChannelDistDir(repoRoot)
+                           package-resolution.ts → resolveClaudeCodeChannelDistDir
+                         Try: requireFromHere.resolve(
+                           "@moltzap/claude-code-channel") → dirname/dist
+                         Fallback: repoRoot/packages/claude-code-channel/dist
+                         (logs warning on fallback)
+```
+
+## PATH-Based (Non-Workspace) Variant
+
+Pass explicit `openclawBin`/`claudeBin`/`channelDistDir` to the constructor
+directly. The "workspace" factory is simply a convenience that resolves all
+three from the monorepo at construction time rather than requiring callers to
+compute paths themselves.
+
+## See Also
+
+- [Per-Adapter Spawn Details](./03-per-adapter-spawn.md)

--- a/packages/runtimes/docs/architecture/04-workspace-path-resolution.md
+++ b/packages/runtimes/docs/architecture/04-workspace-path-resolution.md
@@ -12,13 +12,13 @@ load time (synchronously via `Effect.runSync`).
 
 ```mermaid
 flowchart TD
-    OCWF["createWorkspaceOpenClawAdapter(input)\nopenclaw-adapter.ts → createWorkspaceOpenClawAdapter"]
-    OCPR["resolveWorkspacePackageRoot()\nopenclaw-adapter.ts → resolveWorkspacePackageRoot\nWalk import.meta.url ancestors until &quot;packages&quot; segment found\n→ join(&quot;packages/runtimes&quot;)\nResult: absolute path to packages/runtimes/"]
-    OCRR["repoRoot =\n  input.repoRoot\n  ?? path.dirname(path.dirname(packageRoot))\nResult: monorepo root — two dirs up from packages/runtimes"]
-    OCBIN["openclawBin =\n  input.openclawBin\n  ?? resolveWorkspaceOpenClawBin(...)\n    package-resolution.ts → resolveWorkspaceOpenClawBin\n    resolveWorkspaceBin({ binName: &quot;openclaw&quot;,\n      packageName: &quot;openclaw&quot;,\n      packageRoot: resolveOpenClawPackageRoot() })"]
-    OCSTRAT["resolveWorkspaceBin strategy\npackage-resolution.ts → resolveWorkspaceBin\n1. createRequire(packages/runtimes/package.json)\n   .resolve(&quot;openclaw&quot;) → resolvedFile\n2. packageRootFromResolvedFile(resolvedFile)\n   (walk backward to &quot;openclaw&quot; segment → package root)\n3. packageBinTarget(root, &quot;openclaw&quot;, &quot;openclaw&quot;)\n   reads package.json &quot;bin&quot; → absolute path to bin\nFallback: dependency packageRoot directly"]
-    OCCH["channelDistDir =\n  input.channelDistDir\n  ?? path.join(repoRoot, &quot;packages/openclaw-channel/dist&quot;)"]
-    OCOUT["returns new OpenClawAdapter({\n  server, openclawBin, channelDistDir, repoRoot\n})"]
+    OCWF["createWorkspaceOpenClawAdapter(input)<br>openclaw-adapter.ts → createWorkspaceOpenClawAdapter"]
+    OCPR["resolveWorkspacePackageRoot()<br>openclaw-adapter.ts → resolveWorkspacePackageRoot<br>Walk import.meta.url ancestors until &quot;packages&quot; segment found<br>→ join(&quot;packages/runtimes&quot;)<br>Result: absolute path to packages/runtimes/"]
+    OCRR["repoRoot =<br>  input.repoRoot<br>  ?? path.dirname(path.dirname(packageRoot))<br>Result: monorepo root — two dirs up from packages/runtimes"]
+    OCBIN["openclawBin =<br>  input.openclawBin<br>  ?? resolveWorkspaceOpenClawBin(...)<br>    package-resolution.ts → resolveWorkspaceOpenClawBin<br>    resolveWorkspaceBin({ binName: &quot;openclaw&quot;,<br>      packageName: &quot;openclaw&quot;,<br>      packageRoot: resolveOpenClawPackageRoot() })"]
+    OCSTRAT["resolveWorkspaceBin strategy<br>package-resolution.ts → resolveWorkspaceBin<br>1. createRequire(packages/runtimes/package.json)<br>   .resolve(&quot;openclaw&quot;) → resolvedFile<br>2. packageRootFromResolvedFile(resolvedFile)<br>   (walk backward to &quot;openclaw&quot; segment → package root)<br>3. packageBinTarget(root, &quot;openclaw&quot;, &quot;openclaw&quot;)<br>   reads package.json &quot;bin&quot; → absolute path to bin<br>Fallback: dependency packageRoot directly"]
+    OCCH["channelDistDir =<br>  input.channelDistDir<br>  ?? path.join(repoRoot, &quot;packages/openclaw-channel/dist&quot;)"]
+    OCOUT["returns new OpenClawAdapter({<br>  server, openclawBin, channelDistDir, repoRoot<br>})"]
 
     OCWF --> OCPR --> OCRR --> OCBIN --> OCSTRAT --> OCCH --> OCOUT
 ```
@@ -27,12 +27,12 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    CCWF["createWorkspaceClaudeCodeAdapter(input)\nclaude-code-adapter.ts → createWorkspaceClaudeCodeAdapter\n(mirrors OpenClaw pattern)"]
-    CCBIN["claudeBin =\n  input.claudeBin\n  ?? resolveWorkspaceClaudeBin(...)\n    package-resolution.ts → resolveWorkspaceClaudeBin\n    resolveWorkspaceBin({ binName: &quot;claude&quot;,\n      packageName: &quot;@anthropic-ai/claude-code&quot; })"]
-    CCROOT["resolveClaudeCodePackageRoot()\npackage-resolution.ts → resolveClaudeCodePackageRoot\nimports package.json via static import assertion\nrequireFromHere.resolve(&quot;@anthropic-ai/claude-code/package.json&quot;)\n→ dirname is the package root"]
-    CCCH["channelDistDir =\n  input.channelDistDir\n  ?? resolveClaudeCodeChannelDistDir(repoRoot)\n    package-resolution.ts → resolveClaudeCodeChannelDistDir"]
-    CCCHTRY["Try: requireFromHere.resolve(\n  &quot;@moltzap/claude-code-channel&quot;) → dirname/dist"]
-    CCCHFALL["Fallback: repoRoot/packages/claude-code-channel/dist\n(logs warning on fallback)"]
+    CCWF["createWorkspaceClaudeCodeAdapter(input)<br>claude-code-adapter.ts → createWorkspaceClaudeCodeAdapter<br>(mirrors OpenClaw pattern)"]
+    CCBIN["claudeBin =<br>  input.claudeBin<br>  ?? resolveWorkspaceClaudeBin(...)<br>    package-resolution.ts → resolveWorkspaceClaudeBin<br>    resolveWorkspaceBin({ binName: &quot;claude&quot;,<br>      packageName: &quot;@anthropic-ai/claude-code&quot; })"]
+    CCROOT["resolveClaudeCodePackageRoot()<br>package-resolution.ts → resolveClaudeCodePackageRoot<br>imports package.json via static import assertion<br>requireFromHere.resolve(&quot;@anthropic-ai/claude-code/package.json&quot;)<br>→ dirname is the package root"]
+    CCCH["channelDistDir =<br>  input.channelDistDir<br>  ?? resolveClaudeCodeChannelDistDir(repoRoot)<br>    package-resolution.ts → resolveClaudeCodeChannelDistDir"]
+    CCCHTRY["Try: requireFromHere.resolve(<br>  &quot;@moltzap/claude-code-channel&quot;) → dirname/dist"]
+    CCCHFALL["Fallback: repoRoot/packages/claude-code-channel/dist<br>(logs warning on fallback)"]
 
     CCWF --> CCBIN --> CCROOT --> CCCH
     CCCH --> CCCHTRY

--- a/packages/runtimes/docs/architecture/04-workspace-path-resolution.md
+++ b/packages/runtimes/docs/architecture/04-workspace-path-resolution.md
@@ -10,67 +10,33 @@ load time (synchronously via `Effect.runSync`).
 
 ## OpenClaw (`openclaw-adapter.ts → createWorkspaceOpenClawAdapter`)
 
-```text
-createWorkspaceOpenClawAdapter(input)                  openclaw-adapter.ts → createWorkspaceOpenClawAdapter
-  │
-  ├─ resolveWorkspacePackageRoot()                     openclaw-adapter.ts → resolveWorkspacePackageRoot
-  │    Walk import.meta.url ancestors until a segment
-  │    named "packages" is found → join("packages/runtimes")
-  │    (Result: absolute path to packages/runtimes/)
-  │
-  ├─ repoRoot = input.repoRoot
-  │             ?? path.dirname(path.dirname(packageRoot))
-  │             (Result: monorepo root — two dirs up from packages/runtimes)
-  │
-  ├─ openclawBin = input.openclawBin
-  │                ?? resolveWorkspaceOpenClawBin(...)   package-resolution.ts → resolveWorkspaceOpenClawBin
-  │                     resolveWorkspaceBin({
-  │                       binName: "openclaw",
-  │                       packageName: "openclaw",
-  │                       packageRoot: resolveOpenClawPackageRoot()
-  │                     })
-  │                   Strategy (package-resolution.ts → resolveWorkspaceBin):
-  │                     1. createRequire(packages/runtimes/package.json)
-  │                        .resolve("openclaw")  → resolvedFile
-  │                     2. packageRootFromResolvedFile(resolvedFile)
-  │                        (walks resolved path backward to find
-  │                         the "openclaw" segment → package root)
-  │                     3. packageBinTarget(root, "openclaw", "openclaw")
-  │                        reads package.json "bin" → absolute path to bin
-  │                     Fallback: dependency packageRoot directly
-  │
-  ├─ channelDistDir = input.channelDistDir
-  │                   ?? path.join(repoRoot,
-  │                        "packages/openclaw-channel/dist")
-  │
-  └─ returns new OpenClawAdapter({ server, openclawBin,
-                                   channelDistDir, repoRoot })
+```mermaid
+flowchart TD
+    OCWF["createWorkspaceOpenClawAdapter(input)\nopenclaw-adapter.ts → createWorkspaceOpenClawAdapter"]
+    OCPR["resolveWorkspacePackageRoot()\nopenclaw-adapter.ts → resolveWorkspacePackageRoot\nWalk import.meta.url ancestors until &quot;packages&quot; segment found\n→ join(&quot;packages/runtimes&quot;)\nResult: absolute path to packages/runtimes/"]
+    OCRR["repoRoot =\n  input.repoRoot\n  ?? path.dirname(path.dirname(packageRoot))\nResult: monorepo root — two dirs up from packages/runtimes"]
+    OCBIN["openclawBin =\n  input.openclawBin\n  ?? resolveWorkspaceOpenClawBin(...)\n    package-resolution.ts → resolveWorkspaceOpenClawBin\n    resolveWorkspaceBin({ binName: &quot;openclaw&quot;,\n      packageName: &quot;openclaw&quot;,\n      packageRoot: resolveOpenClawPackageRoot() })"]
+    OCSTRAT["resolveWorkspaceBin strategy\npackage-resolution.ts → resolveWorkspaceBin\n1. createRequire(packages/runtimes/package.json)\n   .resolve(&quot;openclaw&quot;) → resolvedFile\n2. packageRootFromResolvedFile(resolvedFile)\n   (walk backward to &quot;openclaw&quot; segment → package root)\n3. packageBinTarget(root, &quot;openclaw&quot;, &quot;openclaw&quot;)\n   reads package.json &quot;bin&quot; → absolute path to bin\nFallback: dependency packageRoot directly"]
+    OCCH["channelDistDir =\n  input.channelDistDir\n  ?? path.join(repoRoot, &quot;packages/openclaw-channel/dist&quot;)"]
+    OCOUT["returns new OpenClawAdapter({\n  server, openclawBin, channelDistDir, repoRoot\n})"]
+
+    OCWF --> OCPR --> OCRR --> OCBIN --> OCSTRAT --> OCCH --> OCOUT
 ```
 
 ## ClaudeCode (`claude-code-adapter.ts → createWorkspaceClaudeCodeAdapter`)
 
-```text
-createWorkspaceClaudeCodeAdapter(input)                claude-code-adapter.ts → createWorkspaceClaudeCodeAdapter
-  │  (mirrors OpenClaw pattern)
-  │
-  ├─ claudeBin = input.claudeBin
-  │              ?? resolveWorkspaceClaudeBin(...)       package-resolution.ts → resolveWorkspaceClaudeBin
-  │                   resolveWorkspaceBin({
-  │                     binName: "claude",
-  │                     packageName: "@anthropic-ai/claude-code"
-  │                   })
-  │                   resolveClaudeCodePackageRoot():    package-resolution.ts → resolveClaudeCodePackageRoot
-  │                     imports package.json via static import assertion
-  │                     requireFromHere.resolve("@anthropic-ai/claude-code/package.json")
-  │                     → dirname is the package root
-  │
-  └─ channelDistDir = input.channelDistDir
-                      ?? resolveClaudeCodeChannelDistDir(repoRoot)
-                           package-resolution.ts → resolveClaudeCodeChannelDistDir
-                         Try: requireFromHere.resolve(
-                           "@moltzap/claude-code-channel") → dirname/dist
-                         Fallback: repoRoot/packages/claude-code-channel/dist
-                         (logs warning on fallback)
+```mermaid
+flowchart TD
+    CCWF["createWorkspaceClaudeCodeAdapter(input)\nclaude-code-adapter.ts → createWorkspaceClaudeCodeAdapter\n(mirrors OpenClaw pattern)"]
+    CCBIN["claudeBin =\n  input.claudeBin\n  ?? resolveWorkspaceClaudeBin(...)\n    package-resolution.ts → resolveWorkspaceClaudeBin\n    resolveWorkspaceBin({ binName: &quot;claude&quot;,\n      packageName: &quot;@anthropic-ai/claude-code&quot; })"]
+    CCROOT["resolveClaudeCodePackageRoot()\npackage-resolution.ts → resolveClaudeCodePackageRoot\nimports package.json via static import assertion\nrequireFromHere.resolve(&quot;@anthropic-ai/claude-code/package.json&quot;)\n→ dirname is the package root"]
+    CCCH["channelDistDir =\n  input.channelDistDir\n  ?? resolveClaudeCodeChannelDistDir(repoRoot)\n    package-resolution.ts → resolveClaudeCodeChannelDistDir"]
+    CCCHTRY["Try: requireFromHere.resolve(\n  &quot;@moltzap/claude-code-channel&quot;) → dirname/dist"]
+    CCCHFALL["Fallback: repoRoot/packages/claude-code-channel/dist\n(logs warning on fallback)"]
+
+    CCWF --> CCBIN --> CCROOT --> CCCH
+    CCCH --> CCCHTRY
+    CCCH --> CCCHFALL
 ```
 
 ## PATH-Based (Non-Workspace) Variant

--- a/packages/runtimes/docs/architecture/05-shutdown-propagation.md
+++ b/packages/runtimes/docs/architecture/05-shutdown-propagation.md
@@ -1,0 +1,116 @@
+# Shutdown Propagation
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+## Caller-Initiated via `RuntimeFleet.stopAll()`
+
+```text
+fleet.stopAll()
+  → teardownStartedAgents(startedAgents)               fleet.ts → teardownStartedAgents
+       Effect.forEach([...startedAgents].reverse(),
+         agent => agent.runtime.teardown(),
+         { concurrency: 1 })
+       Reverse order = last-spawned torn down first.
+```
+
+## OpenClaw Teardown (`openclaw-adapter.ts → OpenClawAdapter.doTeardown`)
+
+```text
+OpenClawAdapter.doTeardown()
+  1. Effect.sync:
+       if state === null || state.tornDown → return null
+       state.tornDown = true
+       capture { process, stateDir }
+  2. pollExitCode(proc) — Fiber.poll(exitFiber)
+       Option.Some → process already exited, skip signal
+       Option.None → waitAfterSigterm(proc):            openclaw-adapter.ts → waitAfterSigterm
+         proc.kill("SIGTERM")
+         timeout(OPENCLAW_TERM_WAIT_MS = 10 000 ms)     openclaw-adapter.ts → OPENCLAW_TERM_WAIT_MS
+         if still running:
+           proc.kill("SIGKILL")
+           timeout(OPENCLAW_KILL_WAIT_MS = 5 000 ms)    openclaw-adapter.ts → OPENCLAW_KILL_WAIT_MS
+  3. Scope.close(proc.scope, Exit.succeed(undefined))
+       Runs Command.start's kill finalizer +
+       stdout/stderr fiber finalizers.
+  4. fileSystem.remove(stateDir, { recursive: true })
+       Removes temp state dir (openclaw.json, workspace/,
+       logs/, plugin symlinks).
+       Errors are caught and logged as warnings.
+```
+
+## ClaudeCode Teardown (`claude-code-adapter.ts → ClaudeCodeAdapter.doTeardown`)
+
+```text
+ClaudeCodeAdapter.doTeardown()
+  1. Guard: if !state || state.tornDown → return void
+     state.tornDown = true
+     capture { process: proc, stateDir }
+  2. pollExitCode(proc) — Fiber.poll(proc.exitFiber)
+       Option.Some → skip signal (already exited)
+       Option.None → waitAfterSigterm(proc):            claude-code-adapter.ts → waitAfterSigterm
+         proc.kill("SIGTERM")
+         timeout(TERM_WAIT_MS = 10 000 ms)              claude-code-adapter.ts → TERM_WAIT_MS
+         if still running:
+           proc.kill("SIGKILL")
+           timeout(TERM_WAIT_MS = 10 000 ms)
+     Note: No explicit process-group kill — SIGTERM on
+     claude propagates to cc-channel (its MCP child)
+     naturally via the process hierarchy.
+  3. Scope.close(proc.scope, Exit.succeed(undefined))
+  4. fileSystem.remove(stateDir, { recursive: true })
+       Errors caught and logged as warnings.
+```
+
+## Nanoclaw Teardown (`nanoclaw-adapter.ts → NanoclawAdapter.doTeardown`)
+
+```text
+NanoclawAdapter.doTeardown()
+  1. Effect.sync:
+       if !state || state.tornDown → return null
+       state.tornDown = true
+       return state.handle
+  2. stopNanoclawRuntimeEffect(handle)               nanoclaw-process.ts → stopNanoclawRuntimeEffect
+       proc.isRunning?
+         true:
+           killProcessAndWait(proc, "SIGTERM",         nanoclaw-process.ts → killProcessAndWait
+             GRACEFUL_STOP_MS = 3 000 ms)
+           if still running:
+             killProcessAndWait(proc, "SIGKILL",
+               GRACEFUL_STOP_MS)
+       Scope.close(handle.scope, Exit.succeed(undefined))
+       fileSystem.remove(handle.dataDir, { recursive: true })
+     Note: Nanoclaw's container subprocesses are managed by
+     OneCLI/Docker; killing the node process sends SIGTERM
+     to nanoclaw, which is responsible for stopping its own
+     Docker containers.
+```
+
+## OS Signal Propagation (`launchRuntimeFleetWithProcessSignals`)
+
+```text
+SIGINT or SIGTERM arrives at the Node.js process
+  │
+  ├─ handler() fires (installed via process.on):       fleet.ts → installProcessSignalHandlers
+  │    if shutdownSignal.value !== null: return (once only)
+  │    shutdownSignal.value = signal
+  │    Effect.runFork(Fiber.interrupt(fiber))
+  │
+  ├─ Effect fiber interrupted
+  │    → Effect.forEach aborts in-progress startFleetAgent
+  │    → onExit finalizer:
+  │         Exit.isInterrupted → teardownStartedAgents(startedAgents)
+  │         (all successfully-started agents torn down)
+  │
+  └─ fiber observer fires:                             fleet.ts → observeFleetLaunchFiber
+       if shutdownSignal.value !== null && Exit.isInterrupted:
+         resume(RuntimeFleetStartupInterrupted { signal })
+       else:
+         resume(Effect.failCause(exit.cause))
+       cleanup(): process.off() for all registered handlers
+```
+
+## See Also
+
+- [Fleet Launch](./02-fleet-launch.md)
+- [Per-Adapter Spawn Details](./03-per-adapter-spawn.md)
+- [Process State Machine](./07-process-state-machine.md)

--- a/packages/runtimes/docs/architecture/05-shutdown-propagation.md
+++ b/packages/runtimes/docs/architecture/05-shutdown-propagation.md
@@ -4,109 +4,98 @@
 
 ## Caller-Initiated via `RuntimeFleet.stopAll()`
 
-```text
-fleet.stopAll()
-  → teardownStartedAgents(startedAgents)               fleet.ts → teardownStartedAgents
-       Effect.forEach([...startedAgents].reverse(),
-         agent => agent.runtime.teardown(),
-         { concurrency: 1 })
-       Reverse order = last-spawned torn down first.
+```mermaid
+flowchart TD
+    SA["fleet.stopAll()"]
+    TD["teardownStartedAgents(startedAgents)\nfleet.ts → teardownStartedAgents\nEffect.forEach([...startedAgents].reverse(),\n  agent =&gt; agent.runtime.teardown(),\n  { concurrency: 1 })\nReverse order = last-spawned torn down first"]
+
+    SA --> TD
 ```
 
 ## OpenClaw Teardown (`openclaw-adapter.ts → OpenClawAdapter.doTeardown`)
 
-```text
-OpenClawAdapter.doTeardown()
-  1. Effect.sync:
-       if state === null || state.tornDown → return null
-       state.tornDown = true
-       capture { process, stateDir }
-  2. pollExitCode(proc) — Fiber.poll(exitFiber)
-       Option.Some → process already exited, skip signal
-       Option.None → waitAfterSigterm(proc):            openclaw-adapter.ts → waitAfterSigterm
-         proc.kill("SIGTERM")
-         timeout(OPENCLAW_TERM_WAIT_MS = 10 000 ms)     openclaw-adapter.ts → OPENCLAW_TERM_WAIT_MS
-         if still running:
-           proc.kill("SIGKILL")
-           timeout(OPENCLAW_KILL_WAIT_MS = 5 000 ms)    openclaw-adapter.ts → OPENCLAW_KILL_WAIT_MS
-  3. Scope.close(proc.scope, Exit.succeed(undefined))
-       Runs Command.start's kill finalizer +
-       stdout/stderr fiber finalizers.
-  4. fileSystem.remove(stateDir, { recursive: true })
-       Removes temp state dir (openclaw.json, workspace/,
-       logs/, plugin symlinks).
-       Errors are caught and logged as warnings.
+```mermaid
+flowchart TD
+    OCT["OpenClawAdapter.doTeardown()\nopenclaw-adapter.ts → OpenClawAdapter.doTeardown"]
+    OCT1["1. Effect.sync:\n   if state === null || state.tornDown → return null\n   state.tornDown = true\n   capture { process, stateDir }"]
+    OCT2{"2. pollExitCode(proc)\nFiber.poll(exitFiber)"}
+    OCT2A["Option.Some\n→ process already exited, skip signal"]
+    OCT2B["Option.None →\nwaitAfterSigterm(proc)\nopenclaw-adapter.ts → waitAfterSigterm\nproc.kill(&quot;SIGTERM&quot;)\ntimeout(OPENCLAW_TERM_WAIT_MS = 10 000 ms)"]
+    OCT2C{"still running?"}
+    OCT2D["proc.kill(&quot;SIGKILL&quot;)\ntimeout(OPENCLAW_KILL_WAIT_MS = 5 000 ms)"]
+    OCT3["3. Scope.close(proc.scope, Exit.succeed(undefined))\nRuns Command.start kill finalizer +\nstdout/stderr fiber finalizers"]
+    OCT4["4. fileSystem.remove(stateDir, { recursive: true })\nRemoves openclaw.json, workspace/,\nlogs/, plugin symlinks\nErrors caught and logged as warnings"]
+
+    OCT --> OCT1 --> OCT2
+    OCT2 -->|"Option.Some"| OCT2A
+    OCT2 -->|"Option.None"| OCT2B --> OCT2C
+    OCT2C -->|"yes"| OCT2D
+    OCT2C -->|"no"| OCT3
+    OCT2A --> OCT3
+    OCT2D --> OCT3
+    OCT3 --> OCT4
 ```
 
 ## ClaudeCode Teardown (`claude-code-adapter.ts → ClaudeCodeAdapter.doTeardown`)
 
-```text
-ClaudeCodeAdapter.doTeardown()
-  1. Guard: if !state || state.tornDown → return void
-     state.tornDown = true
-     capture { process: proc, stateDir }
-  2. pollExitCode(proc) — Fiber.poll(proc.exitFiber)
-       Option.Some → skip signal (already exited)
-       Option.None → waitAfterSigterm(proc):            claude-code-adapter.ts → waitAfterSigterm
-         proc.kill("SIGTERM")
-         timeout(TERM_WAIT_MS = 10 000 ms)              claude-code-adapter.ts → TERM_WAIT_MS
-         if still running:
-           proc.kill("SIGKILL")
-           timeout(TERM_WAIT_MS = 10 000 ms)
-     Note: No explicit process-group kill — SIGTERM on
-     claude propagates to cc-channel (its MCP child)
-     naturally via the process hierarchy.
-  3. Scope.close(proc.scope, Exit.succeed(undefined))
-  4. fileSystem.remove(stateDir, { recursive: true })
-       Errors caught and logged as warnings.
+```mermaid
+flowchart TD
+    CCT["ClaudeCodeAdapter.doTeardown()\nclaude-code-adapter.ts → ClaudeCodeAdapter.doTeardown"]
+    CCT1["1. Guard: if !state || state.tornDown → return void\n   state.tornDown = true\n   capture { process: proc, stateDir }"]
+    CCT2{"2. pollExitCode(proc)\nFiber.poll(proc.exitFiber)"}
+    CCT2A["Option.Some → skip signal (already exited)"]
+    CCT2B["Option.None →\nwaitAfterSigterm(proc)\nclaude-code-adapter.ts → waitAfterSigterm\nproc.kill(&quot;SIGTERM&quot;)\ntimeout(TERM_WAIT_MS = 10 000 ms)"]
+    CCT2C{"still running?"}
+    CCT2D["proc.kill(&quot;SIGKILL&quot;)\ntimeout(TERM_WAIT_MS = 10 000 ms)"]
+    CCT3["3. Scope.close(proc.scope, Exit.succeed(undefined))\nNote: No explicit process-group kill —\nSIGTERM on claude propagates to cc-channel\n(its MCP child) naturally via process hierarchy"]
+    CCT4["4. fileSystem.remove(stateDir, { recursive: true })\nErrors caught and logged as warnings"]
+
+    CCT --> CCT1 --> CCT2
+    CCT2 -->|"Option.Some"| CCT2A
+    CCT2 -->|"Option.None"| CCT2B --> CCT2C
+    CCT2C -->|"yes"| CCT2D
+    CCT2C -->|"no"| CCT3
+    CCT2A --> CCT3
+    CCT2D --> CCT3
+    CCT3 --> CCT4
 ```
 
 ## Nanoclaw Teardown (`nanoclaw-adapter.ts → NanoclawAdapter.doTeardown`)
 
-```text
-NanoclawAdapter.doTeardown()
-  1. Effect.sync:
-       if !state || state.tornDown → return null
-       state.tornDown = true
-       return state.handle
-  2. stopNanoclawRuntimeEffect(handle)               nanoclaw-process.ts → stopNanoclawRuntimeEffect
-       proc.isRunning?
-         true:
-           killProcessAndWait(proc, "SIGTERM",         nanoclaw-process.ts → killProcessAndWait
-             GRACEFUL_STOP_MS = 3 000 ms)
-           if still running:
-             killProcessAndWait(proc, "SIGKILL",
-               GRACEFUL_STOP_MS)
-       Scope.close(handle.scope, Exit.succeed(undefined))
-       fileSystem.remove(handle.dataDir, { recursive: true })
-     Note: Nanoclaw's container subprocesses are managed by
-     OneCLI/Docker; killing the node process sends SIGTERM
-     to nanoclaw, which is responsible for stopping its own
-     Docker containers.
+```mermaid
+flowchart TD
+    NCT["NanoclawAdapter.doTeardown()\nnanoclaw-adapter.ts → NanoclawAdapter.doTeardown"]
+    NCT1["1. Effect.sync:\n   if !state || state.tornDown → return null\n   state.tornDown = true\n   return state.handle"]
+    NCT2["2. stopNanoclawRuntimeEffect(handle)\nnanoclaw-process.ts → stopNanoclawRuntimeEffect"]
+    NCT2A{"proc.isRunning?"}
+    NCT2B["killProcessAndWait(proc, &quot;SIGTERM&quot;,\nGRACEFUL_STOP_MS = 3 000 ms)\nnanoclaw-process.ts → killProcessAndWait"]
+    NCT2C{"still running?"}
+    NCT2D["killProcessAndWait(proc, &quot;SIGKILL&quot;,\nGRACEFUL_STOP_MS)"]
+    NCT3["Scope.close(handle.scope, Exit.succeed(undefined))\nfileSystem.remove(handle.dataDir, { recursive: true })\nNote: Nanoclaw's container subprocesses managed by\nOneCLI/Docker; killing node sends SIGTERM to nanoclaw,\nwhich stops its own Docker containers"]
+
+    NCT --> NCT1 --> NCT2 --> NCT2A
+    NCT2A -->|"true"| NCT2B --> NCT2C
+    NCT2C -->|"yes"| NCT2D --> NCT3
+    NCT2C -->|"no"| NCT3
+    NCT2A -->|"false (not running)"| NCT3
 ```
 
 ## OS Signal Propagation (`launchRuntimeFleetWithProcessSignals`)
 
-```text
-SIGINT or SIGTERM arrives at the Node.js process
-  │
-  ├─ handler() fires (installed via process.on):       fleet.ts → installProcessSignalHandlers
-  │    if shutdownSignal.value !== null: return (once only)
-  │    shutdownSignal.value = signal
-  │    Effect.runFork(Fiber.interrupt(fiber))
-  │
-  ├─ Effect fiber interrupted
-  │    → Effect.forEach aborts in-progress startFleetAgent
-  │    → onExit finalizer:
-  │         Exit.isInterrupted → teardownStartedAgents(startedAgents)
-  │         (all successfully-started agents torn down)
-  │
-  └─ fiber observer fires:                             fleet.ts → observeFleetLaunchFiber
-       if shutdownSignal.value !== null && Exit.isInterrupted:
-         resume(RuntimeFleetStartupInterrupted { signal })
-       else:
-         resume(Effect.failCause(exit.cause))
-       cleanup(): process.off() for all registered handlers
+```mermaid
+flowchart TD
+    SIG["SIGINT or SIGTERM\narrives at Node.js process"]
+    HANDLER["handler() fires\nfleet.ts → installProcessSignalHandlers\nif shutdownSignal.value !== null: return (once only)\nshutdownSignal.value = signal\nEffect.runFork(Fiber.interrupt(fiber))"]
+    FINT["Effect fiber interrupted\n→ Effect.forEach aborts in-progress startFleetAgent\n→ onExit finalizer:\n   Exit.isInterrupted → teardownStartedAgents(startedAgents)\n   (all successfully-started agents torn down)"]
+    OBS["fiber observer fires\nfleet.ts → observeFleetLaunchFiber"]
+    INT["shutdownSignal.value !== null &amp;&amp; Exit.isInterrupted:\nresume(RuntimeFleetStartupInterrupted { signal })"]
+    ERR["else:\nresume(Effect.failCause(exit.cause))"]
+    CLEAN["cleanup(): process.off() for all registered handlers"]
+
+    SIG --> HANDLER --> FINT --> OBS
+    OBS --> INT
+    OBS --> ERR
+    OBS --> CLEAN
 ```
 
 ## See Also

--- a/packages/runtimes/docs/architecture/05-shutdown-propagation.md
+++ b/packages/runtimes/docs/architecture/05-shutdown-propagation.md
@@ -7,7 +7,7 @@
 ```mermaid
 flowchart TD
     SA["fleet.stopAll()"]
-    TD["teardownStartedAgents(startedAgents)\nfleet.ts → teardownStartedAgents\nEffect.forEach([...startedAgents].reverse(),\n  agent =&gt; agent.runtime.teardown(),\n  { concurrency: 1 })\nReverse order = last-spawned torn down first"]
+    TD["teardownStartedAgents(startedAgents)<br>fleet.ts → teardownStartedAgents<br>Effect.forEach([...startedAgents].reverse(),<br>  agent =&gt; agent.runtime.teardown(),<br>  { concurrency: 1 })<br>Reverse order = last-spawned torn down first"]
 
     SA --> TD
 ```
@@ -16,15 +16,15 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    OCT["OpenClawAdapter.doTeardown()\nopenclaw-adapter.ts → OpenClawAdapter.doTeardown"]
-    OCT1["1. Effect.sync:\n   if state === null || state.tornDown → return null\n   state.tornDown = true\n   capture { process, stateDir }"]
-    OCT2{"2. pollExitCode(proc)\nFiber.poll(exitFiber)"}
-    OCT2A["Option.Some\n→ process already exited, skip signal"]
-    OCT2B["Option.None →\nwaitAfterSigterm(proc)\nopenclaw-adapter.ts → waitAfterSigterm\nproc.kill(&quot;SIGTERM&quot;)\ntimeout(OPENCLAW_TERM_WAIT_MS = 10 000 ms)"]
+    OCT["OpenClawAdapter.doTeardown()<br>openclaw-adapter.ts → OpenClawAdapter.doTeardown"]
+    OCT1["1. Effect.sync:<br>   if state === null || state.tornDown → return null<br>   state.tornDown = true<br>   capture { process, stateDir }"]
+    OCT2{"2. pollExitCode(proc)<br>Fiber.poll(exitFiber)"}
+    OCT2A["Option.Some<br>→ process already exited, skip signal"]
+    OCT2B["Option.None →<br>waitAfterSigterm(proc)<br>openclaw-adapter.ts → waitAfterSigterm<br>proc.kill(&quot;SIGTERM&quot;)<br>timeout(OPENCLAW_TERM_WAIT_MS = 10 000 ms)"]
     OCT2C{"still running?"}
-    OCT2D["proc.kill(&quot;SIGKILL&quot;)\ntimeout(OPENCLAW_KILL_WAIT_MS = 5 000 ms)"]
-    OCT3["3. Scope.close(proc.scope, Exit.succeed(undefined))\nRuns Command.start kill finalizer +\nstdout/stderr fiber finalizers"]
-    OCT4["4. fileSystem.remove(stateDir, { recursive: true })\nRemoves openclaw.json, workspace/,\nlogs/, plugin symlinks\nErrors caught and logged as warnings"]
+    OCT2D["proc.kill(&quot;SIGKILL&quot;)<br>timeout(OPENCLAW_KILL_WAIT_MS = 5 000 ms)"]
+    OCT3["3. Scope.close(proc.scope, Exit.succeed(undefined))<br>Runs Command.start kill finalizer +<br>stdout/stderr fiber finalizers"]
+    OCT4["4. fileSystem.remove(stateDir, { recursive: true })<br>Removes openclaw.json, workspace/,<br>logs/, plugin symlinks<br>Errors caught and logged as warnings"]
 
     OCT --> OCT1 --> OCT2
     OCT2 -->|"Option.Some"| OCT2A
@@ -40,15 +40,15 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    CCT["ClaudeCodeAdapter.doTeardown()\nclaude-code-adapter.ts → ClaudeCodeAdapter.doTeardown"]
-    CCT1["1. Guard: if !state || state.tornDown → return void\n   state.tornDown = true\n   capture { process: proc, stateDir }"]
-    CCT2{"2. pollExitCode(proc)\nFiber.poll(proc.exitFiber)"}
+    CCT["ClaudeCodeAdapter.doTeardown()<br>claude-code-adapter.ts → ClaudeCodeAdapter.doTeardown"]
+    CCT1["1. Guard: if !state || state.tornDown → return void<br>   state.tornDown = true<br>   capture { process: proc, stateDir }"]
+    CCT2{"2. pollExitCode(proc)<br>Fiber.poll(proc.exitFiber)"}
     CCT2A["Option.Some → skip signal (already exited)"]
-    CCT2B["Option.None →\nwaitAfterSigterm(proc)\nclaude-code-adapter.ts → waitAfterSigterm\nproc.kill(&quot;SIGTERM&quot;)\ntimeout(TERM_WAIT_MS = 10 000 ms)"]
+    CCT2B["Option.None →<br>waitAfterSigterm(proc)<br>claude-code-adapter.ts → waitAfterSigterm<br>proc.kill(&quot;SIGTERM&quot;)<br>timeout(TERM_WAIT_MS = 10 000 ms)"]
     CCT2C{"still running?"}
-    CCT2D["proc.kill(&quot;SIGKILL&quot;)\ntimeout(TERM_WAIT_MS = 10 000 ms)"]
-    CCT3["3. Scope.close(proc.scope, Exit.succeed(undefined))\nNote: No explicit process-group kill —\nSIGTERM on claude propagates to cc-channel\n(its MCP child) naturally via process hierarchy"]
-    CCT4["4. fileSystem.remove(stateDir, { recursive: true })\nErrors caught and logged as warnings"]
+    CCT2D["proc.kill(&quot;SIGKILL&quot;)<br>timeout(TERM_WAIT_MS = 10 000 ms)"]
+    CCT3["3. Scope.close(proc.scope, Exit.succeed(undefined))<br>Note: No explicit process-group kill —<br>SIGTERM on claude propagates to cc-channel<br>(its MCP child) naturally via process hierarchy"]
+    CCT4["4. fileSystem.remove(stateDir, { recursive: true })<br>Errors caught and logged as warnings"]
 
     CCT --> CCT1 --> CCT2
     CCT2 -->|"Option.Some"| CCT2A
@@ -64,14 +64,14 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    NCT["NanoclawAdapter.doTeardown()\nnanoclaw-adapter.ts → NanoclawAdapter.doTeardown"]
-    NCT1["1. Effect.sync:\n   if !state || state.tornDown → return null\n   state.tornDown = true\n   return state.handle"]
-    NCT2["2. stopNanoclawRuntimeEffect(handle)\nnanoclaw-process.ts → stopNanoclawRuntimeEffect"]
+    NCT["NanoclawAdapter.doTeardown()<br>nanoclaw-adapter.ts → NanoclawAdapter.doTeardown"]
+    NCT1["1. Effect.sync:<br>   if !state || state.tornDown → return null<br>   state.tornDown = true<br>   return state.handle"]
+    NCT2["2. stopNanoclawRuntimeEffect(handle)<br>nanoclaw-process.ts → stopNanoclawRuntimeEffect"]
     NCT2A{"proc.isRunning?"}
-    NCT2B["killProcessAndWait(proc, &quot;SIGTERM&quot;,\nGRACEFUL_STOP_MS = 3 000 ms)\nnanoclaw-process.ts → killProcessAndWait"]
+    NCT2B["killProcessAndWait(proc, &quot;SIGTERM&quot;,<br>GRACEFUL_STOP_MS = 3 000 ms)<br>nanoclaw-process.ts → killProcessAndWait"]
     NCT2C{"still running?"}
-    NCT2D["killProcessAndWait(proc, &quot;SIGKILL&quot;,\nGRACEFUL_STOP_MS)"]
-    NCT3["Scope.close(handle.scope, Exit.succeed(undefined))\nfileSystem.remove(handle.dataDir, { recursive: true })\nNote: Nanoclaw's container subprocesses managed by\nOneCLI/Docker; killing node sends SIGTERM to nanoclaw,\nwhich stops its own Docker containers"]
+    NCT2D["killProcessAndWait(proc, &quot;SIGKILL&quot;,<br>GRACEFUL_STOP_MS)"]
+    NCT3["Scope.close(handle.scope, Exit.succeed(undefined))<br>fileSystem.remove(handle.dataDir, { recursive: true })<br>Note: Nanoclaw's container subprocesses managed by<br>OneCLI/Docker; killing node sends SIGTERM to nanoclaw,<br>which stops its own Docker containers"]
 
     NCT --> NCT1 --> NCT2 --> NCT2A
     NCT2A -->|"true"| NCT2B --> NCT2C
@@ -84,12 +84,12 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    SIG["SIGINT or SIGTERM\narrives at Node.js process"]
-    HANDLER["handler() fires\nfleet.ts → installProcessSignalHandlers\nif shutdownSignal.value !== null: return (once only)\nshutdownSignal.value = signal\nEffect.runFork(Fiber.interrupt(fiber))"]
-    FINT["Effect fiber interrupted\n→ Effect.forEach aborts in-progress startFleetAgent\n→ onExit finalizer:\n   Exit.isInterrupted → teardownStartedAgents(startedAgents)\n   (all successfully-started agents torn down)"]
-    OBS["fiber observer fires\nfleet.ts → observeFleetLaunchFiber"]
-    INT["shutdownSignal.value !== null &amp;&amp; Exit.isInterrupted:\nresume(RuntimeFleetStartupInterrupted { signal })"]
-    ERR["else:\nresume(Effect.failCause(exit.cause))"]
+    SIG["SIGINT or SIGTERM<br>arrives at Node.js process"]
+    HANDLER["handler() fires<br>fleet.ts → installProcessSignalHandlers<br>if shutdownSignal.value !== null: return (once only)<br>shutdownSignal.value = signal<br>Effect.runFork(Fiber.interrupt(fiber))"]
+    FINT["Effect fiber interrupted<br>→ Effect.forEach aborts in-progress startFleetAgent<br>→ onExit finalizer:<br>   Exit.isInterrupted → teardownStartedAgents(startedAgents)<br>   (all successfully-started agents torn down)"]
+    OBS["fiber observer fires<br>fleet.ts → observeFleetLaunchFiber"]
+    INT["shutdownSignal.value !== null &amp;&amp; Exit.isInterrupted:<br>resume(RuntimeFleetStartupInterrupted { signal })"]
+    ERR["else:<br>resume(Effect.failCause(exit.cause))"]
     CLEAN["cleanup(): process.off() for all registered handlers"]
 
     SIG --> HANDLER --> FINT --> OBS

--- a/packages/runtimes/docs/architecture/06-error-matrix.md
+++ b/packages/runtimes/docs/architecture/06-error-matrix.md
@@ -1,0 +1,22 @@
+# Error Matrix
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+All typed errors in `errors.ts` and `fleet.ts`:
+
+| Error `_tag` | File | Raised by | Fields | Typical caller action |
+|---|---|---|---|---|
+| `SpawnFailed` | `errors.ts` | `Runtime.spawn()` in all three adapters when the child process cannot be started (exec error, bad binary, port allocation failure, state-dir error) | `agentName`, `cause: Error`, `message` | Surface to caller; no retry — binary or config is wrong |
+| `RuntimeReadyTimedOut` | `errors.ts` | `startPendingRuntimeAgent` when `waitUntilReady` returns `Timeout` | `agentName`, `timeoutMs`, `message` | Increase `readyTimeoutMs`, or inspect `runtime.getLogs(0)` for the subprocess output |
+| `RuntimeExitedBeforeReady` | `errors.ts` | `startPendingRuntimeAgent` when `waitUntilReady` returns `ProcessExited` | `agentName`, `exitCode: number \| null`, `stderr`, `message` | Inspect `stderr` (full accumulated stdout+stderr at exit); check binary auth config |
+| `RuntimeFleetStartupInterrupted` | `fleet.ts` | `launchRuntimeFleetWithProcessSignals` when a signal arrives during fleet startup | `signal: Signal`, `message` | Expected on user Ctrl-C; log and exit cleanly |
+
+`RuntimeLaunchFailed` (in `errors.ts`) is the union type
+`SpawnFailed | RuntimeReadyTimedOut | RuntimeExitedBeforeReady` — it is the
+error channel of both `startRuntimeAgent` and `launchRuntimeFleet`.
+
+## See Also
+
+- [Single-Runtime Startup](./01-single-runtime-startup.md)
+- [Fleet Launch](./02-fleet-launch.md)
+- [Process State Machine](./07-process-state-machine.md)

--- a/packages/runtimes/docs/architecture/07-process-state-machine.md
+++ b/packages/runtimes/docs/architecture/07-process-state-machine.md
@@ -12,7 +12,7 @@ stateDiagram-v2
     [*] --> NOT_STARTED
 
     NOT_STARTED --> SPAWNED : spawn() ok
-    NOT_STARTED --> NOT_STARTED : spawn() err — SpawnFailed propagates; state remains null
+    NOT_STARTED --> NOT_STARTED : spawn() err — SpawnFailed propagates, state remains null
     SPAWNED --> READY : Ready outcome
     SPAWNED --> TORN_DOWN : Timeout outcome — teardown() called before RuntimeReadyTimedOut fail
     SPAWNED --> TORN_DOWN : ProcessExited outcome — teardown() called before RuntimeExitedBeforeReady fail

--- a/packages/runtimes/docs/architecture/07-process-state-machine.md
+++ b/packages/runtimes/docs/architecture/07-process-state-machine.md
@@ -7,47 +7,25 @@
 Each adapter instance tracks a single logical process lifecycle through an
 internal `AdapterState` object with a `tornDown` boolean guard.
 
-```text
-States:
+```mermaid
+stateDiagram-v2
+    [*] --> NOT_STARTED
 
-  NOT_STARTED
-    state = null
-    Initial state after adapter construction.
-    waitUntilReady() returns Ready immediately (no-op guard).
-    getLogs() returns { text: "", nextOffset: 0 }.
-    teardown() is a no-op.
-
-  SPAWNED
-    state = { process, stateDir, logBuffer, tornDown: false }
-    Entered when Runtime.spawn() completes successfully.
-    exitFiber is running; stdout/stderr fibers are running.
-    waitUntilReady() races server auth vs. process exit poll.
-
-  READY
-    Same AdapterState shape as SPAWNED; no distinct field.
-    waitUntilReady() returned ReadyOutcome { _tag: "Ready" }.
-    Caller now owns the Runtime; teardown() must be called
-    explicitly (or via fleet.stopAll()).
-
-  TORN_DOWN
-    state.tornDown = true  (set atomically inside doTeardown)
-    Process sent SIGTERM/SIGKILL; scope closed; stateDir removed.
-    teardown() is idempotent — subsequent calls return void
-    immediately (the tornDown guard short-circuits at entry).
-
-Transitions:
-
-  NOT_STARTED ──spawn() ok──▶ SPAWNED
-  NOT_STARTED ──spawn() err──▶ NOT_STARTED (state remains null;
-                                SpawnFailed propagates to caller)
-  SPAWNED ──Ready outcome──▶ READY
-  SPAWNED ──Timeout outcome──▶ TORN_DOWN  (teardown called internally
-                                            before RuntimeReadyTimedOut fail)
-  SPAWNED ──ProcessExited───▶ TORN_DOWN  (teardown called internally
-                                           before RuntimeExitedBeforeReady fail)
-  READY ──teardown()──▶ TORN_DOWN
-  TORN_DOWN ──teardown()──▶ TORN_DOWN  (no-op, idempotent)
+    NOT_STARTED --> SPAWNED : spawn() ok
+    NOT_STARTED --> NOT_STARTED : spawn() err — SpawnFailed propagates; state remains null
+    SPAWNED --> READY : Ready outcome
+    SPAWNED --> TORN_DOWN : Timeout outcome — teardown() called before RuntimeReadyTimedOut fail
+    SPAWNED --> TORN_DOWN : ProcessExited outcome — teardown() called before RuntimeExitedBeforeReady fail
+    READY --> TORN_DOWN : teardown()
+    TORN_DOWN --> TORN_DOWN : teardown() — no-op, idempotent
 ```
+
+**State descriptions:**
+
+- **NOT_STARTED** — `state = null`. Initial state after adapter construction. `waitUntilReady()` returns Ready immediately (no-op guard). `getLogs()` returns `{ text: "", nextOffset: 0 }`. `teardown()` is a no-op.
+- **SPAWNED** — `state = { process, stateDir, logBuffer, tornDown: false }`. Entered when `Runtime.spawn()` completes successfully. `exitFiber` is running; stdout/stderr fibers are running. `waitUntilReady()` races server auth vs. process exit poll.
+- **READY** — Same `AdapterState` shape as SPAWNED; no distinct field. `waitUntilReady()` returned `ReadyOutcome { _tag: "Ready" }`. Caller now owns the Runtime; `teardown()` must be called explicitly (or via `fleet.stopAll()`).
+- **TORN_DOWN** — `state.tornDown = true` (set atomically inside `doTeardown`). Process sent SIGTERM/SIGKILL; scope closed; `stateDir` removed. `teardown()` is idempotent — subsequent calls return void immediately (the `tornDown` guard short-circuits at entry).
 
 ## See Also
 

--- a/packages/runtimes/docs/architecture/07-process-state-machine.md
+++ b/packages/runtimes/docs/architecture/07-process-state-machine.md
@@ -1,0 +1,56 @@
+# Per-Process State Machine
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+## Overview
+
+Each adapter instance tracks a single logical process lifecycle through an
+internal `AdapterState` object with a `tornDown` boolean guard.
+
+```text
+States:
+
+  NOT_STARTED
+    state = null
+    Initial state after adapter construction.
+    waitUntilReady() returns Ready immediately (no-op guard).
+    getLogs() returns { text: "", nextOffset: 0 }.
+    teardown() is a no-op.
+
+  SPAWNED
+    state = { process, stateDir, logBuffer, tornDown: false }
+    Entered when Runtime.spawn() completes successfully.
+    exitFiber is running; stdout/stderr fibers are running.
+    waitUntilReady() races server auth vs. process exit poll.
+
+  READY
+    Same AdapterState shape as SPAWNED; no distinct field.
+    waitUntilReady() returned ReadyOutcome { _tag: "Ready" }.
+    Caller now owns the Runtime; teardown() must be called
+    explicitly (or via fleet.stopAll()).
+
+  TORN_DOWN
+    state.tornDown = true  (set atomically inside doTeardown)
+    Process sent SIGTERM/SIGKILL; scope closed; stateDir removed.
+    teardown() is idempotent — subsequent calls return void
+    immediately (the tornDown guard short-circuits at entry).
+
+Transitions:
+
+  NOT_STARTED ──spawn() ok──▶ SPAWNED
+  NOT_STARTED ──spawn() err──▶ NOT_STARTED (state remains null;
+                                SpawnFailed propagates to caller)
+  SPAWNED ──Ready outcome──▶ READY
+  SPAWNED ──Timeout outcome──▶ TORN_DOWN  (teardown called internally
+                                            before RuntimeReadyTimedOut fail)
+  SPAWNED ──ProcessExited───▶ TORN_DOWN  (teardown called internally
+                                           before RuntimeExitedBeforeReady fail)
+  READY ──teardown()──▶ TORN_DOWN
+  TORN_DOWN ──teardown()──▶ TORN_DOWN  (no-op, idempotent)
+```
+
+## See Also
+
+- [Single-Runtime Startup](./01-single-runtime-startup.md)
+- [Shutdown Propagation](./05-shutdown-propagation.md)
+- [Error Matrix](./06-error-matrix.md)

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -97,14 +97,15 @@ authority checks, and the dispatch admission path.
 define a TypeScript-enforced hierarchy on which service Tags a handler may
 pull at each layer:
 
-```text
-TransportTags  ⊂  IdentityTags  ⊂  NetworkTags  ⊂  TaskTags  ⊂  AppTags
-       │              │                │              │           │
-   ConnId,         + Auth,          + Presence,    + Message,  + AppHost,
-   Db,             ParticipantSvc   ResolverSvc,    Conv,       LeaseRegistry
-   Encryption,                      NetworkSend,    TaskSvc
-   WebhookClient,                   ContactsSvc
-   …
+```mermaid
+flowchart LR
+    T["TransportTags<br/>ConnId, Db,<br/>Encryption,<br/>WebhookClient, …"]
+    I["IdentityTags<br/>+ Auth,<br/>ParticipantSvc"]
+    N["NetworkTags<br/>+ Presence,<br/>ResolverSvc,<br/>NetworkSend,<br/>ContactsSvc"]
+    K["TaskTags<br/>+ Message,<br/>Conv,<br/>TaskSvc"]
+    A["AppTags<br/>+ AppHost,<br/>LeaseRegistry"]
+
+    T -->|"⊂"| I -->|"⊂"| N -->|"⊂"| K -->|"⊂"| A
 ```
 
 A handler bound at the `task` layer can pull `MessageService`, `ConversationService`,

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -1,0 +1,173 @@
+# Architecture — `@moltzap/server-core`
+
+Server-side building blocks for agent-to-agent messaging. Composes Effect
+Layers for the service graph, exposes WebSocket + HTTP transport, runs the
+`AppHost` dispatcher for moderator round-trips, and persists state through
+Kysely against PostgreSQL (or PGlite under test). Consumers either call
+`startServer` for the bundled standalone or assemble their own surface from
+the published handler registries.
+
+## 1. Project Structure
+
+```
+packages/server/src/
+├── app/                # AppHost + composition root
+│   ├── server.ts          # createCoreApp — composes Layers, mounts routes
+│   ├── app-host.ts        # AppHost — dispatch/* + hook fan-out
+│   ├── lease-registry.ts  # In-memory lease state machine + TTL fibers
+│   ├── handlers/          # apps.handlers, dispatches.handlers
+│   ├── hooks.ts           # Hook<TContext, TResult> generic shape
+│   ├── layers.ts          # Tag definitions + Live composition (Tier 1-6)
+│   └── types.ts           # CoreConfig, CoreApp, branded IDs
+├── identity/           # Auth, agents, sessions, participants
+├── network/            # Ping, presence, connection liveness, send routing
+│   ├── agent-endpoint-resolver.ts  # AgentId → HashSet<ConnId> multimap
+│   ├── app-tm-registry.ts          # Default DM/group TM seeding
+│   ├── network-send.ts             # Single outbound surface (send + broadcast)
+│   ├── handlers/
+│   └── services/                   # presence.service, presence-event-sink
+├── task/               # Conversations, messages, dispatch lease lifecycle
+│   ├── handlers/          # conversations, messages, presence, contacts, connect, tasks
+│   └── services/          # conversation.service, message.service, task.service, default-tm
+├── transport/          # WS connection acquisition, dispatch context, layer-tags
+├── rpc/                # Layer-tag hierarchy (used by handler R-channel)
+├── crypto/             # Envelope encryption, key rotation
+├── db/                 # Kysely schema, snowflake IDs, effect-kysely-toolkit
+├── adapters/           # webhook client + typed errors
+├── config/             # YAML config loader + schema validation
+├── runtime/            # InvalidParamsError, validateParams, coalesce helpers
+├── runtime-surface/    # Public host-runtime API (logging, tracing, config)
+├── test-utils/         # PGlite boot + test drivers
+├── standalone.ts       # startServer(configPath) — CLI/binary entry
+└── __tests__/          # unit, integration, conformance
+```
+
+## 2. Public Surface
+
+| Group | Highlights |
+|---|---|
+| Bootstrap | `createCoreApp`, `startServer`, `CoreApp`, `CoreConfig` |
+| Handler registries | `connectHandlers`, `agentsLookupHandlers`, `pingHandlers`, `conversationHandlers`, `messageHandlers`, `presenceHandlers`, `contactHandlers`, `appHandlers` |
+| Services | `AuthService`, `ConversationService`, `MessageService`, `ParticipantService`, `PresenceService`, `AppHost` |
+| Adapters | `WebhookClient` (+ typed errors), `WebhookSessionValidator` |
+| Config | `loadConfigFromFile`, `validateConfig`, `loadRuntimeProcessConfig` |
+| Observability | `createRuntimeObservability`, `withRuntimeLogContext`, `withRuntimeTraceSpan`, `TraceCaptureTag` |
+| Crypto | `EnvelopeEncryption`, `seedInitialKek`, `generateApiKey`, `parseApiKey`, `hashSecret` |
+| DB | `createDb`, `makeEffectKysely`, `transaction`, `nextSnowflakeId`, Kysely toolkit |
+| Types | `AgentId`, `UserId`, `ConversationId` (branded), `Database`, `MoltZapConnection`, `RpcMethodRegistry` |
+
+`defineMethod` is the call-site for handler authors; each handler returns a
+typed `RpcMethodBinding<Params, Result, Error, Tags>`.
+
+## 3. Communication Flows
+
+| Section | Detail doc |
+|---|---|
+| §3.1 Service Layer composition (boot graph) | [docs/architecture/01-service-layer-composition.md](docs/architecture/01-service-layer-composition.md) |
+| §3.2 WebSocket connection lifecycle | [docs/architecture/02-ws-connection-lifecycle.md](docs/architecture/02-ws-connection-lifecycle.md) |
+| §3.3 Request → response handling | [docs/architecture/03-request-response-handling.md](docs/architecture/03-request-response-handling.md) |
+| §3.4 Server-initiated callback (`dispatch/authorize`) | [docs/architecture/04-server-initiated-callback.md](docs/architecture/04-server-initiated-callback.md) |
+| §3.5 AppHost hook unification | [docs/architecture/05-app-host-hook-unification.md](docs/architecture/05-app-host-hook-unification.md) |
+| §3.6 Lease lifecycle | [docs/architecture/06-lease-lifecycle.md](docs/architecture/06-lease-lifecycle.md) |
+| §3.7 HTTP route surface | [docs/architecture/07-http-routes.md](docs/architecture/07-http-routes.md) |
+| §3.8 Notification fan-out | [docs/architecture/08-notification-fanout.md](docs/architecture/08-notification-fanout.md) |
+| §3.9 Shutdown sequence | [docs/architecture/09-shutdown-sequence.md](docs/architecture/09-shutdown-sequence.md) |
+
+## 4. Data Stores
+
+| Store | Type | Purpose |
+|---|---|---|
+| Primary | PostgreSQL (prod) / PGlite (tests) | Agents, conversations, messages, tasks, leases (in-memory copy) |
+| Key tables | — | `agents`, `users`, `sessions`, `conversations`, `conversation_participants`, `messages`, `tasks`, `dispatches` |
+
+PGlite (`@electric-sql/pglite` + `kysely-pglite`) is the in-memory variant
+used by integration tests; the same Kysely schema runs against both. The
+`createDb` factory (`db/client.ts`) dispatches on config — `db.kind = "pg"`
+returns a real `Kysely<Database>`, `db.kind = "pglite"` returns the
+in-memory variant. Handlers and services never branch on `db.kind`.
+
+`tasks` carries `app_id` (nullable) and `tm_endpoint_address` (not null).
+The `app_id IS NULL` discriminator drives the "is this app-bound?"
+behavior across `AppHost.runMessageAuthorize`, `conversation.service`
+authority checks, and the dispatch admission path.
+
+## 5. Layer-tag hierarchy
+
+`packages/server/src/rpc/layer-tags.ts` (and `transport/layer-tags.ts`)
+define a TypeScript-enforced hierarchy on which service Tags a handler may
+pull at each layer:
+
+```text
+TransportTags  ⊂  IdentityTags  ⊂  NetworkTags  ⊂  TaskTags  ⊂  AppTags
+       │              │                │              │           │
+   ConnId,         + Auth,          + Presence,    + Message,  + AppHost,
+   Db,             ParticipantSvc   ResolverSvc,    Conv,       LeaseRegistry
+   Encryption,                      NetworkSend,    TaskSvc
+   WebhookClient,                   ContactsSvc
+   …
+```
+
+A handler bound at the `task` layer can pull `MessageService`, `ConversationService`,
+plus everything from network/identity/transport — but NOT `AppHost`. This
+matches the protocol layer DAG; you can't define an RPC that's notionally a
+"task" method but needs the AppHost. The `R` channel of the handler's
+`Effect` is the enforcement mechanism — `Exclude<AppTags, ConnIdTag>` on
+the dispatcher (in `app/server.ts`) leaves `ConnIdTag` unresolved until the
+per-request `Effect.provide` at handler-invocation time.
+
+## 6. Dependencies
+
+**Runtime**: `effect`, `@effect/platform[-node]`, `@effect/sql`,
+`@effect/sql-kysely`, `kysely`, `pg`, `@electric-sql/pglite`, `kysely-pglite`,
+`@sinclair/typebox`, `ajv`, `ajv-formats`, `yaml`.
+**Internal**: `@moltzap/protocol`.
+**Consumers**: arena (via submodule), standalone deployments via
+`startServer(configPath?)`.
+
+## 7. Tests
+
+- `src/__tests__/integration/` — service + RPC integration tests (PGlite-backed)
+- `src/__tests__/conformance/` — server-side conformance harness (re-uses
+  `@moltzap/protocol/testing/conformance`)
+- Per-module `*.test.ts` for unit coverage
+- Vitest; integration tests excluded from `tsc --build` (memory:
+  `project_integration_tests_not_typechecked` — grep manually for
+  renamed APIs).
+
+## 8. Glossary
+
+- **AppHost** — Server-side dispatcher routing app-callback RPCs
+  (`dispatch/authorize`, `messages/authorize`, hook RPCs) to the
+  registered moderator connection. Owns the in-process + remote hook
+  registries; emits `dispatch/release` and `participants/removed`
+  notifications post-verdict.
+- **TM (Task Manager)** — Authority for a task's conversation set.
+  Default-TM (UUID-bound `DEFAULT_DM_TM_ADDRESS` / `DEFAULT_GROUP_TM_ADDRESS`)
+  for ordinary DMs/groups; app-bound `tm:app:<uuid>` for app-moderated
+  tasks. The `tm_endpoint_address` column on `tasks` is the routing key.
+- **Dispatch lease** — Single-use token gating inbound message processing.
+  In-memory state in `LeaseRegistry`; states PENDING → GRANTED / DENIED /
+  HOLD → CLAIMED → CONSUMED / EXPIRED / ABANDONED. Atomic transitions via
+  `Ref.modify`. CLAIMED rollback restores GRANTED on insert failure.
+- **CoreApp** — The composed runtime: services + Kysely + Layers, returned
+  by `createCoreApp` for embedding in a host process. Provides the
+  `registerRpcMethod` / `onConnection` / `setContactService` /
+  `registerMessageAuthorize` extension hooks.
+- **Layer-tag hierarchy** — TypeScript-enforced constraint on which
+  Effect Tags a handler may pull (`TransportTags ⊂ IdentityTags ⊂
+  NetworkTags ⊂ TaskTags ⊂ AppTags`); prevents low-layer code from
+  depending on high-layer services. Enforced via the `R` channel of the
+  handler's Effect.
+- **AgentEndpointResolver** — `AgentId → HashSet<ConnId>` multimap kept
+  fresh by `network/connect` success and the disconnect finalizer. Read
+  by `NetworkSendService` for O(1) outbound routing.
+- **ConnectionManager** — The set of live `MoltZapConnection` records.
+  Provides `getByAgent`, `getByConvId`, `add`, `remove`, `all`.
+- **Hook envelope** — The `wrapHookEffectWithEnvelope` fail-CLOSED wrapper
+  in `app/app-host.ts`. Adds timeout, on-error, and on-timeout fallback
+  verdicts to any hook runner. Used by `dispatchAuthorizeHook` and
+  `runMessageAuthorize`.
+- **ManagedRuntime** — Effect's persistent runtime, built once at
+  `createCoreApp` time from `FullLive`. Drives all dispatch fibers
+  (RPC handlers, HTTP routes, WS finalizers) so handler `yield* Tag`
+  reads resolve structurally without per-frame `Effect.provide`.

--- a/packages/server/docs/architecture/01-service-layer-composition.md
+++ b/packages/server/docs/architecture/01-service-layer-composition.md
@@ -7,112 +7,87 @@ bottom-up. Each tier's outputs feed the next tier's inputs through
 `Layer.provideMerge` (which keeps lower-tier Tags visible to the rest of
 the graph, vs `Layer.provide` which would consume them):
 
-```text
-                          createCoreApp(config)                  app/server.ts → createCoreApp
-                                   │
-                                   ▼
-                   BaseLive = Layer.mergeAll(
-                     Layer.succeed(DbTag, db),
-                     Layer.succeed(EncryptionTag, envelope),
-                     Layer.succeed(SessionValidatorTag, sv),
-                     Layer.succeed(WebhookClientTag, http),
-                     Layer.succeed(DeliveryWebhookTag, cfg),
-                     config.traceCaptureLayer ?? NoopTraceCaptureLive,
-                   )                                              app/server.ts → createCoreApp (BaseLive block)
-                                   │
-   ┌───────────────────────────────┴───────────────────────────────┐
-   ▼                                                               │
-ServicesLive = Tier6 (provideMerge composition):                   │ app/layers.ts → Tier 1-6 composition
-                                                                   │
-   Tier1                                                           │
-   ├─ ConnectionManagerLive                                        │
-   ├─ AuthServiceLive          (needs Db)                          │
-   ├─ ParticipantServiceLive   (needs Db)                          │
-   └─ ContactsServiceLive      (needs Db)                          │
-       │                                                           │
-       ▼ provideMerge into                                         │
-   Tier2                                                           │
-   ├─ PresenceServiceLive          (needs ConnectionManager)       │
-   ├─ AgentEndpointResolverLive    (no deps; Ref<HashMap>)         │
-   └─ AppTmRegistryLive            (seeds default-DM/group TMs)    │
-       │                                                           │
-       ▼ provideMerge into                                         │
-   Tier2.5                                                         │
-   └─ NetworkSendServiceLive       (needs Resolver + Connections   │
-                                         + AppTmRegistry)          │
-       │                                                           │
-       ▼ provideMerge into                                         │
-   Tier2.6                                                         │
-   └─ LeaseRegistryLive            (needs ConnectionManager)       │
-       │                                                           │
-       ▼ provideMerge into                                         │
-   Tier3                                                           │
-   └─ AppHostLive                  (needs Db + Connections +       │
-                                       LeaseRegistry)              │
-                                    side-effect: registers default │
-                                    messageAuthorize hooks for     │
-                                    DEFAULT_DM/GROUP_TM_ADDRESS    │
-       │                                                           │
-       ▼ provideMerge into                                         │
-   Tier4                                                           │
-   └─ ConversationServiceLive      (needs Db + Participants +      │
-                                        Connections + AppHost)     │
-                                    (AppHost.contactService        │
-                                     captured lazily — post-       │
-                                     construction wire via         │
-                                     setContactService)            │
-       │                                                           │
-       ▼ provideMerge into                                         │
-   Tier5                                                           │
-   └─ MessageServiceLive           (needs every upstream +         │
-                                       Encryption + DeliveryWebhook│
-                                       + Webhook + TraceCapture    │
-                                       + AppHost)                  │
-       │                                                           │
-       ▼ provideMerge into                                         │
-   Tier6                                                           │
-   └─ TaskServiceLive              (needs Db + Conversation +      │
-                                       Message)                    │
-       │                                                           │
-       └────────────────────────────────────┐                      │
-                                            ▼                      │
-                       ServicesWithBase = Layer.provideMerge(  ────┘
-                         ServicesLive, BaseLive)               app/server.ts → createCoreApp (ServicesWithBase)
+```mermaid
+flowchart TD
+    createCoreApp["createCoreApp(config)<br/><i>app/server.ts</i>"]
 
-                                   │
-                                   ▼
-                   WireConvIntoAppHost = Layer.effectDiscard(...)  app/server.ts → createCoreApp (WireConvIntoAppHost)
-                   │  post-construction: appHost.setConversationService(conv)
-                   │  — required because AppHost has a backref into ConversationService
-                   │    for the dispatch-deny path (removeParticipant) but
-                   │    ConversationService is built ABOVE AppHost in the tier order.
-                   ▼
-                   FullLive = Layer.provideMerge(
-                     WireConvIntoAppHost, ServicesWithBase)        app/server.ts → createCoreApp (FullLive)
+    subgraph BaseLive["BaseLive = Layer.mergeAll(…)"]
+        B1["DbTag"]
+        B2["EncryptionTag"]
+        B3["SessionValidatorTag"]
+        B4["WebhookClientTag"]
+        B5["DeliveryWebhookTag"]
+        B6["TraceCaptureLayer"]
+    end
 
-                                   │
-                                   ▼
-                   dispatchRuntime = ManagedRuntime.make(
-                     Layer.mergeAll(NodeHttpServer.layerContext, FullLive)
-                   )                                               app/server.ts → createCoreApp (dispatchRuntime)
-                                   │
-                                   ▼
-                   services = dispatchRuntime.runSync(resolveServices)
-                               ↑                                   app/server.ts → createCoreApp (resolveServices)
-                               │  resolveServices = Effect.all({tag…})
-                               │  produces a plain-object view for non-Effect call sites
-                               │
-                   ┌───────────┴────────────────────────────────────┐
-                   │  Returned CoreApp exposes:                     │
-                   │    • port                                      │
-                   │    • registerRpcMethod  (push onto methods[])  │
-                   │    • onConnection / onDisconnection (hooks)    │
-                   │    • registerApp / registerRemoteApp           │
-                   │    • registerMessageAuthorize / onTaskAuth…    │
-                   │    • setContactService                         │
-                   │    • networkSendService, traceCapture, leases  │
-                   │    • close()                                   │
-                   └────────────────────────────────────────────────┘
+    subgraph ServicesLive["ServicesLive — Tier 1-6 (provideMerge chain) · app/layers.ts"]
+        subgraph Tier1["Tier 1"]
+            T1A["ConnectionManagerLive"]
+            T1B["AuthServiceLive<br/>(needs Db)"]
+            T1C["ParticipantServiceLive<br/>(needs Db)"]
+            T1D["ContactsServiceLive<br/>(needs Db)"]
+        end
+
+        subgraph Tier2["Tier 2"]
+            T2A["PresenceServiceLive<br/>(needs ConnectionManager)"]
+            T2B["AgentEndpointResolverLive<br/>(no deps; Ref&lt;HashMap&gt;)"]
+            T2C["AppTmRegistryLive<br/>(seeds default-DM/group TMs)"]
+        end
+
+        subgraph Tier25["Tier 2.5"]
+            T25["NetworkSendServiceLive<br/>(needs Resolver + Connections + AppTmRegistry)"]
+        end
+
+        subgraph Tier26["Tier 2.6"]
+            T26["LeaseRegistryLive<br/>(needs ConnectionManager)"]
+        end
+
+        subgraph Tier3["Tier 3"]
+            T3["AppHostLive<br/>(needs Db + Connections + LeaseRegistry)<br/>side-effect: registers default messageAuthorize hooks<br/>for DEFAULT_DM/GROUP_TM_ADDRESS"]
+        end
+
+        subgraph Tier4["Tier 4"]
+            T4["ConversationServiceLive<br/>(needs Db + Participants + Connections + AppHost)<br/>AppHost.contactService captured lazily —<br/>post-construction wire via setContactService"]
+        end
+
+        subgraph Tier5["Tier 5"]
+            T5["MessageServiceLive<br/>(needs every upstream +<br/>Encryption + DeliveryWebhook + Webhook + TraceCapture + AppHost)"]
+        end
+
+        subgraph Tier6["Tier 6"]
+            T6["TaskServiceLive<br/>(needs Db + Conversation + Message)"]
+        end
+
+        Tier1 -->|"provideMerge into"| Tier2
+        Tier2 -->|"provideMerge into"| Tier25
+        Tier25 -->|"provideMerge into"| Tier26
+        Tier26 -->|"provideMerge into"| Tier3
+        Tier3 -->|"provideMerge into"| Tier4
+        Tier4 -->|"provideMerge into"| Tier5
+        Tier5 -->|"provideMerge into"| Tier6
+    end
+
+    ServicesWithBase["ServicesWithBase =<br/>Layer.provideMerge(ServicesLive, BaseLive)<br/><i>app/server.ts</i>"]
+
+    WireConv["WireConvIntoAppHost = Layer.effectDiscard(…)<br/>post-construction: appHost.setConversationService(conv)<br/>— AppHost has a backref into ConversationService<br/>for dispatch-deny path (removeParticipant)<br/>but ConversationService is built ABOVE AppHost<br/><i>app/server.ts</i>"]
+
+    FullLive["FullLive = Layer.provideMerge(<br/>WireConvIntoAppHost, ServicesWithBase)<br/><i>app/server.ts</i>"]
+
+    dispatchRuntime["dispatchRuntime = ManagedRuntime.make(<br/>Layer.mergeAll(NodeHttpServer.layerContext, FullLive))<br/><i>app/server.ts</i>"]
+
+    resolveServices["services = dispatchRuntime.runSync(resolveServices)<br/>resolveServices = Effect.all({tag…})<br/>produces a plain-object view for non-Effect call sites<br/><i>app/server.ts</i>"]
+
+    CoreApp["Returned CoreApp exposes:<br/>port · registerRpcMethod · onConnection / onDisconnection<br/>registerApp / registerRemoteApp<br/>registerMessageAuthorize / onTaskAuth…<br/>setContactService<br/>networkSendService · traceCapture · leases<br/>close()"]
+
+    createCoreApp --> BaseLive
+    createCoreApp --> ServicesLive
+    BaseLive --> ServicesWithBase
+    ServicesLive --> ServicesWithBase
+    ServicesWithBase --> WireConv
+    WireConv --> FullLive
+    FullLive --> dispatchRuntime
+    dispatchRuntime --> resolveServices
+    resolveServices --> CoreApp
 ```
 
 The `Layer.provideMerge` discipline (vs `Layer.provide`) is load-bearing:

--- a/packages/server/docs/architecture/01-service-layer-composition.md
+++ b/packages/server/docs/architecture/01-service-layer-composition.md
@@ -1,0 +1,128 @@
+# Service Layer Composition (boot graph)
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`createCoreApp` builds the full service graph via Effect Layers, composed
+bottom-up. Each tier's outputs feed the next tier's inputs through
+`Layer.provideMerge` (which keeps lower-tier Tags visible to the rest of
+the graph, vs `Layer.provide` which would consume them):
+
+```text
+                          createCoreApp(config)                  app/server.ts → createCoreApp
+                                   │
+                                   ▼
+                   BaseLive = Layer.mergeAll(
+                     Layer.succeed(DbTag, db),
+                     Layer.succeed(EncryptionTag, envelope),
+                     Layer.succeed(SessionValidatorTag, sv),
+                     Layer.succeed(WebhookClientTag, http),
+                     Layer.succeed(DeliveryWebhookTag, cfg),
+                     config.traceCaptureLayer ?? NoopTraceCaptureLive,
+                   )                                              app/server.ts → createCoreApp (BaseLive block)
+                                   │
+   ┌───────────────────────────────┴───────────────────────────────┐
+   ▼                                                               │
+ServicesLive = Tier6 (provideMerge composition):                   │ app/layers.ts → Tier 1-6 composition
+                                                                   │
+   Tier1                                                           │
+   ├─ ConnectionManagerLive                                        │
+   ├─ AuthServiceLive          (needs Db)                          │
+   ├─ ParticipantServiceLive   (needs Db)                          │
+   └─ ContactsServiceLive      (needs Db)                          │
+       │                                                           │
+       ▼ provideMerge into                                         │
+   Tier2                                                           │
+   ├─ PresenceServiceLive          (needs ConnectionManager)       │
+   ├─ AgentEndpointResolverLive    (no deps; Ref<HashMap>)         │
+   └─ AppTmRegistryLive            (seeds default-DM/group TMs)    │
+       │                                                           │
+       ▼ provideMerge into                                         │
+   Tier2.5                                                         │
+   └─ NetworkSendServiceLive       (needs Resolver + Connections   │
+                                         + AppTmRegistry)          │
+       │                                                           │
+       ▼ provideMerge into                                         │
+   Tier2.6                                                         │
+   └─ LeaseRegistryLive            (needs ConnectionManager)       │
+       │                                                           │
+       ▼ provideMerge into                                         │
+   Tier3                                                           │
+   └─ AppHostLive                  (needs Db + Connections +       │
+                                       LeaseRegistry)              │
+                                    side-effect: registers default │
+                                    messageAuthorize hooks for     │
+                                    DEFAULT_DM/GROUP_TM_ADDRESS    │
+       │                                                           │
+       ▼ provideMerge into                                         │
+   Tier4                                                           │
+   └─ ConversationServiceLive      (needs Db + Participants +      │
+                                        Connections + AppHost)     │
+                                    (AppHost.contactService        │
+                                     captured lazily — post-       │
+                                     construction wire via         │
+                                     setContactService)            │
+       │                                                           │
+       ▼ provideMerge into                                         │
+   Tier5                                                           │
+   └─ MessageServiceLive           (needs every upstream +         │
+                                       Encryption + DeliveryWebhook│
+                                       + Webhook + TraceCapture    │
+                                       + AppHost)                  │
+       │                                                           │
+       ▼ provideMerge into                                         │
+   Tier6                                                           │
+   └─ TaskServiceLive              (needs Db + Conversation +      │
+                                       Message)                    │
+       │                                                           │
+       └────────────────────────────────────┐                      │
+                                            ▼                      │
+                       ServicesWithBase = Layer.provideMerge(  ────┘
+                         ServicesLive, BaseLive)               app/server.ts → createCoreApp (ServicesWithBase)
+
+                                   │
+                                   ▼
+                   WireConvIntoAppHost = Layer.effectDiscard(...)  app/server.ts → createCoreApp (WireConvIntoAppHost)
+                   │  post-construction: appHost.setConversationService(conv)
+                   │  — required because AppHost has a backref into ConversationService
+                   │    for the dispatch-deny path (removeParticipant) but
+                   │    ConversationService is built ABOVE AppHost in the tier order.
+                   ▼
+                   FullLive = Layer.provideMerge(
+                     WireConvIntoAppHost, ServicesWithBase)        app/server.ts → createCoreApp (FullLive)
+
+                                   │
+                                   ▼
+                   dispatchRuntime = ManagedRuntime.make(
+                     Layer.mergeAll(NodeHttpServer.layerContext, FullLive)
+                   )                                               app/server.ts → createCoreApp (dispatchRuntime)
+                                   │
+                                   ▼
+                   services = dispatchRuntime.runSync(resolveServices)
+                               ↑                                   app/server.ts → createCoreApp (resolveServices)
+                               │  resolveServices = Effect.all({tag…})
+                               │  produces a plain-object view for non-Effect call sites
+                               │
+                   ┌───────────┴────────────────────────────────────┐
+                   │  Returned CoreApp exposes:                     │
+                   │    • port                                      │
+                   │    • registerRpcMethod  (push onto methods[])  │
+                   │    • onConnection / onDisconnection (hooks)    │
+                   │    • registerApp / registerRemoteApp           │
+                   │    • registerMessageAuthorize / onTaskAuth…    │
+                   │    • setContactService                         │
+                   │    • networkSendService, traceCapture, leases  │
+                   │    • close()                                   │
+                   └────────────────────────────────────────────────┘
+```
+
+The `Layer.provideMerge` discipline (vs `Layer.provide`) is load-bearing:
+every downstream tier sees ALL upstream Tags in its R-channel resolution,
+not just the immediately-above tier. That lets RPC handler bodies pull any
+service via `yield* XServiceTag` and have it resolved structurally by the
+shared `dispatchRuntime` — no per-frame `Effect.provide`.
+
+## See also
+
+- [§02 WebSocket connection lifecycle](./02-ws-connection-lifecycle.md)
+- [§06 Lease lifecycle](./06-lease-lifecycle.md)
+- [§09 Shutdown sequence](./09-shutdown-sequence.md)

--- a/packages/server/docs/architecture/02-ws-connection-lifecycle.md
+++ b/packages/server/docs/architecture/02-ws-connection-lifecycle.md
@@ -6,63 +6,31 @@ The `/ws` route upgrades the HTTP request to a Socket, then hands it to
 `handleSocket` which builds a single Scoped Effect for the connection's
 entire lifetime:
 
-```text
-GET /ws (Upgrade: websocket)
-   │
-   ▼ wsRoute: req.upgrade → socket: Socket.Socket           app/server.ts → wsRoute
-   │
-   ▼ handleSocket(socket) — Effect.scoped wrapper           app/server.ts → handleSocket
-   │
-   │  connId = crypto.randomUUID()
-   │  writer = yield* socket.writer
-   │  closeRequested = yield* Deferred.make<void>()
-   │
-   │  ┌─ acquireConnectionRpcClient(connId, write)         transport/connection.ts
-   │  │     makeJsonRpcClient({write, idPrefix})            ── server→client callbacks
-   │  │     scope-bound: finalizer fails every pending Deferred with NotConnectedError
-   │  │
-   │  ▼
-   │  connections.add({
-   │    id, write, shutdown: Deferred.succeed(closeRequested),
-   │    auth: null, lastPong: Date.now(),
-   │    conversationIds: new Set(), mutedConversations: new Set(),
-   │    jsonRpcClient,
-   │  })                                                    app/server.ts → handleSocket (connections.add)
-   │
-   ▼  reader = socket.runRaw(data => handleFrame(decode(data)))
-   │
-   ▼  Effect.raceFirst(reader, Deferred.await(closeRequested))
-   │       ↑
-   │       │ ── raceFirst (not race): an abnormal close that completes the
-   │       │     reader fiber before anyone calls shutdown still triggers
-   │       │     onExit. With plain `race`, abrupt disconnects leak.
-   │       │
-   ▼  Effect.onExit(exit => /* cleanup */)
-        │
-        ├─ if (authCtx) presenceService.setOffline(agentId)
-        │
-        ├─ for hook of disconnectionHooks:
-        │     runUserHook(hook, {agentId, ownerUserId, connId},
-        │                  "Disconnection hook", logContext)
-        │     # SEQUENTIAL (not parallel) — earlier hook's cleanup
-        │     # (e.g. last_seen_at write) completes before next hook
-        │     # observes post-close state.
-        │
-        ├─ if (authCtx)
-        │     agentEndpointResolver.remove(agentId, connId)
-        │     # Slice G1 plan §2.11 — drops the multimap entry
-        │
-        ├─ leaseRegistry.abandon(connId)                    app/server.ts → handleSocket (disconnect finalizer)
-        │     # #529 reshape: drain leases bound to this connection
-        │     #   PENDING → ABANDONED
-        │     #   GRANTED/HOLD → EXPIRED-on-disconnect
-        │     #   CLAIMED → no-op (load-bearing: in-flight messages/send
-        │     #                     owns the lease via acquireUseRelease)
-        │
-        ├─ presenceService.removeConnection(connId)
-        ├─ connections.remove(connId)
-        │
-        └─ logInfo("WebSocket disconnected", {connId})
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant WS as wsRoute<br/>(app/server.ts)
+    participant HS as handleSocket<br/>(app/server.ts)
+    participant RPC as acquireConnectionRpcClient<br/>(transport/connection.ts)
+    participant CM as connections (ConnectionManager)
+    participant Reader as socket reader fiber
+    participant Cleanup as onExit cleanup
+
+    C->>WS: GET /ws (Upgrade: websocket)
+    WS->>HS: req.upgrade → socket: Socket.Socket
+    Note over HS: connId = crypto.randomUUID()<br/>writer = yield* socket.writer<br/>closeRequested = yield* Deferred.make&lt;void&gt;()
+    HS->>RPC: acquireConnectionRpcClient(connId, write)
+    Note over RPC: makeJsonRpcClient({write, idPrefix})<br/>scope-bound: finalizer fails every<br/>pending Deferred with NotConnectedError
+    RPC-->>HS: jsonRpcClient
+    HS->>CM: connections.add({id, write, shutdown, auth: null,<br/>lastPong, conversationIds, mutedConversations, jsonRpcClient})
+    HS->>Reader: socket.runRaw(data => handleFrame(decode(data)))
+    Note over HS,Reader: Effect.raceFirst(reader, Deferred.await(closeRequested))<br/>raceFirst (not race): abrupt disconnect still triggers onExit;<br/>plain `race` would leak on abnormal close
+    Reader-->>Cleanup: connection closes (normal or abrupt)
+    Note over Cleanup: if (authCtx) presenceService.setOffline(agentId)
+    Note over Cleanup: for hook of disconnectionHooks:<br/>runUserHook(hook, {agentId, ownerUserId, connId}, …)<br/>SEQUENTIAL — earlier hook's cleanup completes<br/>before next hook observes post-close state
+    Note over Cleanup: if (authCtx)<br/>agentEndpointResolver.remove(agentId, connId)<br/>(Slice G1 plan §2.11 — drops multimap entry)
+    Note over Cleanup: leaseRegistry.abandon(connId)<br/>PENDING → ABANDONED<br/>GRANTED/HOLD → EXPIRED-on-disconnect<br/>CLAIMED → no-op (load-bearing: in-flight<br/>messages/send owns lease via acquireUseRelease)
+    Note over Cleanup: presenceService.removeConnection(connId)<br/>connections.remove(connId)<br/>logInfo("WebSocket disconnected", {connId})
 ```
 
 ## See also

--- a/packages/server/docs/architecture/02-ws-connection-lifecycle.md
+++ b/packages/server/docs/architecture/02-ws-connection-lifecycle.md
@@ -1,0 +1,72 @@
+# WebSocket Connection Lifecycle (per-connection Scope)
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+The `/ws` route upgrades the HTTP request to a Socket, then hands it to
+`handleSocket` which builds a single Scoped Effect for the connection's
+entire lifetime:
+
+```text
+GET /ws (Upgrade: websocket)
+   │
+   ▼ wsRoute: req.upgrade → socket: Socket.Socket           app/server.ts → wsRoute
+   │
+   ▼ handleSocket(socket) — Effect.scoped wrapper           app/server.ts → handleSocket
+   │
+   │  connId = crypto.randomUUID()
+   │  writer = yield* socket.writer
+   │  closeRequested = yield* Deferred.make<void>()
+   │
+   │  ┌─ acquireConnectionRpcClient(connId, write)         transport/connection.ts
+   │  │     makeJsonRpcClient({write, idPrefix})            ── server→client callbacks
+   │  │     scope-bound: finalizer fails every pending Deferred with NotConnectedError
+   │  │
+   │  ▼
+   │  connections.add({
+   │    id, write, shutdown: Deferred.succeed(closeRequested),
+   │    auth: null, lastPong: Date.now(),
+   │    conversationIds: new Set(), mutedConversations: new Set(),
+   │    jsonRpcClient,
+   │  })                                                    app/server.ts → handleSocket (connections.add)
+   │
+   ▼  reader = socket.runRaw(data => handleFrame(decode(data)))
+   │
+   ▼  Effect.raceFirst(reader, Deferred.await(closeRequested))
+   │       ↑
+   │       │ ── raceFirst (not race): an abnormal close that completes the
+   │       │     reader fiber before anyone calls shutdown still triggers
+   │       │     onExit. With plain `race`, abrupt disconnects leak.
+   │       │
+   ▼  Effect.onExit(exit => /* cleanup */)
+        │
+        ├─ if (authCtx) presenceService.setOffline(agentId)
+        │
+        ├─ for hook of disconnectionHooks:
+        │     runUserHook(hook, {agentId, ownerUserId, connId},
+        │                  "Disconnection hook", logContext)
+        │     # SEQUENTIAL (not parallel) — earlier hook's cleanup
+        │     # (e.g. last_seen_at write) completes before next hook
+        │     # observes post-close state.
+        │
+        ├─ if (authCtx)
+        │     agentEndpointResolver.remove(agentId, connId)
+        │     # Slice G1 plan §2.11 — drops the multimap entry
+        │
+        ├─ leaseRegistry.abandon(connId)                    app/server.ts → handleSocket (disconnect finalizer)
+        │     # #529 reshape: drain leases bound to this connection
+        │     #   PENDING → ABANDONED
+        │     #   GRANTED/HOLD → EXPIRED-on-disconnect
+        │     #   CLAIMED → no-op (load-bearing: in-flight messages/send
+        │     #                     owns the lease via acquireUseRelease)
+        │
+        ├─ presenceService.removeConnection(connId)
+        ├─ connections.remove(connId)
+        │
+        └─ logInfo("WebSocket disconnected", {connId})
+```
+
+## See also
+
+- [§03 Request → response handling](./03-request-response-handling.md)
+- [§06 Lease lifecycle](./06-lease-lifecycle.md) — `leaseRegistry.abandon` detail
+- [§09 Shutdown sequence](./09-shutdown-sequence.md) — `conn.shutdown` signal

--- a/packages/server/docs/architecture/02-ws-connection-lifecycle.md
+++ b/packages/server/docs/architecture/02-ws-connection-lifecycle.md
@@ -9,28 +9,28 @@ entire lifetime:
 ```mermaid
 sequenceDiagram
     participant C as Client
-    participant WS as wsRoute<br/>(app/server.ts)
-    participant HS as handleSocket<br/>(app/server.ts)
-    participant RPC as acquireConnectionRpcClient<br/>(transport/connection.ts)
+    participant WS as wsRoute
+    participant HS as handleSocket
+    participant RPC as acquireConnectionRpcClient
     participant CM as connections (ConnectionManager)
     participant Reader as socket reader fiber
     participant Cleanup as onExit cleanup
 
     C->>WS: GET /ws (Upgrade: websocket)
     WS->>HS: req.upgrade → socket: Socket.Socket
-    Note over HS: connId = crypto.randomUUID()<br/>writer = yield* socket.writer<br/>closeRequested = yield* Deferred.make&lt;void&gt;()
+    Note over HS: connId = crypto.randomUUID()<br>writer = yield* socket.writer<br>closeRequested = yield* Deferred.make<void>()
     HS->>RPC: acquireConnectionRpcClient(connId, write)
-    Note over RPC: makeJsonRpcClient({write, idPrefix})<br/>scope-bound: finalizer fails every<br/>pending Deferred with NotConnectedError
+    Note over RPC: makeJsonRpcClient({write, idPrefix})<br>scope-bound: finalizer fails every<br>pending Deferred with NotConnectedError
     RPC-->>HS: jsonRpcClient
-    HS->>CM: connections.add({id, write, shutdown, auth: null,<br/>lastPong, conversationIds, mutedConversations, jsonRpcClient})
+    HS->>CM: connections.add({id, write, shutdown, auth: null,<br>lastPong, conversationIds, mutedConversations, jsonRpcClient})
     HS->>Reader: socket.runRaw(data => handleFrame(decode(data)))
-    Note over HS,Reader: Effect.raceFirst(reader, Deferred.await(closeRequested))<br/>raceFirst (not race): abrupt disconnect still triggers onExit;<br/>plain `race` would leak on abnormal close
+    Note over HS,Reader: Effect.raceFirst(reader, Deferred.await(closeRequested))<br>raceFirst (not race): abrupt disconnect still triggers onExit—<br>plain `race` would leak on abnormal close
     Reader-->>Cleanup: connection closes (normal or abrupt)
     Note over Cleanup: if (authCtx) presenceService.setOffline(agentId)
-    Note over Cleanup: for hook of disconnectionHooks:<br/>runUserHook(hook, {agentId, ownerUserId, connId}, …)<br/>SEQUENTIAL — earlier hook's cleanup completes<br/>before next hook observes post-close state
-    Note over Cleanup: if (authCtx)<br/>agentEndpointResolver.remove(agentId, connId)<br/>(Slice G1 plan §2.11 — drops multimap entry)
-    Note over Cleanup: leaseRegistry.abandon(connId)<br/>PENDING → ABANDONED<br/>GRANTED/HOLD → EXPIRED-on-disconnect<br/>CLAIMED → no-op (load-bearing: in-flight<br/>messages/send owns lease via acquireUseRelease)
-    Note over Cleanup: presenceService.removeConnection(connId)<br/>connections.remove(connId)<br/>logInfo("WebSocket disconnected", {connId})
+    Note over Cleanup: for hook of disconnectionHooks:<br>runUserHook(hook, {agentId, ownerUserId, connId}, …)<br>SEQUENTIAL — earlier hook's cleanup completes<br>before next hook observes post-close state
+    Note over Cleanup: if (authCtx)<br>agentEndpointResolver.remove(agentId, connId)<br>(Slice G1 plan §2.11 — drops multimap entry)
+    Note over Cleanup: leaseRegistry.abandon(connId)<br>PENDING → ABANDONED<br>GRANTED/HOLD → EXPIRED-on-disconnect<br>CLAIMED → no-op (load-bearing: in-flight<br>messages/send owns lease via acquireUseRelease)
+    Note over Cleanup: presenceService.removeConnection(connId)<br>connections.remove(connId)<br>logInfo("WebSocket disconnected", {connId})
 ```
 
 ## See also

--- a/packages/server/docs/architecture/03-request-response-handling.md
+++ b/packages/server/docs/architecture/03-request-response-handling.md
@@ -5,71 +5,44 @@
 `handleFrame(raw)` decodes once via `decodeClientInbound` (from `@moltzap/protocol`),
 then `Match.value` routes by the discriminated tag:
 
-```text
-raw string from socket
-   │
-   ▼ JSON.parse  ────────────── parse fail →  handleParseFailure (rate-limited log)
-   │                                          + sendFrame(encodeErrorResponse(
-   │                                              null, {code: -32700,
-   │                                              message: "Invalid JSON"}))
-   │
-   ▼ decodeClientInbound(parsed)              ── @moltzap/protocol → rpc-registry.ts → decodeClientInbound
-   │
-   │       MalformedFrameError  →  sendInvalidRequest(null)
-   │
-   ▼ Match.value(decoded).pipe(
-        Match.tag("ResponseSuccess", ({id, result}) => handleResponseFrame(...)),
-        Match.tag("ResponseError",   ({id, error})  => handleResponseFrame(...)),
-        Match.tag("Notification",    () => sendInvalidRequest(null)),  ← server doesn't take notifications
-        Match.tag("ClientRequest",   ({definition, params, id}) =>
-                                       handleRequestFrame(
-                                         definition.encodeRequest(id, params))),
-        Match.exhaustive,
-      )                                                      app/server.ts → handleFrame, the Match.value dispatch block
-   │
-   │
-   ┌── ClientRequest path ──┐         ┌── Response* path ────┐
-   ▼                        │         ▼                       │
-handleRequestFrame(frame)             handleResponseFrame(frame)
-   │                                  │
-   ▼ conn = connections.get(connId)   ▼  conn.jsonRpcClient.resolve(frame)
-   │   if undefined → return          │      ↑
-   │                                  │      │  routes the response to the
-   ▼ isConnect = frame.method ===     │      │  Deferred this server-side
-   │            Connect.name          │      │  client created when calling
-   │                                  │      │  out via dispatch/authorize
-   ▼ !isConnect && !conn.auth         │      │  or any other S→C callback
-   │   → sendFrame(encodeErrorResp(   │      │
-   │     id, {code: Unauthorized,     │      ▼  matched? log warning if no
-   │      message: "Not authenticated.│         pending entry matches
-   │      Send network/connect first."}))
-   │
-   ▼ jsonRpcServer.handle(frame, {auth, connId})    ── @moltzap/protocol
-   │                                                   makeJsonRpcServer.handle
-   │
-   │  Inside makeJsonRpcServer:
-   │   ─ handlerByMethod.get(frame.method)
-   │   ─ decodeRpcParams(handler.definition, frame.params)
-   │   ─ rpcHandler.handle(params, ctx) — Effect<unknown, unknown, R>
-   │     ↑
-   │     │ runs INSIDE dispatchRuntime so R = AppTags is resolved
-   │     │ structurally; the handler body can `yield* XServiceTag`
-   │     │ freely.
-   │     ▼
-   │   ─ Exit.isSuccess  → successResponse(frame, ms, value)
-   │     Exit.isFailure  → failureResponse(frame, ms, cause)
-   │                          ├─ tagged error in registry → knownWireErrorResponse
-   │                          └─ otherwise → internalErrorResponse (-32603)
-   │
-   ▼ sendFrame(response)
-   │
-   ▼ if (isConnect) fireConnectionHooks
-        │
-        ├─ db.selectFrom("agents").select("name")...
-        ├─ for hook of connectionHooks:
-        │     runUserHook(hook, {agentId, agentName, ownerUserId, connId},
-        │                  "Connection hook", logContext)
-        │     # USER_HOOK_TIMEOUT_MS = 2_000
+```mermaid
+flowchart TD
+    A["raw string from socket"]
+    A -->|"JSON.parse"| B{"parse ok?"}
+    B -->|"fail"| B1["handleParseFailure (rate-limited log)<br/>+ sendFrame(encodeErrorResponse(null,<br/>{code: -32700, message: 'Invalid JSON'}))"]
+    B -->|"ok"| C["decodeClientInbound(parsed)<br/><i>@moltzap/protocol → rpc-registry.ts</i>"]
+    C -->|"MalformedFrameError"| C1["sendInvalidRequest(null)"]
+    C -->|"ok"| D["Match.value(decoded)<br/><i>app/server.ts → handleFrame</i>"]
+
+    D -->|"ResponseSuccess / ResponseError"| E["handleResponseFrame(frame)"]
+    D -->|"Notification"| D1["sendInvalidRequest(null)<br/>(server doesn't accept notifications)"]
+    D -->|"ClientRequest"| F["handleRequestFrame(frame)"]
+
+    E --> E1["conn.jsonRpcClient.resolve(frame)<br/>routes response to the Deferred created<br/>when calling out via dispatch/authorize<br/>or any other S→C callback"]
+    E1 --> E2{"pending entry<br/>matched?"}
+    E2 -->|"no"| E3["log warning"]
+
+    F --> F1{"conn = connections.get(connId)<br/>found?"}
+    F1 -->|"no"| F1a["return"]
+    F1 -->|"yes"| F2["isConnect = (frame.method === Connect.name)"]
+    F2 --> F3{"!isConnect &&<br/>!conn.auth?"}
+    F3 -->|"yes"| F3a["sendFrame(encodeErrorResp(id,<br/>{code: Unauthorized,<br/>message: 'Not authenticated.<br/>Send network/connect first.'})"]
+    F3 -->|"no"| F4["jsonRpcServer.handle(frame, {auth, connId})<br/><i>@moltzap/protocol → makeJsonRpcServer.handle</i>"]
+
+    F4 --> F5["handlerByMethod.get(frame.method)<br/>decodeRpcParams(handler.definition, frame.params)<br/>rpcHandler.handle(params, ctx)<br/>runs inside dispatchRuntime — R = AppTags resolved<br/>structurally; handler body can yield* XServiceTag freely"]
+
+    F5 --> F6{"Exit?"}
+    F6 -->|"isSuccess"| F6a["successResponse(frame, ms, value)"]
+    F6 -->|"isFailure — tagged error"| F6b["knownWireErrorResponse"]
+    F6 -->|"isFailure — untagged"| F6c["internalErrorResponse (-32603)"]
+
+    F6a --> G["sendFrame(response)"]
+    F6b --> G
+    F6c --> G
+
+    G --> H{"isConnect?"}
+    H -->|"yes"| I["fireConnectionHooks<br/>db.selectFrom('agents').select('name')…<br/>for hook of connectionHooks:<br/>runUserHook(hook, {agentId, agentName, ownerUserId, connId}, …)<br/>USER_HOOK_TIMEOUT_MS = 2_000"]
+    H -->|"no"| J["done"]
 ```
 
 ## See also

--- a/packages/server/docs/architecture/03-request-response-handling.md
+++ b/packages/server/docs/architecture/03-request-response-handling.md
@@ -1,0 +1,79 @@
+# Request → Response Handling
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`handleFrame(raw)` decodes once via `decodeClientInbound` (from `@moltzap/protocol`),
+then `Match.value` routes by the discriminated tag:
+
+```text
+raw string from socket
+   │
+   ▼ JSON.parse  ────────────── parse fail →  handleParseFailure (rate-limited log)
+   │                                          + sendFrame(encodeErrorResponse(
+   │                                              null, {code: -32700,
+   │                                              message: "Invalid JSON"}))
+   │
+   ▼ decodeClientInbound(parsed)              ── @moltzap/protocol → rpc-registry.ts → decodeClientInbound
+   │
+   │       MalformedFrameError  →  sendInvalidRequest(null)
+   │
+   ▼ Match.value(decoded).pipe(
+        Match.tag("ResponseSuccess", ({id, result}) => handleResponseFrame(...)),
+        Match.tag("ResponseError",   ({id, error})  => handleResponseFrame(...)),
+        Match.tag("Notification",    () => sendInvalidRequest(null)),  ← server doesn't take notifications
+        Match.tag("ClientRequest",   ({definition, params, id}) =>
+                                       handleRequestFrame(
+                                         definition.encodeRequest(id, params))),
+        Match.exhaustive,
+      )                                                      app/server.ts → handleFrame, the Match.value dispatch block
+   │
+   │
+   ┌── ClientRequest path ──┐         ┌── Response* path ────┐
+   ▼                        │         ▼                       │
+handleRequestFrame(frame)             handleResponseFrame(frame)
+   │                                  │
+   ▼ conn = connections.get(connId)   ▼  conn.jsonRpcClient.resolve(frame)
+   │   if undefined → return          │      ↑
+   │                                  │      │  routes the response to the
+   ▼ isConnect = frame.method ===     │      │  Deferred this server-side
+   │            Connect.name          │      │  client created when calling
+   │                                  │      │  out via dispatch/authorize
+   ▼ !isConnect && !conn.auth         │      │  or any other S→C callback
+   │   → sendFrame(encodeErrorResp(   │      │
+   │     id, {code: Unauthorized,     │      ▼  matched? log warning if no
+   │      message: "Not authenticated.│         pending entry matches
+   │      Send network/connect first."}))
+   │
+   ▼ jsonRpcServer.handle(frame, {auth, connId})    ── @moltzap/protocol
+   │                                                   makeJsonRpcServer.handle
+   │
+   │  Inside makeJsonRpcServer:
+   │   ─ handlerByMethod.get(frame.method)
+   │   ─ decodeRpcParams(handler.definition, frame.params)
+   │   ─ rpcHandler.handle(params, ctx) — Effect<unknown, unknown, R>
+   │     ↑
+   │     │ runs INSIDE dispatchRuntime so R = AppTags is resolved
+   │     │ structurally; the handler body can `yield* XServiceTag`
+   │     │ freely.
+   │     ▼
+   │   ─ Exit.isSuccess  → successResponse(frame, ms, value)
+   │     Exit.isFailure  → failureResponse(frame, ms, cause)
+   │                          ├─ tagged error in registry → knownWireErrorResponse
+   │                          └─ otherwise → internalErrorResponse (-32603)
+   │
+   ▼ sendFrame(response)
+   │
+   ▼ if (isConnect) fireConnectionHooks
+        │
+        ├─ db.selectFrom("agents").select("name")...
+        ├─ for hook of connectionHooks:
+        │     runUserHook(hook, {agentId, agentName, ownerUserId, connId},
+        │                  "Connection hook", logContext)
+        │     # USER_HOOK_TIMEOUT_MS = 2_000
+```
+
+## See also
+
+- [§02 WebSocket connection lifecycle](./02-ws-connection-lifecycle.md) — how the socket and reader fiber are set up
+- [§04 Server-initiated callback](./04-server-initiated-callback.md) — `handleResponseFrame` settles server-originated Deferreds
+- [§07 HTTP routes](./07-http-routes.md) — parallel HTTP surface

--- a/packages/server/docs/architecture/04-server-initiated-callback.md
+++ b/packages/server/docs/architecture/04-server-initiated-callback.md
@@ -7,59 +7,41 @@ forks a fiber that calls **out** to the moderator. The reverse direction
 uses the same `@moltzap/protocol` runtimes — `JsonRpcClient` on the server
 side, `JsonRpcServer` on the moderator's client side:
 
-```text
-recipient sends inbound message
-       │
-       ▼  messages.handlers → MessageService.send → AppHost.runAuthorizeDispatch
-       │       (or runMessageAuthorize for #560 path)
-       │
-       ▼  app/app-host.ts → dispatchAuthorizeHook
-       │
-       ├──── inProcess hook registered  ────▶  runInProcessHookEffect
-       │                                          (handler runs in-process)
-       │
-       ├──── remote registration found  ────▶  runRemoteHookEffect
-       │                                          (dispatch over WS)
-       │
-       └──── neither                     ────▶  Effect.succeed({decision: "grant"})
+```mermaid
+sequenceDiagram
+    participant Recv as Recipient (client)
+    participant MH as messages.handlers
+    participant MS as MessageService
+    participant AH as AppHost.runAuthorizeDispatch<br/>(app/app-host.ts)
+    participant Mod as Moderator (client)
+    participant LR as LeaseRegistry
 
-         remote path:
-              │
-              ▼  remote = remoteRegistrations.get(appId)
-              ▼  conn = connections.get(remote.connectionId)
-              ▼  conn.jsonRpcClient.call(DispatchAuthorize, params)
-              │                  ↑
-              │                  │  per-connection client minted at
-              │                  │  acquireConnectionRpcClient time
-              │                  │
-              │  ── pending["server-N"] = Deferred ─→ write frame
-              │                                          │
-              │                                          ▼
-              │                                       moderator's wire
-              │                                          │
-              │                                          ▼
-              │                              decodeServerInbound → ServerRequest
-              │                              client-side JsonRpcServer.handle
-              │                              taskCallbackHandlers["dispatch/authorize"]
-              │                              moderator app code → verdict
-              │                                          │
-              │                                          ▼  response frame
-              │
-              ▼  conn.jsonRpcClient.resolve(frame) settles the Deferred
-              ▼  envelope.admission unpacks {decision: grant|deny|hold}
-              │
-              ▼  wrapHookEffectWithEnvelope:
-              │     - timeout (manifest dispatch_authorize.timeout_ms,
-              │                default DEFAULT_APP_HOOK_TIMEOUT_MS)
-              │     - on timeout → {decision: "deny", reason: "timeout"}
-              │     - on RPC error → {decision: "deny", reason: "dispatch/authorize error"}
-              │     ── fail-CLOSED per architect plan §3.4
-              │
-              ▼  back into AppHost.runAuthorizeDispatch
-                 ▼  if deny → leaseRegistry.resolve(leaseId, {deny, reason})
-                              ConversationService.removeParticipant
-                 ▼  if grant → leaseRegistry.resolve(leaseId, {grant})
-                 ▼  emit dispatch/release{verdict} → recipient connection
+    Recv->>MH: inbound message
+    MH->>MS: MessageService.send
+    MS->>AH: runAuthorizeDispatch<br/>(or runMessageAuthorize for #560 path)
+
+    alt inProcess hook registered
+        AH->>AH: runInProcessHookEffect<br/>(handler runs in-process)
+    else remote registration found
+        AH->>AH: runRemoteHookEffect<br/>(dispatch over WS)
+        Note over AH: remote = remoteRegistrations.get(appId)<br/>conn = connections.get(remote.connectionId)
+        AH->>Mod: conn.jsonRpcClient.call(DispatchAuthorize, params)<br/>pending["server-N"] = Deferred → write frame<br/>(per-connection client minted at acquireConnectionRpcClient time)
+        Note over Mod: decodeServerInbound → ServerRequest<br/>client-side JsonRpcServer.handle<br/>taskCallbackHandlers["dispatch/authorize"]<br/>moderator app code → verdict
+        Mod-->>AH: response frame<br/>conn.jsonRpcClient.resolve(frame) settles Deferred<br/>envelope.admission unpacks {decision: grant|deny|hold}
+    else neither
+        AH->>AH: Effect.succeed({decision: "grant"})
+    end
+
+    Note over AH: wrapHookEffectWithEnvelope (fail-CLOSED per architect plan §3.4):<br/>timeout → {decision: "deny", reason: "timeout"}<br/>RPC error → {decision: "deny", reason: "dispatch/authorize error"}
+
+    AH->>LR: leaseRegistry.resolve(leaseId, verdict)
+    alt deny
+        LR-->>AH: DENIED
+        AH->>MS: ConversationService.removeParticipant
+    else grant
+        LR-->>AH: GRANTED
+    end
+    AH->>Recv: emit dispatch/release{verdict}
 ```
 
 The same shape applies to `runMessageAuthorize` (#560) — it's the second

--- a/packages/server/docs/architecture/04-server-initiated-callback.md
+++ b/packages/server/docs/architecture/04-server-initiated-callback.md
@@ -12,27 +12,27 @@ sequenceDiagram
     participant Recv as Recipient (client)
     participant MH as messages.handlers
     participant MS as MessageService
-    participant AH as AppHost.runAuthorizeDispatch<br/>(app/app-host.ts)
+    participant AH as AppHost.runAuthorizeDispatch
     participant Mod as Moderator (client)
     participant LR as LeaseRegistry
 
     Recv->>MH: inbound message
     MH->>MS: MessageService.send
-    MS->>AH: runAuthorizeDispatch<br/>(or runMessageAuthorize for #560 path)
+    MS->>AH: runAuthorizeDispatch<br>(or runMessageAuthorize for #560 path)
 
     alt inProcess hook registered
-        AH->>AH: runInProcessHookEffect<br/>(handler runs in-process)
+        AH->>AH: runInProcessHookEffect<br>(handler runs in-process)
     else remote registration found
-        AH->>AH: runRemoteHookEffect<br/>(dispatch over WS)
-        Note over AH: remote = remoteRegistrations.get(appId)<br/>conn = connections.get(remote.connectionId)
-        AH->>Mod: conn.jsonRpcClient.call(DispatchAuthorize, params)<br/>pending["server-N"] = Deferred → write frame<br/>(per-connection client minted at acquireConnectionRpcClient time)
-        Note over Mod: decodeServerInbound → ServerRequest<br/>client-side JsonRpcServer.handle<br/>taskCallbackHandlers["dispatch/authorize"]<br/>moderator app code → verdict
-        Mod-->>AH: response frame<br/>conn.jsonRpcClient.resolve(frame) settles Deferred<br/>envelope.admission unpacks {decision: grant|deny|hold}
+        AH->>AH: runRemoteHookEffect<br>(dispatch over WS)
+        Note over AH: remote = remoteRegistrations.get(appId)<br>conn = connections.get(remote.connectionId)
+        AH->>Mod: conn.jsonRpcClient.call(DispatchAuthorize, params)<br>pending["server-N"] = Deferred → write frame<br>(per-connection client minted at acquireConnectionRpcClient time)
+        Note over Mod: decodeServerInbound → ServerRequest<br>client-side JsonRpcServer.handle<br>taskCallbackHandlers["dispatch/authorize"]<br>moderator app code → verdict
+        Mod-->>AH: response frame<br>conn.jsonRpcClient.resolve(frame) settles Deferred<br>envelope.admission unpacks {decision: grant|deny|hold}
     else neither
         AH->>AH: Effect.succeed({decision: "grant"})
     end
 
-    Note over AH: wrapHookEffectWithEnvelope (fail-CLOSED per architect plan §3.4):<br/>timeout → {decision: "deny", reason: "timeout"}<br/>RPC error → {decision: "deny", reason: "dispatch/authorize error"}
+    Note over AH: wrapHookEffectWithEnvelope (fail-CLOSED per architect plan §3.4):<br>timeout → {decision: "deny", reason: "timeout"}<br>RPC error → {decision: "deny", reason: "dispatch/authorize error"}
 
     AH->>LR: leaseRegistry.resolve(leaseId, verdict)
     alt deny

--- a/packages/server/docs/architecture/04-server-initiated-callback.md
+++ b/packages/server/docs/architecture/04-server-initiated-callback.md
@@ -1,0 +1,74 @@
+# Server-Initiated Callback (the `dispatch/authorize` path)
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+When an inbound `messages/send` needs admission, `AppHost.runAuthorizeDispatch`
+forks a fiber that calls **out** to the moderator. The reverse direction
+uses the same `@moltzap/protocol` runtimes — `JsonRpcClient` on the server
+side, `JsonRpcServer` on the moderator's client side:
+
+```text
+recipient sends inbound message
+       │
+       ▼  messages.handlers → MessageService.send → AppHost.runAuthorizeDispatch
+       │       (or runMessageAuthorize for #560 path)
+       │
+       ▼  app/app-host.ts → dispatchAuthorizeHook
+       │
+       ├──── inProcess hook registered  ────▶  runInProcessHookEffect
+       │                                          (handler runs in-process)
+       │
+       ├──── remote registration found  ────▶  runRemoteHookEffect
+       │                                          (dispatch over WS)
+       │
+       └──── neither                     ────▶  Effect.succeed({decision: "grant"})
+
+         remote path:
+              │
+              ▼  remote = remoteRegistrations.get(appId)
+              ▼  conn = connections.get(remote.connectionId)
+              ▼  conn.jsonRpcClient.call(DispatchAuthorize, params)
+              │                  ↑
+              │                  │  per-connection client minted at
+              │                  │  acquireConnectionRpcClient time
+              │                  │
+              │  ── pending["server-N"] = Deferred ─→ write frame
+              │                                          │
+              │                                          ▼
+              │                                       moderator's wire
+              │                                          │
+              │                                          ▼
+              │                              decodeServerInbound → ServerRequest
+              │                              client-side JsonRpcServer.handle
+              │                              taskCallbackHandlers["dispatch/authorize"]
+              │                              moderator app code → verdict
+              │                                          │
+              │                                          ▼  response frame
+              │
+              ▼  conn.jsonRpcClient.resolve(frame) settles the Deferred
+              ▼  envelope.admission unpacks {decision: grant|deny|hold}
+              │
+              ▼  wrapHookEffectWithEnvelope:
+              │     - timeout (manifest dispatch_authorize.timeout_ms,
+              │                default DEFAULT_APP_HOOK_TIMEOUT_MS)
+              │     - on timeout → {decision: "deny", reason: "timeout"}
+              │     - on RPC error → {decision: "deny", reason: "dispatch/authorize error"}
+              │     ── fail-CLOSED per architect plan §3.4
+              │
+              ▼  back into AppHost.runAuthorizeDispatch
+                 ▼  if deny → leaseRegistry.resolve(leaseId, {deny, reason})
+                              ConversationService.removeParticipant
+                 ▼  if grant → leaseRegistry.resolve(leaseId, {grant})
+                 ▼  emit dispatch/release{verdict} → recipient connection
+```
+
+The same shape applies to `runMessageAuthorize` (#560) — it's the second
+caller of the unified `wrapHookEffectWithEnvelope` (`app/app-host.ts → runMessageAuthorize`),
+keyed by `EndpointAddress` instead of `appId`, with verdicts in the
+Forward/Block shape instead of grant/deny/hold.
+
+## See also
+
+- [§05 AppHost hook unification](./05-app-host-hook-unification.md) — `wrapHookEffectWithEnvelope` and the registry shape
+- [§06 Lease lifecycle](./06-lease-lifecycle.md) — `leaseRegistry.resolve` state transitions
+- [§03 Request → response handling](./03-request-response-handling.md) — `handleResponseFrame` that settles the Deferred

--- a/packages/server/docs/architecture/05-app-host-hook-unification.md
+++ b/packages/server/docs/architecture/05-app-host-hook-unification.md
@@ -6,48 +6,30 @@ The `Hook<TContext, TResult>` abstraction (`app/hooks.ts`) lets every
 "send context, get verdict" S→C interaction use the same registry +
 resolution + envelope shape:
 
-```text
-                  Hook<TContext, TResult>
-                        │
-   ┌────────────────────┴────────────────────┐
-   ▼                                         ▼
-appId-keyed registry              EndpointAddress-keyed registry
-hooks: Map<AppId, {                messageAuthorizeHooks:
-  taskAuthorizeDispatch?,            Map<EndpointAddress, MessageAuthorizeHook>
-  onClose?,                                  │
-  contactPolicyAllowed?,                    seeded at boot for
-  invalidContacts?,                         DEFAULT_DM_TM_ADDRESS,
-}>                                          DEFAULT_GROUP_TM_ADDRESS
-   │                                      via AppHostLive Effect.gen
-   │                                       │ (registers default hooks in `AppHostLive`
-   │                                       │  in `app/layers.ts`)
-   │  ┌──── remoteRegistrations: Map<AppId, {connectionId}>
-   │  │     (apps/register success → AppHost.registerRemoteApp)
-   │  │
-   │  └────────────┬─────────────────────────┘
-                   │
-                   ▼ Three-step resolution (each hook runner)
-                   │
-              1. lookup in-process registry by primary key
-                   │  found → runInProcessHookEffect(hook, ctx)
-                   │
-              2. derive remote key (appId), look up remoteRegistrations
-                   │  found → runRemoteHookEffect({appId, definition,
-                   │           connectionId, params})
-                   │
-              3. synthetic default
-                   │  messageAuthorize: Forward {recipients: participants\sender}
-                   │  authorizeDispatch: {decision: "grant"}
-                   │
-                   ▼
-              wrapHookEffectWithEnvelope({
-                raw, timeoutMs, onTimeout, onError, log contexts
-              })
-                   │
-                   └─ ALL paths fail-CLOSED:
-                      timeout / handler throw / RPC failure / decode failure
-                      collapse to onTimeout()/onError()
-                      (e.g. messageAuthorize: Block{reason:"tm_unreachable"})
+```mermaid
+flowchart TD
+    Hook["Hook&lt;TContext, TResult&gt;<br/>(app/hooks.ts)"]
+
+    Hook --> RegA["appId-keyed registry<br/>hooks: Map&lt;AppId, {<br/>  taskAuthorizeDispatch?,<br/>  onClose?,<br/>  contactPolicyAllowed?,<br/>  invalidContacts?,<br/>}>"]
+
+    Hook --> RegB["EndpointAddress-keyed registry<br/>messageAuthorizeHooks:<br/>Map&lt;EndpointAddress, MessageAuthorizeHook&gt;<br/>seeded at boot for<br/>DEFAULT_DM_TM_ADDRESS,<br/>DEFAULT_GROUP_TM_ADDRESS<br/>via AppHostLive Effect.gen<br/>(app/layers.ts)"]
+
+    RegA --> Remote["remoteRegistrations: Map&lt;AppId, {connectionId}&gt;<br/>(apps/register success → AppHost.registerRemoteApp)"]
+    RegB --> Remote
+
+    Remote --> Resolve["Three-step resolution (each hook runner)"]
+
+    Resolve --> Step1{"1. lookup in-process registry<br/>by primary key"}
+    Step1 -->|"found"| IP["runInProcessHookEffect(hook, ctx)"]
+    Step1 -->|"not found"| Step2{"2. derive remote key (appId),<br/>look up remoteRegistrations"}
+    Step2 -->|"found"| RP["runRemoteHookEffect({appId, definition,<br/>connectionId, params})"]
+    Step2 -->|"not found"| Step3["3. synthetic default<br/>messageAuthorize: Forward {recipients: participants\\sender}<br/>authorizeDispatch: {decision: 'grant'}"]
+
+    IP --> Envelope["wrapHookEffectWithEnvelope({<br/>raw, timeoutMs, onTimeout, onError, log contexts<br/>})"]
+    RP --> Envelope
+    Step3 --> Envelope
+
+    Envelope --> FailClosed["ALL paths fail-CLOSED:<br/>timeout / handler throw / RPC failure / decode failure<br/>collapse to onTimeout() / onError()<br/>(e.g. messageAuthorize: Block{reason: 'tm_unreachable'})"]
 ```
 
 ## See also

--- a/packages/server/docs/architecture/05-app-host-hook-unification.md
+++ b/packages/server/docs/architecture/05-app-host-hook-unification.md
@@ -1,0 +1,56 @@
+# AppHost Hook Unification
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+The `Hook<TContext, TResult>` abstraction (`app/hooks.ts`) lets every
+"send context, get verdict" S→C interaction use the same registry +
+resolution + envelope shape:
+
+```text
+                  Hook<TContext, TResult>
+                        │
+   ┌────────────────────┴────────────────────┐
+   ▼                                         ▼
+appId-keyed registry              EndpointAddress-keyed registry
+hooks: Map<AppId, {                messageAuthorizeHooks:
+  taskAuthorizeDispatch?,            Map<EndpointAddress, MessageAuthorizeHook>
+  onClose?,                                  │
+  contactPolicyAllowed?,                    seeded at boot for
+  invalidContacts?,                         DEFAULT_DM_TM_ADDRESS,
+}>                                          DEFAULT_GROUP_TM_ADDRESS
+   │                                      via AppHostLive Effect.gen
+   │                                       │ (registers default hooks in `AppHostLive`
+   │                                       │  in `app/layers.ts`)
+   │  ┌──── remoteRegistrations: Map<AppId, {connectionId}>
+   │  │     (apps/register success → AppHost.registerRemoteApp)
+   │  │
+   │  └────────────┬─────────────────────────┘
+                   │
+                   ▼ Three-step resolution (each hook runner)
+                   │
+              1. lookup in-process registry by primary key
+                   │  found → runInProcessHookEffect(hook, ctx)
+                   │
+              2. derive remote key (appId), look up remoteRegistrations
+                   │  found → runRemoteHookEffect({appId, definition,
+                   │           connectionId, params})
+                   │
+              3. synthetic default
+                   │  messageAuthorize: Forward {recipients: participants\sender}
+                   │  authorizeDispatch: {decision: "grant"}
+                   │
+                   ▼
+              wrapHookEffectWithEnvelope({
+                raw, timeoutMs, onTimeout, onError, log contexts
+              })
+                   │
+                   └─ ALL paths fail-CLOSED:
+                      timeout / handler throw / RPC failure / decode failure
+                      collapse to onTimeout()/onError()
+                      (e.g. messageAuthorize: Block{reason:"tm_unreachable"})
+```
+
+## See also
+
+- [§04 Server-initiated callback](./04-server-initiated-callback.md) — `dispatchAuthorizeHook` and `runMessageAuthorize` as the two callers of `wrapHookEffectWithEnvelope`
+- [§06 Lease lifecycle](./06-lease-lifecycle.md) — what happens after a verdict is delivered

--- a/packages/server/docs/architecture/06-lease-lifecycle.md
+++ b/packages/server/docs/architecture/06-lease-lifecycle.md
@@ -5,72 +5,57 @@
 The `LeaseRegistry` is an in-process `Ref<Map<LeaseId, LeaseEntry>>` with
 per-lease TTL fibers; no DB row. State transitions are atomic via `Ref.modify`:
 
-```text
-              ┌──────── lease state machine ────────────┐
-              │                                          │
-              ▼                                          │
-          PENDING ───── moderator verdict ─────────────┐ │
-              │                                        │ │
-              │  conn close                            │ │
-              ▼                                        ▼ │
-          ABANDONED                              GRANTED │
-                                                     │  │
-                                      messages/send  │  │
-                                      claim ────────▶│  │
-                                                     ▼  │
-                                                 CLAIMED│
-                                                     │  │
-                                        insert ok  ──┴─▶│ CONSUMED
-                                                        │
-                                        insert fail ──▶ │ rollback → GRANTED
-                                                        │
-                                          TTL fires  ──▶│ EXPIRED
-                                                        │
-                                   moderator deny ────▶ │ DENIED
-                                                        │
-                                   conn close (G/H) ──▶ │ EXPIRED-on-disconnect
-              │
-              ▼
-          HOLD (moderator returned hold)
-              │
-              ▼ retry on next inbound message in same conversation
-          [re-park → next verdict]
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING
+
+    PENDING --> GRANTED : moderator verdict (grant)
+    PENDING --> DENIED : moderator deny
+    PENDING --> HOLD : moderator returned hold
+    PENDING --> ABANDONED : conn close
+
+    HOLD --> PENDING : retry on next inbound message in same conversation (re-park)
+
+    GRANTED --> CLAIMED : messages/send claim
+    GRANTED --> EXPIRED : TTL fires
+    GRANTED --> EXPIRED_ON_DISCONNECT : conn close (GRANTED/HOLD)
+
+    CLAIMED --> CONSUMED : insert ok
+    CLAIMED --> GRANTED : insert fail (rollback)
+
+    CONSUMED --> [*]
+    DENIED --> [*]
+    ABANDONED --> [*]
+    EXPIRED --> [*]
+    EXPIRED_ON_DISCONNECT --> [*]
 ```
 
-```text
-Recipient flow (with lease):
-   │
-   ▼  dispatch/request (C→S)                  app/handlers/apps.handlers.ts
-   │     ▼
-   │   LeaseRegistry.mint(ctx) → {leaseId, dispatchId}     PENDING
-   │     ▼
-   │   ack returned IMMEDIATELY (no wait on moderator)
-   │     ▼
-   │   Effect.fork: dispatchAuthorizeHook(ctx)
-   │     ↑  moderator round-trip (see §04 server-initiated callback)
-   │     │
-   │     ▼  verdict
-   │   LeaseRegistry.resolve(leaseId, verdict)
-   │     ▼  state → GRANTED | DENIED | HOLD
-   │     ▼
-   │   emit dispatch/release{verdict} to recipient connection
-   │
-   ▼ recipient parks client-side; when release arrives, runs InboundHandler
-   ▼ handler invokes messages/send with dispatchLeaseId
-   │
-   ▼  messages/send handler:
-   │     LeaseRegistry.claim(leaseId) → Claim handle      GRANTED → CLAIMED
-   │     Effect.acquireUseRelease(
-   │       acquire = claim,
-   │       use     = messageService.sendInsert(...) → carrier,
-   │       release = exit → if Exit.isSuccess
-   │                          then claim.finalize(messageId)  CLAIMED → CONSUMED
-   │                          else claim.rollback()           CLAIMED → GRANTED
-   │     )
-   │     messageService.sendCommit(carrier, ...)
-   │     // post-insert side effects: TM routing + broadcast + trace
-   │     // do NOT affect lease state. sendCommit failure leaves lease
-   │     // CONSUMED and durable row intact — caller must not retry.
+```mermaid
+sequenceDiagram
+    participant Recv as Recipient (client)
+    participant AH as apps.handlers<br/>(app/handlers/apps.handlers.ts)
+    participant LR as LeaseRegistry
+    participant Mod as Moderator (round-trip)
+    participant MS as MessageService
+
+    Recv->>AH: dispatch/request (C→S)
+    AH->>LR: LeaseRegistry.mint(ctx)
+    LR-->>AH: {leaseId, dispatchId} — state: PENDING
+    AH-->>Recv: ack returned IMMEDIATELY (no wait on moderator)
+    AH->>Mod: Effect.fork: dispatchAuthorizeHook(ctx)<br/>(moderator round-trip — see §04 server-initiated callback)
+    Mod-->>AH: verdict
+    AH->>LR: LeaseRegistry.resolve(leaseId, verdict)
+    LR-->>AH: state → GRANTED | DENIED | HOLD
+    AH->>Recv: emit dispatch/release{verdict}
+
+    Note over Recv: recipient parks client-side;<br/>when release arrives, runs InboundHandler
+
+    Recv->>MS: messages/send with dispatchLeaseId
+    MS->>LR: LeaseRegistry.claim(leaseId)
+    LR-->>MS: Claim handle — state: GRANTED → CLAIMED
+    Note over MS: Effect.acquireUseRelease(<br/>acquire = claim,<br/>use = messageService.sendInsert(…) → carrier,<br/>release = exit →<br/>  if Exit.isSuccess → claim.finalize(messageId) CLAIMED→CONSUMED<br/>  else → claim.rollback() CLAIMED→GRANTED<br/>)
+    MS->>MS: messageService.sendCommit(carrier, …)
+    Note over MS: post-insert side effects: TM routing + broadcast + trace<br/>do NOT affect lease state.<br/>sendCommit failure leaves lease CONSUMED and durable<br/>row intact — caller must not retry.
 ```
 
 Connection close cleanup (`leaseRegistry.abandon(connId)` in the disconnect

--- a/packages/server/docs/architecture/06-lease-lifecycle.md
+++ b/packages/server/docs/architecture/06-lease-lifecycle.md
@@ -33,7 +33,7 @@ stateDiagram-v2
 ```mermaid
 sequenceDiagram
     participant Recv as Recipient (client)
-    participant AH as apps.handlers<br/>(app/handlers/apps.handlers.ts)
+    participant AH as apps.handlers
     participant LR as LeaseRegistry
     participant Mod as Moderator (round-trip)
     participant MS as MessageService
@@ -42,20 +42,20 @@ sequenceDiagram
     AH->>LR: LeaseRegistry.mint(ctx)
     LR-->>AH: {leaseId, dispatchId} — state: PENDING
     AH-->>Recv: ack returned IMMEDIATELY (no wait on moderator)
-    AH->>Mod: Effect.fork: dispatchAuthorizeHook(ctx)<br/>(moderator round-trip — see §04 server-initiated callback)
+    AH->>Mod: Effect.fork: dispatchAuthorizeHook(ctx)<br>(moderator round-trip — see §04 server-initiated callback)
     Mod-->>AH: verdict
     AH->>LR: LeaseRegistry.resolve(leaseId, verdict)
     LR-->>AH: state → GRANTED | DENIED | HOLD
     AH->>Recv: emit dispatch/release{verdict}
 
-    Note over Recv: recipient parks client-side;<br/>when release arrives, runs InboundHandler
+    Note over Recv: recipient parks client-side—<br>when release arrives, runs InboundHandler
 
     Recv->>MS: messages/send with dispatchLeaseId
     MS->>LR: LeaseRegistry.claim(leaseId)
     LR-->>MS: Claim handle — state: GRANTED → CLAIMED
-    Note over MS: Effect.acquireUseRelease(<br/>acquire = claim,<br/>use = messageService.sendInsert(…) → carrier,<br/>release = exit →<br/>  if Exit.isSuccess → claim.finalize(messageId) CLAIMED→CONSUMED<br/>  else → claim.rollback() CLAIMED→GRANTED<br/>)
+    Note over MS: Effect.acquireUseRelease(<br>acquire = claim,<br>use = messageService.sendInsert(…) → carrier,<br>release = exit →<br>  if Exit.isSuccess → claim.finalize(messageId) CLAIMED→CONSUMED<br>  else → claim.rollback() CLAIMED→GRANTED<br>)
     MS->>MS: messageService.sendCommit(carrier, …)
-    Note over MS: post-insert side effects: TM routing + broadcast + trace<br/>do NOT affect lease state.<br/>sendCommit failure leaves lease CONSUMED and durable<br/>row intact — caller must not retry.
+    Note over MS: post-insert side effects: TM routing + broadcast + trace<br>do NOT affect lease state.<br>sendCommit failure leaves lease CONSUMED and durable<br>row intact — caller must not retry.
 ```
 
 Connection close cleanup (`leaseRegistry.abandon(connId)` in the disconnect

--- a/packages/server/docs/architecture/06-lease-lifecycle.md
+++ b/packages/server/docs/architecture/06-lease-lifecycle.md
@@ -1,0 +1,87 @@
+# Lease Lifecycle (`#529` reshape)
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+The `LeaseRegistry` is an in-process `Ref<Map<LeaseId, LeaseEntry>>` with
+per-lease TTL fibers; no DB row. State transitions are atomic via `Ref.modify`:
+
+```text
+              ┌──────── lease state machine ────────────┐
+              │                                          │
+              ▼                                          │
+          PENDING ───── moderator verdict ─────────────┐ │
+              │                                        │ │
+              │  conn close                            │ │
+              ▼                                        ▼ │
+          ABANDONED                              GRANTED │
+                                                     │  │
+                                      messages/send  │  │
+                                      claim ────────▶│  │
+                                                     ▼  │
+                                                 CLAIMED│
+                                                     │  │
+                                        insert ok  ──┴─▶│ CONSUMED
+                                                        │
+                                        insert fail ──▶ │ rollback → GRANTED
+                                                        │
+                                          TTL fires  ──▶│ EXPIRED
+                                                        │
+                                   moderator deny ────▶ │ DENIED
+                                                        │
+                                   conn close (G/H) ──▶ │ EXPIRED-on-disconnect
+              │
+              ▼
+          HOLD (moderator returned hold)
+              │
+              ▼ retry on next inbound message in same conversation
+          [re-park → next verdict]
+```
+
+```text
+Recipient flow (with lease):
+   │
+   ▼  dispatch/request (C→S)                  app/handlers/apps.handlers.ts
+   │     ▼
+   │   LeaseRegistry.mint(ctx) → {leaseId, dispatchId}     PENDING
+   │     ▼
+   │   ack returned IMMEDIATELY (no wait on moderator)
+   │     ▼
+   │   Effect.fork: dispatchAuthorizeHook(ctx)
+   │     ↑  moderator round-trip (see §04 server-initiated callback)
+   │     │
+   │     ▼  verdict
+   │   LeaseRegistry.resolve(leaseId, verdict)
+   │     ▼  state → GRANTED | DENIED | HOLD
+   │     ▼
+   │   emit dispatch/release{verdict} to recipient connection
+   │
+   ▼ recipient parks client-side; when release arrives, runs InboundHandler
+   ▼ handler invokes messages/send with dispatchLeaseId
+   │
+   ▼  messages/send handler:
+   │     LeaseRegistry.claim(leaseId) → Claim handle      GRANTED → CLAIMED
+   │     Effect.acquireUseRelease(
+   │       acquire = claim,
+   │       use     = messageService.sendInsert(...) → carrier,
+   │       release = exit → if Exit.isSuccess
+   │                          then claim.finalize(messageId)  CLAIMED → CONSUMED
+   │                          else claim.rollback()           CLAIMED → GRANTED
+   │     )
+   │     messageService.sendCommit(carrier, ...)
+   │     // post-insert side effects: TM routing + broadcast + trace
+   │     // do NOT affect lease state. sendCommit failure leaves lease
+   │     // CONSUMED and durable row intact — caller must not retry.
+```
+
+Connection close cleanup (`leaseRegistry.abandon(connId)` in the disconnect
+finalizer): scans all leases bound to that connection, walks the same
+table — PENDING→ABANDONED, GRANTED/HOLD→EXPIRED-on-disconnect, CLAIMED
+no-op. The CLAIMED no-op is load-bearing — without it, a recipient
+disconnect mid-insert could roll back a committed durable row, permitting
+a duplicate retry.
+
+## See also
+
+- [§02 WebSocket connection lifecycle](./02-ws-connection-lifecycle.md) — where `leaseRegistry.abandon` is called in the disconnect finalizer
+- [§04 Server-initiated callback](./04-server-initiated-callback.md) — moderator round-trip that produces the verdict
+- [§05 AppHost hook unification](./05-app-host-hook-unification.md) — how verdicts are shaped by `wrapHookEffectWithEnvelope`

--- a/packages/server/docs/architecture/07-http-routes.md
+++ b/packages/server/docs/architecture/07-http-routes.md
@@ -1,0 +1,27 @@
+# HTTP Route Surface
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Three mounted routes per the conditional mount in `httpApp` (in `app/server.ts`):
+
+| Route | Always | Method | Body | Status codes |
+|---|---|---|---|---|
+| `/health` | yes | GET | — | 200 `{status, connections}` |
+| `/ws` | yes | GET (Upgrade) | — | 101 (upgrade) |
+| `/api/v1/auth/register` | unless `skipDefaultRegisterRoute` | POST | `Register.params` | 201 `{agentId, apiKey, claimToken, claimUrl}`, 400, 403 (invite), 500 |
+| `/api/v1/auth/claim` | unless `skipDefaultRegisterRoute` | POST | `Claim.params` | 200 (idempotent) / 201 (first), 401, 403, 500 |
+| `/api/v1/admin/register-agent` | only when `skipDefaultRegisterRoute=false` AND `registrationSecret` set | POST | superset of `Register.params` + `ownerUserId` | 200 (rotated) / 201 (new), 400, 403, 409, 500 |
+
+All bodied routes funnel through `readValidatedBody` (in `app/server.ts`) for
+shared JSON-decode + Ajv validation. Invite-gate checks use `safeEqual`
+(constant-time) to compare `inviteCode` against `registrationSecret`.
+
+The `/api/v1/auth/claim` success path (`CLAIM_SUCCESS` arm in `app/server.ts`) refreshes
+`conn.auth.ownerUserId` on every live connection of the just-claimed
+agent so subsequent owner-gated RPCs see fresh state
+without needing the client to reconnect (#495).
+
+## See also
+
+- [§02 WebSocket connection lifecycle](./02-ws-connection-lifecycle.md) — `/ws` upgrade path
+- [§03 Request → response handling](./03-request-response-handling.md) — frame handling once upgraded

--- a/packages/server/docs/architecture/08-notification-fanout.md
+++ b/packages/server/docs/architecture/08-notification-fanout.md
@@ -1,0 +1,33 @@
+# Notification Fan-out (PresenceService example)
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Most notifications originate inside a service and reach the wire via
+`ConnectionManager.broadcast` or per-connection `conn.write`. The
+`PresenceEventSink` indirection lets the service emit events without
+knowing about `ConnectionManager` directly:
+
+```text
+PresenceService.setOnline(agentId)              network/services/presence.service.ts
+       │
+       ▼  sink.emit({tag: "PresenceChanged", agentId, status: "online", ts})
+       │      ↑
+       │      │  sink = createConnectionFanOutPresenceEventSink({connections})
+       │      │       network/services/presence-event-sink.ts
+       │      ▼
+       │  for conn of connections.all():
+       │      if conn.subscribesTo(PresenceChanged):
+       │          conn.write(JSON.stringify(PresenceChanged.encode(params)))
+       │
+       ▼  fire-and-forget; sink errors logged but don't block setOnline
+```
+
+This pattern (service emits typed events, sink fans out) repeats for
+participants/{added,removed}, message delivery webhook fan-out, and
+dispatch/release. The single-write-side helps trace lookups: every wire
+emission has one originating service.
+
+## See also
+
+- [§02 WebSocket connection lifecycle](./02-ws-connection-lifecycle.md) — `conn.write` set up at connection time
+- [§04 Server-initiated callback](./04-server-initiated-callback.md) — `dispatch/release` notification emitted post-verdict

--- a/packages/server/docs/architecture/08-notification-fanout.md
+++ b/packages/server/docs/architecture/08-notification-fanout.md
@@ -7,19 +7,16 @@ Most notifications originate inside a service and reach the wire via
 `PresenceEventSink` indirection lets the service emit events without
 knowing about `ConnectionManager` directly:
 
-```text
-PresenceService.setOnline(agentId)              network/services/presence.service.ts
-       │
-       ▼  sink.emit({tag: "PresenceChanged", agentId, status: "online", ts})
-       │      ↑
-       │      │  sink = createConnectionFanOutPresenceEventSink({connections})
-       │      │       network/services/presence-event-sink.ts
-       │      ▼
-       │  for conn of connections.all():
-       │      if conn.subscribesTo(PresenceChanged):
-       │          conn.write(JSON.stringify(PresenceChanged.encode(params)))
-       │
-       ▼  fire-and-forget; sink errors logged but don't block setOnline
+```mermaid
+flowchart LR
+    PS["PresenceService.setOnline(agentId)<br/><i>network/services/presence.service.ts</i>"]
+    Sink["sink.emit({tag: 'PresenceChanged', agentId, status: 'online', ts})<br/>sink = createConnectionFanOutPresenceEventSink({connections})<br/><i>network/services/presence-event-sink.ts</i>"]
+    Fan["for conn of connections.all():<br/>if conn.subscribesTo(PresenceChanged):<br/>conn.write(JSON.stringify(PresenceChanged.encode(params)))"]
+    FF["fire-and-forget<br/>sink errors logged but don't block setOnline"]
+
+    PS -->|"emit"| Sink
+    Sink -->|"fan-out"| Fan
+    Fan --> FF
 ```
 
 This pattern (service emits typed events, sink fans out) repeats for

--- a/packages/server/docs/architecture/09-shutdown-sequence.md
+++ b/packages/server/docs/architecture/09-shutdown-sequence.md
@@ -1,0 +1,41 @@
+# Shutdown Sequence
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+`CoreApp.close()` (in `app/server.ts → close`) tears down in a specific order so
+in-flight work has a chance to finish before its dependencies vanish:
+
+```text
+close()
+   │
+   ▼  messageService.close()
+   │     # interrupt in-flight delivery-webhook retries BEFORE scope close
+   │     # so pending POSTs don't race the HTTP server teardown
+   │
+   ▼  appHost.destroy()
+   │     # clears manifests, in-process hook registries, remote registrations
+   │     # WARNING: runs BEFORE connections close, so an in-flight RPC may
+   │     # observe cleared manifests. SHUTDOWN_DRAIN_MS (500ms) sleep below
+   │     # is the only mitigation today (tracked in /review output 2026-04-16).
+   │
+   ▼  for conn of connections.all():
+   │     yield* conn.shutdown
+   │       # signals the per-connection closeRequested Deferred,
+   │       # which unblocks raceFirst → triggers onExit cleanup
+   │
+   ▼  Effect.sleep(500ms)  ── drain in-flight RPCs
+   │
+   ▼  Scope.close(appScope, Exit.void)
+   │     # tears down NodeHttpServer + upgrade wiring
+   │
+   ▼  dispatchRuntime.dispose()
+   │     # disposes the ManagedRuntime, finalizing service Layers
+   │
+   ▼  config.dbCleanup?.()
+        # optional caller-supplied hook (e.g. PGlite shutdown in tests)
+```
+
+## See also
+
+- [§01 Service layer composition](./01-service-layer-composition.md) — `dispatchRuntime` and `FullLive` that are disposed here
+- [§02 WebSocket connection lifecycle](./02-ws-connection-lifecycle.md) — `conn.shutdown` / `closeRequested` Deferred detail

--- a/packages/server/docs/architecture/09-shutdown-sequence.md
+++ b/packages/server/docs/architecture/09-shutdown-sequence.md
@@ -5,34 +5,18 @@
 `CoreApp.close()` (in `app/server.ts → close`) tears down in a specific order so
 in-flight work has a chance to finish before its dependencies vanish:
 
-```text
-close()
-   │
-   ▼  messageService.close()
-   │     # interrupt in-flight delivery-webhook retries BEFORE scope close
-   │     # so pending POSTs don't race the HTTP server teardown
-   │
-   ▼  appHost.destroy()
-   │     # clears manifests, in-process hook registries, remote registrations
-   │     # WARNING: runs BEFORE connections close, so an in-flight RPC may
-   │     # observe cleared manifests. SHUTDOWN_DRAIN_MS (500ms) sleep below
-   │     # is the only mitigation today (tracked in /review output 2026-04-16).
-   │
-   ▼  for conn of connections.all():
-   │     yield* conn.shutdown
-   │       # signals the per-connection closeRequested Deferred,
-   │       # which unblocks raceFirst → triggers onExit cleanup
-   │
-   ▼  Effect.sleep(500ms)  ── drain in-flight RPCs
-   │
-   ▼  Scope.close(appScope, Exit.void)
-   │     # tears down NodeHttpServer + upgrade wiring
-   │
-   ▼  dispatchRuntime.dispose()
-   │     # disposes the ManagedRuntime, finalizing service Layers
-   │
-   ▼  config.dbCleanup?.()
-        # optional caller-supplied hook (e.g. PGlite shutdown in tests)
+```mermaid
+flowchart LR
+    A["close()<br/><i>app/server.ts → close</i>"]
+    B["messageService.close()<br/>interrupt in-flight delivery-webhook retries<br/>BEFORE scope close — prevents pending POSTs<br/>racing the HTTP server teardown"]
+    C["appHost.destroy()<br/>clears manifests, in-process hook registries,<br/>remote registrations<br/>WARNING: runs BEFORE connections close —<br/>in-flight RPC may observe cleared manifests.<br/>SHUTDOWN_DRAIN_MS (500ms) below is the only<br/>mitigation today (tracked in /review 2026-04-16)"]
+    D["for conn of connections.all():<br/>yield* conn.shutdown<br/>signals per-connection closeRequested Deferred,<br/>unblocks raceFirst → triggers onExit cleanup"]
+    E["Effect.sleep(500ms)<br/>drain in-flight RPCs"]
+    F["Scope.close(appScope, Exit.void)<br/>tears down NodeHttpServer + upgrade wiring"]
+    G["dispatchRuntime.dispose()<br/>disposes ManagedRuntime, finalizing service Layers"]
+    H["config.dbCleanup?.()\noptional caller-supplied hook<br/>(e.g. PGlite shutdown in tests)"]
+
+    A --> B --> C --> D --> E --> F --> G --> H
 ```
 
 ## See also

--- a/packages/server/docs/architecture/09-shutdown-sequence.md
+++ b/packages/server/docs/architecture/09-shutdown-sequence.md
@@ -14,7 +14,7 @@ flowchart LR
     E["Effect.sleep(500ms)<br/>drain in-flight RPCs"]
     F["Scope.close(appScope, Exit.void)<br/>tears down NodeHttpServer + upgrade wiring"]
     G["dispatchRuntime.dispose()<br/>disposes ManagedRuntime, finalizing service Layers"]
-    H["config.dbCleanup?.()\noptional caller-supplied hook<br/>(e.g. PGlite shutdown in tests)"]
+    H["config.dbCleanup?.()<br>optional caller-supplied hook<br/>(e.g. PGlite shutdown in tests)"]
 
     A --> B --> C --> D --> E --> F --> G --> H
 ```


### PR DESCRIPTION
## Summary

Adds 7 per-package `ARCHITECTURE.md` index files plus 53 detail docs under `packages/*/docs/architecture/`. Each index links out to deep sequence diagrams, state machines, and request/response walkthroughs for the package — **~4,800 lines of docs total, no source code touched.**

Format adapts [architecture.md](https://architecture.md/) to package scope: skips repo-level sections (CI/CD, deploy, cloud-provider) and keeps what's load-bearing per-package — structure, public surface, communication flows, dependencies, tests, glossary.

## Per package

| Package | Index | Detail docs |
|---|---:|---:|
| `protocol` | 111 lines | 10 — frame decode (both sides), RPC server/client lifecycle, end-to-end `messages/send`, server-initiated callback (`dispatch/authorize`), tagged error registry, conformance suite, layer DAG |
| `client` | 81 lines | 7 — connection lifecycle + reconnect, outbound `messages/send`, inbound dispatch + lease state machine, notification subscription, error taxonomy, CLI flows, state machines |
| `server` | 173 lines | 9 — Tier 1-6 Layer composition, WS connection scope, request/response routing, server-initiated callback, AppHost hook unification (3-step resolution + fail-CLOSED envelope), lease lifecycle, HTTP routes, notification fan-out, shutdown |
| `runtimes` | 76 lines | 7 — single-runtime startup, fleet launch + interruption, per-adapter spawn details (OpenClaw / Nanoclaw / ClaudeCode), workspace path resolution, shutdown propagation, error matrix, process state machine |
| `claude-code-channel` | 81 lines | 6 — boot sequence, inbound→Claude push, Claude reply→MoltZap outbound, lease state machine, allowlist gating, shutdown |
| `openclaw-channel` | 78 lines | 7 — `startAccount` lifecycle, outbound `sendText` Effect↔Promise boundary, inbound `onInbound` (the ~500-line Effect.gen), 5 notification extractors, `deliver()` error handling, `stopAccount`, `resolveTarget` |
| `nanoclaw-channel` | 71 lines | 7 — construction + `registerChannel` hook, connect/disconnect, inbound 5-step pipeline, outbound `sendMessage`, JID conversions, `emitChatMetadata` + `ensureAutoRegistered`, `toNewMessage` projection |

## Citation style

All cross-references to source code use **grep-stable symbol names** (`file.ts → functionName`) rather than `file.ts:NNN`. Line numbers rot at every refactor; symbol names survive. Zero `:NNN` citations remain across the 60 files.

For code blocks inside a function, citations use enclosing-function + verbal pointer (e.g. `server.ts → handleFrame, the Match.value dispatch block`) so the reader can scroll-find the block within the function.

## Test plan

- [ ] Read each package's top-level `ARCHITECTURE.md` and verify the §1 Project Structure tree matches the actual `src/` layout
- [ ] Spot-check 3-5 detail docs for accuracy of diagrammed flow vs. the actual source
- [ ] Verify all 60 `← Back to ARCHITECTURE` links resolve
- [ ] Verify the index link tables (in each top-level file) all point to existing detail docs
- [ ] Confirm no source files were modified (`git diff main -- ':!packages/*/ARCHITECTURE.md' ':!packages/*/docs/'` should be empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)