### PR TITLE
chore(eslint): declare architecture publicTypePackages + allowedTestPublicSubpaths

### DIFF
--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -76,6 +76,66 @@ const documentationRules = {
   rules: guard.configs.documentation.rules,
 };
 
+// Architecture options consumed by @safer-by-default/architecture-lsp's
+// LSP server + `check.js` CLI. The analyzer reads these from
+// settings["agent-code-guard"].architecture; see safer-by-default PR #313.
+//
+// publicTypePackages: vendor packages whose types are intentionally part
+// of the public contract — channels and the client SDK expose Effect and
+// the moltzap protocol/client types directly. Wrapping them at every
+// boundary would produce noise without changing the actual contract.
+//
+// allowedTestPublicSubpaths: package.json `exports` keys that intentionally
+// expose test-only paths for cross-package integration testing.
+const architectureSettings = {
+  "agent-code-guard": {
+    architecture: {
+      publicTypePackages: [
+        {
+          package: "effect",
+          reason:
+            "Foundational Effect runtime; intentionally part of public contract",
+        },
+        {
+          package: "@effect/platform",
+          reason: "Effect platform abstractions used at boundaries",
+        },
+        {
+          package: "@effect/platform-node",
+          reason: "Effect Node integration used at boundaries",
+        },
+        {
+          package: "@sinclair/typebox",
+          reason: "Schema runtime; types are the contract",
+        },
+        {
+          package: "@moltzap/protocol",
+          reason: "Intra-monorepo protocol; foundational shared contract",
+        },
+        {
+          package: "@moltzap/client",
+          reason:
+            "Intra-monorepo client SDK; channels depend on its public surface",
+        },
+      ],
+      allowedTestPublicSubpaths: [
+        {
+          subpath: "./test-utils",
+          reason: "Test helpers exposed for cross-package integration testing",
+        },
+        {
+          subpath: "./test",
+          reason: "Test harness API for downstream packages",
+        },
+        {
+          subpath: "./test-support",
+          reason: "Channel test support exposed for integration tests",
+        },
+      ],
+    },
+  },
+};
+
 export function packageEslintConfig(options = {}) {
   const strictRules = makeStrictRules(options);
   return [
@@ -85,7 +145,7 @@ export function packageEslintConfig(options = {}) {
       ignores: ["**/*.test.ts", "**/*.spec.ts"],
       languageOptions: tsLanguageOptions,
       plugins: guard.configs.strict.plugins,
-      settings: guard.configs.strict.settings,
+      settings: { ...guard.configs.strict.settings, ...architectureSettings },
       rules: strictRules,
     },
     makeTestSupportRules(strictRules),
@@ -103,7 +163,7 @@ export function rootEslintConfig() {
       files: ["*.ts"],
       languageOptions: tsLanguageOptions,
       plugins: guard.configs.strict.plugins,
-      settings: guard.configs.strict.settings,
+      settings: { ...guard.configs.strict.settings, ...architectureSettings },
       rules: strictRules,
     },
     eslintDisableCommentRules,


### PR DESCRIPTION
## Summary

Declares the architecture options that `@safer-by-default/architecture-lsp` will consume when it lands the loader (chughtapan/safer-by-default#313, stacked on chughtapan/safer-by-default#312).

Settings live at `settings["agent-code-guard"].architecture` in the shared eslint flat config — same file linters already read, no new config surface.

### What it changes

- **`publicTypePackages`** — vendor packages whose types are intentionally part of public contracts:
  - `effect`, `@effect/platform`, `@effect/platform-node` — foundational Effect runtime/platform
  - `@sinclair/typebox` — schema runtime; types ARE the contract
  - `@moltzap/protocol`, `@moltzap/client` — intra-monorepo contracts
- **`allowedTestPublicSubpaths`** — package.json `exports` keys that intentionally expose test-only paths for cross-package integration testing (`./test-utils`, `./test`, `./test-support`)

### Effect

| Setting | Today's CI | Local LSP (with safer-by-default#313 + #312) |
|---|---|---|
| `pnpm lint` | unchanged | unchanged |
| Architecture LSP squiggles | n/a | 27 ERRORs → 4 |
| `check.js` from repo root | 417/27 ERR | 380/4 ERR |

Today's `pnpm lint` runs `eslint-plugin-agent-code-guard@0.0.14` which doesn't carry the architecture rules — so this PR is a forward-looking config change. CI is unchanged. The 23 ERROR drop only materializes once safer-by-default releases.

### Out of scope

- The 4 remaining ERRORs all live in `packages/openclaw-channel/src/test-utils/container-core.ts` referencing `node:fs`/`node:child_process` for container management. Two ways to address in a follow-up:
  1. Add `{ package: "node", reason: "..." }` to `publicTypePackages` for that package's eslint config only.
  2. Refactor `container-core.ts` to expose moltzap-owned types and wrap the Node APIs.
- The 376 remaining WARNs (`no-cross-domain-sibling-import`, `file-implicit-boundary-module`, etc.) are real structural concerns — separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)