### PR TITLE
[impl-junior] #648: scrub 3 stale dead-code citations

### DIFF
--- a/packages/client/src/cli/commands/send.ts
+++ b/packages/client/src/cli/commands/send.ts
@@ -52,9 +52,8 @@ const replyToOption = Options.text("reply-to").pipe(
  * does NOT yet honor `--as`/`--profile` end-to-end — rewiring legacy
  * commands onto the v2 Transport layer is tracked as a follow-up (see the
  * PR body "Concerns" block). The flag semantics documented above describe
- * the v2 contract; new v2 subcommands (`apps/*`, `permissions/*`,
- * `messages list`, `conversations {get,archive,unarchive}`) honor them
- * today.
+ * the v2 contract; new v2 subcommands (`apps/*`, `messages list`,
+ * `conversations {get,archive,unarchive}`) honor them today.
  */
 export const sendCommand = Command.make(
   "send",

--- a/packages/protocol/ARCHITECTURE.md
+++ b/packages/protocol/ARCHITECTURE.md
@@ -25,7 +25,7 @@ packages/protocol/src/
 │   ├── dispatch.ts            # buildServerDispatcher (static-table dispatch + capability auto-provision)
 │   └── typed-dispatcher.types-check.ts  # 6 type canaries on the live typed surface
 │
-├── identity/               # Agents, users, sessions, attestation, contact policy
+├── identity/               # Agents, users, sessions, contact policy
 ├── network/                # Ping, presence, connection liveness, actor-model types
 ├── task/                   # Conversations, messages, dispatch, TM authority
 ├── app/                    # AppHost RPCs (apps/register, dispatch/*, hooks)

--- a/packages/protocol/scripts/docs/schema.ts
+++ b/packages/protocol/scripts/docs/schema.ts
@@ -87,7 +87,6 @@ function methodSortKey(method: string): string {
     "invites",
     "presence",
     "apps",
-    "permissions",
     "system",
   ];
   const prefix = method.split("/")[0] ?? "";


### PR DESCRIPTION
## Summary

Three mechanical doc edits removing stale citations of deleted surfaces, per sub-issue #648.

| # | File | Edit |
|---|------|------|
| 1 | `packages/protocol/scripts/docs/schema.ts` | Drop `"permissions"` from `prefixOrder` array (line 90) |
| 2 | `packages/client/src/cli/commands/send.ts` | Drop `permissions/*` from JSDoc parenthetical (lines 55–57) |
| 3 | `packages/protocol/ARCHITECTURE.md` | Drop `attestation` from `identity/` tree comment (line 28) |

## Verification

Deleted surfaces confirmed absent at HEAD:

- `git grep -l 'permissions/' packages/protocol/src/methods/` → 0 hits
- `git ls-tree -r HEAD --name-only packages/protocol/src/identity/ | grep -i attestation` → 0 hits

## Gates

- `pnpm -r build` ✅ all 7 packages
- `pnpm -r lint` ✅ all 7 packages
- /simplify: no findings (pure deletions; no new code)
- /review: clean (8-line diff below specialist threshold; scope CLEAN)

## Out of scope (per #648)

- `TaskManagerAction` JSDoc at `methods.ts:52` + `hooks.ts:78` — intentional historical design citations, kept.
- Other 6 `permissions` grep hits — false positives or deletion-regression tests, untouched.

Closes #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)