### PR TITLE
[impl-staff] #599 D2: moltzap start CLI (rebased onto post-D1-merge main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,7 +340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Today's two-step workflow (`conversations create` -> `send conv:<id>
   <text>`) collapses into one subcommand for the common case.
   Per-flow walkthrough at
-  `packages/client/docs/architecture/09-moltzap-start-cli.md`.
+  `packages/client/docs/architecture/moltzap-start-cli.md`.
 - **Exit-code contract:** `0` full success, `1` `TaskCreate` failed
   (stdout empty), `2` partial success (`TaskCreate` OK +
   `MessagesSend` failed — no rollback; the task + empty conversation
@@ -357,6 +357,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   intercept-able via `commands/test-transport.ts -> makeFakeTransport`.
   See architect plan §R1 + per-flow doc §"Why we don't reuse
   `resolveParticipant`" for the transport-uniformity reasoning.
+- **Dedup-hit reuse (spec D2 amendment N6):** idempotent reruns of
+  `moltzap start` on `DEFAULT_APP_ID` are now first-class. When the
+  server returns `{ task: existing, conversation: null }` (the D1
+  task-level dedup case), `start.ts -> findReusableConversation` calls
+  `TaskConversationList` (caller-scoped, server-sorted by activity
+  desc), filters items where `item.taskId === existingTaskId` AND
+  `item.conversation.archivedAt === undefined`, and reuses the
+  most-recently-active match. Stdout becomes
+  `Task started: <taskId> (reusing existing conversation: <convId>)`;
+  optional `--message` routes to the reused conversation. If no usable
+  conversation is found (task closed, all conversations archived, or
+  outside the dedup-lookup pagination window of
+  `DEDUP_LOOKUP_MAX_PAGES × DEDUP_LOOKUP_PAGE_SIZE = 1000` rows), the
+  CLI prints `Task already exists but is closed: <taskId>` to stderr
+  and exits 1. If `TaskConversationList` itself fails mid-lookup, the
+  CLI surfaces a dedup-specific diagnostic
+  (`Task <id> already exists but reusable-conversation lookup failed: <err>`)
+  instead of the generic `Failed:` prefix so the user is not misled
+  into retrying an already-successful `TaskCreate`. Replaces the
+  pre-fix-roll `TransportDecodeError` misclassification that broke
+  reruns on the second invocation.
+- **Zero-participant wire-shape carve-out (spec D2 amendment N7):**
+  `TaskCreate.params.initialConversation` now OMITS `participants`
+  entirely when `invitedAgentIds.length === 0`. The protocol
+  `InitialConversationSchema.participants` is
+  `Type.Optional(Type.Array(AgentId, { minItems: 1 }))`; the empty
+  array passed pre-fix-roll failed server AJV. The server adds the
+  caller to `conversation_participants` implicitly when `participants`
+  is absent.
 
 ### Phase 12 — `@moltzap/protocol` finalization
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,14 +349,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unresolvable `agent:<token>`). Exit 64 matches POSIX `EX_USAGE`
   (sysexits.h). `--app-id` validation uses an RFC 4122 UUID v4 regex
   client-side BEFORE any RPC (per architect plan §6 Invariant 7).
-- **Participant resolution:** new local `start.ts -> resolveAgentToken`
+- **Participant resolution:** new local `start.ts -> resolveAgentTokens`
   helper routes name-shaped lookups through the CLI `Transport`
   service (`transport.ts -> rpc(AgentsLookupByName, ...)`) rather than
   the daemon-only `socket-client.ts -> resolveParticipant`. This keeps
   `--as` direct-WS invocations working and makes the resolver
   intercept-able via `commands/test-transport.ts -> makeFakeTransport`.
-  See architect plan §R1 + per-flow doc §"Why we don't reuse
-  `resolveParticipant`" for the transport-uniformity reasoning.
+  Coalesces all name-shaped tokens into ONE batched
+  `AgentsLookupByName({ names: [...uniqueNames] })` RPC instead of one
+  per token (group tasks no longer pay N round-trips). UUID-shaped
+  tokens skip the wire entirely. When >100 distinct name tokens are
+  passed, the CLI rejects with exit 64 (`Too many distinct agent
+  names: <count> (max <max>)`) BEFORE the RPC — the schema's
+  `maxItems: 100` cap is surfaced as a usage error instead of an
+  opaque AJV decode failure. See architect plan §R1 + per-flow doc
+  §"Why we don't reuse `resolveParticipant`" for the transport-
+  uniformity reasoning.
 - **Dedup-hit reuse (spec D2 amendment N6):** idempotent reruns of
   `moltzap start` on `DEFAULT_APP_ID` are now first-class. When the
   server returns `{ task: existing, conversation: null }` (the D1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,25 +331,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `11-typed-dispatcher.md` §6.
 
 
-### Spec D2 (#599) — `moltzap start` CLI (architect stub; impl-staff fills body)
+### Spec D2 (#599) — `moltzap start` CLI
 
-- **Added (stub):** `packages/client/src/cli/commands/start.ts` — new
-  `moltzap start <name> <participant>... [--message <text>] [--app-id <uuid>]`
-  subcommand. Composes Spec D1 (#598) atomic `TaskCreate({ appId,
-  invitedAgentIds, initialConversation })` plus optional follow-up
-  `MessagesSend`. `Command.make` wrapper + positional/option arg
-  declarations + the `runStartCommand` exit-code dispatcher + the
-  `resolveAgentToken` participant resolver are all wired AT THIS
-  COMMIT (including registration in `cli/index.ts`). Only the
-  function bodies of `startCommandHandler`, `runStartCommand`, and
-  `resolveAgentToken` are stub-fail-fast; impl-staff replaces those
-  three bodies and adds `start.test.ts` per the architect plan in
+- **Added (`@moltzap/client`):** `moltzap start <name> <participant>...
+  [--message <text>] [--app-id <uuid>]` — single-command CLI that
+  composes Spec D1 (#598) atomic `TaskCreate({ appId, invitedAgentIds,
+  initialConversation })` with an optional follow-up `MessagesSend`.
+  Today's two-step workflow (`conversations create` -> `send conv:<id>
+  <text>`) collapses into one subcommand for the common case.
+  Per-flow walkthrough at
   `packages/client/docs/architecture/09-moltzap-start-cli.md`.
-- **Exit-code contract (planned):** `0` full success, `1` `TaskCreate`
-  failed, `2` partial (`TaskCreate` OK + `MessagesSend` failed; no
-  rollback), `64` usage error (bad `--app-id` UUID or unresolvable
-  participant token). Documented at the top of `start.ts` and in the
-  per-flow doc.
+- **Exit-code contract:** `0` full success, `1` `TaskCreate` failed
+  (stdout empty), `2` partial success (`TaskCreate` OK +
+  `MessagesSend` failed — no rollback; the task + empty conversation
+  persist and the user can retry with `moltzap send conv:<id>
+  <text>`), `64` usage error (bad `--app-id` UUID v4 syntax or
+  unresolvable `agent:<token>`). Exit 64 matches POSIX `EX_USAGE`
+  (sysexits.h). `--app-id` validation uses an RFC 4122 UUID v4 regex
+  client-side BEFORE any RPC (per architect plan §6 Invariant 7).
+- **Participant resolution:** new local `start.ts -> resolveAgentToken`
+  helper routes name-shaped lookups through the CLI `Transport`
+  service (`transport.ts -> rpc(AgentsLookupByName, ...)`) rather than
+  the daemon-only `socket-client.ts -> resolveParticipant`. This keeps
+  `--as` direct-WS invocations working and makes the resolver
+  intercept-able via `commands/test-transport.ts -> makeFakeTransport`.
+  See architect plan §R1 + per-flow doc §"Why we don't reuse
+  `resolveParticipant`" for the transport-uniformity reasoning.
 
 ### Phase 12 — `@moltzap/protocol` finalization
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,6 +330,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   insert-before-write, atomic insert/take, late-frame drop) into
   `11-typed-dispatcher.md` §6.
 
+
+### Spec D2 (#599) — `moltzap start` CLI (architect stub; impl-staff fills body)
+
+- **Added (stub):** `packages/client/src/cli/commands/start.ts` — new
+  `moltzap start <name> <participant>... [--message <text>] [--app-id <uuid>]`
+  subcommand. Composes Spec D1 (#598) atomic `TaskCreate({ appId,
+  invitedAgentIds, initialConversation })` plus optional follow-up
+  `MessagesSend`. Stub-only at this commit; impl-staff lands the
+  handler body and the `Command.make` registration in `cli/index.ts`
+  per the architect plan in
+  `packages/client/docs/architecture/09-moltzap-start-cli.md`.
+- **Exit-code contract (planned):** `0` full success, `1` `TaskCreate`
+  failed, `2` partial (`TaskCreate` OK + `MessagesSend` failed; no
+  rollback), `64` usage error (bad `--app-id` UUID or unresolvable
+  participant token). Documented at the top of `start.ts` and in the
+  per-flow doc.
+
 ### Phase 12 — `@moltzap/protocol` finalization
 
 - **BREAKING (Phase 12 — protocol surface):** Root facade reduced to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,9 +337,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `moltzap start <name> <participant>... [--message <text>] [--app-id <uuid>]`
   subcommand. Composes Spec D1 (#598) atomic `TaskCreate({ appId,
   invitedAgentIds, initialConversation })` plus optional follow-up
-  `MessagesSend`. Stub-only at this commit; impl-staff lands the
-  handler body and the `Command.make` registration in `cli/index.ts`
-  per the architect plan in
+  `MessagesSend`. `Command.make` wrapper + positional/option arg
+  declarations + the `runStartCommand` exit-code dispatcher + the
+  `resolveAgentToken` participant resolver are all wired AT THIS
+  COMMIT (including registration in `cli/index.ts`). Only the
+  function bodies of `startCommandHandler`, `runStartCommand`, and
+  `resolveAgentToken` are stub-fail-fast; impl-staff replaces those
+  three bodies and adds `start.test.ts` per the architect plan in
   `packages/client/docs/architecture/09-moltzap-start-cli.md`.
 - **Exit-code contract (planned):** `0` full success, `1` `TaskCreate`
   failed, `2` partial (`TaskCreate` OK + `MessagesSend` failed; no

--- a/packages/client/ARCHITECTURE.md
+++ b/packages/client/ARCHITECTURE.md
@@ -56,7 +56,7 @@ understand the lease and connection state machines that underpin all flows.
 | [Notification Subscription](docs/architecture/notification-subscription.md) | Typed `subscribe(def, refinement?)` Stream + `subscribeAll` escape hatch; lazy-materialization cancellation contract; tagged errors |
 | [Error Taxonomy](docs/architecture/error-taxonomy.md) | All Effect-tagged error types, where each is raised, and propagation invariants |
 | [CLI Command Flow](docs/architecture/cli-command-flow.md) | `moltzap register` and `moltzap send` command flows, daemon socket delegation |
-| [`moltzap start` CLI](docs/architecture/moltzap-start-cli.md) | Spec D2 (#599) single-command flow over Spec D1 atomic `TaskCreate` + optional `MessagesSend`. Exit-code contract (0/1/2/64) and partial-failure semantics |
+| [`moltzap start` CLI](docs/architecture/moltzap-start-cli.md) | Spec D2 (#599) single-command flow over Spec D1 atomic `TaskCreate` + optional `MessagesSend`. Exit-code contract (0/1/2/64), partial-failure semantics, dedup-hit conversation reuse via `TaskConversationList` (N6), and zero-participant wire-shape carve-out (N7) |
 | [State Machines](docs/architecture/state-machines.md) | Dispatch lease and connection state machines |
 | [Channel-base subpath](docs/architecture/channel-base.md) | `@moltzap/client/channel-base` — canonical `LeaseAlreadyConsumed`, `LeaseStore`/`LeaseGuard`, markup-parameterized `formatCrossConv`/`formatGroupBlock` (shared by openclaw, claude-code, nanoclaw) |
 

--- a/packages/client/ARCHITECTURE.md
+++ b/packages/client/ARCHITECTURE.md
@@ -56,6 +56,7 @@ understand the lease and connection state machines that underpin all flows.
 | [Notification Subscription](docs/architecture/notification-subscription.md) | Typed `subscribe(def, refinement?)` Stream + `subscribeAll` escape hatch; lazy-materialization cancellation contract; tagged errors |
 | [Error Taxonomy](docs/architecture/error-taxonomy.md) | All Effect-tagged error types, where each is raised, and propagation invariants |
 | [CLI Command Flow](docs/architecture/cli-command-flow.md) | `moltzap register` and `moltzap send` command flows, daemon socket delegation |
+| [`moltzap start` CLI](docs/architecture/moltzap-start-cli.md) | Spec D2 (#599) single-command flow over Spec D1 atomic `TaskCreate` + optional `MessagesSend`. Exit-code contract (0/1/2/64) and partial-failure semantics |
 | [State Machines](docs/architecture/state-machines.md) | Dispatch lease and connection state machines |
 | [Channel-base subpath](docs/architecture/channel-base.md) | `@moltzap/client/channel-base` — canonical `LeaseAlreadyConsumed`, `LeaseStore`/`LeaseGuard`, markup-parameterized `formatCrossConv`/`formatGroupBlock` (shared by openclaw, claude-code, nanoclaw) |
 

--- a/packages/client/docs/architecture/moltzap-start-cli.md
+++ b/packages/client/docs/architecture/moltzap-start-cli.md
@@ -1,0 +1,299 @@
+# `moltzap start` CLI
+
+← Back to [package ARCHITECTURE](../../ARCHITECTURE.md)
+
+Spec D2 (#599) adds a single-command CLI for starting a task with named
+participants and (optionally) sending the first message in one shot.
+Composes Spec D1 (#598) atomic `TaskCreate({ appId, invitedAgentIds,
+initialConversation })` plus a follow-up `MessagesSend` when
+`--message` is supplied.
+
+## 1. Wire surface consumed
+
+D2 is a pure consumer of D1's wire shapes; D2 adds **no new RPCs, no
+new notifications, no new errors at the wire**. Only the CLI-local
+tagged errors `InvalidAppIdError` and `UnresolvedParticipantError`
+live in `commands/start.ts`.
+
+| RPC | Provided by | When called |
+|---|---|---|
+| `TaskCreate` | Spec D1 (#635) → `packages/protocol/src/task/tasks.ts → TaskCreate` | Every invocation |
+| `MessagesSend` | Pre-D1, unchanged | Only when `--message` is set |
+| `AgentsLookupByName` | Pre-D1, unchanged | Per participant token, name → uuid |
+
+`TaskCreate` is called with `{ appId, invitedAgentIds, initialConversation:
+{ name, participants } }` where `initialConversation.participants ===
+invitedAgentIds` (the caller is implicit per D1 spec body Goal 5;
+server adds the caller to both `task_participants` and
+`conversation_participants`). Per D1 plan §R8 / Canary `_C5` the
+response shape is `{ task, conversation: Conversation | null }`; when
+`initialConversation` is sent, `conversation` is non-null.
+
+## 2. Command shape
+
+```
+moltzap start <name> <participant>... [--message <text>] [--app-id <uuid>]
+```
+
+- `<name>` — required positional. Conversation name (shown by
+  `moltzap conversations list`).
+- `<participant>...` — zero-or-more positional tokens, each
+  `agent:<name>` or `agent:<uuid>`. Empty admitted (caller-only task
+  per D1 spec body Goal 5; spec D2 ACs do not require, but impl-staff
+  handler MUST NOT reject).
+- `--message <text>` — optional. If supplied, a follow-up
+  `MessagesSend` runs after the atomic `TaskCreate`.
+- `--app-id <uuid>` — optional. Defaults to `DEFAULT_APP_ID`
+  (D1 plan §R3, exported from `@moltzap/protocol`). Syntactic UUID v4
+  validation happens client-side BEFORE any RPC; server rejection of a
+  syntactically valid UUID still produces a `TransportError` at exit 1.
+
+DM-vs-Group is **implicit** from participant count: exactly one
+invited agent (caller + 1 = 2 participants) is today's DM shape;
+two-or-more invited agents (caller + N = ≥3) is today's group shape.
+No `--dm` / `--group` flag (spec D2 Goal 1).
+
+## 3. Flow
+
+```mermaid
+sequenceDiagram
+    participant shell
+    participant cli as @effect/cli
+    participant start as start.ts → startCommandHandler
+    participant sock as socket-client.ts → resolveParticipant
+    participant tx as transport.ts → rpc
+
+    shell->>cli: moltzap start <name> agent:bob ... [--message <txt>] [--app-id <uuid>]
+    cli->>start: StartCommandArgs
+
+    Note over start: 1. validateAppIdSyntax(args.appId)<br>invalid → InvalidAppIdError → exit 64
+
+    Note over start: 2. Effect.all(participants.map(resolveParticipant))<br>any failure → UnresolvedParticipantError → exit 64
+    start->>sock: resolveParticipant("agent:bob")
+    sock-->>start: { type: "agent", id: AgentId }
+
+    Note over start: 3. rpc(TaskCreate, {appId, invitedAgentIds, initialConversation:{name, participants}})
+    start->>tx: TaskCreate
+    tx-->>start: { task, conversation }
+    Note over start: failure → TransportError → exit 1<br>stdout: nothing
+    Note over start: success → stdout: Task started: <taskId> (conversation: <convId>)
+
+    alt --message supplied
+        Note over start: 4. rpc(MessagesSend, {conversationId: conv.id, parts:[{type:text,text}]})
+        start->>tx: MessagesSend
+        tx-->>start: { message }
+        Note over start: success → stdout: Message sent: <msgId> → exit 0
+        Note over start: failure → stderr: Error sending message: <err> → exit 2<br>(stdout already has Task started line)
+    else --message omitted
+        Note over start: exit 0
+    end
+```
+
+## 4. Exit-code contract
+
+| Code | Meaning | Stdout state | Stderr state |
+|---|---|---|---|
+| 0 | Full success | `Task started: …` (+ `Message sent: …` when `--message`) | empty |
+| 1 | `TaskCreate` failed | empty | `Failed: <err.message>` |
+| 2 | `TaskCreate` OK, `MessagesSend` failed | `Task started: …` (no `Message sent`) | `Error sending message: <err.message>` |
+| 64 | Usage error (bad `--app-id` UUID OR unresolvable agent token) | empty | `Invalid --app-id: not a UUID` OR `Cannot resolve "<token>": <reason>` |
+
+NO rollback on exit 2: the task + empty conversation persist; user can
+retry `moltzap send conv:<id> <text>` (Non-goal 3).
+
+Exit code 64 matches POSIX `EX_USAGE` (sysexits.h) for script-friendly
+discrimination between "your input was wrong" (64) and "the wire was
+wrong" (1, 2).
+
+## 5. Authority + identity
+
+The command runs with the caller's identity per the global `--as` /
+`--profile` flags — same precedence rules as `moltzap send` (see
+[CLI Command Flow](./cli-command-flow.md) for the daemon-vs-direct
+branch and the `transport.ts` selection logic). `TaskCreate` is open
+to any authenticated agent (Spec D1 plan §"Authority matrix");
+server-side contact-policy gating per
+`requireContactPolicyForCreate` may reject the call with a
+`TransportRpcError` mapped to exit 1.
+
+## 6. Implementation sketch (impl-staff target)
+
+The handler body is NOT in the stub. Impl-staff lands the following
+shape (pseudocode; final Effect form may differ):
+
+```ts
+export const startCommandHandler = (args: StartCommandArgs) =>
+  Effect.gen(function* () {
+    // 1. Validate --app-id syntax
+    const appId =
+      args.appId !== undefined
+        ? yield* validateAppId(args.appId)  // → InvalidAppIdError on bad UUID
+        : DEFAULT_APP_ID;
+
+    // 2. Resolve participants
+    const invitedAgentIds = yield* Effect.all(
+      args.participants.map((tok) =>
+        resolveParticipant(tok).pipe(
+          Effect.map((p) => p.id),
+          Effect.mapError(() =>
+            new UnresolvedParticipantError({ token: tok, reason: "not-found" }),
+          ),
+        ),
+      ),
+    );
+
+    // 3. TaskCreate atomic
+    const { task, conversation } = yield* rpc(TaskCreate, {
+      appId,
+      invitedAgentIds,
+      initialConversation: { name: args.name, participants: invitedAgentIds },
+    }).pipe(
+      Effect.tapError((err) =>
+        Effect.sync(() => {
+          // Exit 1: nothing printed yet, transport adapter prints stderr
+        }),
+      ),
+    );
+
+    if (conversation === null) {
+      // D1 canary _C5 guarantees non-null when initialConversation sent;
+      // defend against a stale D1 build with a decode-time exit 1.
+      return yield* Effect.fail(
+        new TransportDecodeError({ method: "task/create", cause: "missing conversation" }),
+      );
+    }
+
+    yield* Effect.sync(() =>
+      console.log(`Task started: ${task.id} (conversation: ${conversation.id})`),
+    );
+
+    // 4. Optional MessagesSend
+    if (args.message !== undefined) {
+      const sendResult = yield* rpc(MessagesSend, {
+        conversationId: conversation.id,
+        parts: [{ type: "text", text: args.message }],
+      }).pipe(
+        Effect.either,  // capture, don't propagate, so we can dispatch exit 2
+      );
+      if (Either.isLeft(sendResult)) {
+        yield* Effect.sync(() => {
+          console.error(`Error sending message: ${sendResult.left.message}`);
+          process.exit(EXIT_CODE_PARTIAL_SUCCESS);
+        });
+        return;
+      }
+      yield* Effect.sync(() =>
+        console.log(`Message sent: ${sendResult.right.message.id}`),
+      );
+    }
+  });
+```
+
+### Partial-failure dispatcher — why not `runHandler`?
+
+The shared `runHandler(...)` adapter in `transport.ts` maps every
+caught error to exit code 1 unconditionally. D2 needs three exit codes
+(0/1/2/64) keyed on the stage where the error arose. Impl-staff has
+two options:
+
+1. **Local dispatcher** — wrap `startCommandHandler` in a
+   `start`-specific adapter (`runStartCommand` in `start.ts` or a
+   sibling) that inspects the `_tag` and dispatches:
+   - `InvalidAppIdError` / `UnresolvedParticipantError` → 64
+   - bare `TransportError` (TaskCreate stage) → 1
+   - (caught inline above) MessagesSend failure → 2
+2. **Inline `process.exit`** — call `process.exit(64)` / `process.exit(2)`
+   at the failure site (see sketch above for the partial-success branch).
+
+The current `register.ts` pattern uses inline `process.exit` (option
+2); the v2 subcommands (`messages list`, `conversations {get, archive,
+unarchive}`) use `runHandler` (option 1, but exit-1-only). D2 needs
+option 1 with a **two-stage `TransportError` discriminator** OR option
+2 throughout. Architect picks **option 2** for the stub-time contract
+(matches the partial-success need without a new shared adapter); the
+final implementation choice is impl-staff's call subject to
+`/simplify` review.
+
+### Why call `resolveParticipant` instead of a new helper
+
+Today `commands/conversations.ts → createConversation` calls
+`resolveParticipant(...)` (which returns `{ type: "agent", id }`) and
+passes the full ref to `ConversationsCreate.participants`
+(historically a `agentParticipantRefSchema[]` field). D2's
+`TaskCreate.initialConversation.participants` is `AgentId[]` (Spec D1
+canary `_L1`..`_L3`); the impl-staff handler maps `.id` per token
+after resolution. No new helper is needed; the spec body's optional
+"extract to `lib/agents.ts`" refactor is OUT-OF-SCOPE for the stub
+(declined; would touch `commands/conversations.ts` Non-goal 1 only if
+the helper were private, which it isn't — `resolveParticipant` is
+already public in `socket-client.ts`).
+
+## 7. Test alignment
+
+Spec D2 acceptance criteria → test files:
+
+| AC | Test file | Strategy |
+|---|---|---|
+| RPC payload assertions | `start.test.ts` | `makeFakeTransport` records `{method, params}`; assert `TaskCreate` and `MessagesSend` payloads against parsed CLI args |
+| Participant model: `length === 1` | `start.test.ts > dm-shape` | fixture: one `agent:` token → assert `invitedAgentIds.length === 1` |
+| Participant model: `length >= 2` | `start.test.ts > group-shape` | fixture: two `agent:` tokens → assert `invitedAgentIds.length === 2` and order preserved |
+| Caller NOT in `invitedAgentIds` | `start.test.ts > caller-excluded` | assert caller's own `AgentId` does NOT appear in `params.invitedAgentIds` |
+| Output strings | `start.test.ts > output-format` | `console.log` spy; assert exact strings incl. `Task started: <id> (conversation: <id>)` and `Message sent: <id>` |
+| `--app-id` default | `start.test.ts > default-app-id` | omit `--app-id` flag; assert recorded `params.appId === DEFAULT_APP_ID` (imported from `@moltzap/protocol`) |
+| `--app-id` invalid UUID | `start.test.ts > invalid-app-id` | pass `--app-id not-a-uuid`; assert exit 64, stderr `Invalid --app-id: not a UUID`, zero recorded RPC calls |
+| `--app-id` server reject | `start.test.ts > server-reject-app-id` | mock transport returns `TransportRpcError`; assert exit 1, stderr has error |
+| Partial failure | `start.test.ts > partial-success` | `TaskCreate` success + `MessagesSend` fail → assert stdout has `Task started:` line, stderr `Error sending message:`, exit 2 |
+| Unresolved participant | `start.test.ts > unresolved-participant` | `AgentsLookupByName` returns empty agents; assert exit 64, stderr names the token, ZERO `TaskCreate` / `MessagesSend` calls |
+| Help text | `start.test.ts > help` | snapshot `moltzap start --help`; assert presence of synopsis, `--message`, `--app-id`, and the four exit codes |
+| CHANGELOG | (manual review at PR time) | grep root `CHANGELOG.md` `[Unreleased]` for the new-command entry |
+
+Test infra reuses `makeFakeTransport(...)` from
+`commands/test-transport.ts`. Helpers `vi.spyOn(console, "log")` and
+`process.exit = vi.fn() as never` match the pattern in
+`register.test.ts` and `send.test.ts`. CLI commands run via
+`startCommand.handler({...})` with `Effect.provideService(Transport,
+fakeTransport)`.
+
+For the `AgentsLookupByName` mock: `makeFakeTransport`'s `respond`
+callback returns an `{ agents: [...] }` shape for the lookup method;
+empty array drives the "unresolved" failure. Daemon-socket path is
+NOT exercised by unit tests — they use `Transport` directly.
+
+## 8. Concerns from D1 dependency
+
+- **`TaskCreate` from `@moltzap/protocol` is not yet on `main`.** D1 stub
+  lives at `architect/598-task-conversation` @ `bc913ba` (plan #635
+  plan-approved); the descriptor + brand + constant land in the
+  package only when D1 impl-staff (HARD-blocked on Spec E Phase 1)
+  merges. D2's impl-staff PR therefore depends on D1's impl-staff PR
+  landing first — orchestrator should sequence D2 impl AFTER D1 impl,
+  not concurrent. The architect plan + stub are unblocked (this
+  branch).
+- **D1 plan §15 process-issue** flags Spec D2 acceptance criterion
+  "Participant-resolution failure exit 64 with NO RPC calls" against
+  the fact that `resolveParticipant` itself calls
+  `AgentsLookupByName` (an RPC) when the token is a name (not a UUID).
+  Strict reading of the AC fails if the lookup is counted as an RPC;
+  generous reading admits it because the lookup is read-only and does
+  not mutate. Architect interpretation (this plan): the AC means "NO
+  `TaskCreate` / `MessagesSend` calls", since only those two are
+  spec-D2's mutating calls. Re-confirm in N=2 review.
+
+## 9. Cold-start reading order
+
+A consumer wanting to understand the `moltzap start` command in the
+fewest hops:
+
+1. Read this doc (you are here).
+2. Read [CLI Command Flow](./cli-command-flow.md) for the
+   identity/transport machinery the command inherits (`--as`,
+   `--profile`, daemon vs direct).
+3. Read [Error Taxonomy](./error-taxonomy.md) for the
+   `TransportError` shape that the partial-failure dispatcher branches
+   on.
+4. Read D1 per-flow doc
+   `packages/protocol/docs/architecture/12-task-conversation-family.md`
+   for the `TaskCreate` semantics: appId-only, dedup behavior, and
+   the `conversation: Conversation | null` result shape.
+5. Read Spec D2 body (#599) for the acceptance criteria and the
+   partial-failure / exit-code contract verbatim.

--- a/packages/client/docs/architecture/moltzap-start-cli.md
+++ b/packages/client/docs/architecture/moltzap-start-cli.md
@@ -70,7 +70,6 @@ sequenceDiagram
     participant shell
     participant cli as @effect/cli
     participant start as start.ts → startCommandHandler
-    participant sock as socket-client.ts → resolveParticipant
     participant tx as transport.ts → rpc
 
     shell->>cli: moltzap start <name> agent:bob ... [--message <txt>] [--app-id <uuid>]
@@ -78,9 +77,9 @@ sequenceDiagram
 
     Note over start: 1. validateAppIdSyntax(args.appId)<br>invalid → InvalidAppIdError → exit 64
 
-    Note over start: 2. Effect.all(participants.map(resolveParticipant))<br>any failure → UnresolvedParticipantError → exit 64
-    start->>sock: resolveParticipant("agent:bob")
-    sock-->>start: { type: "agent", id: AgentId }
+    Note over start: 2. Effect.all(participants.map(resolveAgentToken))<br>name-shaped tokens fan out through Transport; UUID-shaped tokens<br>short-circuit client-side. Any failure → UnresolvedParticipantError → exit 64
+    start->>tx: rpc(AgentsLookupByName, { names: ["bob"] }) (per name-shaped token)
+    tx-->>start: { agents: [{ id, ... }] } or empty
 
     Note over start: 3. rpc(TaskCreate, {appId, invitedAgentIds, initialConversation:{name, participants}})
     start->>tx: TaskCreate
@@ -140,16 +139,12 @@ export const startCommandHandler = (args: StartCommandArgs) =>
         ? yield* validateAppId(args.appId)  // → InvalidAppIdError on bad UUID
         : DEFAULT_APP_ID;
 
-    // 2. Resolve participants
+    // 2. Resolve participants via the local Transport-routed helper.
+    //    resolveAgentToken returns bare AgentId (NOT a participant ref),
+    //    so no .map(p => p.id) step is needed. The helper itself maps
+    //    shape failures + lookup-empty results to UnresolvedParticipantError.
     const invitedAgentIds = yield* Effect.all(
-      args.participants.map((tok) =>
-        resolveParticipant(tok).pipe(
-          Effect.map((p) => p.id),
-          Effect.mapError(() =>
-            new UnresolvedParticipantError({ token: tok, reason: "not-found" }),
-          ),
-        ),
-      ),
+      args.participants.map(resolveAgentToken),
     );
 
     // 3. TaskCreate atomic
@@ -317,15 +312,15 @@ NOT exercised by unit tests — they use `Transport` directly.
   landing first — orchestrator should sequence D2 impl AFTER D1 impl,
   not concurrent. The architect plan + stub are unblocked (this
   branch).
-- **D1 plan §15 process-issue** flags Spec D2 acceptance criterion
-  "Participant-resolution failure exit 64 with NO RPC calls" against
-  the fact that `resolveParticipant` itself calls
-  `AgentsLookupByName` (an RPC) when the token is a name (not a UUID).
-  Strict reading of the AC fails if the lookup is counted as an RPC;
-  generous reading admits it because the lookup is read-only and does
-  not mutate. Architect interpretation (this plan): the AC means "NO
-  `TaskCreate` / `MessagesSend` calls", since only those two are
-  spec-D2's mutating calls. Re-confirm in N=2 review.
+- **Spec D2 AC interpretation: "NO RPC calls" reads as "no mutating
+  RPC calls".** `start.ts → resolveAgentToken` calls
+  `rpc(AgentsLookupByName, ...)` for name-shaped tokens (a server
+  RPC), which the strict reading of the AC would prohibit. Architect
+  interpretation: the AC means "NO `TaskCreate` / `MessagesSend`
+  calls", since only those two are spec-D2's mutating calls. The
+  read-only lookup is intentional + necessary (UUID-only tokens are
+  the only alternative and would break the `agent:&lt;name>`
+  shorthand). Re-confirmed in r2 N=2 review.
 
 ## 9. Cold-start reading order
 

--- a/packages/client/docs/architecture/moltzap-start-cli.md
+++ b/packages/client/docs/architecture/moltzap-start-cli.md
@@ -19,7 +19,17 @@ live in `commands/start.ts`.
 |---|---|---|
 | `TaskCreate` | Spec D1 (#635) → `packages/protocol/src/task/tasks.ts → TaskCreate` | Every invocation |
 | `MessagesSend` | Pre-D1, unchanged | Only when `--message` is set |
-| `AgentsLookupByName` | Pre-D1, unchanged | Per participant token, name → uuid |
+| `AgentsLookupByName` | Pre-D1, unchanged | Per name-shaped participant token (uuid-shaped tokens skip the lookup) |
+
+**All three RPCs go through `transport.ts → rpc(...)` (the CLI
+`Transport` service), NOT `socket-client.ts → request(...)` (the
+daemon-socket helper). D2 deliberately does not reuse
+`socket-client.ts → resolveParticipant` because that helper hard-wires
+the daemon-socket path — it would break `--as` direct-WS invocations
+and would not be mockable via `commands/test-transport.ts →
+makeFakeTransport`. Architect plan §R1 explains the divergence; the
+local resolver `start.ts → resolveAgentToken` is the new helper that
+covers D2's testability + transport-uniformity needs.**
 
 `TaskCreate` is called with `{ appId, invitedAgentIds, initialConversation:
 { name, participants } }` where `initialConversation.participants ===
@@ -189,44 +199,82 @@ export const startCommandHandler = (args: StartCommandArgs) =>
   });
 ```
 
-### Partial-failure dispatcher — why not `runHandler`?
+### Partial-failure dispatcher — canonical contract
 
 The shared `runHandler(...)` adapter in `transport.ts` maps every
-caught error to exit code 1 unconditionally. D2 needs three exit codes
-(0/1/2/64) keyed on the stage where the error arose. Impl-staff has
-two options:
+caught error to exit code 1 unconditionally. D2 needs three non-default
+exit codes (2, 64, plus 0/1) keyed on the stage where the error
+arose. Architect picks a **hybrid two-stage dispatcher**, codified in
+the stub (`start.ts → runStartCommand` + `start.ts →
+startCommandHandler`):
 
-1. **Local dispatcher** — wrap `startCommandHandler` in a
-   `start`-specific adapter (`runStartCommand` in `start.ts` or a
-   sibling) that inspects the `_tag` and dispatches:
-   - `InvalidAppIdError` / `UnresolvedParticipantError` → 64
-   - bare `TransportError` (TaskCreate stage) → 1
-   - (caught inline above) MessagesSend failure → 2
-2. **Inline `process.exit`** — call `process.exit(64)` / `process.exit(2)`
-   at the failure site (see sketch above for the partial-success branch).
+- **`runStartCommand(effect)`** is the outer adapter (replaces
+  `runHandler` in the `Command.make` wrapper). It pattern-matches the
+  caught `StartCommandError` on `_tag` and dispatches:
+  - `InvalidAppIdError` → `process.exit(EXIT_CODES.USAGE_ERROR)` + stderr `Invalid --app-id: not a UUID`
+  - `UnresolvedParticipantError` → `process.exit(EXIT_CODES.USAGE_ERROR)` + stderr `Cannot resolve "<token>": <reason>`
+  - any other `StartCommandError` (the `TransportError` union from
+    `transport.ts`, including `TransportRpcError`,
+    `TransportDecodeError`, `ServiceUnreachableError`, etc.) →
+    `process.exit(EXIT_CODES.TASK_CREATE_FAILED)` + stderr
+    `Failed: <err.message>`
+- **Inline `process.exit(EXIT_CODES.PARTIAL_SUCCESS)`** inside the
+  handler body for the post-`TaskCreate` `MessagesSend` failure. This
+  path cannot route through `runStartCommand` because the stdout
+  `Task started: ...` line has already been printed; re-throwing the
+  error and letting `runStartCommand` dispatch would discard the
+  successful task creation from the user's view. The handler uses
+  `Effect.either(rpc(MessagesSend, ...))` to catch in-band, then
+  `Effect.sync(() => { console.error(...); process.exit(2); })`.
 
-The current `register.ts` pattern uses inline `process.exit` (option
-2); the v2 subcommands (`messages list`, `conversations {get, archive,
-unarchive}`) use `runHandler` (option 1, but exit-1-only). D2 needs
-option 1 with a **two-stage `TransportError` discriminator** OR option
-2 throughout. Architect picks **option 2** for the stub-time contract
-(matches the partial-success need without a new shared adapter); the
-final implementation choice is impl-staff's call subject to
-`/simplify` review.
+This split is the architect-locked contract. Impl-staff implements
+both halves (the `Effect.catchAll` body of `runStartCommand` and the
+`Effect.either` branch of the handler); `/simplify` review may
+re-examine the partition but the exit-code-by-stage contract is fixed
+by the spec D2 ACs.
 
-### Why call `resolveParticipant` instead of a new helper
+Test-side: `process.exit = vi.fn() as never` (per `register.test.ts`
+pattern); assert `expect(process.exit).toHaveBeenCalledWith(64)` /
+`...(2)` / `...(1)` per scenario.
 
-Today `commands/conversations.ts → createConversation` calls
-`resolveParticipant(...)` (which returns `{ type: "agent", id }`) and
-passes the full ref to `ConversationsCreate.participants`
-(historically a `agentParticipantRefSchema[]` field). D2's
-`TaskCreate.initialConversation.participants` is `AgentId[]` (Spec D1
-canary `_L1`..`_L3`); the impl-staff handler maps `.id` per token
-after resolution. No new helper is needed; the spec body's optional
-"extract to `lib/agents.ts`" refactor is OUT-OF-SCOPE for the stub
-(declined; would touch `commands/conversations.ts` Non-goal 1 only if
-the helper were private, which it isn't — `resolveParticipant` is
-already public in `socket-client.ts`).
+### Why we don't reuse `resolveParticipant`
+
+`socket-client.ts → resolveParticipant` is the helper today's
+`commands/conversations.ts → createConversation` uses. It returns
+`{ type: "agent", id: AgentId }` after a server lookup via
+`socket-client.ts → request(AgentsLookupByName, ...)`. D2 does NOT
+reuse it. Reasons:
+
+1. **Transport mismatch.** `socket-client.ts → request` hard-wires
+   the daemon-socket path (`MoltZapService.SOCKET_PATH`). D2's
+   `TaskCreate` and `MessagesSend` calls go through
+   `transport.ts → rpc(...)` (the `Transport` Effect service),
+   which is selected by `cli/index.ts → moltzapBase` from `--as` /
+   `--profile` / daemon precedence. A `moltzap --as <key> start
+   ... agent:bob ...` invocation would resolve `bob` through the
+   daemon socket (potentially unreachable) but call `TaskCreate`
+   through direct-WS — a confusing split.
+2. **Testability.** `commands/test-transport.ts → makeFakeTransport`
+   intercepts `Transport.rpc` calls. It cannot intercept the
+   daemon-socket path. Spec D2 ACs require unit tests that mock
+   `AgentsLookupByName`'s response (empty vs. populated) to drive
+   the resolution-failure branch. Without a transport-routed
+   resolver, this test is not implementable cleanly.
+3. **Wire-shape match.** D2's `TaskCreate.initialConversation.participants`
+   is `Array(AgentId)` (Spec D1 canary `_L1..L3`), not
+   `agentParticipantRefSchema[]`. The local resolver returns bare
+   `AgentId` directly, eliminating a `.map(p => p.id)` step.
+
+D2 introduces `start.ts → resolveAgentToken` (transport-routed
+sibling): parses `agent:<rest>` and either short-circuits if `rest`
+is a UUID v4 or calls `rpc(AgentsLookupByName, { names: [rest] })`.
+On empty result → `UnresolvedParticipantError({ token, reason:
+"not-found" })`. On shape failure (no `agent:` prefix, etc.) →
+`UnresolvedParticipantError({ token, reason: "shape" })`.
+
+`commands/conversations.ts` keeps using `resolveParticipant`
+unchanged (Non-goal 1). D3 may consolidate when the legacy command
+deletes.
 
 ## 7. Test alignment
 

--- a/packages/client/docs/architecture/moltzap-start-cli.md
+++ b/packages/client/docs/architecture/moltzap-start-cli.md
@@ -29,7 +29,7 @@ daemon-socket helper). D2 deliberately does not reuse
 the daemon-socket path — it would break `--as` direct-WS invocations
 and would not be mockable via `commands/test-transport.ts →
 makeFakeTransport`. Architect plan §R1 explains the divergence; the
-local resolver `start.ts → resolveAgentToken` is the new helper that
+local resolver `start.ts → resolveAgentTokens` is the new helper that
 covers D2's testability + transport-uniformity needs.**
 
 `TaskCreate` is called with `{ appId, invitedAgentIds, initialConversation
@@ -91,9 +91,10 @@ sequenceDiagram
 
     Note over start: 1. validateAppIdSyntax(args.appId)<br>invalid → InvalidAppIdError → exit 64
 
-    Note over start: 2. Effect.all(participants.map(resolveAgentToken))<br>name-shaped tokens fan out through Transport; UUID-shaped tokens<br>short-circuit client-side. Any failure → UnresolvedParticipantError → exit 64
-    start->>tx: rpc(AgentsLookupByName, { names: ["bob"] }) (per name-shaped token)
-    tx-->>start: { agents: [{ id, ... }] } or empty
+    Note over start: 2. resolveAgentTokens(participants)<br>Classify each token: shape-fail → UnresolvedParticipantError → exit 64;<br>UUID-shaped → short-circuit client-side; name-shaped → defer to one batched RPC.
+    start->>tx: rpc(AgentsLookupByName, { names: [...uniqueNames] }) (one call total, name-shaped tokens only)
+    tx-->>start: { agents: [{ id, name, ... }, ...] }
+    Note over start: Build name → AgentId map; resolve each token in input order.<br>First name with no matching agent → UnresolvedParticipantError → exit 64.
 
     Note over start: 3. rpc(TaskCreate, {appId, invitedAgentIds, initialConversation})<br>initialConversation omits participants when invitedAgentIds.length === 0 (P2-B)
     start->>tx: TaskCreate
@@ -132,7 +133,7 @@ sequenceDiagram
 | 0 | Full success (fresh create OR dedup hit with reusable conversation) | `Task started: …` (+ `Message sent: …` when `--message`) | empty |
 | 1 | `TaskCreate` wire failure OR dedup hit on a closed/unreachable task (P2-A) | empty | `Failed: <err.message>` OR `Task already exists but is closed: <taskId>` |
 | 2 | `TaskCreate` (or dedup reuse) OK, `MessagesSend` failed | `Task started: …` (no `Message sent`) | `Error sending message: <err.message>` |
-| 64 | Usage error (bad `--app-id` UUID OR unresolvable agent token) | empty | `Invalid --app-id: not a UUID` OR `Cannot resolve "<token>": <reason>` |
+| 64 | Usage error (bad `--app-id` UUID OR unresolvable agent token OR >100 distinct name-shaped tokens) | empty | `Invalid --app-id: not a UUID` OR `Cannot resolve "<token>": <reason>` OR `Too many distinct agent names: <count> (max <max>)` |
 
 NO rollback on exit 2: the task + empty conversation persist; user can
 retry `moltzap send conv:<id> <text>` (Non-goal 3).
@@ -152,72 +153,59 @@ server-side contact-policy gating per
 `requireContactPolicyForCreate` may reject the call with a
 `TransportRpcError` mapped to exit 1.
 
-## 6. Implementation sketch (impl-staff target)
+## 6. Implementation sketch
 
-The handler body is NOT in the stub. Impl-staff lands the following
-shape (pseudocode; final Effect form may differ):
+The handler body lives in `commands/start.ts → startCommandHandler`.
+Sketch matches the current code shape (P2-A dedup + P2-B carve-out +
+P3-2 batched lookup all landed):
 
 ```ts
 export const startCommandHandler = (args: StartCommandArgs) =>
   Effect.gen(function* () {
-    // 1. Validate --app-id syntax
-    const appId =
-      args.appId !== undefined
-        ? yield* validateAppId(args.appId)  // → InvalidAppIdError on bad UUID
-        : DEFAULT_APP_ID;
+    // 1. Validate --app-id syntax (defaults to DEFAULT_APP_ID).
+    const appId = yield* resolveAppId(args.appId);
 
     // 2. Resolve participants via the local Transport-routed helper.
-    //    resolveAgentToken returns bare AgentId (NOT a participant ref),
-    //    so no .map(p => p.id) step is needed. The helper itself maps
-    //    shape failures + lookup-empty results to UnresolvedParticipantError.
-    const invitedAgentIds = yield* Effect.all(
-      args.participants.map(resolveAgentToken),
-    );
+    //    `resolveAgentTokens` coalesces all name-shaped tokens into ONE
+    //    batched `rpc(AgentsLookupByName, { names: [...uniqueNames] })`
+    //    call (P3-2); UUID-shaped tokens short-circuit client-side. The
+    //    helper maps shape failures + lookup-empty results to
+    //    `UnresolvedParticipantError` and returns bare `AgentId[]`
+    //    matching `TaskCreate.params.invitedAgentIds` directly.
+    const invitedAgentIds = yield* resolveAgentTokens(args.participants);
 
-    // 3. TaskCreate atomic
-    const { task, conversation } = yield* rpc(TaskCreate, {
-      appId,
-      invitedAgentIds,
-      initialConversation: { name: args.name, participants: invitedAgentIds },
-    }).pipe(
-      Effect.tapError((err) =>
-        Effect.sync(() => {
-          // Exit 1: nothing printed yet, transport adapter prints stderr
-        }),
-      ),
-    );
+    // 3. TaskCreate atomic. P2-B carve-out: when `invitedAgentIds` is
+    //    empty, omit `participants` from `initialConversation` entirely
+    //    (the schema's `Type.Array(AgentId, { minItems: 1 })` rejects
+    //    `[]`; the server adds the caller to participants implicitly).
+    const outcome = yield* createTaskAtomic(appId, invitedAgentIds, args.name);
 
-    if (conversation === null) {
-      // D1 canary _C5 guarantees non-null when initialConversation sent;
-      // defend against a stale D1 build with a decode-time exit 1.
-      return yield* Effect.fail(
-        new TransportDecodeError({ method: "task/create", cause: "missing conversation" }),
-      );
+    // 4. Branch on `{ task, conversation: Conversation | null }`.
+    //    `conversation === null` is the DEDUP HIT path (P2-A) — the
+    //    server matched an existing task on `{caller} ∪ invitedAgentIds`
+    //    and returned it. Handler routes through `handleDedupOutcome`,
+    //    which uses `findReusableConversation` to locate a non-archived
+    //    conversation under the existing task (`TaskConversationList`
+    //    with cursor follow, capped at `DEDUP_LOOKUP_MAX_PAGES`). If
+    //    found → reuse stdout line; if not → closed-task diagnostic +
+    //    exit 1.
+    const messageOpt = Option.fromNullable(args.message);
+    if (outcome.kind === "dedup") {
+      yield* handleDedupOutcome(outcome.task, messageOpt);
+      return;
     }
 
-    yield* Effect.sync(() =>
-      console.log(`Task started: ${task.id} (conversation: ${conversation.id})`),
-    );
+    // 5. Fresh-create success path.
+    yield* printTaskCreated(outcome.task, outcome.conversation);
 
-    // 4. Optional MessagesSend
-    if (args.message !== undefined) {
-      const sendResult = yield* rpc(MessagesSend, {
-        conversationId: conversation.id,
-        parts: [{ type: "text", text: args.message }],
-      }).pipe(
-        Effect.either,  // capture, don't propagate, so we can dispatch exit 2
-      );
-      if (Either.isLeft(sendResult)) {
-        yield* Effect.sync(() => {
-          console.error(`Error sending message: ${sendResult.left.message}`);
-          process.exit(EXIT_CODE_PARTIAL_SUCCESS);
-        });
-        return;
-      }
-      yield* Effect.sync(() =>
-        console.log(`Message sent: ${sendResult.right.message.id}`),
-      );
-    }
+    // 6. Optional MessagesSend. Wrapped in `Effect.either` so a wire
+    //    failure surfaces as inline `process.exit(2)` (preserves the
+    //    already-printed `Task started:` stdout line) rather than
+    //    routing through `runStartCommand`'s catchAll.
+    yield* Option.match(messageOpt, {
+      onNone: () => Effect.void,
+      onSome: (m) => sendFirstMessage(outcome.conversation.id, m),
+    });
   });
 ```
 
@@ -287,11 +275,13 @@ reuse it. Reasons:
    `agentParticipantRefSchema[]`. The local resolver returns bare
    `AgentId` directly, eliminating a `.map(p => p.id)` step.
 
-D2 introduces `start.ts → resolveAgentToken` (transport-routed
-sibling): parses `agent:<rest>` and either short-circuits if `rest`
-is a UUID v4 or calls `rpc(AgentsLookupByName, { names: [rest] })`.
-On empty result → `UnresolvedParticipantError({ token, reason:
-"not-found" })`. On shape failure (no `agent:` prefix, etc.) →
+D2 introduces `start.ts → resolveAgentTokens` (transport-routed
+sibling): classifies each token (shape-fail / UUID-shaped / name-shaped)
+and coalesces all name-shaped tokens into ONE batched
+`rpc(AgentsLookupByName, { names: [...uniqueNames] })` call (P3-2);
+UUID-shaped tokens short-circuit client-side. Names with no matching
+agent in the response → `UnresolvedParticipantError({ token, reason:
+"not-found" })`. Shape failures (no `agent:` prefix, etc.) →
 `UnresolvedParticipantError({ token, reason: "shape" })`.
 
 `commands/conversations.ts` keeps using `resolveParticipant`
@@ -347,9 +337,10 @@ NOT exercised by unit tests — they use `Transport` directly.
   not concurrent. The architect plan + stub are unblocked (this
   branch).
 - **Spec D2 AC interpretation: "NO RPC calls" reads as "no mutating
-  RPC calls".** `start.ts → resolveAgentToken` calls
-  `rpc(AgentsLookupByName, ...)` for name-shaped tokens (a server
-  RPC), which the strict reading of the AC would prohibit. Architect
+  RPC calls".** `start.ts → resolveAgentTokens` calls
+  `rpc(AgentsLookupByName, ...)` (batched, one call total) for
+  name-shaped tokens (a server RPC), which the strict reading of the
+  AC would prohibit. Architect
   interpretation: the AC means "NO `TaskCreate` / `MessagesSend`
   calls", since only those two are spec-D2's mutating calls. The
   read-only lookup is intentional + necessary (UUID-only tokens are

--- a/packages/client/docs/architecture/moltzap-start-cli.md
+++ b/packages/client/docs/architecture/moltzap-start-cli.md
@@ -20,6 +20,7 @@ live in `commands/start.ts`.
 | `TaskCreate` | Spec D1 (#635) → `packages/protocol/src/task/tasks.ts → TaskCreate` | Every invocation |
 | `MessagesSend` | Pre-D1, unchanged | Only when `--message` is set |
 | `AgentsLookupByName` | Pre-D1, unchanged | Per name-shaped participant token (uuid-shaped tokens skip the lookup) |
+| `TaskConversationList` | Spec D1 (#598) → `packages/protocol/src/task/tasks.ts → TaskConversationList` | Only on `TaskCreate` dedup hit (P2-A); used by `findReusableConversation` to locate a reusable conversation under the existing task |
 
 **All three RPCs go through `transport.ts → rpc(...)` (the CLI
 `Transport` service), NOT `socket-client.ts → request(...)` (the
@@ -31,13 +32,26 @@ makeFakeTransport`. Architect plan §R1 explains the divergence; the
 local resolver `start.ts → resolveAgentToken` is the new helper that
 covers D2's testability + transport-uniformity needs.**
 
-`TaskCreate` is called with `{ appId, invitedAgentIds, initialConversation:
-{ name, participants } }` where `initialConversation.participants ===
-invitedAgentIds` (the caller is implicit per D1 spec body Goal 5;
-server adds the caller to both `task_participants` and
-`conversation_participants`). Per D1 plan §R8 / Canary `_C5` the
-response shape is `{ task, conversation: Conversation | null }`; when
-`initialConversation` is sent, `conversation` is non-null.
+`TaskCreate` is called with `{ appId, invitedAgentIds, initialConversation
+}` where `initialConversation` carries `participants: invitedAgentIds`
+ONLY when `invitedAgentIds.length > 0` — the caller-only path
+(`invitedAgentIds === []`) MUST omit the `participants` field entirely
+because `InitialConversationSchema.participants` is
+`Type.Optional(Type.Array(AgentId, { minItems: 1 }))` (P2-B carve-out
+named in spec D2 amendment N7; pinned by `start.test.ts →
+zeroParticipants`). The server adds the caller to both
+`task_participants` and `conversation_participants` implicitly.
+
+Per D1 plan §R8 / Canary `_C5` the response shape is
+`{ task, conversation: Conversation | null }`. The `conversation === null`
+branch fires on the **dedup hit** path: when `appId === DEFAULT_APP_ID`
+AND the caller already owns a task with the exact same
+`{caller} ∪ invitedAgentIds` participant set, the server returns the
+existing task with no new conversation (D1 Goal 3 — dedup is task-level,
+not conversation-level). The CLI MUST NOT treat this as a decode error
+(P2-A); instead it auto-fetches a reusable conversation under the
+existing task via `findReusableConversation` and reprints the standard
+`Task started:` line with a `reusing existing conversation:` label.
 
 ## 2. Command shape
 
@@ -81,13 +95,26 @@ sequenceDiagram
     start->>tx: rpc(AgentsLookupByName, { names: ["bob"] }) (per name-shaped token)
     tx-->>start: { agents: [{ id, ... }] } or empty
 
-    Note over start: 3. rpc(TaskCreate, {appId, invitedAgentIds, initialConversation:{name, participants}})
+    Note over start: 3. rpc(TaskCreate, {appId, invitedAgentIds, initialConversation})<br>initialConversation omits participants when invitedAgentIds.length === 0 (P2-B)
     start->>tx: TaskCreate
-    tx-->>start: { task, conversation }
+    tx-->>start: { task, conversation: Conversation | null }
     Note over start: failure → TransportError → exit 1<br>stdout: nothing
-    Note over start: success → stdout: Task started: <taskId> (conversation: <convId>)
 
-    alt --message supplied
+    alt conversation !== null (fresh create)
+        Note over start: stdout: Task started: <taskId> (conversation: <convId>)
+    else conversation === null (dedup hit — P2-A)
+        Note over start: 3b. rpc(TaskConversationList, {limit, cursor?}) — follow nextCursor until match
+        start->>tx: TaskConversationList
+        tx-->>start: { items, nextCursor? }
+        Note over start: findReusableConversation(taskId): pick first item where<br>item.taskId === existingTaskId AND item.conversation.archivedAt === undefined
+        alt reusable conversation found
+            Note over start: stdout: Task started: <taskId> (reusing existing conversation: <convId>)
+        else no usable conversation (closed task, all archived, out of lookup window)
+            Note over start: stderr: Task already exists but is closed: <taskId> → exit 1
+        end
+    end
+
+    alt --message supplied AND a conversation is in hand
         Note over start: 4. rpc(MessagesSend, {conversationId: conv.id, parts:[{type:text,text}]})
         start->>tx: MessagesSend
         tx-->>start: { message }
@@ -102,9 +129,9 @@ sequenceDiagram
 
 | Code | Meaning | Stdout state | Stderr state |
 |---|---|---|---|
-| 0 | Full success | `Task started: …` (+ `Message sent: …` when `--message`) | empty |
-| 1 | `TaskCreate` failed | empty | `Failed: <err.message>` |
-| 2 | `TaskCreate` OK, `MessagesSend` failed | `Task started: …` (no `Message sent`) | `Error sending message: <err.message>` |
+| 0 | Full success (fresh create OR dedup hit with reusable conversation) | `Task started: …` (+ `Message sent: …` when `--message`) | empty |
+| 1 | `TaskCreate` wire failure OR dedup hit on a closed/unreachable task (P2-A) | empty | `Failed: <err.message>` OR `Task already exists but is closed: <taskId>` |
+| 2 | `TaskCreate` (or dedup reuse) OK, `MessagesSend` failed | `Task started: …` (no `Message sent`) | `Error sending message: <err.message>` |
 | 64 | Usage error (bad `--app-id` UUID OR unresolvable agent token) | empty | `Invalid --app-id: not a UUID` OR `Cannot resolve "<token>": <reason>` |
 
 NO rollback on exit 2: the task + empty conversation persist; user can
@@ -288,6 +315,13 @@ Spec D2 acceptance criteria → test files:
 | Partial failure | `start.test.ts > partial-success` | `TaskCreate` success + `MessagesSend` fail → assert stdout has `Task started:` line, stderr `Error sending message:`, exit 2 |
 | Unresolved participant | `start.test.ts > unresolved-participant` | `AgentsLookupByName` returns empty agents; assert exit 64, stderr names the token, ZERO `TaskCreate` / `MessagesSend` calls |
 | Help text | `start.test.ts > help` | snapshot `moltzap start --help`; assert presence of synopsis, `--message`, `--app-id`, and the four exit codes |
+| **Dedup hit, single conversation** (P2-A) | `start.test.ts > dedupHitSingleConversation` | `TaskCreate` returns `{ task: existing, conversation: null }`; `TaskConversationList` returns one matching item; assert stdout `Task started: <id> (reusing existing conversation: <id>)` |
+| **Dedup hit, multiple conversations** (P2-A tie-break) | `start.test.ts > dedupHitMultipleConversations` | server-order first match wins (most-recently-active) |
+| **Dedup hit + `--message`** (P2-A reuse-conv MessagesSend route) | `start.test.ts > dedupHitWithMessage` | `MessagesSend.params.conversationId === existing.conversation.id` |
+| **Dedup hit, filtering** (P2-A taskId + archivedAt filter) | `start.test.ts > dedupHitFiltersOtherTaskAndArchived` | items from other tasks AND `archivedAt !== undefined` items are skipped |
+| **Dedup hit, closed task** (P2-A no-usable-conv branch) | `start.test.ts > dedupHitTaskClosedNoUsableConversation` | `findReusableConversation` returns null → stderr `Task already exists but is closed: <taskId>` + exit 1 |
+| **Dedup hit, pagination** (P2-A cursor follow) | `start.test.ts > dedupHitPaginatesUntilFound` | first page has no match → follow `nextCursor` until found |
+| **Zero-participant wire shape** (P2-B carve-out) | `start.test.ts > zeroParticipants` | `TaskCreate.params.initialConversation` deep-equals `{ name }` (no `participants` key) |
 | CHANGELOG | (manual review at PR time) | grep root `CHANGELOG.md` `[Unreleased]` for the new-command entry |
 
 Test infra reuses `makeFakeTransport(...)` from

--- a/packages/client/src/cli/commands/start.test.ts
+++ b/packages/client/src/cli/commands/start.test.ts
@@ -102,10 +102,13 @@ interface RespondConfig {
 }
 
 const respondLookup = (call: TestTransportCall, config: RespondConfig) => {
+  // Batched lookup (P3-2): coalesce all requested-name agent cards from
+  // the mock's `lookupResults` map. Names with no entry return nothing
+  // — the handler maps that to `UnresolvedParticipantError` per token.
   const params = call.params as { names: readonly string[] };
-  const requestedName = params.names[0] ?? "";
   const lookupResults = config.lookupResults ?? {};
-  return { agents: lookupResults[requestedName] ?? [] };
+  const agents = params.names.flatMap((name) => lookupResults[name] ?? []);
+  return { agents };
 };
 
 const respondFromConfig =
@@ -201,6 +204,23 @@ const restoreHarness = () => {
   stderrSpy.mockRestore();
 };
 
+/**
+ * Single-source the install/restore lifecycle for one `body` execution.
+ * Used by property-test iterators (`expectNonV4Rejected`,
+ * `expectNonAgentTokenRejected`) so each `fc.assert` iteration gets a
+ * fresh, isolated harness without inline `installHarness()` / explicit
+ * `restoreHarness()` calls that drift out of sync over time. `finally`
+ * guarantees restore even on `expect` throw.
+ */
+const withInstalledHarness = (body: () => void): void => {
+  installHarness();
+  try {
+    body();
+  } finally {
+    restoreHarness();
+  }
+};
+
 const stderrLines = () => stderrSpy.mock.calls.map((c) => String(c[0] ?? ""));
 
 // ─── Test bodies: participant model ───────────────────────────────────────
@@ -222,6 +242,34 @@ const groupShape = () =>
     yield* runWith(transport, standardArgs(["agent:bob", "agent:carol"]));
     const params = taskCreateParams(calls);
     expect(params.invitedAgentIds).toEqual([BOB_AGENT_ID, CAROL_AGENT_ID]);
+    // Pins the P3-2 batched-lookup optimization: N name-shaped tokens
+    // coalesce into ONE `AgentsLookupByName` RPC, not N. Drift here
+    // re-introduces a fan-out per token (visible cost on group tasks).
+    const lookups = calls.filter((c) => c.method === AgentsLookupByName.name);
+    expect(lookups).toHaveLength(1);
+    expect(lookups[0]!.params).toEqual({ names: ["bob", "carol"] });
+  });
+
+const duplicateNameDedupesLookup = () =>
+  Effect.gen(function* () {
+    // P3-2 secondary invariant: duplicate name tokens dedupe in the
+    // batched lookup payload (one wire-name per unique value) but
+    // resolve to the agent id at every input position. UUID-shaped
+    // siblings still skip the wire.
+    const { calls, transport } = makeTransportWith(onlyBobLookup());
+    yield* runWith(
+      transport,
+      standardArgs(["agent:bob", `agent:${DAVE_AGENT_ID_UUID}`, "agent:bob"]),
+    );
+    const params = taskCreateParams(calls);
+    expect(params.invitedAgentIds).toEqual([
+      BOB_AGENT_ID,
+      DAVE_AGENT_ID_UUID,
+      BOB_AGENT_ID,
+    ]);
+    const lookups = calls.filter((c) => c.method === AgentsLookupByName.name);
+    expect(lookups).toHaveLength(1);
+    expect(lookups[0]!.params).toEqual({ names: ["bob"] });
   });
 
 const callerExcluded = () =>
@@ -268,6 +316,10 @@ describe("moltzap start — participant model", () => {
   it("caller-excluded", callerExcluded);
   it("uuid-shorthand", uuidShorthand);
   it("zero-participants admitted (plan §R4)", zeroParticipants);
+  it(
+    "duplicate name tokens dedupe in batched lookup (P3-2)",
+    duplicateNameDedupesLookup,
+  );
 });
 
 // ─── Test bodies: output format ───────────────────────────────────────────
@@ -339,20 +391,20 @@ const nonV4HexDigit = fc
  * Runs synchronously via `Effect.runSync` because the test transport
  * never suspends.
  */
-const expectNonV4Rejected = (digit: string) => {
-  const uuid = `11111111-2222-${digit}333-8444-555555555555`;
-  const { calls, transport } = makeTransportWith({});
-  installHarness();
-  Effect.runSync(runWith(transport, standardArgs([], { appId: uuid })));
-  expect(exitSpy).toHaveBeenCalledWith(64);
-  expect(calls).toEqual([]);
-  restoreHarness();
-};
+const expectNonV4Rejected = (digit: string) =>
+  withInstalledHarness(() => {
+    const uuid = `11111111-2222-${digit}333-8444-555555555555`;
+    const { calls, transport } = makeTransportWith({});
+    Effect.runSync(runWith(transport, standardArgs([], { appId: uuid })));
+    expect(exitSpy).toHaveBeenCalledWith(64);
+    expect(calls).toEqual([]);
+  });
 
 const invariantNonV4Rejection = () => {
   fc.assert(fc.property(nonV4HexDigit, expectNonV4Rejected), { numRuns: 30 });
-  // Re-install for afterEach symmetry; the property body restored
-  // its own harness on each iteration.
+  // Re-install for afterEach symmetry; each property iteration tore
+  // down its harness via `withInstalledHarness`, leaving none for the
+  // outer afterEach to restore.
   installHarness();
 };
 
@@ -423,19 +475,42 @@ const unresolvedShape = () =>
     expect(calls).toEqual([]);
   });
 
+const tooManyDistinctNames = () =>
+  Effect.gen(function* () {
+    // P3-2 carve-out: `AgentsLookupByName.params.names` is capped at
+    // `maxItems: 100`. With 101 DISTINCT name tokens, the batched RPC
+    // would otherwise fail server-side AJV → opaque exit 1. The
+    // pre-RPC cap check surfaces it as exit 64 with a clear message.
+    const tokens = Array.from(
+      { length: 101 },
+      (_, i) => `agent:user${i.toString().padStart(3, "0")}`,
+    );
+    const { calls, transport } = makeTransportWith({});
+    yield* runWith(transport, standardArgs(tokens));
+    expect(exitSpy).toHaveBeenCalledWith(64);
+    // Cap fires BEFORE the RPC — zero wire calls.
+    expect(calls).toEqual([]);
+    // Structural assertion: diagnostic mentions BOTH the offending
+    // count and the schema cap so the user can reduce input directly.
+    expect(
+      stderrLines().some(
+        (s) => s.includes("Too many") && s.includes("101") && s.includes("100"),
+      ),
+    ).toBe(true);
+  });
+
 /**
  * Property body: any token without the `agent:` prefix fails at the
  * shape check before any RPC. The handler must always exit 64 with
  * zero RPC calls — the resolver short-circuits at the prefix test.
  */
-const expectNonAgentTokenRejected = (token: string) => {
-  installHarness();
-  const { calls, transport } = makeTransportWith({});
-  Effect.runSync(runWith(transport, standardArgs([token])));
-  expect(exitSpy).toHaveBeenCalledWith(64);
-  expect(calls).toEqual([]);
-  restoreHarness();
-};
+const expectNonAgentTokenRejected = (token: string) =>
+  withInstalledHarness(() => {
+    const { calls, transport } = makeTransportWith({});
+    Effect.runSync(runWith(transport, standardArgs([token])));
+    expect(exitSpy).toHaveBeenCalledWith(64);
+    expect(calls).toEqual([]);
+  });
 
 const nonAgentToken = fc
   .string({ minLength: 1, maxLength: 30 })
@@ -462,6 +537,10 @@ describe("moltzap start — failure paths", () => {
     unresolvedLookupEmpty,
   );
   it("unresolved (shape) -> exit 64, ZERO RPC calls", unresolvedShape);
+  it(
+    ">100 distinct names -> exit 64 with TooManyParticipantNamesError diagnostic",
+    tooManyDistinctNames,
+  );
   plainIt(
     "invariant: non-agent: prefix tokens exit 64 with ZERO RPC calls",
     invariantNonAgentRejection,

--- a/packages/client/src/cli/commands/start.test.ts
+++ b/packages/client/src/cli/commands/start.test.ts
@@ -21,6 +21,7 @@ import {
   AgentsLookupByName,
   DEFAULT_APP_ID,
   MessagesSend,
+  TaskConversationList,
   TaskCreate,
 } from "@moltzap/protocol";
 import { Transport } from "../transport.js";
@@ -97,6 +98,7 @@ interface RespondConfig {
   readonly lookupResults?: Record<string, ReturnType<typeof agentCard>[]>;
   readonly taskCreate?: () => unknown | Error;
   readonly messagesSend?: () => unknown | Error;
+  readonly taskConversationList?: (call: TestTransportCall) => unknown | Error;
 }
 
 const respondLookup = (call: TestTransportCall, config: RespondConfig) => {
@@ -117,6 +119,11 @@ const respondFromConfig =
     if (call.method === MessagesSend.name) {
       return (config.messagesSend ?? MESSAGES_SEND_OK)();
     }
+    if (call.method === TaskConversationList.name) {
+      return (
+        config.taskConversationList ?? (() => ({ items: [] as unknown[] }))
+      )(call);
+    }
     return new Error(`Unexpected RPC: ${call.method}`);
   };
 
@@ -134,7 +141,12 @@ const findCallOf = (calls: readonly TestTransportCall[], method: string) =>
 type TaskCreateParams = {
   appId: string;
   invitedAgentIds: readonly string[];
-  initialConversation: { name: string; participants: readonly string[] };
+  // Spec D2 (#599) amendment N7 — `participants` is OPTIONAL on the
+  // wire (caller-only path omits it; see `start.ts → createTaskAtomic`).
+  initialConversation: {
+    name: string;
+    participants?: readonly string[];
+  };
 };
 
 const taskCreateParams = (
@@ -237,7 +249,12 @@ const zeroParticipants = () =>
     yield* runWith(transport, standardArgs([]));
     const params = taskCreateParams(calls);
     expect(params.invitedAgentIds).toEqual([]);
-    expect(params.initialConversation.participants).toEqual([]);
+    // P2-B: zero-participant path MUST omit `participants` from
+    // `initialConversation` so the wire payload satisfies
+    // `InitialConversationSchema` (participants is Optional with
+    // `minItems: 1`). The exact shape pin guards against drift.
+    expect(params.initialConversation).toEqual({ name: CONVERSATION_NAME });
+    expect("participants" in params.initialConversation).toBe(false);
     const lookups = calls.filter((c) => c.method === AgentsLookupByName.name);
     expect(lookups).toEqual([]);
   });
@@ -448,6 +465,348 @@ describe("moltzap start — failure paths", () => {
   plainIt(
     "invariant: non-agent: prefix tokens exit 64 with ZERO RPC calls",
     invariantNonAgentRejection,
+  );
+});
+
+// ─── Test bodies: dedup hit (P2-A, spec D2 amendment N6) ─────────────────
+
+const EXISTING_TASK_ID = "00000000-0000-4000-8000-0000000000d1";
+const EXISTING_CONV_ID_ACTIVE = "00000000-0000-4000-8000-0000000000d2";
+const EXISTING_CONV_ID_OLDER = "00000000-0000-4000-8000-0000000000d3";
+const OTHER_TASK_ID = "00000000-0000-4000-8000-0000000000e9";
+
+// Widened-status type so active/closed fixtures share a common shape
+// (default + override into `TASK_CREATE_DEDUP` without an `unknown` cast).
+// `satisfies` would be tighter but `taskFixture` itself is loose-typed
+// upstream (string id, no `as Task` cast) — adding a strict satisfies
+// here would propagate that brittleness without the corresponding
+// upstream fix. The widened alias is the local lower bound that the
+// dedup tests need; protocol-schema drift is caught by the protocol
+// type canaries (`task-conversation-family.types-check.ts`), not by
+// fixture site checks.
+type TaskLikeFixture = Omit<typeof taskFixture, "status" | "endedAt"> & {
+  status: "active" | "closed";
+  endedAt: string | null;
+};
+
+const existingTaskFixture: TaskLikeFixture = {
+  ...taskFixture,
+  id: EXISTING_TASK_ID,
+};
+
+const existingTaskClosedFixture: TaskLikeFixture = {
+  ...existingTaskFixture,
+  status: "closed",
+  endedAt: NOW_ISO,
+};
+
+const conversationFixtureActive = {
+  ...conversationFixture,
+  id: EXISTING_CONV_ID_ACTIVE,
+  createdAt: "2026-05-19T01:00:00Z",
+};
+
+const conversationFixtureOlder = {
+  ...conversationFixture,
+  id: EXISTING_CONV_ID_OLDER,
+  createdAt: "2026-05-18T00:00:00Z",
+};
+
+const TASK_CREATE_DEDUP =
+  (task: TaskLikeFixture = existingTaskFixture) =>
+  () => ({
+    task,
+    conversation: null,
+  });
+
+const taskConvListItem = (
+  taskId: string,
+  conversation: typeof conversationFixture,
+) => ({
+  taskId,
+  conversation,
+  participants: [INITIATOR_ID, BOB_AGENT_ID],
+});
+
+const dedupHitSingleConversation = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: TASK_CREATE_DEDUP(),
+      taskConversationList: () => ({
+        items: [taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive)],
+      }),
+    });
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${EXISTING_TASK_ID} (reusing existing conversation: ${EXISTING_CONV_ID_ACTIVE})`,
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+    // Must have called TaskConversationList exactly once (single page,
+    // single match). Cursor MUST NOT be passed on first page.
+    const listCall = findCallOf(calls, TaskConversationList.name);
+    expect(listCall).toBeDefined();
+    expect(listCall!.params).toEqual({ limit: 100 });
+  });
+
+const dedupHitMultipleConversations = () =>
+  Effect.gen(function* () {
+    // Server-side ordering is activity-desc, so the FIRST item under
+    // the target task is the most-recently-active. The handler picks
+    // it without re-sorting (per spec D2 amendment N6 tie-break: "first
+    // match in server iteration order").
+    const { transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: TASK_CREATE_DEDUP(),
+      taskConversationList: () => ({
+        items: [
+          // Server order: active first, older second.
+          taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive),
+          taskConvListItem(EXISTING_TASK_ID, conversationFixtureOlder),
+        ],
+      }),
+    });
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${EXISTING_TASK_ID} (reusing existing conversation: ${EXISTING_CONV_ID_ACTIVE})`,
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+const dedupHitWithMessage = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: TASK_CREATE_DEDUP(),
+      taskConversationList: () => ({
+        items: [taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive)],
+      }),
+    });
+    yield* runWith(
+      transport,
+      standardArgs(["agent:bob"], { message: "hello" }),
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${EXISTING_TASK_ID} (reusing existing conversation: ${EXISTING_CONV_ID_ACTIVE})`,
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(`Message sent: ${MESSAGE_ID}`);
+    // The MessagesSend payload MUST route to the REUSED conversation,
+    // not the (null) freshly-created one.
+    const sendCall = findCallOf(calls, MessagesSend.name);
+    expect(sendCall).toBeDefined();
+    expect(
+      (sendCall!.params as { conversationId: string }).conversationId,
+    ).toBe(EXISTING_CONV_ID_ACTIVE);
+  });
+
+const dedupHitFiltersOtherTaskAndArchived = () =>
+  Effect.gen(function* () {
+    // The list mixes items from other tasks AND archived rows under
+    // our task — the handler must skip both and find the lone non-
+    // archived match.
+    const archivedConv = {
+      ...conversationFixtureOlder,
+      archivedAt: NOW_ISO,
+    };
+    const { transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: TASK_CREATE_DEDUP(),
+      taskConversationList: () => ({
+        items: [
+          taskConvListItem(OTHER_TASK_ID, conversationFixtureActive),
+          taskConvListItem(EXISTING_TASK_ID, archivedConv),
+          taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive),
+        ],
+      }),
+    });
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${EXISTING_TASK_ID} (reusing existing conversation: ${EXISTING_CONV_ID_ACTIVE})`,
+    );
+  });
+
+const dedupHitTaskClosedNoUsableConversation = () =>
+  Effect.gen(function* () {
+    // Existing task is reported by the dedup query but all
+    // conversations under it are archived → `findReusableConversation`
+    // returns null → handler emits closed-task diagnostic + exit 1.
+    const archivedConv = {
+      ...conversationFixtureActive,
+      archivedAt: NOW_ISO,
+    };
+    const { transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: TASK_CREATE_DEDUP(existingTaskClosedFixture),
+      taskConversationList: () => ({
+        items: [taskConvListItem(EXISTING_TASK_ID, archivedConv)],
+      }),
+    });
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    expect(stderrLines()).toContain(
+      `Task already exists but is closed: ${EXISTING_TASK_ID}`,
+    );
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+const dedupHitPaginatesUntilFound = () =>
+  Effect.gen(function* () {
+    // First page is full of OTHER tasks → handler must follow
+    // `nextCursor` to find the target on page two. Pin both calls so a
+    // regression that drops pagination support fails the test.
+    let callCount = 0;
+    const { calls, transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: TASK_CREATE_DEDUP(),
+      taskConversationList: () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            items: [taskConvListItem(OTHER_TASK_ID, conversationFixtureOlder)],
+            nextCursor: "2026-05-18T12:00:00Z",
+          };
+        }
+        return {
+          items: [
+            taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive),
+          ],
+        };
+      },
+    });
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    expect(callCount).toBe(2);
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${EXISTING_TASK_ID} (reusing existing conversation: ${EXISTING_CONV_ID_ACTIVE})`,
+    );
+    // Second call MUST forward the cursor returned by the first page.
+    const listCalls = calls.filter(
+      (c) => c.method === TaskConversationList.name,
+    );
+    expect(listCalls).toHaveLength(2);
+    expect(listCalls[1]!.params).toEqual({
+      limit: 100,
+      cursor: "2026-05-18T12:00:00Z",
+    });
+  });
+
+const dedupHitCapsAtMaxPages = () =>
+  Effect.gen(function* () {
+    // Adversarial server that NEVER returns nextCursor: undefined. The
+    // handler MUST stop at `DEDUP_LOOKUP_MAX_PAGES = 10` and surface
+    // the closed-task diagnostic; without the cap this loops forever
+    // and the test times out. Pins the cap value as a contract.
+    let pageCount = 0;
+    const { calls, transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: TASK_CREATE_DEDUP(),
+      taskConversationList: () => {
+        pageCount += 1;
+        return {
+          items: [taskConvListItem(OTHER_TASK_ID, conversationFixtureOlder)],
+          nextCursor: `cursor-page-${pageCount}`,
+        };
+      },
+    });
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    const listCalls = calls.filter(
+      (c) => c.method === TaskConversationList.name,
+    );
+    expect(listCalls).toHaveLength(10); // DEDUP_LOOKUP_MAX_PAGES
+    expect(stderrLines()).toContain(
+      `Task already exists but is closed: ${EXISTING_TASK_ID}`,
+    );
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+const dedupHitClosedTaskWithMessage = () =>
+  Effect.gen(function* () {
+    // Partial-failure: TaskCreate dedup-hit + closed-task + --message.
+    // The user's message is intentionally DROPPED — handler exits 1
+    // before reaching `sendFirstMessage`. Pinned so any future change
+    // to add a separate diagnostic ('Message NOT sent: ...') has to
+    // update this test, preventing silent regression.
+    const archivedConv = {
+      ...conversationFixtureActive,
+      archivedAt: NOW_ISO,
+    };
+    const { calls, transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: TASK_CREATE_DEDUP(existingTaskClosedFixture),
+      taskConversationList: () => ({
+        items: [taskConvListItem(EXISTING_TASK_ID, archivedConv)],
+      }),
+    });
+    yield* runWith(
+      transport,
+      standardArgs(["agent:bob"], { message: "hello" }),
+    );
+    expect(calls.filter((c) => c.method === MessagesSend.name)).toEqual([]);
+    expect(stderrLines()).toContain(
+      `Task already exists but is closed: ${EXISTING_TASK_ID}`,
+    );
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+const dedupHitListRpcFailure = () =>
+  Effect.gen(function* () {
+    // TaskCreate succeeds (dedup hit). TaskConversationList fails with
+    // a wire error (e.g. cursor-format drift). Without the
+    // `DedupListFailedError` remap, the user would see
+    // `Failed: <list-error>` and assume TaskCreate failed → retry →
+    // re-dedup forever. The remap surfaces the existing taskId so the
+    // user knows the task is real.
+    const { transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: TASK_CREATE_DEDUP(),
+      taskConversationList: () => new Error("cursor server-rejected"),
+    });
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    expect(
+      stderrLines().some(
+        (s) =>
+          s.startsWith(`Task ${EXISTING_TASK_ID} already exists`) &&
+          s.includes("reusable-conversation lookup failed"),
+      ),
+    ).toBe(true);
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+describe("moltzap start — dedup hit (P2-A / spec D2 amendment N6)", () => {
+  beforeEach(installHarness);
+  afterEach(restoreHarness);
+
+  it("single existing conversation -> reuses it", dedupHitSingleConversation);
+  it(
+    "multiple conversations -> picks first in server iteration order",
+    dedupHitMultipleConversations,
+  );
+  it("with --message -> sends to reused conversation", dedupHitWithMessage);
+  it(
+    "filters items from other tasks and archived rows",
+    dedupHitFiltersOtherTaskAndArchived,
+  );
+  it(
+    "task closed / all archived -> exit 1 with stderr diagnostic",
+    dedupHitTaskClosedNoUsableConversation,
+  );
+  it(
+    "paginates via nextCursor when first page misses",
+    dedupHitPaginatesUntilFound,
+  );
+  it(
+    "caps at DEDUP_LOOKUP_MAX_PAGES when server never returns final page",
+    dedupHitCapsAtMaxPages,
+  );
+  it(
+    "closed task + --message -> message dropped, exit 1",
+    dedupHitClosedTaskWithMessage,
+  );
+  it(
+    "TaskConversationList wire failure -> distinct diagnostic, NOT 'Failed: ...'",
+    dedupHitListRpcFailure,
   );
 });
 

--- a/packages/client/src/cli/commands/start.test.ts
+++ b/packages/client/src/cli/commands/start.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Unit tests for `moltzap start` (spec D2 #599 / sub-issue #661).
+ *
+ * Coverage map matches per-flow doc 09 §7. Each test body is a named
+ * helper to keep describe-blocks under the 50-line per-function limit
+ * (matches the pattern in `transport.test.ts`).
+ */
+import { Effect } from "effect";
+import * as fc from "fast-check";
+import { it as effectIt } from "@effect/vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it as plainIt,
+  vi,
+  type MockInstance,
+} from "vitest";
+import {
+  AgentsLookupByName,
+  DEFAULT_APP_ID,
+  MessagesSend,
+  TaskCreate,
+} from "@moltzap/protocol";
+import { Transport } from "../transport.js";
+import { makeFakeTransport, type TestTransportCall } from "./test-transport.js";
+import { runStartHandler, startCommand } from "./start.js";
+
+const it = effectIt.effect;
+
+// ─── Contractual literals (also asserted in `help` test) ──────────────────
+
+const HELP_SYNOPSIS = "Start a task with named participants";
+const HELP_MENTIONS_MESSAGES_SEND = "MessagesSend";
+const HELP_APP_ID_FLAG = "--app-id";
+const HELP_EXIT_CODES_HEADING = "Exit codes:";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────
+
+const CONVERSATION_NAME = "demo";
+const TASK_ID = "00000000-0000-4000-8000-000000000001";
+const CONVERSATION_ID = "00000000-0000-4000-8000-00000000000c";
+const MESSAGE_ID = "00000000-0000-4000-8000-00000000000a";
+const INITIATOR_ID = "00000000-0000-4000-8000-0000000000f0";
+const BOB_AGENT_ID = "00000000-0000-4000-8000-000000000ab1";
+const CAROL_AGENT_ID = "00000000-0000-4000-8000-000000000ab2";
+const DAVE_AGENT_ID_UUID = "00000000-0000-4000-8000-000000000ab3";
+const NOW_ISO = "2026-05-19T00:00:00Z";
+const VALID_APP_ID_OVERRIDE = "11111111-2222-4333-8444-555555555555";
+const UUID_V1_OVERRIDE = "11111111-2222-1333-8444-555555555555";
+
+const taskFixture = {
+  id: TASK_ID,
+  appId: DEFAULT_APP_ID,
+  initiatorAgentId: INITIATOR_ID,
+  status: "active" as const,
+  tmEndpointAddress: "endpoint",
+  startedAt: NOW_ISO,
+  endedAt: null,
+  createdAt: NOW_ISO,
+};
+
+const conversationFixture = {
+  id: CONVERSATION_ID,
+  type: "group" as const,
+  name: CONVERSATION_NAME,
+  createdBy: INITIATOR_ID,
+  createdAt: NOW_ISO,
+  updatedAt: NOW_ISO,
+};
+
+const messageFixture = {
+  id: MESSAGE_ID,
+  conversationId: CONVERSATION_ID,
+  senderId: INITIATOR_ID,
+  parts: [{ type: "text" as const, text: "hello" }],
+  createdAt: NOW_ISO,
+};
+
+const agentCard = (id: string, name: string) => ({
+  id,
+  name,
+  status: "active" as const,
+});
+
+const TASK_CREATE_OK = () => ({
+  task: taskFixture,
+  conversation: conversationFixture,
+});
+
+const MESSAGES_SEND_OK = () => ({ message: messageFixture });
+
+// ─── Fake transport assembly ──────────────────────────────────────────────
+
+interface RespondConfig {
+  readonly lookupResults?: Record<string, ReturnType<typeof agentCard>[]>;
+  readonly taskCreate?: () => unknown | Error;
+  readonly messagesSend?: () => unknown | Error;
+}
+
+const respondLookup = (call: TestTransportCall, config: RespondConfig) => {
+  const params = call.params as { names: readonly string[] };
+  const requestedName = params.names[0] ?? "";
+  const lookupResults = config.lookupResults ?? {};
+  return { agents: lookupResults[requestedName] ?? [] };
+};
+
+const respondFromConfig =
+  (config: RespondConfig) => (call: TestTransportCall) => {
+    if (call.method === AgentsLookupByName.name) {
+      return respondLookup(call, config);
+    }
+    if (call.method === TaskCreate.name) {
+      return (config.taskCreate ?? TASK_CREATE_OK)();
+    }
+    if (call.method === MessagesSend.name) {
+      return (config.messagesSend ?? MESSAGES_SEND_OK)();
+    }
+    return new Error(`Unexpected RPC: ${call.method}`);
+  };
+
+const makeTransportWith = (config: RespondConfig) =>
+  makeFakeTransport(respondFromConfig(config));
+
+const runWith = (
+  transport: ReturnType<typeof makeFakeTransport>["transport"],
+  args: Parameters<typeof runStartHandler>[0],
+) => runStartHandler(args).pipe(Effect.provideService(Transport, transport));
+
+const findCallOf = (calls: readonly TestTransportCall[], method: string) =>
+  calls.find((c) => c.method === method);
+
+type TaskCreateParams = {
+  appId: string;
+  invitedAgentIds: readonly string[];
+  initialConversation: { name: string; participants: readonly string[] };
+};
+
+const taskCreateParams = (
+  calls: readonly TestTransportCall[],
+): TaskCreateParams =>
+  findCallOf(calls, TaskCreate.name)!.params as TaskCreateParams;
+
+const mutatingCalls = (calls: readonly TestTransportCall[]) =>
+  calls.filter(
+    (c) => c.method === TaskCreate.name || c.method === MessagesSend.name,
+  );
+
+const standardArgs = (
+  participants: readonly string[],
+  overrides: Partial<Parameters<typeof runStartHandler>[0]> = {},
+): Parameters<typeof runStartHandler>[0] => ({
+  name: CONVERSATION_NAME,
+  participants,
+  message: undefined,
+  appId: undefined,
+  ...overrides,
+});
+
+const onlyBobLookup = (): RespondConfig => ({
+  lookupResults: { bob: [agentCard(BOB_AGENT_ID, "bob")] },
+});
+
+const bobCarolLookup = (): RespondConfig => ({
+  lookupResults: {
+    bob: [agentCard(BOB_AGENT_ID, "bob")],
+    carol: [agentCard(CAROL_AGENT_ID, "carol")],
+  },
+});
+
+// ─── Shared harness (console + process.exit) ──────────────────────────────
+
+let stdoutSpy: MockInstance;
+let stderrSpy: MockInstance;
+let exitSpy: ReturnType<typeof vi.fn>;
+const originalExit = process.exit;
+
+const installHarness = () => {
+  stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  exitSpy = vi.fn();
+  process.exit = exitSpy as never;
+};
+
+const restoreHarness = () => {
+  process.exit = originalExit;
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+};
+
+const stderrLines = () => stderrSpy.mock.calls.map((c) => String(c[0] ?? ""));
+
+// ─── Test bodies: participant model ───────────────────────────────────────
+
+const dmShape = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith(onlyBobLookup());
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    const params = taskCreateParams(calls);
+    expect(params.invitedAgentIds).toEqual([BOB_AGENT_ID]);
+    expect(params.invitedAgentIds.length).toBe(1);
+    expect(params.initialConversation.participants).toEqual([BOB_AGENT_ID]);
+    expect(params.initialConversation.name).toBe(CONVERSATION_NAME);
+  });
+
+const groupShape = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith(bobCarolLookup());
+    yield* runWith(transport, standardArgs(["agent:bob", "agent:carol"]));
+    const params = taskCreateParams(calls);
+    expect(params.invitedAgentIds).toEqual([BOB_AGENT_ID, CAROL_AGENT_ID]);
+  });
+
+const callerExcluded = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith(onlyBobLookup());
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    const params = taskCreateParams(calls);
+    expect(params.invitedAgentIds).not.toContain(INITIATOR_ID);
+    expect(params.invitedAgentIds).toEqual([BOB_AGENT_ID]);
+  });
+
+const uuidShorthand = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith({});
+    yield* runWith(transport, standardArgs([`agent:${DAVE_AGENT_ID_UUID}`]));
+    const lookups = calls.filter((c) => c.method === AgentsLookupByName.name);
+    expect(lookups).toEqual([]);
+    const params = taskCreateParams(calls);
+    expect(params.invitedAgentIds).toEqual([DAVE_AGENT_ID_UUID]);
+  });
+
+const zeroParticipants = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith({});
+    yield* runWith(transport, standardArgs([]));
+    const params = taskCreateParams(calls);
+    expect(params.invitedAgentIds).toEqual([]);
+    expect(params.initialConversation.participants).toEqual([]);
+    const lookups = calls.filter((c) => c.method === AgentsLookupByName.name);
+    expect(lookups).toEqual([]);
+  });
+
+describe("moltzap start — participant model", () => {
+  beforeEach(installHarness);
+  afterEach(restoreHarness);
+
+  it("dm-shape", dmShape);
+  it("group-shape, order preserved", groupShape);
+  it("caller-excluded", callerExcluded);
+  it("uuid-shorthand", uuidShorthand);
+  it("zero-participants admitted (plan §R4)", zeroParticipants);
+});
+
+// ─── Test bodies: output format ───────────────────────────────────────────
+
+const outputFormat = () =>
+  Effect.gen(function* () {
+    const { transport } = makeTransportWith(onlyBobLookup());
+    yield* runWith(
+      transport,
+      standardArgs(["agent:bob"], { message: "hello" }),
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${TASK_ID} (conversation: ${CONVERSATION_ID})`,
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(`Message sent: ${MESSAGE_ID}`);
+  });
+
+describe("moltzap start — output format", () => {
+  beforeEach(installHarness);
+  afterEach(restoreHarness);
+
+  it("prints exact stdout strings with response IDs", outputFormat);
+});
+
+// ─── Test bodies: --app-id ────────────────────────────────────────────────
+
+const defaultAppId = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith(onlyBobLookup());
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    expect(taskCreateParams(calls).appId).toBe(DEFAULT_APP_ID);
+  });
+
+const validAppIdOverride = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith(onlyBobLookup());
+    yield* runWith(
+      transport,
+      standardArgs(["agent:bob"], { appId: VALID_APP_ID_OVERRIDE }),
+    );
+    expect(taskCreateParams(calls).appId).toBe(VALID_APP_ID_OVERRIDE);
+  });
+
+const invalidAppIdGarbage = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith({});
+    yield* runWith(transport, standardArgs([], { appId: "not-a-uuid" }));
+    expect(exitSpy).toHaveBeenCalledWith(64);
+    expect(calls).toEqual([]);
+    expect(stderrSpy).toHaveBeenCalledWith("Invalid --app-id: not a UUID");
+  });
+
+const invalidAppIdUuidV1 = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith({});
+    yield* runWith(transport, standardArgs([], { appId: UUID_V1_OVERRIDE }));
+    expect(exitSpy).toHaveBeenCalledWith(64);
+    expect(calls).toEqual([]);
+  });
+
+const nonV4HexDigit = fc
+  .integer({ min: 0, max: 15 })
+  .filter((n) => n !== 4)
+  .map((n) => n.toString(16));
+
+/**
+ * Property body: builds a syntactically-valid UUID with a non-4
+ * version digit and asserts the handler exits 64 with zero RPC calls.
+ * Runs synchronously via `Effect.runSync` because the test transport
+ * never suspends.
+ */
+const expectNonV4Rejected = (digit: string) => {
+  const uuid = `11111111-2222-${digit}333-8444-555555555555`;
+  const { calls, transport } = makeTransportWith({});
+  installHarness();
+  Effect.runSync(runWith(transport, standardArgs([], { appId: uuid })));
+  expect(exitSpy).toHaveBeenCalledWith(64);
+  expect(calls).toEqual([]);
+  restoreHarness();
+};
+
+const invariantNonV4Rejection = () => {
+  fc.assert(fc.property(nonV4HexDigit, expectNonV4Rejected), { numRuns: 30 });
+  // Re-install for afterEach symmetry; the property body restored
+  // its own harness on each iteration.
+  installHarness();
+};
+
+describe("moltzap start — --app-id", () => {
+  beforeEach(installHarness);
+  afterEach(restoreHarness);
+
+  it("default sends DEFAULT_APP_ID", defaultAppId);
+  it("override sends the provided v4", validAppIdOverride);
+  it("garbage UUID -> exit 64, ZERO RPC calls", invalidAppIdGarbage);
+  it("UUID v1 -> exit 64, ZERO RPC calls", invalidAppIdUuidV1);
+  plainIt(
+    "invariant: every non-v4 syntax exits 64 with ZERO RPC calls",
+    invariantNonV4Rejection,
+  );
+});
+
+// ─── Test bodies: failure paths ───────────────────────────────────────────
+
+const serverRejectsTaskCreate = () =>
+  Effect.gen(function* () {
+    const { transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskCreate: () => new Error("app not installed"),
+    });
+    yield* runWith(
+      transport,
+      standardArgs(["agent:bob"], { appId: VALID_APP_ID_OVERRIDE }),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderrLines().some((s) => s.startsWith("Failed: "))).toBe(true);
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+const partialSuccess = () =>
+  Effect.gen(function* () {
+    const { transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      messagesSend: () => new Error("conv full"),
+    });
+    yield* runWith(
+      transport,
+      standardArgs(["agent:bob"], { message: "hello" }),
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${TASK_ID} (conversation: ${CONVERSATION_ID})`,
+    );
+    expect(
+      stderrLines().some((s) => s.startsWith("Error sending message: ")),
+    ).toBe(true);
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+
+const unresolvedLookupEmpty = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith({ lookupResults: {} });
+    yield* runWith(transport, standardArgs(["agent:unknown"]));
+    expect(exitSpy).toHaveBeenCalledWith(64);
+    expect(mutatingCalls(calls)).toEqual([]);
+    expect(stderrLines().some((s) => s.includes("agent:unknown"))).toBe(true);
+  });
+
+const unresolvedShape = () =>
+  Effect.gen(function* () {
+    const { calls, transport } = makeTransportWith({});
+    yield* runWith(transport, standardArgs(["bob"]));
+    expect(exitSpy).toHaveBeenCalledWith(64);
+    expect(calls).toEqual([]);
+  });
+
+/**
+ * Property body: any token without the `agent:` prefix fails at the
+ * shape check before any RPC. The handler must always exit 64 with
+ * zero RPC calls — the resolver short-circuits at the prefix test.
+ */
+const expectNonAgentTokenRejected = (token: string) => {
+  installHarness();
+  const { calls, transport } = makeTransportWith({});
+  Effect.runSync(runWith(transport, standardArgs([token])));
+  expect(exitSpy).toHaveBeenCalledWith(64);
+  expect(calls).toEqual([]);
+  restoreHarness();
+};
+
+const nonAgentToken = fc
+  .string({ minLength: 1, maxLength: 30 })
+  .filter((s) => !s.startsWith("agent:"));
+
+const invariantNonAgentRejection = () => {
+  fc.assert(fc.property(nonAgentToken, expectNonAgentTokenRejected), {
+    numRuns: 30,
+  });
+  installHarness();
+};
+
+describe("moltzap start — failure paths", () => {
+  beforeEach(installHarness);
+  afterEach(restoreHarness);
+
+  it("server-reject TaskCreate -> exit 1", serverRejectsTaskCreate);
+  it(
+    "partial-success TaskCreate OK + MessagesSend fail -> exit 2",
+    partialSuccess,
+  );
+  it(
+    "unresolved (lookup empty) -> exit 64, ZERO mutating RPCs",
+    unresolvedLookupEmpty,
+  );
+  it("unresolved (shape) -> exit 64, ZERO RPC calls", unresolvedShape);
+  plainIt(
+    "invariant: non-agent: prefix tokens exit 64 with ZERO RPC calls",
+    invariantNonAgentRejection,
+  );
+});
+
+// ─── Tests: help text ─────────────────────────────────────────────────────
+
+const helpDescription = () => {
+  const desc = JSON.stringify(startCommand);
+  expect(desc).toContain(HELP_SYNOPSIS);
+  expect(desc).toContain(HELP_MENTIONS_MESSAGES_SEND);
+  expect(desc).toContain(HELP_APP_ID_FLAG);
+  expect(desc).toContain(HELP_EXIT_CODES_HEADING);
+};
+
+describe("moltzap start — help", () => {
+  plainIt(
+    "Command.withDescription contains synopsis + --app-id + exit-code table",
+    helpDescription,
+  );
+});

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -252,6 +252,9 @@ const createTaskAtomic = (
   Transport
 > =>
   Effect.gen(function* () {
+    // Defensive copies: TaskCreate's params type expects mutable arrays
+    // (TypeBox's Static<Array> resolves to T[], not readonly T[]); pass
+    // shallow clones so the caller's readonly contract isn't bypassed.
     const result = yield* rpc(TaskCreate, {
       appId,
       invitedAgentIds: [...invitedAgentIds],
@@ -311,7 +314,7 @@ const startCommandHandler = (
     );
     yield* printTaskStarted(task, conversation);
     if (args.message !== undefined) {
-      yield* sendFirstMessage(conversation.id as ConversationId, args.message);
+      yield* sendFirstMessage(conversation.id, args.message);
     }
   }).pipe(Effect.withSpan("startCommandHandler"));
 

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -4,77 +4,59 @@
  * Spec D2 (#599) — single-command CLI composition over Spec D1's atomic
  * `TaskCreate({ appId, invitedAgentIds, initialConversation })` plus an
  * optional `MessagesSend`. Today's two-step workflow
- * (`conversations create` → `send conv:&lt;id> &lt;text>`) collapses into one
- * subcommand for the common case.
- *
- * Architect stub (sub-issue #643). The `Command.make` registration is
- * already wired in `cli/index.ts` AT THIS COMMIT. The function body of
- * `startCommandHandler` (and the exit-code dispatcher `runStartCommand`)
- * are intentionally fail-fast `Effect.fail` stubs; impl-staff replaces
- * those two bodies per the plan in
- * `packages/client/docs/architecture/09-moltzap-start-cli.md` and adds
- * the test file `start.test.ts`. No other files change in impl-staff.
+ * (`conversations create` -> `send conv:&lt;id> &lt;text>`) collapses into
+ * one subcommand for the common case.
  *
  * See also:
- *   - Spec D1 architect plan (#635) for `TaskCreate` / `DEFAULT_APP_ID` /
- *     `AppId` / `ParticipantNotAdmittedError` definitions on branch
- *     `architect/598-task-conversation`.
+ *   - `packages/protocol/src/task/tasks.ts -> TaskCreate` / `DEFAULT_APP_ID` /
+ *     `AppId` — D1 (#598) wire surface this command composes.
  *   - `packages/client/docs/architecture/09-moltzap-start-cli.md` for the
  *     command flow diagram, exit-code contract, and test alignment.
- *   - `packages/client/src/cli/commands/conversations.ts → createConversation`
- *     for the legacy two-step DM/Group create path D2 replaces.
- *   - `packages/client/src/cli/socket-client.ts → resolveParticipant` —
+ *   - `packages/client/src/cli/commands/conversations.ts -> createConversation`
+ *     for the legacy two-step DM/Group create path D2 replaces. Untouched
+ *     in D2; D3 (#600) deletes it.
+ *   - `packages/client/src/cli/socket-client.ts -> resolveParticipant` —
  *     NOT reused by D2 because that helper goes via the daemon
- *     socket (`socket-client.ts → request`), bypassing the CLI
+ *     socket (`socket-client.ts -> request`), bypassing the CLI
  *     `Transport` service that `start.ts` uses for `TaskCreate` /
  *     `MessagesSend`. Mixing the two would make `--as`-mode name lookups
  *     hit the daemon (potentially absent) and would not be testable
- *     via `makeFakeTransport`. D2 introduces a `resolveAgentToken`
- *     local helper that goes through `transport.ts → rpc` instead
+ *     via `makeFakeTransport`. D2 introduces a local `resolveAgentToken`
+ *     helper that goes through `transport.ts -> rpc` instead
  *     (see per-flow doc §6 + §"Why we don't reuse `resolveParticipant`").
  */
 import { Args, Command, Options } from "@effect/cli";
-import { Data, Effect, Option } from "effect";
-import type { Transport, TransportError } from "../transport.js";
+import { Data, Effect, Either, Option } from "effect";
+import {
+  AgentsLookupByName,
+  DEFAULT_APP_ID,
+  MessagesSend,
+  TaskCreate,
+  type AgentId,
+  type AppId,
+  type Conversation,
+  type Task,
+} from "@moltzap/protocol";
+import type { ConversationId } from "@moltzap/protocol/task";
+import {
+  rpc,
+  TransportDecodeError,
+  type Transport,
+  type TransportError,
+} from "../transport.js";
 
 // ─── Exit-code contract (spec D2 Goal 5 + Goal 7) ─────────────────────────
 
 /**
- * Exit-code table for the `moltzap start` command. Impl-staff re-
- * exports individual constants only as tests need them (knip flags
- * unused exports). At stub time these are documented here and used in
- * the help-text composition below.
+ * Exit-code table for the `moltzap start` command. Values are documented
+ * in `Command.withDescription` help text below; the handler branches on
+ * these via `runStartCommand` and inline `process.exit` in the
+ * partial-success path.
  */
 const EXIT_CODES = {
-  /**
-   * Full success: `TaskCreate` resolved AND, if `--message` was
-   * supplied, `MessagesSend` resolved too. Stdout printed both lines.
-   */
   SUCCESS: 0,
-
-  /**
-   * `TaskCreate` failed (transport or server-rejected). Stdout printed
-   * nothing; stderr has the error. `--message` was never attempted.
-   */
   TASK_CREATE_FAILED: 1,
-
-  /**
-   * Partial success: `TaskCreate` succeeded but the follow-up
-   * `MessagesSend` failed. Stdout printed `Task started: ...` (the
-   * task + conversation exist); stderr has `Error sending message:
-   * ...`. The empty conversation is intentionally left in place
-   * (Non-goal 3 — no rollback). User retries via
-   * `moltzap send conv:&lt;id> &lt;text>`.
-   */
   PARTIAL_SUCCESS: 2,
-
-  /**
-   * Client-side usage error: invalid `--app-id` UUID syntax OR an
-   * unresolvable `agent:&lt;token>` participant. NO mutating RPCs were
-   * made (Goal 7; note `AgentsLookupByName` is read-only — see
-   * `UnresolvedParticipantError` docstring). Matches POSIX `EX_USAGE`
-   * (sysexits.h).
-   */
   USAGE_ERROR: 64,
 } as const;
 
@@ -82,11 +64,10 @@ const EXIT_CODES = {
 
 /**
  * `--app-id &lt;value>` failed syntactic UUID v4 validation before any RPC.
- * Maps to `EXIT_CODES.USAGE_ERROR`; stderr prints `Invalid --app-id:
- * not a UUID`.
- *
- * Internal at stub time; impl-staff re-exports if tests need the class
- * for `expect().toBeInstanceOf(...)`-style assertions.
+ * Maps to `EXIT_CODES.USAGE_ERROR`; stderr prints
+ * `Invalid --app-id: not a UUID`. Local to this module — tests assert
+ * by exit code + stderr text rather than `expect().toBeInstanceOf(...)`,
+ * so the class stays unexported per the architect plan.
  */
 class InvalidAppIdError extends Data.TaggedError("InvalidAppIdError")<{
   readonly value: string;
@@ -95,14 +76,13 @@ class InvalidAppIdError extends Data.TaggedError("InvalidAppIdError")<{
 /**
  * An `agent:&lt;name>` or `agent:&lt;uuid>` participant token could not be
  * resolved (name not in the agent roster, or token mis-shaped). Maps
- * to `EXIT_CODES.USAGE_ERROR`; stderr names the unresolved token. The
- * resolver does call `AgentsLookupByName` (a server RPC) — which is
- * read-only and does not mutate server state, so the partial-failure
- * invariant is unaffected. The spec D2 AC clause "NO RPC calls" reads
- * as "NO mutating (TaskCreate/MessagesSend) calls" in this plan; see
- * §15 process-issues + per-flow doc §8.
+ * to `EXIT_CODES.USAGE_ERROR`; stderr names the unresolved token.
  *
- * Internal at stub time; impl-staff re-exports if tests need the class.
+ * Resolver calls `AgentsLookupByName` (a server RPC) for name-shaped
+ * tokens. That RPC is read-only and does not mutate server state, so
+ * the partial-failure invariant is unaffected. The spec D2 AC clause
+ * "NO RPC calls" reads as "NO mutating (TaskCreate / MessagesSend)
+ * calls" in this plan; see per-flow doc §8 + plan §R5.
  */
 class UnresolvedParticipantError extends Data.TaggedError(
   "UnresolvedParticipantError",
@@ -118,185 +98,269 @@ class UnresolvedParticipantError extends Data.TaggedError(
  * `Args.repeated` admits zero participants — caller-only tasks are
  * permitted at the wire (Spec D1 per-flow doc 12) but not exercised by
  * spec D2 ACs (which cover `length === 1` DM and `length >= 2` group
- * shapes). Impl-staff handler must NOT reject empty `participants`.
+ * shapes). Handler MUST NOT reject empty `participants`.
  */
 export interface StartCommandArgs {
-  /** Conversation name (positional `&lt;name>`). */
   readonly name: string;
-
-  /**
-   * Raw participant tokens (positional `&lt;participant>...`), each
-   * `agent:&lt;name>` or `agent:&lt;uuid>`. Resolution is per-token via
-   * `resolveAgentToken` (local helper below) which routes through
-   * `transport.ts → rpc(AgentsLookupByName, ...)` for name-shaped
-   * tokens and short-circuits UUID-shaped tokens client-side.
-   * Failures map to `UnresolvedParticipantError` and exit 64 BEFORE
-   * `TaskCreate`. See per-flow doc 09 §"Why we don't reuse
-   * `resolveParticipant`" for the transport divergence reasoning.
-   */
   readonly participants: readonly string[];
-
-  /**
-   * `--message &lt;text>`. When undefined, only `TaskCreate` runs and the
-   * partial-success path (exit code 2) cannot trigger.
-   */
   readonly message: string | undefined;
-
-  /**
-   * `--app-id &lt;uuid>`. When undefined, the handler substitutes
-   * `DEFAULT_APP_ID` from `@moltzap/protocol` (D1 surface). When set,
-   * client validates UUID v4 syntax before any RPC; syntactic failure
-   * maps to `InvalidAppIdError` and exit 64.
-   */
   readonly appId: string | undefined;
 }
 
 /**
  * Exhaustive error union for the start-command handler. The wrapping
- * `Command.make` adapter converts each tag to an exit code via the
- * table documented at the top of this file:
+ * `runStartCommand` adapter converts each tag to an exit code:
  *
- *   `InvalidAppIdError`           → 64 (usage)
- *   `UnresolvedParticipantError`  → 64 (usage)
- *   `TransportError` from `TaskCreate`   → 1  (rpc)
- *   `TransportError` from `MessagesSend` → 2  (partial)
+ *   `InvalidAppIdError`           -> 64 (usage)
+ *   `UnresolvedParticipantError`  -> 64 (usage)
+ *   any other `TransportError`    -> 1  (rpc; from `TaskCreate`)
  *
- * The handler distinguishes the two `TransportError` cases by which
- * stage they arose in (TaskCreate vs MessagesSend) — see per-flow doc
- * §"Partial-failure dispatcher" for the impl-staff sketch.
+ * The post-`TaskCreate` `MessagesSend` failure path exits 2 via inline
+ * `process.exit` inside the handler body, NOT through `runStartCommand`
+ * (see per-flow doc §"Partial-failure dispatcher").
+ *
+ * `TransportError` here is the union from `transport.ts -> TransportError`
+ * which includes `TransportDecodeError`, `TransportRpcError`,
+ * `ServiceUnreachableError`, `TransportTimeoutError`, and
+ * `TransportConfigError`.
  */
-export type StartCommandError =
+type StartCommandError =
   | TransportError
   | InvalidAppIdError
   | UnresolvedParticipantError;
 
-// ─── Handler signature ────────────────────────────────────────────────────
+// ─── UUID validation ──────────────────────────────────────────────────────
 
 /**
- * `moltzap start &lt;name> &lt;participant>... [--message &lt;text>] [--app-id &lt;uuid>]`
+ * RFC 4122 UUID v4 regex per plan Invariant 7. The `4` in the third
+ * group pins the version; the `[89ab]` in the fourth group pins the
+ * variant. Pre-existing `socket-client.ts -> UUID_RE` accepts any UUID
+ * version, which would let v3/v5/v7 tokens through; spec D2 Goal 7
+ * requires v4-specific rejection at exit 64.
+ */
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const validateAppId = (
+  value: string,
+): Effect.Effect<AppId, InvalidAppIdError> =>
+  UUID_V4_RE.test(value)
+    ? Effect.succeed(value as AppId)
+    : Effect.fail(new InvalidAppIdError({ value }));
+
+// ─── Participant token resolver ───────────────────────────────────────────
+
+const AGENT_TOKEN_PREFIX = "agent:";
+
+/**
+ * Parse `agent:&lt;uuid>` (short-circuits client-side) or `agent:&lt;name>`
+ * (routes through `transport.ts -> rpc(AgentsLookupByName, ...)`).
+ * Returns bare `AgentId` matching `TaskCreate.params.invitedAgentIds:
+ * Array(AgentId)` directly (no `.map(p => p.id)` step needed).
  *
- * Flow (impl-staff fills the body — see per-flow doc 09 §"Implementation
- * sketch"):
+ * Failure modes:
+ *   - Token does not start with `agent:` -> `UnresolvedParticipantError({
+ *     reason: "shape" })`.
+ *   - Token is `agent:&lt;name>` and lookup returns zero agents ->
+ *     `UnresolvedParticipantError({ reason: "not-found" })`.
+ *
+ * Architect plan §R1 explains why this is a local helper rather than
+ * reusing `socket-client.ts -> resolveParticipant` (transport mismatch,
+ * testability, wire-shape match).
+ */
+const resolveAgentToken = (
+  token: string,
+): Effect.Effect<
+  AgentId,
+  UnresolvedParticipantError | TransportError,
+  Transport
+> =>
+  Effect.gen(function* () {
+    if (!token.startsWith(AGENT_TOKEN_PREFIX)) {
+      return yield* Effect.fail(
+        new UnresolvedParticipantError({ token, reason: "shape" }),
+      );
+    }
+    const rest = token.slice(AGENT_TOKEN_PREFIX.length);
+    if (rest.length === 0) {
+      return yield* Effect.fail(
+        new UnresolvedParticipantError({ token, reason: "shape" }),
+      );
+    }
+    if (UUID_V4_RE.test(rest)) {
+      return rest as AgentId;
+    }
+    const result = yield* rpc(AgentsLookupByName, { names: [rest] });
+    const firstAgent = result.agents[0];
+    if (firstAgent === undefined) {
+      return yield* Effect.fail(
+        new UnresolvedParticipantError({ token, reason: "not-found" }),
+      );
+    }
+    return firstAgent.id;
+  });
+
+// ─── Handler stages ───────────────────────────────────────────────────────
+
+const resolveAppId = (
+  raw: string | undefined,
+): Effect.Effect<AppId, InvalidAppIdError> =>
+  raw === undefined ? Effect.succeed(DEFAULT_APP_ID) : validateAppId(raw);
+
+const printTaskStarted = (
+  task: Task,
+  conversation: Conversation,
+): Effect.Effect<void> =>
+  Effect.sync(() => {
+    console.log(`Task started: ${task.id} (conversation: ${conversation.id})`);
+  });
+
+const printMessageSent = (messageId: string): Effect.Effect<void> =>
+  Effect.sync(() => {
+    console.log(`Message sent: ${messageId}`);
+  });
+
+const sendFirstMessage = (
+  conversationId: ConversationId,
+  text: string,
+): Effect.Effect<void, never, Transport> =>
+  Effect.either(
+    rpc(MessagesSend, {
+      conversationId,
+      parts: [{ type: "text", text }],
+    }),
+  ).pipe(
+    Effect.flatMap(
+      Either.match({
+        onLeft: (err) =>
+          Effect.sync(() => {
+            console.error(`Error sending message: ${err.message}`);
+            process.exit(EXIT_CODES.PARTIAL_SUCCESS);
+          }),
+        onRight: (ok) => printMessageSent(ok.message.id),
+      }),
+    ),
+  );
+
+const createTaskAtomic = (
+  appId: AppId,
+  invitedAgentIds: readonly AgentId[],
+  name: string,
+): Effect.Effect<
+  { readonly task: Task; readonly conversation: Conversation },
+  TransportError,
+  Transport
+> =>
+  Effect.gen(function* () {
+    const result = yield* rpc(TaskCreate, {
+      appId,
+      invitedAgentIds: [...invitedAgentIds],
+      initialConversation: {
+        name,
+        participants: [...invitedAgentIds],
+      },
+    });
+    // D1 canary _C5: when initialConversation is sent, conversation is
+    // non-null. A null here means a stale D1 build; surface as a typed
+    // decode error -> exit 1.
+    if (result.conversation === null) {
+      return yield* Effect.fail(
+        new TransportDecodeError({
+          method: TaskCreate.name,
+          cause:
+            "TaskCreate returned conversation: null despite initialConversation",
+        }),
+      );
+    }
+    return { task: result.task, conversation: result.conversation };
+  });
+
+// ─── Handler body ─────────────────────────────────────────────────────────
+
+/**
+ * `moltzap start` handler. Four stages (see per-flow doc 09 §6):
  *
  *   1. Validate `args.appId` UUID v4 if set; else use `DEFAULT_APP_ID`.
- *      Failure → `InvalidAppIdError`; `runStartCommand` maps to exit 64,
- *      no RPCs.
- *   2. Resolve every `args.participants[i]` via the local
- *      `resolveAgentToken(token)` helper below (which goes through
- *      `transport.ts → rpc(AgentsLookupByName, ...)` so `--as` direct-WS
- *      mode works and tests can mock via `makeFakeTransport`). Any token
- *      failing resolution → `UnresolvedParticipantError` → exit 64.
- *   3. Call `rpc(TaskCreate, { appId, invitedAgentIds, initialConversation:
- *      { name: args.name, participants: invitedAgentIds } })`. Failure →
- *      `TransportError` → exit 1 (handler `Effect.fail`s; `runStartCommand`
- *      catches and dispatches), no stdout. On success, read
- *      `{ task, conversation }` directly from the response object (NO
- *      follow-up fetch) and print `Task started: ${task.id} (conversation:
- *      ${conversation.id})` to stdout. `conversation` is non-null here
- *      because `initialConversation` was supplied (D1 plan §R8 / canary _C5).
- *   4. If `args.message` is set, call `rpc(MessagesSend, { conversationId:
- *      conversation.id, parts: [{ type: "text", text: args.message }] })`.
- *      Success → print `Message sent: ${message.id}`, exit 0. Failure →
- *      use `Effect.either` to catch in-band, print
- *      `Error sending message: ${err.message}` to stderr, then exit 2
- *      via inline `process.exit` (the partial-success branch needs to
- *      preserve the already-printed stdout line and cannot just `Effect.fail`).
- *      NO rollback.
- *
- * NB: D1 plan §R8 / Canary _C5 locks the wire result shape as `conversation:
- * Conversation | null`. The impl-staff handler asserts non-null when
- * `initialConversation` was sent — at runtime the field is always present
- * because D2 always sends `initialConversation`. The assertion narrows
- * TypeScript's union; a stale D1 build that returns `null` despite
- * `initialConversation` is treated as a `TransportDecodeError` (exit 1).
- *
- * NB-2: `StartCommandError`'s `TransportError` arm is the union from
- * `transport.ts → TransportError` which includes `TransportDecodeError` +
- * `TransportRpcError` + `ServiceUnreachableError` + `TransportTimeoutError`
- * + `TransportConfigError`. The exit-code dispatcher `runStartCommand`
- * collapses all of them to exit 1 unless they arose from the post-
- * `TaskCreate` `MessagesSend` (which exits 2 via inline `process.exit`
- * inside the handler body itself).
+ *      Failure -> `InvalidAppIdError` -> exit 64 via `runStartCommand`.
+ *   2. Resolve `args.participants` via `resolveAgentToken` (per-token,
+ *      sequential via `Effect.all`). Any token failure ->
+ *      `UnresolvedParticipantError` -> exit 64.
+ *   3. `rpc(TaskCreate, { appId, invitedAgentIds, initialConversation:
+ *      { name, participants: invitedAgentIds } })`. Failure ->
+ *      `TransportError` -> exit 1 via `runStartCommand`, no stdout. On
+ *      success print `Task started: &lt;taskId> (conversation: &lt;convId>)`.
+ *   4. If `args.message` is set, call `rpc(MessagesSend, { conversationId,
+ *      parts: [{ type: "text", text }] })` wrapped in `Effect.either`.
+ *      Success -> print `Message sent: &lt;msgId>`, exit 0. Failure -> print
+ *      `Error sending message: &lt;err>` to stderr, exit 2 via inline
+ *      `process.exit` (preserves the already-printed stdout line; cannot
+ *      route through `runStartCommand`).
  */
 const startCommandHandler = (
   args: StartCommandArgs,
 ): Effect.Effect<void, StartCommandError, Transport> =>
-  // Architect stub: chain through `resolveAgentToken` so both symbols
-  // are referenced and the unused-declaration check stays clean.
-  // Impl-staff replaces this entire body with the four-step flow
-  // documented in the JSDoc above (and in per-flow doc 09 §6).
-  resolveAgentToken(args.participants[0] ?? "stub").pipe(
-    Effect.flatMap(() =>
-      Effect.fail(
-        new InvalidAppIdError({
-          value: "architect stub — body lands in impl-staff PR (spec D2 #599)",
-        }),
-      ),
-    ),
-  );
+  Effect.gen(function* () {
+    const appId = yield* resolveAppId(args.appId);
+    const invitedAgentIds = yield* Effect.all(
+      args.participants.map(resolveAgentToken),
+    );
+    const { task, conversation } = yield* createTaskAtomic(
+      appId,
+      invitedAgentIds,
+      args.name,
+    );
+    yield* printTaskStarted(task, conversation);
+    if (args.message !== undefined) {
+      yield* sendFirstMessage(conversation.id as ConversationId, args.message);
+    }
+  }).pipe(Effect.withSpan("startCommandHandler"));
+
+// ─── Exit-code dispatcher ─────────────────────────────────────────────────
 
 /**
- * Local participant-token resolver: parses `agent:&lt;uuid>` /
- * `agent:&lt;name>` tokens. UUID-shaped tokens skip the server lookup;
- * name-shaped tokens go through `transport.ts → rpc(AgentsLookupByName, ...)`
- * — NOT `socket-client.ts → request(AgentsLookupByName, ...)`. This is
- * the deliberate divergence from `socket-client.ts → resolveParticipant`:
+ * Outer adapter that replaces the shared `transport.ts -> runHandler`
+ * (which collapses every error to exit 1) with a `_tag`-aware mapping
+ * per the spec D2 exit-code contract:
  *
- *   - In `--as`-mode (direct WS), the daemon socket may not even be
- *     reachable; routing name lookups through the daemon-only
- *     `socket-client.ts → request` would break that flow.
- *   - Tests using `commands/test-transport.ts → makeFakeTransport`
- *     intercept `Transport` calls, not the daemon socket. A test that
- *     mocks `AgentsLookupByName` via `makeFakeTransport` would fail
- *     to intercept the existing `resolveParticipant` lookup.
+ *   `InvalidAppIdError`           -> 64 + stderr `Invalid --app-id: not a UUID`
+ *   `UnresolvedParticipantError`  -> 64 + stderr `Cannot resolve "&lt;token>": &lt;reason>`
+ *   any other `StartCommandError` -> 1  + stderr `Failed: &lt;err.message>`
  *
- * Impl-staff fills the body with: parse `agent:&lt;rest>`; if `rest`
- * matches UUID v4, return as `AgentId`; else `rpc(AgentsLookupByName,
- * { names: [rest] })` and return the first hit, or
- * `UnresolvedParticipantError({ token, reason: "not-found" })` on empty
- * result. Token shape errors (no `agent:` prefix, etc.) map to
- * `UnresolvedParticipantError({ token, reason: "shape" })`.
- *
- * Stub body: fail-fast.
- */
-const resolveAgentToken = (
-  _token: string,
-): Effect.Effect<
-  unknown, // AgentId at impl-staff time; opaque here to avoid an unused-import
-  UnresolvedParticipantError,
-  Transport
-> =>
-  Effect.fail(
-    new UnresolvedParticipantError({
-      token: "architect stub — body lands in impl-staff PR",
-      reason: "shape",
-    }),
-  );
-
-/**
- * Exit-code dispatcher for `moltzap start`. Replaces the generic
- * `transport.ts → runHandler` (which collapses every error to exit 1)
- * with a `_tag`-aware mapper:
- *
- *   `InvalidAppIdError`           → 64 (usage)  + stderr `Invalid --app-id: not a UUID`
- *   `UnresolvedParticipantError`  → 64 (usage)  + stderr `Cannot resolve "&lt;token>": &lt;reason>`
- *   any other `StartCommandError` → 1  (rpc)    + stderr `Failed: &lt;err.message>`
- *
- * The exit-2 partial-success path is NOT dispatched here — that branch
- * runs inline inside the handler body (after `Task started:` has been
- * printed to stdout, the partial-failure stage cannot be re-thrown
- * because doing so would discard the stdout line; the handler instead
- * calls `process.exit(EXIT_CODES.PARTIAL_SUCCESS)` directly from inside
- * `Effect.sync` after `console.error`).
- *
- * Stub body: pass-through that runs the handler unchanged. Impl-staff
- * fills the `_tag`-aware `Effect.catchAll` block.
+ * The exit-2 partial-success branch runs inline inside
+ * `startCommandHandler` (after `Task started:` has been printed to
+ * stdout) and never reaches this adapter — re-throwing the post-
+ * `TaskCreate` error here would discard the already-printed stdout
+ * line.
  */
 const runStartCommand = (
   effect: Effect.Effect<void, StartCommandError, Transport>,
-): Effect.Effect<void, StartCommandError, Transport> => effect;
+): Effect.Effect<void, never, Transport> =>
+  effect.pipe(
+    Effect.catchTag("InvalidAppIdError", () =>
+      Effect.sync(() => {
+        console.error("Invalid --app-id: not a UUID");
+        process.exit(EXIT_CODES.USAGE_ERROR);
+      }),
+    ),
+    Effect.catchTag("UnresolvedParticipantError", (err) =>
+      Effect.sync(() => {
+        console.error(`Cannot resolve "${err.token}": ${err.reason}`);
+        process.exit(EXIT_CODES.USAGE_ERROR);
+      }),
+    ),
+    Effect.catchAll((err) =>
+      Effect.sync(() => {
+        const msg =
+          err.message !== undefined && err.message !== ""
+            ? err.message
+            : err._tag;
+        console.error(`Failed: ${msg}`);
+        process.exit(EXIT_CODES.TASK_CREATE_FAILED);
+      }),
+    ),
+  );
 
-// ─── @effect/cli wiring (architect stub — handler delegates to impl-staff) ─
+// ─── @effect/cli wiring ───────────────────────────────────────────────────
 
 const nameArg = Args.text({ name: "name" }).pipe(
   Args.withDescription("Conversation name"),
@@ -327,15 +391,17 @@ const appIdOption = Options.text("app-id").pipe(
 );
 
 /**
- * `moltzap start &lt;name> &lt;participant>... [--message &lt;text>] [--app-id &lt;uuid>]`
- *
- * Architect stub: the underlying `startCommandHandler` is a body that
- * fails fast; impl-staff lands the real body per
- * `packages/client/docs/architecture/09-moltzap-start-cli.md`. The
- * `Command.make` wrapper here exists so impl-staff inherits a complete
- * CLI shape (positional `&lt;name>`, repeated `&lt;participant>...`,
- * `--message`, `--app-id`) with the exact descriptions that will ship.
+ * Test seam: invoke the handler directly with parsed args, bypassing
+ * `@effect/cli`'s parser. Returns the same `Effect` the `Command.make`
+ * wrapper would produce, including the `runStartCommand` exit-code
+ * dispatcher. Tests `Effect.provideService(Transport, fake)` and assert
+ * `process.exit` was called with the expected code.
  */
+export const runStartHandler = (
+  args: StartCommandArgs,
+): Effect.Effect<void, never, Transport> =>
+  runStartCommand(startCommandHandler(args));
+
 export const startCommand = Command.make(
   "start",
   {
@@ -345,14 +411,12 @@ export const startCommand = Command.make(
     appId: appIdOption,
   },
   ({ name, participants, message, appId }) =>
-    runStartCommand(
-      startCommandHandler({
-        name,
-        participants,
-        message: Option.getOrUndefined(message),
-        appId: Option.getOrUndefined(appId),
-      }),
-    ),
+    runStartHandler({
+      name,
+      participants,
+      message: Option.getOrUndefined(message),
+      appId: Option.getOrUndefined(appId),
+    }),
 ).pipe(
   Command.withDescription(
     "Start a task with named participants and (optionally) send the " +

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -1,0 +1,279 @@
+/**
+ * `moltzap start &lt;name> &lt;participant>... [--message &lt;text>] [--app-id &lt;uuid>]`
+ *
+ * Spec D2 (#599) — single-command CLI composition over Spec D1's atomic
+ * `TaskCreate({ appId, invitedAgentIds, initialConversation })` plus an
+ * optional `MessagesSend`. Today's two-step workflow
+ * (`conversations create` → `send conv:&lt;id> &lt;text>`) collapses into one
+ * subcommand for the common case.
+ *
+ * Architect stub (sub-issue #643). NO function bodies, NO command
+ * registration in `cli/index.ts`. Impl-staff lands both per the plan in
+ * `packages/client/docs/architecture/09-moltzap-start-cli.md`.
+ *
+ * See also:
+ *   - Spec D1 architect plan (#635) for `TaskCreate` / `DEFAULT_APP_ID` /
+ *     `AppId` / `ParticipantNotAdmittedError` definitions on branch
+ *     `architect/598-task-conversation`.
+ *   - `packages/client/docs/architecture/09-moltzap-start-cli.md` for the
+ *     command flow diagram, exit-code contract, and test alignment.
+ *   - `packages/client/src/cli/commands/conversations.ts → createConversation`
+ *     for the legacy two-step DM/Group create path D2 replaces.
+ *   - `packages/client/src/cli/socket-client.ts → resolveParticipant` for
+ *     the `agent:&lt;name>` / `agent:&lt;uuid>` token resolver this command
+ *     re-uses (caller maps `.id` after resolution to get a bare `AgentId`).
+ */
+import { Args, Command, Options } from "@effect/cli";
+import { Data, Effect, Option } from "effect";
+import {
+  runHandler,
+  type Transport,
+  type TransportError,
+} from "../transport.js";
+
+// ─── Exit-code contract (spec D2 Goal 5 + Goal 7) ─────────────────────────
+
+/**
+ * Exit-code table for the `moltzap start` command. Impl-staff re-
+ * exports individual constants only as tests need them (knip flags
+ * unused exports). At stub time these are documented here and used in
+ * the help-text composition below.
+ */
+const EXIT_CODES = {
+  /**
+   * Full success: `TaskCreate` resolved AND, if `--message` was
+   * supplied, `MessagesSend` resolved too. Stdout printed both lines.
+   */
+  SUCCESS: 0,
+
+  /**
+   * `TaskCreate` failed (transport or server-rejected). Stdout printed
+   * nothing; stderr has the error. `--message` was never attempted.
+   */
+  TASK_CREATE_FAILED: 1,
+
+  /**
+   * Partial success: `TaskCreate` succeeded but the follow-up
+   * `MessagesSend` failed. Stdout printed `Task started: ...` (the
+   * task + conversation exist); stderr has `Error sending message:
+   * ...`. The empty conversation is intentionally left in place
+   * (Non-goal 3 — no rollback). User retries via
+   * `moltzap send conv:&lt;id> &lt;text>`.
+   */
+  PARTIAL_SUCCESS: 2,
+
+  /**
+   * Client-side usage error: invalid `--app-id` UUID syntax OR an
+   * unresolvable `agent:&lt;token>` participant. NO mutating RPCs were
+   * made (Goal 7; note `AgentsLookupByName` is read-only — see
+   * `UnresolvedParticipantError` docstring). Matches POSIX `EX_USAGE`
+   * (sysexits.h).
+   */
+  USAGE_ERROR: 64,
+} as const;
+
+// ─── Tagged errors (CLI-local) ────────────────────────────────────────────
+
+/**
+ * `--app-id &lt;value>` failed syntactic UUID v4 validation before any RPC.
+ * Maps to `EXIT_CODES.USAGE_ERROR`; stderr prints `Invalid --app-id:
+ * not a UUID`.
+ *
+ * Internal at stub time; impl-staff re-exports if tests need the class
+ * for `expect().toBeInstanceOf(...)`-style assertions.
+ */
+class InvalidAppIdError extends Data.TaggedError("InvalidAppIdError")<{
+  readonly value: string;
+}> {}
+
+/**
+ * An `agent:&lt;name>` or `agent:&lt;uuid>` participant token could not be
+ * resolved (name not in the agent roster, or token mis-shaped). Maps
+ * to `EXIT_CODES.USAGE_ERROR`; stderr names the unresolved token. The
+ * resolver does call `AgentsLookupByName` (a server RPC) — which is
+ * read-only and does not mutate server state, so the partial-failure
+ * invariant is unaffected. The spec D2 AC clause "NO RPC calls" reads
+ * as "NO mutating (TaskCreate/MessagesSend) calls" in this plan; see
+ * §15 process-issues + per-flow doc §8.
+ *
+ * Internal at stub time; impl-staff re-exports if tests need the class.
+ */
+class UnresolvedParticipantError extends Data.TaggedError(
+  "UnresolvedParticipantError",
+)<{
+  readonly token: string;
+  readonly reason: "shape" | "not-found";
+}> {}
+
+// ─── Public types ─────────────────────────────────────────────────────────
+
+/**
+ * Parsed CLI arguments for the `start` command. `@effect/cli`'s
+ * `Args.repeated` admits zero participants — caller-only tasks are
+ * permitted at the wire (Spec D1 per-flow doc 12) but not exercised by
+ * spec D2 ACs (which cover `length === 1` DM and `length >= 2` group
+ * shapes). Impl-staff handler must NOT reject empty `participants`.
+ */
+export interface StartCommandArgs {
+  /** Conversation name (positional `&lt;name>`). */
+  readonly name: string;
+
+  /**
+   * Raw participant tokens (positional `&lt;participant>...`), each
+   * `agent:&lt;name>` or `agent:&lt;uuid>`. Resolution is per-token via
+   * `resolveParticipant` (socket-client.ts); failures map to
+   * `UnresolvedParticipantError` and exit 64 BEFORE `TaskCreate`.
+   */
+  readonly participants: readonly string[];
+
+  /**
+   * `--message &lt;text>`. When undefined, only `TaskCreate` runs and the
+   * partial-success path (exit code 2) cannot trigger.
+   */
+  readonly message: string | undefined;
+
+  /**
+   * `--app-id &lt;uuid>`. When undefined, the handler substitutes
+   * `DEFAULT_APP_ID` from `@moltzap/protocol` (D1 surface). When set,
+   * client validates UUID v4 syntax before any RPC; syntactic failure
+   * maps to `InvalidAppIdError` and exit 64.
+   */
+  readonly appId: string | undefined;
+}
+
+/**
+ * Exhaustive error union for the start-command handler. The wrapping
+ * `Command.make` adapter converts each tag to an exit code via the
+ * table documented at the top of this file:
+ *
+ *   `InvalidAppIdError`           → 64 (usage)
+ *   `UnresolvedParticipantError`  → 64 (usage)
+ *   `TransportError` from `TaskCreate`   → 1  (rpc)
+ *   `TransportError` from `MessagesSend` → 2  (partial)
+ *
+ * The handler distinguishes the two `TransportError` cases by which
+ * stage they arose in (TaskCreate vs MessagesSend) — see per-flow doc
+ * §"Partial-failure dispatcher" for the impl-staff sketch.
+ */
+export type StartCommandError =
+  | TransportError
+  | InvalidAppIdError
+  | UnresolvedParticipantError;
+
+// ─── Handler signature ────────────────────────────────────────────────────
+
+/**
+ * `moltzap start &lt;name> &lt;participant>... [--message &lt;text>] [--app-id &lt;uuid>]`
+ *
+ * Flow (impl-staff fills the body — see per-flow doc 09 §"Implementation
+ * sketch"):
+ *
+ *   1. Validate `args.appId` UUID v4 if set; else use `DEFAULT_APP_ID`.
+ *      Failure → `InvalidAppIdError` → exit 64, no RPCs.
+ *   2. Resolve every `args.participants[i]` via `resolveParticipant(...)`
+ *      from `socket-client.ts`; map `.id` to get `AgentId`. Any token
+ *      failing resolution → `UnresolvedParticipantError` → exit 64.
+ *   3. Call `rpc(TaskCreate, { appId, invitedAgentIds, initialConversation:
+ *      { name: args.name, participants: invitedAgentIds } })`. Failure →
+ *      `TransportError` → exit 1, no stdout. On success, read
+ *      `{ task, conversation }` directly from the response object (NO
+ *      follow-up fetch) and print `Task started: ${task.id} (conversation:
+ *      ${conversation.id})` to stdout. `conversation` is non-null here
+ *      because `initialConversation` was supplied (D1 plan §R8 / canary _C5).
+ *   4. If `args.message` is set, call `rpc(MessagesSend, { conversationId:
+ *      conversation.id, parts: [{ type: "text", text: args.message }] })`.
+ *      Success → print `Message sent: ${message.id}`, exit 0. Failure →
+ *      print `Error sending message: ${err.message}` to stderr, exit 2.
+ *      NO rollback.
+ *
+ * NB: D1 plan §R8 / Canary _C5 locks the wire result shape as `conversation:
+ * Conversation | null`. The impl-staff handler asserts non-null when
+ * `initialConversation` was sent — at runtime the field is always present
+ * because D2 always sends `initialConversation`. The assertion narrows
+ * TypeScript's union; a stale D1 build that returns `null` despite
+ * `initialConversation` is treated as a `TransportDecodeError` (exit 1).
+ * @throws — `process.exit` is called inside the wrapping
+ * `Command.make` adapter, NOT here. This handler returns an Effect; the
+ * `runHandler` analogue in `transport.ts` (or a partial-failure-aware
+ * variant — see per-flow doc 09 §"Exit-code dispatcher") translates the
+ * tag to an exit code.
+ */
+const startCommandHandler = (
+  _args: StartCommandArgs,
+): Effect.Effect<void, StartCommandError, Transport> =>
+  Effect.fail(
+    new InvalidAppIdError({
+      value: "architect stub — body lands in impl-staff PR (spec D2 #599)",
+    }),
+  );
+
+// ─── @effect/cli wiring (architect stub — handler delegates to impl-staff) ─
+
+const nameArg = Args.text({ name: "name" }).pipe(
+  Args.withDescription("Conversation name"),
+);
+
+const participantsArg = Args.text({ name: "participant" }).pipe(
+  Args.withDescription(
+    "Participant token (e.g. agent:bob or agent:<uuid>). " +
+      "Zero or more allowed; D2 ACs cover 1 (DM-shape) and >=2 (group-shape).",
+  ),
+  Args.repeated,
+);
+
+const messageOption = Options.text("message").pipe(
+  Options.withDescription(
+    "First message body. If supplied, MessagesSend runs after the atomic " +
+      "TaskCreate (separate RPC, not server-atomic).",
+  ),
+  Options.optional,
+);
+
+const appIdOption = Options.text("app-id").pipe(
+  Options.withDescription(
+    "App UUID v4. Defaults to DEFAULT_APP_ID (D1 #635). Invalid syntax " +
+      "exits 64 with NO RPC calls (Goal 7).",
+  ),
+  Options.optional,
+);
+
+/**
+ * `moltzap start &lt;name> &lt;participant>... [--message &lt;text>] [--app-id &lt;uuid>]`
+ *
+ * Architect stub: the underlying `startCommandHandler` is a body that
+ * fails fast; impl-staff lands the real body per
+ * `packages/client/docs/architecture/09-moltzap-start-cli.md`. The
+ * `Command.make` wrapper here exists so impl-staff inherits a complete
+ * CLI shape (positional `&lt;name>`, repeated `&lt;participant>...`,
+ * `--message`, `--app-id`) with the exact descriptions that will ship.
+ */
+export const startCommand = Command.make(
+  "start",
+  {
+    name: nameArg,
+    participants: participantsArg,
+    message: messageOption,
+    appId: appIdOption,
+  },
+  ({ name, participants, message, appId }) =>
+    runHandler(
+      startCommandHandler({
+        name,
+        participants,
+        message: Option.getOrUndefined(message),
+        appId: Option.getOrUndefined(appId),
+      }),
+    ),
+).pipe(
+  Command.withDescription(
+    "Start a task with named participants and (optionally) send the " +
+      "first message in one atomic step. Spec D2 #599 — composes Spec D1 " +
+      "TaskCreate + MessagesSend.\n" +
+      "\n" +
+      "Exit codes:\n" +
+      `  ${EXIT_CODES.SUCCESS}   success (TaskCreate + optional MessagesSend resolved)\n` +
+      `  ${EXIT_CODES.TASK_CREATE_FAILED}   TaskCreate failed (stdout empty)\n` +
+      `  ${EXIT_CODES.PARTIAL_SUCCESS}   TaskCreate OK, MessagesSend failed (no rollback)\n` +
+      `  ${EXIT_CODES.USAGE_ERROR}  usage error (bad --app-id UUID or unresolvable agent token)`,
+  ),
+);

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -10,7 +10,7 @@
  * See also:
  *   - `packages/protocol/src/task/tasks.ts -> TaskCreate` / `DEFAULT_APP_ID` /
  *     `AppId` — D1 (#598) wire surface this command composes.
- *   - `packages/client/docs/architecture/09-moltzap-start-cli.md` for the
+ *   - `packages/client/docs/architecture/moltzap-start-cli.md` for the
  *     command flow diagram, exit-code contract, and test alignment.
  *   - `packages/client/src/cli/commands/conversations.ts -> createConversation`
  *     for the legacy two-step DM/Group create path D2 replaces. Untouched

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -21,7 +21,7 @@
  *     `Transport` service that `start.ts` uses for `TaskCreate` /
  *     `MessagesSend`. Mixing the two would make `--as`-mode name lookups
  *     hit the daemon (potentially absent) and would not be testable
- *     via `makeFakeTransport`. D2 introduces a local `resolveAgentToken`
+ *     via `makeFakeTransport`. D2 introduces a local `resolveAgentTokens`
  *     helper that goes through `transport.ts -> rpc` instead
  *     (see per-flow doc §6 + §"Why we don't reuse `resolveParticipant`").
  */
@@ -89,6 +89,30 @@ class UnresolvedParticipantError extends Data.TaggedError(
   readonly reason: "shape" | "not-found";
 }> {}
 
+/**
+ * Too many DISTINCT name-shaped tokens to batch into one
+ * `AgentsLookupByName` RPC (schema caps `names` at `maxItems: 100`).
+ * Maps to `EXIT_CODES.USAGE_ERROR`; stderr names the offending count.
+ *
+ * Distinct from `UnresolvedParticipantError` — fires BEFORE any RPC, on
+ * a count check. Without this carve-out, 101+ unique names would
+ * trigger an opaque AJV decode failure mapped to exit 1 ("Failed:
+ * params decode error"); this surfaces it as a usage error instead.
+ */
+class TooManyParticipantNamesError extends Data.TaggedError(
+  "TooManyParticipantNamesError",
+)<{
+  readonly count: number;
+  readonly max: number;
+}> {}
+
+/**
+ * Cap pinned to `AgentsLookupByName.params.names: Type.Array(...,
+ * { maxItems: 100 })`. Drift here vs. the schema causes a confusing
+ * exit-1 AJV rejection instead of the exit-64 usage error.
+ */
+const MAX_NAME_LOOKUP_BATCH = 100;
+
 // ─── Public types ─────────────────────────────────────────────────────────
 
 /**
@@ -109,9 +133,10 @@ export interface StartCommandArgs {
  * Exhaustive error union for the start-command handler. The wrapping
  * `runStartCommand` adapter converts each tag to an exit code:
  *
- *   `InvalidAppIdError`           -> 64 (usage)
- *   `UnresolvedParticipantError`  -> 64 (usage)
- *   any other `TransportError`    -> 1  (rpc; from `TaskCreate`)
+ *   `InvalidAppIdError`             -> 64 (usage)
+ *   `UnresolvedParticipantError`    -> 64 (usage)
+ *   `TooManyParticipantNamesError`  -> 64 (usage; >100 distinct names)
+ *   any other `TransportError`      -> 1  (rpc; from `TaskCreate`)
  *
  * The post-`TaskCreate` `MessagesSend` failure path exits 2 via inline
  * `process.exit` inside the handler body, NOT through `runStartCommand`
@@ -125,7 +150,8 @@ export interface StartCommandArgs {
 type StartCommandError =
   | TransportError
   | InvalidAppIdError
-  | UnresolvedParticipantError;
+  | UnresolvedParticipantError
+  | TooManyParticipantNamesError;
 
 // ─── UUID validation ──────────────────────────────────────────────────────
 
@@ -151,51 +177,126 @@ const validateAppId = (
 const AGENT_TOKEN_PREFIX = "agent:";
 
 /**
- * Parse `agent:&lt;uuid>` (short-circuits client-side) or `agent:&lt;name>`
- * (routes through `transport.ts -> rpc(AgentsLookupByName, ...)`).
- * Returns bare `AgentId` matching `TaskCreate.params.invitedAgentIds:
- * Array(AgentId)` directly (no `.map(p => p.id)` step needed).
+ * Per-token classification result. Shape failures fail-fast at classify
+ * time; UUID-shaped tokens short-circuit client-side; name-shaped tokens
+ * are deferred to a SINGLE batched `AgentsLookupByName` RPC.
+ */
+type Classified =
+  | { readonly kind: "uuid"; readonly id: AgentId }
+  | { readonly kind: "name"; readonly token: string; readonly name: string };
+
+const classifyToken = (
+  token: string,
+): Effect.Effect<Classified, UnresolvedParticipantError> => {
+  const failShape = Effect.fail(
+    new UnresolvedParticipantError({ token, reason: "shape" }),
+  );
+  if (!token.startsWith(AGENT_TOKEN_PREFIX)) return failShape;
+  const rest = token.slice(AGENT_TOKEN_PREFIX.length);
+  if (rest.length === 0) return failShape;
+  if (UUID_V4_RE.test(rest)) {
+    return Effect.succeed({ kind: "uuid", id: rest as AgentId } as const);
+  }
+  return Effect.succeed({ kind: "name", token, name: rest } as const);
+};
+
+/**
+ * Resolve all participant tokens to bare `AgentId`s matching
+ * `TaskCreate.params.invitedAgentIds: Array(AgentId)` directly (no
+ * `.map(p => p.id)` step needed).
  *
- * Failure modes:
- *   - Token does not start with `agent:` -> `UnresolvedParticipantError({
- *     reason: "shape" })`.
- *   - Token is `agent:&lt;name>` and lookup returns zero agents ->
- *     `UnresolvedParticipantError({ reason: "not-found" })`.
+ * Failure modes (first in input order wins):
+ *   - Token does not start with `agent:` (or is `agent:` with empty
+ *     name) -> `UnresolvedParticipantError({ reason: "shape" })`.
+ *   - Token is `agent:&lt;name>` and the batched lookup returns no agent
+ *     matching `name` -> `UnresolvedParticipantError({ reason:
+ *     "not-found" })`.
+ *
+ * WHY one batched RPC instead of one-per-token: `AgentsLookupByName`
+ * accepts `names: Array(..., { minItems: 1, maxItems: 100 })`. Coalesce
+ * unique name-shaped tokens into a single RPC; UUID-shaped tokens skip
+ * the wire entirely. Resolution map keys on agent name so duplicate
+ * tokens (`agent:bob agent:bob`) resolve to the same id without
+ * re-asking the server.
  *
  * Architect plan §R1 explains why this is a local helper rather than
  * reusing `socket-client.ts -> resolveParticipant` (transport mismatch,
  * testability, wire-shape match).
  */
-const resolveAgentToken = (
-  token: string,
+const uniqueNamesOf = (classified: readonly Classified[]): readonly string[] =>
+  Array.from(
+    new Set(classified.flatMap((c) => (c.kind === "name" ? [c.name] : []))),
+  );
+
+/**
+ * Look up `names` in one batched RPC (no-op when empty) and return a
+ * name→AgentId map keyed by FIRST agent per name. The server's response
+ * is a flat agents array; mapping by name preserves the pre-P3-2
+ * tie-break ("first agent wins"). Caps at `MAX_NAME_LOOKUP_BATCH`
+ * BEFORE the RPC to keep the >100 case as a usage error rather than a
+ * decode failure.
+ */
+const lookupAgentIdsByName = (
+  names: readonly string[],
 ): Effect.Effect<
-  AgentId,
-  UnresolvedParticipantError | TransportError,
+  ReadonlyMap<string, AgentId>,
+  TransportError | TooManyParticipantNamesError,
   Transport
 > =>
   Effect.gen(function* () {
-    if (!token.startsWith(AGENT_TOKEN_PREFIX)) {
+    const byName = new Map<string, AgentId>();
+    if (names.length === 0) return byName;
+    if (names.length > MAX_NAME_LOOKUP_BATCH) {
       return yield* Effect.fail(
-        new UnresolvedParticipantError({ token, reason: "shape" }),
+        new TooManyParticipantNamesError({
+          count: names.length,
+          max: MAX_NAME_LOOKUP_BATCH,
+        }),
       );
     }
-    const rest = token.slice(AGENT_TOKEN_PREFIX.length);
-    if (rest.length === 0) {
-      return yield* Effect.fail(
-        new UnresolvedParticipantError({ token, reason: "shape" }),
-      );
+    // Defensive copy: AgentsLookupByName.params.names resolves to
+    // mutable `string[]` (TypeBox's `Static<Array>`); pass a shallow
+    // clone so the caller's readonly contract isn't bypassed.
+    const result = yield* rpc(AgentsLookupByName, { names: [...names] });
+    for (const agent of result.agents) {
+      if (!byName.has(agent.name)) byName.set(agent.name, agent.id);
     }
-    if (UUID_V4_RE.test(rest)) {
-      return rest as AgentId;
+    return byName;
+  });
+
+const resolveAgentTokens = (
+  tokens: readonly string[],
+): Effect.Effect<
+  readonly AgentId[],
+  UnresolvedParticipantError | TooManyParticipantNamesError | TransportError,
+  Transport
+> =>
+  Effect.gen(function* () {
+    const classified = yield* Effect.all(tokens.map(classifyToken));
+    const agentIdByName = yield* lookupAgentIdsByName(
+      uniqueNamesOf(classified),
+    );
+    // Single for-loop avoids a second `Effect.all` over pure post-batch
+    // resolution (N extra Effect cells); fail-fast on first miss preserves
+    // input-order error semantics.
+    const resolved: AgentId[] = [];
+    for (const entry of classified) {
+      if (entry.kind === "uuid") {
+        resolved.push(entry.id);
+        continue;
+      }
+      const id = agentIdByName.get(entry.name);
+      if (id === undefined) {
+        return yield* Effect.fail(
+          new UnresolvedParticipantError({
+            token: entry.token,
+            reason: "not-found",
+          }),
+        );
+      }
+      resolved.push(id);
     }
-    const result = yield* rpc(AgentsLookupByName, { names: [rest] });
-    const firstAgent = result.agents[0];
-    if (firstAgent === undefined) {
-      return yield* Effect.fail(
-        new UnresolvedParticipantError({ token, reason: "not-found" }),
-      );
-    }
-    return firstAgent.id;
+    return resolved;
   });
 
 // ─── Handler stages ───────────────────────────────────────────────────────
@@ -448,8 +549,9 @@ const handleDedupOutcome = (
  *
  *   1. Validate `args.appId` UUID v4 if set; else use `DEFAULT_APP_ID`.
  *      Failure -> `InvalidAppIdError` -> exit 64 via `runStartCommand`.
- *   2. Resolve `args.participants` via `resolveAgentToken` (per-token,
- *      sequential via `Effect.all`). Any token failure ->
+ *   2. Resolve `args.participants` via `resolveAgentTokens` (single
+ *      batched `AgentsLookupByName` RPC for name-shaped tokens;
+ *      UUID-shaped tokens short-circuit). Any token failure ->
  *      `UnresolvedParticipantError` -> exit 64.
  *   3. `rpc(TaskCreate, { appId, invitedAgentIds, initialConversation })`
  *      where `initialConversation` carries `participants` ONLY when
@@ -481,9 +583,7 @@ const startCommandHandler = (
 ): Effect.Effect<void, StartCommandError, Transport> =>
   Effect.gen(function* () {
     const appId = yield* resolveAppId(args.appId);
-    const invitedAgentIds = yield* Effect.all(
-      args.participants.map(resolveAgentToken),
-    );
+    const invitedAgentIds = yield* resolveAgentTokens(args.participants);
     const outcome = yield* createTaskAtomic(appId, invitedAgentIds, args.name);
     const messageOpt = Option.fromNullable(args.message);
     if (outcome.kind === "dedup") {
@@ -504,9 +604,10 @@ const startCommandHandler = (
  * (which collapses every error to exit 1) with a `_tag`-aware mapping
  * per the spec D2 exit-code contract:
  *
- *   `InvalidAppIdError`           -> 64 + stderr `Invalid --app-id: not a UUID`
- *   `UnresolvedParticipantError`  -> 64 + stderr `Cannot resolve "&lt;token>": &lt;reason>`
- *   any other `StartCommandError` -> 1  + stderr `Failed: &lt;err.message>`
+ *   `InvalidAppIdError`             -> 64 + stderr `Invalid --app-id: not a UUID`
+ *   `UnresolvedParticipantError`    -> 64 + stderr `Cannot resolve "&lt;token>": &lt;reason>`
+ *   `TooManyParticipantNamesError`  -> 64 + stderr `Too many distinct agent names: &lt;count> (max &lt;max>)`
+ *   any other `StartCommandError`   -> 1  + stderr `Failed: &lt;err.message>`
  *
  * The exit-2 partial-success branch runs inline inside
  * `startCommandHandler` (after `Task started:` has been printed to
@@ -530,12 +631,20 @@ const runStartCommand = (
         process.exit(EXIT_CODES.USAGE_ERROR);
       }),
     ),
+    Effect.catchTag("TooManyParticipantNamesError", (err) =>
+      Effect.sync(() => {
+        console.error(
+          `Too many distinct agent names: ${err.count} (max ${err.max})`,
+        );
+        process.exit(EXIT_CODES.USAGE_ERROR);
+      }),
+    ),
     Effect.catchAll((err) =>
       Effect.sync(() => {
-        const msg =
-          err.message !== undefined && err.message !== ""
-            ? err.message
-            : err._tag;
+        // `Data.TaggedError` populates `message` for every tagged-error
+        // subclass; `|| err._tag` is a belt-and-suspenders fallback for
+        // the (impossible-per-Data-contract) empty-message case.
+        const msg = err.message || err._tag;
         console.error(`Failed: ${msg}`);
         process.exit(EXIT_CODES.TASK_CREATE_FAILED);
       }),
@@ -612,6 +721,6 @@ export const startCommand = Command.make(
       `  ${EXIT_CODES.SUCCESS}   success (TaskCreate + optional MessagesSend resolved)\n` +
       `  ${EXIT_CODES.TASK_CREATE_FAILED}   TaskCreate failed (stdout empty)\n` +
       `  ${EXIT_CODES.PARTIAL_SUCCESS}   TaskCreate OK, MessagesSend failed (no rollback)\n` +
-      `  ${EXIT_CODES.USAGE_ERROR}  usage error (bad --app-id UUID or unresolvable agent token)`,
+      `  ${EXIT_CODES.USAGE_ERROR}  usage error (bad --app-id UUID, unresolvable agent token, or >${MAX_NAME_LOOKUP_BATCH} distinct name-shaped tokens)`,
   ),
 );

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -359,6 +359,9 @@ export const startCommand = Command.make(
       "first message in one atomic step. Spec D2 #599 — composes Spec D1 " +
       "TaskCreate + MessagesSend.\n" +
       "\n" +
+      "Zero participants creates a caller-only task (rare; usually you " +
+      "will pass one or more `agent:<name>` tokens).\n" +
+      "\n" +
       "Exit codes:\n" +
       `  ${EXIT_CODES.SUCCESS}   success (TaskCreate + optional MessagesSend resolved)\n` +
       `  ${EXIT_CODES.TASK_CREATE_FAILED}   TaskCreate failed (stdout empty)\n` +

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -7,9 +7,13 @@
  * (`conversations create` → `send conv:&lt;id> &lt;text>`) collapses into one
  * subcommand for the common case.
  *
- * Architect stub (sub-issue #643). NO function bodies, NO command
- * registration in `cli/index.ts`. Impl-staff lands both per the plan in
- * `packages/client/docs/architecture/09-moltzap-start-cli.md`.
+ * Architect stub (sub-issue #643). The `Command.make` registration is
+ * already wired in `cli/index.ts` AT THIS COMMIT. The function body of
+ * `startCommandHandler` (and the exit-code dispatcher `runStartCommand`)
+ * are intentionally fail-fast `Effect.fail` stubs; impl-staff replaces
+ * those two bodies per the plan in
+ * `packages/client/docs/architecture/09-moltzap-start-cli.md` and adds
+ * the test file `start.test.ts`. No other files change in impl-staff.
  *
  * See also:
  *   - Spec D1 architect plan (#635) for `TaskCreate` / `DEFAULT_APP_ID` /
@@ -19,17 +23,19 @@
  *     command flow diagram, exit-code contract, and test alignment.
  *   - `packages/client/src/cli/commands/conversations.ts → createConversation`
  *     for the legacy two-step DM/Group create path D2 replaces.
- *   - `packages/client/src/cli/socket-client.ts → resolveParticipant` for
- *     the `agent:&lt;name>` / `agent:&lt;uuid>` token resolver this command
- *     re-uses (caller maps `.id` after resolution to get a bare `AgentId`).
+ *   - `packages/client/src/cli/socket-client.ts → resolveParticipant` —
+ *     NOT reused by D2 because that helper goes via the daemon
+ *     socket (`socket-client.ts → request`), bypassing the CLI
+ *     `Transport` service that `start.ts` uses for `TaskCreate` /
+ *     `MessagesSend`. Mixing the two would make `--as`-mode name lookups
+ *     hit the daemon (potentially absent) and would not be testable
+ *     via `makeFakeTransport`. D2 introduces a `resolveAgentToken`
+ *     local helper that goes through `transport.ts → rpc` instead
+ *     (see per-flow doc §6 + §"Why we don't reuse `resolveParticipant`").
  */
 import { Args, Command, Options } from "@effect/cli";
 import { Data, Effect, Option } from "effect";
-import {
-  runHandler,
-  type Transport,
-  type TransportError,
-} from "../transport.js";
+import type { Transport, TransportError } from "../transport.js";
 
 // ─── Exit-code contract (spec D2 Goal 5 + Goal 7) ─────────────────────────
 
@@ -169,13 +175,17 @@ export type StartCommandError =
  * sketch"):
  *
  *   1. Validate `args.appId` UUID v4 if set; else use `DEFAULT_APP_ID`.
- *      Failure → `InvalidAppIdError` → exit 64, no RPCs.
- *   2. Resolve every `args.participants[i]` via `resolveParticipant(...)`
- *      from `socket-client.ts`; map `.id` to get `AgentId`. Any token
+ *      Failure → `InvalidAppIdError`; `runStartCommand` maps to exit 64,
+ *      no RPCs.
+ *   2. Resolve every `args.participants[i]` via the local
+ *      `resolveAgentToken(token)` helper below (which goes through
+ *      `transport.ts → rpc(AgentsLookupByName, ...)` so `--as` direct-WS
+ *      mode works and tests can mock via `makeFakeTransport`). Any token
  *      failing resolution → `UnresolvedParticipantError` → exit 64.
  *   3. Call `rpc(TaskCreate, { appId, invitedAgentIds, initialConversation:
  *      { name: args.name, participants: invitedAgentIds } })`. Failure →
- *      `TransportError` → exit 1, no stdout. On success, read
+ *      `TransportError` → exit 1 (handler `Effect.fail`s; `runStartCommand`
+ *      catches and dispatches), no stdout. On success, read
  *      `{ task, conversation }` directly from the response object (NO
  *      follow-up fetch) and print `Task started: ${task.id} (conversation:
  *      ${conversation.id})` to stdout. `conversation` is non-null here
@@ -183,7 +193,10 @@ export type StartCommandError =
  *   4. If `args.message` is set, call `rpc(MessagesSend, { conversationId:
  *      conversation.id, parts: [{ type: "text", text: args.message }] })`.
  *      Success → print `Message sent: ${message.id}`, exit 0. Failure →
- *      print `Error sending message: ${err.message}` to stderr, exit 2.
+ *      use `Effect.either` to catch in-band, print
+ *      `Error sending message: ${err.message}` to stderr, then exit 2
+ *      via inline `process.exit` (the partial-success branch needs to
+ *      preserve the already-printed stdout line and cannot just `Effect.fail`).
  *      NO rollback.
  *
  * NB: D1 plan §R8 / Canary _C5 locks the wire result shape as `conversation:
@@ -192,20 +205,92 @@ export type StartCommandError =
  * because D2 always sends `initialConversation`. The assertion narrows
  * TypeScript's union; a stale D1 build that returns `null` despite
  * `initialConversation` is treated as a `TransportDecodeError` (exit 1).
- * @throws — `process.exit` is called inside the wrapping
- * `Command.make` adapter, NOT here. This handler returns an Effect; the
- * `runHandler` analogue in `transport.ts` (or a partial-failure-aware
- * variant — see per-flow doc 09 §"Exit-code dispatcher") translates the
- * tag to an exit code.
+ *
+ * NB-2: `StartCommandError`'s `TransportError` arm is the union from
+ * `transport.ts → TransportError` which includes `TransportDecodeError` +
+ * `TransportRpcError` + `ServiceUnreachableError` + `TransportTimeoutError`
+ * + `TransportConfigError`. The exit-code dispatcher `runStartCommand`
+ * collapses all of them to exit 1 unless they arose from the post-
+ * `TaskCreate` `MessagesSend` (which exits 2 via inline `process.exit`
+ * inside the handler body itself).
  */
 const startCommandHandler = (
-  _args: StartCommandArgs,
+  args: StartCommandArgs,
 ): Effect.Effect<void, StartCommandError, Transport> =>
+  // Architect stub: chain through `resolveAgentToken` so both symbols
+  // are referenced and the unused-declaration check stays clean.
+  // Impl-staff replaces this entire body with the four-step flow
+  // documented in the JSDoc above (and in per-flow doc 09 §6).
+  resolveAgentToken(args.participants[0] ?? "stub").pipe(
+    Effect.flatMap(() =>
+      Effect.fail(
+        new InvalidAppIdError({
+          value: "architect stub — body lands in impl-staff PR (spec D2 #599)",
+        }),
+      ),
+    ),
+  );
+
+/**
+ * Local participant-token resolver: parses `agent:&lt;uuid>` /
+ * `agent:&lt;name>` tokens. UUID-shaped tokens skip the server lookup;
+ * name-shaped tokens go through `transport.ts → rpc(AgentsLookupByName, ...)`
+ * — NOT `socket-client.ts → request(AgentsLookupByName, ...)`. This is
+ * the deliberate divergence from `socket-client.ts → resolveParticipant`:
+ *
+ *   - In `--as`-mode (direct WS), the daemon socket may not even be
+ *     reachable; routing name lookups through the daemon-only
+ *     `socket-client.ts → request` would break that flow.
+ *   - Tests using `commands/test-transport.ts → makeFakeTransport`
+ *     intercept `Transport` calls, not the daemon socket. A test that
+ *     mocks `AgentsLookupByName` via `makeFakeTransport` would fail
+ *     to intercept the existing `resolveParticipant` lookup.
+ *
+ * Impl-staff fills the body with: parse `agent:&lt;rest>`; if `rest`
+ * matches UUID v4, return as `AgentId`; else `rpc(AgentsLookupByName,
+ * { names: [rest] })` and return the first hit, or
+ * `UnresolvedParticipantError({ token, reason: "not-found" })` on empty
+ * result. Token shape errors (no `agent:` prefix, etc.) map to
+ * `UnresolvedParticipantError({ token, reason: "shape" })`.
+ *
+ * Stub body: fail-fast.
+ */
+const resolveAgentToken = (
+  _token: string,
+): Effect.Effect<
+  unknown, // AgentId at impl-staff time; opaque here to avoid an unused-import
+  UnresolvedParticipantError,
+  Transport
+> =>
   Effect.fail(
-    new InvalidAppIdError({
-      value: "architect stub — body lands in impl-staff PR (spec D2 #599)",
+    new UnresolvedParticipantError({
+      token: "architect stub — body lands in impl-staff PR",
+      reason: "shape",
     }),
   );
+
+/**
+ * Exit-code dispatcher for `moltzap start`. Replaces the generic
+ * `transport.ts → runHandler` (which collapses every error to exit 1)
+ * with a `_tag`-aware mapper:
+ *
+ *   `InvalidAppIdError`           → 64 (usage)  + stderr `Invalid --app-id: not a UUID`
+ *   `UnresolvedParticipantError`  → 64 (usage)  + stderr `Cannot resolve "&lt;token>": &lt;reason>`
+ *   any other `StartCommandError` → 1  (rpc)    + stderr `Failed: &lt;err.message>`
+ *
+ * The exit-2 partial-success path is NOT dispatched here — that branch
+ * runs inline inside the handler body (after `Task started:` has been
+ * printed to stdout, the partial-failure stage cannot be re-thrown
+ * because doing so would discard the stdout line; the handler instead
+ * calls `process.exit(EXIT_CODES.PARTIAL_SUCCESS)` directly from inside
+ * `Effect.sync` after `console.error`).
+ *
+ * Stub body: pass-through that runs the handler unchanged. Impl-staff
+ * fills the `_tag`-aware `Effect.catchAll` block.
+ */
+const runStartCommand = (
+  effect: Effect.Effect<void, StartCommandError, Transport>,
+): Effect.Effect<void, StartCommandError, Transport> => effect;
 
 // ─── @effect/cli wiring (architect stub — handler delegates to impl-staff) ─
 
@@ -256,7 +341,7 @@ export const startCommand = Command.make(
     appId: appIdOption,
   },
   ({ name, participants, message, appId }) =>
-    runHandler(
+    runStartCommand(
       startCommandHandler({
         name,
         participants,

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -127,8 +127,12 @@ export interface StartCommandArgs {
   /**
    * Raw participant tokens (positional `&lt;participant>...`), each
    * `agent:&lt;name>` or `agent:&lt;uuid>`. Resolution is per-token via
-   * `resolveParticipant` (socket-client.ts); failures map to
-   * `UnresolvedParticipantError` and exit 64 BEFORE `TaskCreate`.
+   * `resolveAgentToken` (local helper below) which routes through
+   * `transport.ts → rpc(AgentsLookupByName, ...)` for name-shaped
+   * tokens and short-circuits UUID-shaped tokens client-side.
+   * Failures map to `UnresolvedParticipantError` and exit 64 BEFORE
+   * `TaskCreate`. See per-flow doc 09 §"Why we don't reuse
+   * `resolveParticipant`" for the transport divergence reasoning.
    */
   readonly participants: readonly string[];
 

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -31,19 +31,17 @@ import {
   AgentsLookupByName,
   DEFAULT_APP_ID,
   MessagesSend,
+  TaskConversationList,
   TaskCreate,
   type AgentId,
   type AppId,
   type Conversation,
   type Task,
+  type TaskConversationListItem,
+  type TaskId,
 } from "@moltzap/protocol";
 import type { ConversationId } from "@moltzap/protocol/task";
-import {
-  rpc,
-  TransportDecodeError,
-  type Transport,
-  type TransportError,
-} from "../transport.js";
+import { rpc, type Transport, type TransportError } from "../transport.js";
 
 // ─── Exit-code contract (spec D2 Goal 5 + Goal 7) ─────────────────────────
 
@@ -207,12 +205,35 @@ const resolveAppId = (
 ): Effect.Effect<AppId, InvalidAppIdError> =>
   raw === undefined ? Effect.succeed(DEFAULT_APP_ID) : validateAppId(raw);
 
-const printTaskStarted = (
+const printTaskCreated = (
   task: Task,
   conversation: Conversation,
 ): Effect.Effect<void> =>
   Effect.sync(() => {
     console.log(`Task started: ${task.id} (conversation: ${conversation.id})`);
+  });
+
+const printTaskReused = (
+  task: Task,
+  conversation: Conversation,
+): Effect.Effect<void> =>
+  Effect.sync(() => {
+    console.log(
+      `Task started: ${task.id} (reusing existing conversation: ${conversation.id})`,
+    );
+  });
+
+const printTaskAlreadyClosed = (taskId: TaskId): Effect.Effect<void> =>
+  Effect.sync(() => {
+    // WHY this single message covers two distinct conditions:
+    // (a) the existing task has no non-archived conversation, OR
+    // (b) the dedup-lookup window (1000 rows) did not surface one.
+    // (b) is rare per the activity-desc server ordering; if a heavy
+    // user trips it on an active task, the spec D2 amendment N6
+    // diagnostic is intentionally conservative ("closed") rather than
+    // claiming false freshness. The follow-up `moltzap conversations
+    // list` invocation surfaces the real state.
+    console.error(`Task already exists but is closed: ${taskId}`);
   });
 
 const printMessageSent = (messageId: string): Effect.Effect<void> =>
@@ -242,41 +263,183 @@ const sendFirstMessage = (
     ),
   );
 
+/**
+ * Outcome of the atomic `TaskCreate` call. The dedup branch fires when
+ * `appId === DEFAULT_APP_ID` AND the caller already owns a task with
+ * the exact same `{caller} ∪ invitedAgentIds` participant set (see
+ * `packages/server/src/task/handlers/tasks.handlers.ts → maybeTaskCreateDedup`
+ * and protocol per-flow doc 12 §3). The server returns
+ * `{ task: existing, conversation: null }` even when
+ * `initialConversation` was supplied — dedup is task-level, not
+ * conversation-level — so the CLI MUST treat `conversation === null`
+ * as a legitimate outcome rather than a decode error.
+ */
+type CreateTaskOutcome =
+  | {
+      readonly kind: "created";
+      readonly task: Task;
+      readonly conversation: Conversation;
+    }
+  | { readonly kind: "dedup"; readonly task: Task };
+
 const createTaskAtomic = (
   appId: AppId,
   invitedAgentIds: readonly AgentId[],
   name: string,
-): Effect.Effect<
-  { readonly task: Task; readonly conversation: Conversation },
-  TransportError,
-  Transport
-> =>
+): Effect.Effect<CreateTaskOutcome, TransportError, Transport> =>
   Effect.gen(function* () {
     // Defensive copies: TaskCreate's params type expects mutable arrays
     // (TypeBox's Static<Array> resolves to T[], not readonly T[]); pass
     // shallow clones so the caller's readonly contract isn't bypassed.
+    //
+    // Spec D2 (#599) amendment N7 (zero-participant carve-out):
+    // `InitialConversationSchema.participants` is `Type.Optional(Type.Array(AgentId,
+    // { minItems: 1 }))` — an EMPTY array fails server AJV. The
+    // caller-only path (help text + plan §R4 + `start.test.ts →
+    // zeroParticipants`) MUST omit `participants` entirely; the server
+    // adds the caller to `conversation_participants` implicitly. See
+    // `packages/protocol/src/task/tasks.ts → InitialConversationSchema`.
+    const initialConversation =
+      invitedAgentIds.length === 0
+        ? { name }
+        : { name, participants: [...invitedAgentIds] };
     const result = yield* rpc(TaskCreate, {
       appId,
       invitedAgentIds: [...invitedAgentIds],
-      initialConversation: {
-        name,
-        participants: [...invitedAgentIds],
-      },
+      initialConversation,
     });
-    // D1 canary _C5: when initialConversation is sent, conversation is
-    // non-null. A null here means a stale D1 build; surface as a typed
-    // decode error -> exit 1.
     if (result.conversation === null) {
-      return yield* Effect.fail(
-        new TransportDecodeError({
-          method: TaskCreate.name,
-          cause:
-            "TaskCreate returned conversation: null despite initialConversation",
-        }),
-      );
+      // Dedup hit (per `tasks.handlers.ts → maybeTaskCreateDedup`): the
+      // server matched an existing task by `{caller} ∪ invitedAgentIds`
+      // and returned it with `conversation: null`. Handler resolves a
+      // reusable conversation via `findReusableConversation` instead of
+      // failing.
+      return { kind: "dedup", task: result.task } as const;
     }
-    return { task: result.task, conversation: result.conversation };
+    return {
+      kind: "created",
+      task: result.task,
+      conversation: result.conversation,
+    } as const;
   });
+
+// ─── Dedup-hit conversation lookup (spec D2 amendment N6) ─────────────────
+
+/**
+ * Page size + safety cap on `TaskConversationList` follow-up calls. The
+ * dedup-hit conversation should appear in the first page for any
+ * recently-touched task (server orders by activity desc, see
+ * `packages/server/src/task/services/conversation/list-pagination.ts →
+ * queryConversationListRows`). The cap protects against pathological
+ * cases where the caller has a very long list and the target task is
+ * older than the window can see — in which case we surface the closed-
+ * task diagnostic rather than spin indefinitely.
+ */
+const DEDUP_LOOKUP_PAGE_SIZE = 100;
+const DEDUP_LOOKUP_MAX_PAGES = 10;
+
+/**
+ * P2-A (spec D2 amendment N6) — locate a reusable conversation under a
+ * dedup-hit task. Tie-break rule: "first match in server iteration
+ * order" — server sorts by activity desc, so this is equivalent to
+ * most-recently-active. WHY a small page-count cap: a freshly-touched
+ * dedup-hit task lives near the top of the activity-sorted list; the
+ * 1000-row ceiling protects against pathological lists where the
+ * target is older than the lookup window can see (the closed-task
+ * diagnostic is the correct fallback per spec D2 amendment N6).
+ */
+
+/**
+ * Filter rule for the dedup-hit lookup: (a) the item's `taskId` must
+ * match the existing task we are reusing (the list is caller-scoped
+ * across ALL of the caller's tasks, not task-scoped); (b) the
+ * conversation must be non-archived (server includes archived rows
+ * unfiltered per `TaskConversationList`'s contract — clients filter
+ * `archivedAt !== undefined` locally; archived strings are absent
+ * on the wire when the row is active, never `null`, per
+ * `ConversationSchema.archivedAt: Type.Optional(DateTimeString)`).
+ */
+const pickReusableFromPage = (
+  items: ReadonlyArray<TaskConversationListItem>,
+  taskId: TaskId,
+): Conversation | null => {
+  const match = items.find(
+    (item) =>
+      item.taskId === taskId && item.conversation.archivedAt === undefined,
+  );
+  return match === undefined ? null : match.conversation;
+};
+
+const findReusableConversation = (
+  taskId: TaskId,
+): Effect.Effect<Conversation | null, TransportError, Transport> =>
+  Effect.gen(function* () {
+    let cursor: string | undefined = undefined;
+    for (let page = 0; page < DEDUP_LOOKUP_MAX_PAGES; page++) {
+      const params: { limit: number; cursor?: string } = {
+        limit: DEDUP_LOOKUP_PAGE_SIZE,
+      };
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = yield* rpc(TaskConversationList, params);
+      const hit = pickReusableFromPage(result.items, taskId);
+      if (hit !== null) return hit;
+      if (result.nextCursor === undefined) return null;
+      cursor = result.nextCursor;
+    }
+    return null;
+  });
+
+/**
+ * Spec D2 amendment N6 — dedup-hit branch. `TaskConversationList`
+ * wire failures are captured inline via `Effect.either` (same pattern
+ * + same reason as `sendFirstMessage`'s partial-success handling)
+ * because `TaskCreate` already succeeded server-side; routing the
+ * list error through `runStartCommand`'s `catchAll` would print
+ * `Failed: &lt;list-error>`, misleading the user into thinking the
+ * create failed.
+ */
+const onReuseFound = (
+  task: Task,
+  reuse: Conversation,
+  message: Option.Option<string>,
+): Effect.Effect<void, never, Transport> =>
+  Effect.zipRight(
+    printTaskReused(task, reuse),
+    Option.match(message, {
+      onNone: () => Effect.void,
+      onSome: (m) => sendFirstMessage(reuse.id, m),
+    }),
+  );
+
+const onReuseNull = (task: Task): Effect.Effect<void, never, Transport> =>
+  Effect.zipRight(
+    printTaskAlreadyClosed(task.id),
+    Effect.sync(() => {
+      process.exit(EXIT_CODES.TASK_CREATE_FAILED);
+    }),
+  );
+
+const handleDedupOutcome = (
+  task: Task,
+  message: Option.Option<string>,
+): Effect.Effect<void, never, Transport> =>
+  Effect.either(findReusableConversation(task.id)).pipe(
+    Effect.flatMap(
+      Either.match({
+        onLeft: (err) =>
+          Effect.sync(() => {
+            console.error(
+              `Task ${task.id} already exists but reusable-conversation lookup failed: ${err.message}`,
+            );
+            process.exit(EXIT_CODES.TASK_CREATE_FAILED);
+          }),
+        onRight: (reuse) =>
+          reuse === null
+            ? onReuseNull(task)
+            : onReuseFound(task, reuse, message),
+      }),
+    ),
+  );
 
 // ─── Handler body ─────────────────────────────────────────────────────────
 
@@ -288,16 +451,30 @@ const createTaskAtomic = (
  *   2. Resolve `args.participants` via `resolveAgentToken` (per-token,
  *      sequential via `Effect.all`). Any token failure ->
  *      `UnresolvedParticipantError` -> exit 64.
- *   3. `rpc(TaskCreate, { appId, invitedAgentIds, initialConversation:
- *      { name, participants: invitedAgentIds } })`. Failure ->
- *      `TransportError` -> exit 1 via `runStartCommand`, no stdout. On
- *      success print `Task started: &lt;taskId> (conversation: &lt;convId>)`.
- *   4. If `args.message` is set, call `rpc(MessagesSend, { conversationId,
- *      parts: [{ type: "text", text }] })` wrapped in `Effect.either`.
- *      Success -> print `Message sent: &lt;msgId>`, exit 0. Failure -> print
+ *   3. `rpc(TaskCreate, { appId, invitedAgentIds, initialConversation })`
+ *      where `initialConversation` carries `participants` ONLY when
+ *      `invitedAgentIds.length > 0` (P2-B). Two success outcomes:
+ *      - `created`: server returned a fresh `conversation`. Print
+ *        `Task started: &lt;taskId> (conversation: &lt;convId>)`.
+ *      - `dedup`: server returned `conversation: null` because
+ *        `{caller} ∪ invitedAgentIds` already owned a task on this
+ *        appId (P2-A). Auto-fetch the most-recently-active non-
+ *        archived conversation under the existing task via
+ *        `findReusableConversation` and print
+ *        `Task started: &lt;taskId> (reusing existing conversation: &lt;convId>)`.
+ *        If no usable conversation exists (closed task, all archived,
+ *        or out of dedup-lookup window), print
+ *        `Task already exists but is closed: &lt;taskId>` to stderr and
+ *        exit 1.
+ *      `TaskCreate` wire failure -> `TransportError` -> exit 1 via
+ *      `runStartCommand`, no stdout.
+ *   4. If `args.message` is set AND a conversation was produced (either
+ *      kind), call `rpc(MessagesSend, { conversationId, parts: [{ type:
+ *      "text", text }] })` wrapped in `Effect.either`. Success -> print
+ *      `Message sent: &lt;msgId>`, exit 0. Failure -> print
  *      `Error sending message: &lt;err>` to stderr, exit 2 via inline
- *      `process.exit` (preserves the already-printed stdout line; cannot
- *      route through `runStartCommand`).
+ *      `process.exit` (preserves the already-printed stdout line;
+ *      cannot route through `runStartCommand`).
  */
 const startCommandHandler = (
   args: StartCommandArgs,
@@ -307,15 +484,17 @@ const startCommandHandler = (
     const invitedAgentIds = yield* Effect.all(
       args.participants.map(resolveAgentToken),
     );
-    const { task, conversation } = yield* createTaskAtomic(
-      appId,
-      invitedAgentIds,
-      args.name,
-    );
-    yield* printTaskStarted(task, conversation);
-    if (args.message !== undefined) {
-      yield* sendFirstMessage(conversation.id, args.message);
+    const outcome = yield* createTaskAtomic(appId, invitedAgentIds, args.name);
+    const messageOpt = Option.fromNullable(args.message);
+    if (outcome.kind === "dedup") {
+      yield* handleDedupOutcome(outcome.task, messageOpt);
+      return;
     }
+    yield* printTaskCreated(outcome.task, outcome.conversation);
+    yield* Option.match(messageOpt, {
+      onNone: () => Effect.void,
+      onSome: (m) => sendFirstMessage(outcome.conversation.id, m),
+    });
   }).pipe(Effect.withSpan("startCommandHandler"));
 
 // ─── Exit-code dispatcher ─────────────────────────────────────────────────

--- a/packages/client/src/cli/index.ts
+++ b/packages/client/src/cli/index.ts
@@ -16,6 +16,7 @@ import { pingCommand } from "./commands/ping.js";
 import { presenceCommand } from "./commands/presence.js";
 import { registerCommand } from "./commands/register.js";
 import { sendCommand } from "./commands/send.js";
+import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";
 import { whoamiCommand } from "./commands/whoami.js";
 import { LoggerLive, minLogLevel } from "./runtime.js";
@@ -153,6 +154,8 @@ const moltzapBase = Command.make("moltzap", {
     agentsCommand,
     // sbd#177 v2 additions:
     messagesCommand,
+    // Spec D2 (#599) — architect stub; impl-staff fills the handler body:
+    startCommand,
   ]),
 );
 


### PR DESCRIPTION
## Summary

**Re-opening PR #665** — that PR auto-closed when D1 (#659) merged and its base branch `impl/598-task-conversation-family` was deleted. This is the same branch (`impl/599-d2-cli-moltzap-start`), rebased onto post-D1-merge `main @ 57fddc1` and now targeting `main` directly. Stamina N=2 fix-roll APPROVE verdicts on the same branch content carry over.

D2 of the layered protocol refactor — `moltzap start` CLI command. Backed by architect plan #643 (plan-approved) for spec #599.

Adds `packages/client/src/cli/commands/start.ts` implementing the `moltzap start` CLI handler that bootstraps a `MoltZapWsClient` + creates an initial `TaskConversation` (uses the D1 `TaskCreate{appId}` API + the `TaskConversation*` family).

## Scope

- `packages/client/src/cli/commands/start.ts` — CLI handler
- `packages/client/src/cli/commands/start.test.ts` — tests
- `packages/client/src/cli/index.ts` — register `start` command
- `packages/client/docs/architecture/moltzap-start-cli.md` — flow doc (renamed during rebase from `09-` prefix per Spec-F #632 doc-naming convention)
- `packages/client/ARCHITECTURE.md` — index link
- `CHANGELOG.md` — entry

## Rebase notes

Spec-F #632 doc-naming convention (drop NN- prefixes) landed in main concurrently. Conflict resolution kept main's structure; renamed D2's new doc + updated cross-refs. Final commit `69a5a2c` fixes a missed source-header citation in `start.ts`. Otherwise the diff is byte-identical to PR #665 @ `de7d1cd`.

See PR #665 rebase comment for full /document-release + gate evidence:
https://github.com/chughtapan/moltzap/pull/665#issuecomment-4494597682

## Test plan

- [ ] CI: ci / conformance / test all green
- [ ] codex `--mode review` APPROVE (carried over from #665 @ de7d1cd; re-confirm if CI requests)
- [ ] review-senior APPROVE (Stamina N=2 verdicts already on #665)
- [ ] No `TODO` / `XXX` / `FIXME` / `it.todo` added (no-defer per `feedback_no_defer_finish_in_impl`)

## Gates green at post-rebase HEAD (`69a5a2c`)

- `pnpm install --frozen-lockfile` ✓
- `pnpm -r build` ✓ (7 packages)
- `pnpm -r lint` (knip + eslint --max-warnings=0) ✓
- `pnpm exec oxfmt --check` ✓ (570 files)
- `./scripts/sloppy-code-guard.sh` ✓
- `pnpm -r test` ✓ (303 client tests + all others)
- `pnpm --filter @moltzap/server-core test:conformance` ✓ (45 tests)

Sub-issue: #661 · Parent epic: #602 · Supersedes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)