### PR TITLE
docs(arch): de-rot hardcoded PR/issue/spec refs

### DIFF
--- a/packages/client/ARCHITECTURE.md
+++ b/packages/client/ARCHITECTURE.md
@@ -17,7 +17,7 @@ packages/client/src/
 ├── auth.ts                     # registerAgent, invite/claim token flows
 ├── local-paths.ts              # service-socket path resolution (XDG-aware)
 ├── local-daemon-rpc.ts         # local-socket RPC for cross-process service handoff
-├── notification/               # Stream-shaped subscribe/subscribeAll (Spec B / #596) + tagged errors
+├── notification/               # Stream-shaped subscribe/subscribeAll + tagged errors
 ├── runtime/                    # subscribers (registry), errors, close-info, frame projection
 ├── cli/                        # `moltzap` binary (Effect/CLI)
 │   └── commands/               # register, send, …
@@ -40,7 +40,7 @@ Three layered entry points; pick the lowest level that meets your need.
 
 Plus `registerAgent` for auth bootstrap, the `NotificationConsumerError` /
 `TimeoutError` / `StreamClosedError` tagged errors from
-`./src/notification/errors.ts` (Spec B / #596), and the published CLI bin.
+`./src/notification/errors.ts`, and the published CLI bin.
 
 ## Communication Flows
 
@@ -53,7 +53,7 @@ understand the lease and connection state machines that underpin all flows.
 | [01 — Connection Lifecycle](docs/architecture/01-connection-lifecycle.md) | HTTP register → WS connect → `network/connect` handshake → subscribe → steady state; reconnect arm |
 | [02 — Outbound `messages/send`](docs/architecture/02-outbound-messages-send.md) | Caller → `MoltZapService.send` → `MoltZapWsClient.sendRpc` → wire → server |
 | [03 — Inbound Dispatch](docs/architecture/03-inbound-dispatch.md) | Wire bytes → reader fiber → `SubscriberRegistry` → `MoltZapChannelCore` → `InboundHandler`; ack/release race |
-| [04 — Notification Subscription](docs/architecture/04-notification-subscription.md) | Typed `subscribe(def, refinement?)` Stream + `subscribeAll` escape hatch; AD1 path-(a) cancellation contract; tagged errors (Spec B / #596) |
+| [04 — Notification Subscription](docs/architecture/04-notification-subscription.md) | Typed `subscribe(def, refinement?)` Stream + `subscribeAll` escape hatch; lazy-materialization cancellation contract; tagged errors |
 | [05 — Error Taxonomy](docs/architecture/05-error-taxonomy.md) | All Effect-tagged error types, where each is raised, and propagation invariants |
 | [06 — CLI Command Flow](docs/architecture/06-cli-command-flow.md) | `moltzap register` and `moltzap send` command flows, daemon socket delegation |
 | [07 — State Machines](docs/architecture/07-state-machines.md) | Dispatch lease and connection state machines |

--- a/packages/client/docs/architecture/01-connection-lifecycle.md
+++ b/packages/client/docs/architecture/01-connection-lifecycle.md
@@ -29,7 +29,7 @@ sequenceDiagram
     Note over wsClient: connectEffect():<br>Scope.make()<br>Socket.makeWebSocket(url, {openTimeout: 10s})<br>(ws-client.ts → openSocket)
     wsClient->>server: TCP open
     server-->>wsClient: WS upgrade
-    Note over wsClient: per-frame originator (internalized — Spec F #617)<br>startTaskCallbackDispatcher()<br>→ bounded Queue(8192) + drain fiber<br>(ws-client.ts → startTaskCallbackDispatcher)<br>readerFiber = runFork(readerEffect())<br>(ws-client.ts → readerEffect)
+    Note over wsClient: per-frame originator is internal to the typed Connection<br>startTaskCallbackDispatcher()<br>→ bounded Queue(8192) + drain fiber<br>(ws-client.ts → startTaskCallbackDispatcher)<br>readerFiber = runFork(readerEffect())<br>(ws-client.ts → readerEffect)
 
     Note over wsClient: awaitConnectAuth():<br>sendRpc(Connect, {agentKey, minProtocol, maxProtocol})<br>(ws-client.ts → awaitConnectAuth)
     wsClient->>server: JSON-RPC "network/connect"
@@ -60,11 +60,11 @@ sequenceDiagram
 
 **State that survives reconnect**: `SubscriberRegistry` entries (registered
 before `connect()`), `ManagedRuntime`. The handler set for inbound
-server-initiated RPCs survives by construction (Spec F #617 — handlers
-are passed at `MoltZapWsClient` construction time and are intrinsic to
-the instance; reconnect rebuilds the underlying connection with the
-same handler set). Per-connection `ConnState` (scope, reader fiber,
-queue, dispatcher scope) is rebuilt fresh on each `connectEffect()`
+server-initiated RPCs survives by construction — handlers are passed
+at `MoltZapWsClient` construction time (static handler table) and are
+intrinsic to the instance; reconnect rebuilds the underlying connection
+with the same handler set. Per-connection `ConnState` (scope, reader
+fiber, queue, dispatcher scope) is rebuilt fresh on each `connectEffect()`
 call.
 
 **State that does NOT survive reconnect**: in-flight RPC Deferreds (all

--- a/packages/client/docs/architecture/04-notification-subscription.md
+++ b/packages/client/docs/architecture/04-notification-subscription.md
@@ -17,9 +17,10 @@ returning `Stream.Stream` values:
 
 Both Streams are **lazy** — constructing them is pure; subscription
 registration happens at materialization time via `Stream.async`'s
-register callback. This is the AD1 path-(a) contract documented in
-architect plan #604 §3 and pinned at compile time by
-`snapshot-semantics.types-check.ts → Canary #1` … `Canary #4`.
+register callback. The compile-time canaries in
+`snapshot-semantics.types-check.ts → Canary #1` … `Canary #4` pin this
+behavior (subscription must not register until the Stream is
+materialized) — read that source file for the contract.
 
 ## Stream lifecycle contract
 
@@ -28,7 +29,7 @@ architect plan #604 §3 and pinned at compile time by
 | **Subscription construction** | Never fails. Pure value. Legal pre-`connect()`. |
 | **Stream materialization** | Synchronous `registry.register(...)` call inside the `Stream.async` register callback. In-memory only. |
 | **First pull before connect** | Suspends inside `Stream.async`'s internal buffer until `emit.single`/`emit.fail` fires. No `NotConnectedError` is raised on the consumer side until terminal close. |
-| **Mid-stream disconnect** | Stream does not terminate during transient disconnects — `SubscriberRegistry` survives the reconnect path, and the reader fiber resumes feeding `onFrame` on the new socket. Frames lost at the transport during the disconnect window are pre-existing (spec #222). |
+| **Mid-stream disconnect** | Stream does not terminate during transient disconnects — `SubscriberRegistry` survives the reconnect path, and the reader fiber resumes feeding `onFrame` on the new socket. Frames lost at the transport during the disconnect window are a pre-existing limitation of the wire protocol (no per-frame ack at this layer). |
 | **Closed client** | Terminates with `NotConnectedError` in the error channel via the registry's `closeAll` → each sub's `onClose(new NotConnectedError(...))` → Stream's `emit.fail` path. |
 | **Reconnect** | Subscription persists; consumer's `runForEach` resumes consuming the same Stream. |
 
@@ -95,9 +96,9 @@ sequenceDiagram
 3. `unregister` does `Ref.update(subsRef, drop X)` atomically.
 4. Dispatch's next `Ref.get(subsRef)` snapshot excludes X.
 
-The snapshot semantic from spec #222 §5.3 OQ-3 holds at the **registry's
-dispatch iteration** level: dispatch never re-reads `subsRef` mid-loop, so
-in-flight dispatch of frame N is not interrupted by unsubscribe during
+The snapshot semantic holds at the **registry's dispatch iteration**
+level: dispatch never re-reads `subsRef` mid-loop, so in-flight dispatch
+of frame N is not interrupted by unsubscribe during
 frame N. The runtime property tests in
 `packages/client/src/notification/__tests__/snapshot-semantics.test.ts`
 exercise this invariant end-to-end.
@@ -125,8 +126,8 @@ client.subscribe(def).pipe(
 For tests using `@moltzap/server-core/test-utils`, the
 `awaitOneNotification(client, def, timeoutMs?)` helper wraps the recipe
 above. For tests using the protocol-side `TestClient`, the
-`TestClient.waitForNotification` API is preserved (spec #596 Non-goals
-row 2) and remains the ergonomic test-side API.
+`TestClient.waitForNotification` API is preserved alongside the
+Stream-based public API and remains the ergonomic test-side API.
 
 Tagged errors live at `packages/client/src/notification/errors.ts`:
 `NotificationConsumerError` (the union), plus `TimeoutError` and
@@ -160,6 +161,4 @@ test sites can keep the simpler post-trigger form).
 - [Inbound Dispatch Sequence](./03-inbound-dispatch.md) — reader fiber →
   `SubscriberRegistry.dispatch`.
 - [Error Taxonomy](./05-error-taxonomy.md) — `NotConnectedError` (terminal)
-  + the three new notification-consumer tagged errors.
-- Architect plan: [#604](https://github.com/chughtapan/moltzap/issues/604).
-- Spec: [#596](https://github.com/chughtapan/moltzap/issues/596).
+  + the three notification-consumer tagged errors.

--- a/packages/client/docs/architecture/08-channel-base.md
+++ b/packages/client/docs/architecture/08-channel-base.md
@@ -6,8 +6,6 @@ the three channel adapters (`openclaw-channel`, `claude-code-channel`,
 error, the `LeaseStore` / `LeaseGuard` lease lifecycle primitives, and the
 markup-parameterized cross-conv + group-block formatters.
 
-Spec: #597. Architect plan: #605. Parent epic: #602.
-
 ## 1. Goals
 
 Before this layer existed, the three channels each carried a near-duplicate
@@ -68,7 +66,10 @@ on-retry semantic), `consume(key)` (read-and-delete), `clear(key?)`,
 
 Nanoclaw stores `(jid, dispatchLeaseId)` and uses `peek` deliberately so
 that retries after a consumed lease trigger the server's CONSUMED rejection
-rather than silently falling back to an unleased send (cutover #533).
+rather than silently falling back to an unleased send (single-use lease
+enforcement is server-side; the channel must thread the lease id even on
+retries so the server can return CONSUMED rather than accepting a
+duplicate send).
 
 ### `LeaseGuard`
 
@@ -93,8 +94,9 @@ ownership lives in the variant table or the callback.
 `{ name, participants }`. Openclaw consumes the narrowed fields to derive its
 `groupSubject` / `groupMembers` dispatch-context fields; nanoclaw routes them
 into `formatGroupBlock(fields, { markup: "xml-system-reminder" })`;
-claude-code does not consume group metadata at all (P3 #607 resolution —
-adding a no-op consistency call would be dead code).
+claude-code does not consume group metadata at all (adding a no-op
+consistency call to share the import would be dead code; the
+minimal-changes principle won over consistency-for-its-own-sake).
 
 `formatGroupBlock(fields, { markup })` renders the formatted block.
 `"xml-system-reminder"` emits the nanoclaw output verbatim;
@@ -239,8 +241,6 @@ Neither option carries weight; primitives are the cleaner abstraction.
 
 ## 6. See also
 
-- Spec: chughtapan/moltzap#597
-- Architect plan: chughtapan/moltzap#605
 - `packages/openclaw-channel/docs/architecture/04-deliver-error-handling.md`
 - `packages/nanoclaw-channel/docs/architecture/04-outbound-send-message.md`
 - `packages/claude-code-channel/docs/architecture/04-lease-state-machine.md`

--- a/packages/nanoclaw-channel/docs/architecture/03-inbound-flow.md
+++ b/packages/nanoclaw-channel/docs/architecture/03-inbound-flow.md
@@ -21,7 +21,7 @@ sequenceDiagram
 
     Note over Handler: Step 2 — rememberDispatchLease(chatJid, enriched)<br>if enriched.dispatchLeaseId:<br>  leaseStore.remember(chatJid, leaseId)
 
-    Note over Handler: LeaseStore<string, string> (peek-style)<br>keyed by chatJid (not conversationId)<br>value = LAST inbound lease for that jid<br>NOT cleared on send (post-cutover #533)
+    Note over Handler: LeaseStore<string, string> (peek-style)<br>keyed by chatJid (not conversationId)<br>value = LAST inbound lease for that jid<br>NOT cleared on send (server enforces single-use; deliberate stale-entry-on-retry)
 
     Note over Handler: Step 3 — maybeAutoRegister(chatJid, conversationId)<br>evalMode=false → skip<br>evalMode=true  → ensureAutoRegistered() (§3.6)
 

--- a/packages/nanoclaw-channel/docs/architecture/04-outbound-send-message.md
+++ b/packages/nanoclaw-channel/docs/architecture/04-outbound-send-message.md
@@ -4,7 +4,9 @@
 
 `sendMessage` is the reply path. It enforces JID ownership, looks up the
 most recent dispatch lease for the JID, and calls `core.sendReply`.
-Single-use lease semantics are enforced server-side (cutover #533).
+Single-use lease semantics are enforced server-side — the lease is
+consumed on first successful `messages/send`; subsequent attempts with
+the same lease id return CONSUMED.
 
 ```mermaid
 flowchart TD

--- a/packages/openclaw-channel/ARCHITECTURE.md
+++ b/packages/openclaw-channel/ARCHITECTURE.md
@@ -42,9 +42,9 @@ Subpath exports: `./test-utils` (Docker-backed integration harness),
 | `startAccount` lifecycle (connect, abort, reconnect handlers) | [01-start-account-lifecycle.md](docs/architecture/01-start-account-lifecycle.md) |
 | Outbound `sendText` — Effect ↔ Promise boundary | [02-outbound-send-text.md](docs/architecture/02-outbound-send-text.md) |
 | Inbound `onInbound` callback — full Effect chain | [03-inbound-on-inbound.md](docs/architecture/03-inbound-on-inbound.md) |
-| `deliver()` error handling — RpcServerError discrimination (PR #587) | [05-deliver-error-handling.md](docs/architecture/05-deliver-error-handling.md) |
-| `stopAccount` lifecycle (teardown, race notes) | [06-stop-account-lifecycle.md](docs/architecture/06-stop-account-lifecycle.md) |
-| `resolveTarget` format and error shape (two callers) | [07-resolve-target.md](docs/architecture/07-resolve-target.md) |
+| `deliver()` error handling — RpcServerError discrimination | [04-deliver-error-handling.md](docs/architecture/04-deliver-error-handling.md) |
+| `stopAccount` lifecycle (teardown, race notes) | [05-stop-account-lifecycle.md](docs/architecture/05-stop-account-lifecycle.md) |
+| `resolveTarget` format and error shape (two callers) | [06-resolve-target.md](docs/architecture/06-resolve-target.md) |
 
 ## 4. Dependencies
 

--- a/packages/openclaw-channel/docs/architecture/04-deliver-error-handling.md
+++ b/packages/openclaw-channel/docs/architecture/04-deliver-error-handling.md
@@ -30,7 +30,7 @@ flowchart TD
     B -->|"FAILURE: RpcServerError<br>via catchLeaseInvalid + .catchAll"| D{"err.code ===<br>TaskClosedError.code<br>(-32020)?"}
 
     D -->|yes — TERMINAL| E["log.warn({ conversationId, code, msg },<br>'send rejected — task closed, dropping')<br>return true"]
-    E --> F["WHY true? Lease is consumed server-side.<br>Returning true tells OpenClaw 'delivered'<br>so it does NOT retry. Retrying would create<br>a new orphan send.<br>(PR #587 fix: previously returned false,<br>causing infinite retry loops on closed tasks.)"]
+    E --> F["WHY true? Lease is consumed server-side.<br>Returning true tells OpenClaw 'delivered'<br>so it does NOT retry. Retrying would create<br>a new orphan send and the prior bug<br>(false → infinite retry loop on closed tasks)<br>must not regress."]
 
     D -->|no — RETRY-ELIGIBLE| G["log.error('failed to send reply: …')<br>return false"]
     G --> H["WHY false? Non-terminal server error<br>(e.g. rate limit, transient server fault).<br>OpenClaw may retry."]

--- a/packages/server/ARCHITECTURE.md
+++ b/packages/server/ARCHITECTURE.md
@@ -153,8 +153,8 @@ handler-invocation time.
   by `createCoreApp` for embedding in a host process. Provides the
   `onConnection` / `setContactService` / `registerMessageAuthorize` /
   `registerApp` / `registerRemoteApp` extension hooks. The static RPC
-  handler table is baked at `createCoreApp` time per Spec F #617
-  invariant I1 — post-construction method registration is not supported.
+  handler table is baked at `createCoreApp` time — post-construction
+  method registration is not supported.
 - **Layer-tag hierarchy** — TypeScript-enforced constraint on which
   Effect Tags a handler may pull (`TransportTags ⊂ IdentityTags ⊂
   NetworkTags ⊂ TaskTags ⊂ AppTags`); prevents low-layer code from

--- a/packages/server/docs/architecture/01-service-layer-composition.md
+++ b/packages/server/docs/architecture/01-service-layer-composition.md
@@ -77,7 +77,7 @@ flowchart TD
 
     resolveServices["services = dispatchRuntime.runSync(resolveServices)<br/>resolveServices = Effect.all({tag…})<br/>produces a plain-object view for non-Effect call sites<br/><i>app/server.ts</i>"]
 
-    CoreApp["Returned CoreApp exposes:<br/>port · onConnection / onDisconnection<br/>registerApp / registerRemoteApp<br/>registerMessageAuthorize / onTaskAuth…<br/>setContactService<br/>networkSendService · traceCapture · leases<br/>close()<br/>(Spec F #617 I1: RPC handler table baked at<br/>construction; no post-construction method registration)"]
+    CoreApp["Returned CoreApp exposes:<br/>port · onConnection / onDisconnection<br/>registerApp / registerRemoteApp<br/>registerMessageAuthorize / onTaskAuth…<br/>setContactService<br/>networkSendService · traceCapture · leases<br/>close()<br/>(RPC handler table baked at construction;<br/>no post-construction method registration)"]
 
     createCoreApp --> BaseLive
     createCoreApp --> ServicesLive

--- a/packages/server/docs/architecture/02-ws-connection-lifecycle.md
+++ b/packages/server/docs/architecture/02-ws-connection-lifecycle.md
@@ -22,7 +22,7 @@ sequenceDiagram
     WS->>HS: req.upgrade → socket: Socket.Socket
     Note over HS: connId = crypto.randomUUID()<br>writer = yield* socket.writer<br>closeRequested = yield* Deferred.make<void>()
     HS->>RPC: acquireConnectionRpcClient(connId, write)
-    Note over RPC: per-connection JSON-RPC originator<br>(internalized inside the typed Connection per Spec F #617 §6 FRI)<br>scope-bound: finalizer fails every<br>pending Deferred with NotConnectedError
+    Note over RPC: per-connection JSON-RPC originator<br>(internal to the typed Connection)<br>scope-bound: finalizer fails every<br>pending Deferred with NotConnectedError
     RPC-->>HS: originator
     HS->>CM: connections.add({id, write, shutdown, auth: null,<br>lastPong, conversationIds, mutedConversations, originator})
     HS->>Reader: socket.runRaw(data => handleFrame(decode(data)))

--- a/packages/server/docs/architecture/06-lease-lifecycle.md
+++ b/packages/server/docs/architecture/06-lease-lifecycle.md
@@ -1,4 +1,4 @@
-# Lease Lifecycle (`#529` reshape)
+# Lease Lifecycle
 
 ← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
 

--- a/packages/server/docs/architecture/07-http-routes.md
+++ b/packages/server/docs/architecture/07-http-routes.md
@@ -18,8 +18,8 @@ shared JSON-decode + Ajv validation. Invite-gate checks use `safeEqual`
 
 The `/api/v1/auth/claim` success path (`CLAIM_SUCCESS` arm in `app/http-routes.ts`) refreshes
 `conn.auth.ownerUserId` on every live connection of the just-claimed
-agent so subsequent owner-gated RPCs see fresh state
-without needing the client to reconnect (#495).
+agent so subsequent owner-gated RPCs see fresh state without needing
+the client to reconnect.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Architecture docs accumulated 25+ inline references to PR numbers,
issue numbers, and spec codenames (`Spec A`, `Spec B`, `Spec E`,
`Spec F`) that rot the moment the underlying issue is renumbered or
the codename retires. Replace each with a description of the design
or behavior the reference was standing in for. GitHub commit history
remains the durable archive for "why did this change in 2026."

**Stacked on top of #654** (consolidation + renumber). Base branch is
`docs/consolidate-dispatch-flow`. When #654 merges, retarget this to
`main`.

## What changed, by category

| Pattern | Action |
|---|---|
| `Spec X #NNN` inline goal-labels (e.g. `Spec F G4/G5`, `Spec F #617 §6 FRI`) | Describe the design directly. |
| `(cutover #NNN)` on lease-handling sites | Describe the single-use-lease constraint inline. |
| `(PR #NNN fix: …)` on bug-rationale comments | Keep the rationale prose; drop the PR number. |
| `Spec: #597. Architect plan: #605.` intro/footer stubs | Delete entirely. |
| `spec #NNN §X.Y.Z` inline citations | Drop the spec ref; keep the prose. |

## Bonus fix included

`packages/openclaw-channel/ARCHITECTURE.md` §3 Communication Flows
table still cited the pre-renumber paths (`05-deliver-error-handling`,
`06-stop-account-lifecycle`, `07-resolve-target`) — the renumber commit
in #654 missed it. Updated to the current `04/05/06` paths.

## Files touched (13)

Client: `ARCHITECTURE.md`, `01-connection-lifecycle.md`,
`04-notification-subscription.md`, `08-channel-base.md`.

Nanoclaw: `03-inbound-flow.md`, `04-outbound-send-message.md`.

Openclaw: `ARCHITECTURE.md`, `04-deliver-error-handling.md`.

Server: `ARCHITECTURE.md`, `01-service-layer-composition.md`,
`02-ws-connection-lifecycle.md`, `06-lease-lifecycle.md`,
`07-http-routes.md`.

## Verification

```
grep -rnE "#[0-9]{2,}|spec #|cutover #|architect plan #|PR #[0-9]|Spec [A-Z]\b" \
  packages/*/docs/architecture/*.md packages/*/ARCHITECTURE.md \
  | grep -v 'fill:#'
```

returns zero matches.

## Test plan

- [ ] Render the 13 files on GitHub; confirm the rewritten passages
      still read coherently (especially `08-channel-base.md` §3 lease
      projection narrative, where the cutover rationale was reworded)
- [ ] Confirm `openclaw-channel/ARCHITECTURE.md` §3 table links open
      the right files
- [ ] No follow-up grep finds reintroduced refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)