### PR TITLE
[impl-junior] #647: clarify zero-participant admission in moltzap start

### DIFF
--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -359,6 +359,9 @@ export const startCommand = Command.make(
       "first message in one atomic step. Spec D2 #599 — composes Spec D1 " +
       "TaskCreate + MessagesSend.\n" +
       "\n" +
+      "Zero participants creates a caller-only task (rare; usually you " +
+      "will pass one or more `agent:<name>` tokens).\n" +
+      "\n" +
       "Exit codes:\n" +
       `  ${EXIT_CODES.SUCCESS}   success (TaskCreate + optional MessagesSend resolved)\n` +
       `  ${EXIT_CODES.TASK_CREATE_FAILED}   TaskCreate failed (stdout empty)\n` +


### PR DESCRIPTION
## Summary

Doc-only edit: adds a help-text line to `startCommand → Command.withDescription` clarifying that zero participants creates a caller-only task.

## Why

#647 (codex-d2-r1 N=2 P3 deferral) flagged that the public synopsis glyph `<participant>...` reads as "one or more" to a cold-start user, but architect plan §R4 admits zero participants (D1 per-flow doc 12 — caller-only tasks). The fix recipe in #647 offered three options; this PR takes **option 2**: a top-level help-text line, since the synopsis glyph itself is auto-generated by `@effect/cli` from `Args.repeated` and unbracket-able without contradicting R4.

## Change

`packages/client/src/cli/commands/start.ts → startCommand`, in the `Command.withDescription` string, adds one paragraph between the summary and the exit-code table:

> Zero participants creates a caller-only task (rare; usually you will pass one or more \`agent:<name>\` tokens).

+3 lines. No code logic, no surface change. Base: `architect/599-moltzap-start`.

## Pre-PR gates

- `/simplify`: clean — 3-line string-concat follows surrounding `+`-concat pattern in the same block; no reuse opportunity (this IS the help-text source).
- `/review`: clean — no risk surface for any /review checklist category (no SQL/race/LLM/shell/enum/coercion/time-window).
- pnpm `--filter @moltzap/client build`: ✅
- pnpm `--filter @moltzap/client lint`: ✅
- pnpm `--filter @moltzap/client test`: ✅ 281 passed
- pre-commit hooks: ✅ tsc + Type Safety / Effect Hygiene / Bare Catch / Test Integrity guards all passed.

## Parent

- Sub-issue: #647
- Plan: #643
- Spec: #599
- Epic: #602

## Test plan
- [x] Workspace build green
- [x] Workspace lint green
- [x] `@moltzap/client` test suite green (281 passed)
- [x] No diff outside `start.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)