### PR TITLE
chore(eslint): declare protocol layer stack (transport→identity→network→task→app)

### DIFF
--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -136,8 +136,27 @@ const architectureSettings = {
   },
 };
 
+// Per-package architecture additions (e.g., `layers`) merge ON TOP of
+// the shared architectureSettings. Packages that don't pass `architecture`
+// get the shared defaults.
+function buildArchitectureSettings(extra) {
+  if (extra === undefined) return architectureSettings;
+  return {
+    "agent-code-guard": {
+      architecture: {
+        ...architectureSettings["agent-code-guard"].architecture,
+        ...extra,
+      },
+    },
+  };
+}
+
 export function packageEslintConfig(options = {}) {
   const strictRules = makeStrictRules(options);
+  const settings = {
+    ...guard.configs.strict.settings,
+    ...buildArchitectureSettings(options.architecture),
+  };
   return [
     packageIgnores,
     {
@@ -145,7 +164,7 @@ export function packageEslintConfig(options = {}) {
       ignores: ["**/*.test.ts", "**/*.spec.ts"],
       languageOptions: tsLanguageOptions,
       plugins: guard.configs.strict.plugins,
-      settings: { ...guard.configs.strict.settings, ...architectureSettings },
+      settings,
       rules: strictRules,
     },
     makeTestSupportRules(strictRules),

--- a/packages/protocol/eslint.config.mjs
+++ b/packages/protocol/eslint.config.mjs
@@ -1,3 +1,47 @@
 import { packageEslintConfig } from "../../eslint.shared.mjs";
 
-export default packageEslintConfig({ maxLines: 1200 });
+// Protocol's strict layer stack (top → bottom):
+//   app → task → network → identity → transport
+//
+// Each folder is its own layer. Imports flow downward only: a layer
+// may import from any layer below it; the reverse fires
+// `no-upward-layer-import`. Declaring layers also suppresses
+// `no-cross-domain-sibling-import` between any two layered folders.
+//
+// Layer index convention: index 0 sits at the TOP of the stack
+// (composition / entrypoints), higher indices are deeper foundations.
+export default packageEslintConfig({
+  maxLines: 1200,
+  architecture: {
+    layers: [
+      {
+        name: "app",
+        folders: ["app"],
+        reason:
+          "Composition layer: AppHost RPCs composed over task, network, identity, transport descriptors.",
+      },
+      {
+        name: "task",
+        folders: ["task"],
+        reason: "Task domain: conversations, messages, dispatch, TM authority.",
+      },
+      {
+        name: "network",
+        folders: ["network"],
+        reason:
+          "Network domain: ping, presence, connection liveness, actor-model types.",
+      },
+      {
+        name: "identity",
+        folders: ["identity"],
+        reason: "Identity domain: agents, users, sessions, contact policy.",
+      },
+      {
+        name: "transport",
+        folders: ["transport"],
+        reason:
+          "Wire layer: Ajv frames, RpcDefinition primitives, dispatch — no domain semantics.",
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary

**Stacked on #671** (publicTypePackages). Declares protocol's documented 5-layer stack so `@safer-by-default/architecture-lsp` knows the architectural intent. Each domain is its own layer; imports flow strictly downward.

### Layering

From `packages/protocol/ARCHITECTURE.md` §1, made executable:

| Index | Layer | Folder | Role |
|---|---|---|---|
| 0 | app | `app/` | Composition over the four domains |
| 1 | task | `task/` | Conversations, messages, dispatch, TM authority |
| 2 | network | `network/` | Ping, presence, connection liveness |
| 3 | identity | `identity/` | Agents, users, sessions, contact policy |
| 4 | transport | `transport/` | Ajv frames, RpcDefinition primitives |

Layer index 0 = top of stack; higher indices are deeper foundations. A higher layer (lower index) may import any lower layer (higher index); the reverse fires `no-upward-layer-import`.

## Impact

Smoke against moltzap with `safer-by-default#312` + `#313` wired locally:

| Metric | Before | After |
|---|---|---|
| Total findings | 380 | **347** (-33) |
| `no-cross-domain-sibling-import` (protocol) | 34 | **0** |
| `no-upward-layer-import` (new, real signal) | 0 | 3 |

The 3 new `no-upward-layer-import` warnings are all in `src/transport/typed-dispatcher.types-check.ts` — a type-canary file that intentionally reaches up into `task/` and `app/` to compile-check the dispatcher signature against real protocol descriptors. Three ways to address in a follow-up:

1. Move the canary into `task/` or `app/` (whichever is the highest layer it references).
2. Treat `*.types-check.ts` as test-like in the analyzer (would require a safer-by-default change).
3. Inline `// @agent-code-guard/architecture-exception` directive.

Out of scope here — the goal of this PR is declaring the existing intent. The canary just had nowhere to "live" before; now it's measurable.

## Mechanism

- **`eslint.shared.mjs`** — `packageEslintConfig({ architecture })` now accepts a per-package architecture extension that shallow-merges into the shared settings.
- **`packages/protocol/eslint.config.mjs`** — passes the 5-layer declaration.

Server's layers wait for the `app/` audit moves to land first (next PR), so the layer declaration matches the cleaned-up structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)