### PR TITLE
feat(#685): proactive client-side DM dedup

### DIFF
--- a/packages/client/docs/architecture/moltzap-start-cli.md
+++ b/packages/client/docs/architecture/moltzap-start-cli.md
@@ -17,10 +17,11 @@ live in `commands/start.ts`.
 
 | RPC | Provided by | When called |
 |---|---|---|
-| `TaskRequest` | Spec D1 (#635) → `packages/protocol/src/task/tasks.ts → TaskRequest` | Every invocation |
+| `TaskRequest` | Spec D1 (#635) → `packages/protocol/src/task/tasks.ts → TaskRequest` | Only when the proactive dedup scan finds no reusable conversation |
 | `MessagesSend` | Pre-D1, unchanged | Only when `--message` is set |
 | `AgentsLookupByName` | Pre-D1, unchanged | Per name-shaped participant token (uuid-shaped tokens skip the lookup) |
-| `TaskConversationList` | Spec D1 (#598) → `packages/protocol/src/task/tasks.ts → TaskConversationList` | Only on `TaskRequest` dedup hit (P2-A); used by `findReusableConversation` to locate a reusable conversation under the existing task |
+| `TaskList` | Spec D1 → `packages/protocol/src/task/tasks.ts → TaskList` | Proactive DM dedup (#685): one call to collect the caller's active task ids under `appId` (skipped for zero-participant `start`s) |
+| `TaskConversationList` | Spec D1 (#598) → `packages/protocol/src/task/tasks.ts → TaskConversationList` | Proactive DM dedup (#685): paginated scan to find a non-archived conversation whose task participant set matches `{caller} ∪ invitedAgentIds` |
 
 **All three RPCs go through `transport.ts → rpc(...)` (the CLI
 `Transport` service), NOT `socket-client.ts → request(...)` (the
@@ -42,16 +43,31 @@ named in spec D2 amendment N7; pinned by `start.test.ts →
 zeroParticipants`). The server adds the caller to both
 `task_participants` and `conversation_participants` implicitly.
 
-Per D1 plan §R8 / Canary `_C5` the response shape is
-`{ task, conversation: Conversation | null }`. The `conversation === null`
-branch fires on the **dedup hit** path: when `appId === DEFAULT_APP_ID`
-AND the caller already owns a task with the exact same
-`{caller} ∪ invitedAgentIds` participant set, the server returns the
-existing task with no new conversation (D1 Goal 3 — dedup is task-level,
-not conversation-level). The CLI MUST NOT treat this as a decode error
-(P2-A); instead it auto-fetches a reusable conversation under the
-existing task via `findReusableConversation` and reprints the standard
-`Task started:` line with a `reusing existing conversation:` label.
+### Proactive "one DM per pair" dedup (#685)
+
+Server-side `DEFAULT_APP_ID` dedup was retired in #677; the D3 server
+always mints + returns a conversation when `task/request` is accepted
+with an `initialConversation` (the `conversation: null` arm only fires
+when no `initialConversation` was supplied — which `start` never does).
+The "one DM per pair" UX therefore runs **client-side and BEFORE**
+`TaskRequest`:
+
+1. `findReusableDmConversation(appId, invitedAgentIds)` — skipped
+   entirely for zero-participant (solo) `start`s.
+2. `TaskList` (one call) collects the caller's `active` task ids under
+   `appId`. `TaskConversationListItem` carries no `appId`, so this is
+   how the scan is scoped to the requested app.
+3. `TaskConversationList` (paginated, capped at `DEDUP_SCAN_MAX_PAGES`)
+   is scanned for the first non-archived conversation whose `taskId` is
+   in that active set AND whose task participant set matches
+   `{caller} ∪ invitedAgentIds`. The caller is implicitly in every
+   listed task, so the match is `invited ⊆ participants` and
+   `|participants| === |unique(invited)| + 1` — no need to know the
+   caller's own agent id.
+4. On a hit → reuse that conversation, print the `Task started:` line
+   with a `reusing existing conversation:` label, and skip `TaskRequest`.
+   On a miss (or a transient scan failure — the scan is best-effort) →
+   fall through to `TaskRequest` and create a fresh task.
 
 ## 2. Command shape
 
@@ -91,28 +107,25 @@ sequenceDiagram
 
     Note over start: 1. validateAppIdSyntax(args.appId)<br>invalid → InvalidAppIdError → exit 64
 
-    Note over start: 2. resolveAgentTokens(participants)<br>Classify each token: shape-fail → UnresolvedParticipantError → exit 64;<br>UUID-shaped → short-circuit client-side; name-shaped → defer to one batched RPC.
+    Note over start: 2. resolveAgentTokens(participants)<br>Classify each token: shape-fail → UnresolvedParticipantError → exit 64.<br>UUID-shaped → short-circuit client-side, name-shaped → defer to one batched RPC.
     start->>tx: rpc(AgentsLookupByName, { names: [...uniqueNames] }) (one call total, name-shaped tokens only)
     tx-->>start: { agents: [{ id, name, ... }, ...] }
-    Note over start: Build name → AgentId map; resolve each token in input order.<br>First name with no matching agent → UnresolvedParticipantError → exit 64.
+    Note over start: Build name → AgentId map, resolve each token in input order.<br>First name with no matching agent → UnresolvedParticipantError → exit 64.
 
-    Note over start: 3. rpc(TaskRequest, {appId, invitedAgentIds, initialConversation})<br>initialConversation omits participants when invitedAgentIds.length === 0 (P2-B)
-    start->>tx: TaskRequest
-    tx-->>start: { task, conversation: Conversation | null }
-    Note over start: failure → TransportError → exit 1<br>stdout: nothing
+    Note over start: 3. Proactive dedup (#685), skipped when invitedAgentIds is empty.<br>Best-effort: a scan failure falls through to create.
+    start->>tx: rpc(TaskList, {limit: 200}) — collect active task ids for appId
+    tx-->>start: { tasks }
+    start->>tx: rpc(TaskConversationList, {limit, cursor?}) — follow nextCursor, capped
+    tx-->>start: { items, nextCursor? }
+    Note over start: pickReusableFromPage: first non-archived item whose taskId is in the<br>active-for-app set AND participants == {caller} ∪ invitedAgentIds
 
-    alt conversation !== null (fresh create)
-        Note over start: stdout: Task started: <taskId> (conversation: <convId>)
-    else conversation === null (dedup hit — P2-A)
-        Note over start: 3b. rpc(TaskConversationList, {limit, cursor?}) — follow nextCursor until match
-        start->>tx: TaskConversationList
-        tx-->>start: { items, nextCursor? }
-        Note over start: findReusableConversation(taskId): pick first item where<br>item.taskId === existingTaskId AND item.conversation.archivedAt === undefined
-        alt reusable conversation found
-            Note over start: stdout: Task started: <taskId> (reusing existing conversation: <convId>)
-        else no usable conversation (closed task, all archived, out of lookup window)
-            Note over start: stderr: Task already exists but is closed: <taskId> → exit 1
-        end
+    alt reusable conversation found
+        Note over start: stdout: Task started: <taskId> (reusing existing conversation: <convId>)
+    else no reuse → create
+        Note over start: 4. rpc(TaskRequest, {appId, invitedAgentIds, initialConversation})<br>initialConversation omits participants when invitedAgentIds.length === 0 (P2-B)
+        start->>tx: TaskRequest
+        tx-->>start: { task, conversation }
+        Note over start: failure → TransportError → exit 1, stdout nothing<br>success → stdout: Task started: <taskId> (conversation: <convId>)
     end
 
     alt --message supplied AND a conversation is in hand
@@ -130,9 +143,9 @@ sequenceDiagram
 
 | Code | Meaning | Stdout state | Stderr state |
 |---|---|---|---|
-| 0 | Full success (fresh create OR dedup hit with reusable conversation) | `Task started: …` (+ `Message sent: …` when `--message`) | empty |
-| 1 | `TaskRequest` wire failure OR dedup hit on a closed/unreachable task (P2-A) | empty | `Failed: <err.message>` OR `Task already exists but is closed: <taskId>` |
-| 2 | `TaskRequest` (or dedup reuse) OK, `MessagesSend` failed | `Task started: …` (no `Message sent`) | `Error sending message: <err.message>` |
+| 0 | Full success (reused existing DM OR fresh create) | `Task started: …` (+ `Message sent: …` when `--message`) | empty |
+| 1 | `TaskRequest` wire failure | empty | `Failed: <err.message>` |
+| 2 | Reuse or create OK, `MessagesSend` failed | `Task started: …` (no `Message sent`) | `Error sending message: <err.message>` |
 | 64 | Usage error (bad `--app-id` UUID OR unresolvable agent token OR >100 distinct name-shaped tokens) | empty | `Invalid --app-id: not a UUID` OR `Cannot resolve "<token>": <reason>` OR `Too many distinct agent names: <count> (max <max>)` |
 
 NO rollback on exit 2: the task + empty conversation persist; user can
@@ -156,8 +169,8 @@ server-side contact-policy gating per
 ## 6. Implementation sketch
 
 The handler body lives in `commands/start.ts → startCommandHandler`.
-Sketch matches the current code shape (P2-A dedup + P2-B carve-out +
-P3-2 batched lookup all landed):
+Sketch matches the current code shape (proactive #685 dedup + P2-B
+carve-out + P3-2 batched lookup all landed):
 
 ```ts
 export const startCommandHandler = (args: StartCommandArgs) =>
@@ -173,38 +186,43 @@ export const startCommandHandler = (args: StartCommandArgs) =>
     //    `UnresolvedParticipantError` and returns bare `AgentId[]`
     //    matching `TaskRequest.params.invitedAgentIds` directly.
     const invitedAgentIds = yield* resolveAgentTokens(args.participants);
-
-    // 3. TaskRequest atomic. P2-B carve-out: when `invitedAgentIds` is
-    //    empty, omit `participants` from `initialConversation` entirely
-    //    (the schema's `Type.Array(AgentId, { minItems: 1 })` rejects
-    //    `[]`; the server adds the caller to participants implicitly).
-    const outcome = yield* createTaskAtomic(appId, invitedAgentIds, args.name);
-
-    // 4. Branch on `{ task, conversation: Conversation | null }`.
-    //    `conversation === null` is the DEDUP HIT path (P2-A) — the
-    //    server matched an existing task on `{caller} ∪ invitedAgentIds`
-    //    and returned it. Handler routes through `handleDedupOutcome`,
-    //    which uses `findReusableConversation` to locate a non-archived
-    //    conversation under the existing task (`TaskConversationList`
-    //    with cursor follow, capped at `DEDUP_LOOKUP_MAX_PAGES`). If
-    //    found → reuse stdout line; if not → closed-task diagnostic +
-    //    exit 1.
     const messageOpt = Option.fromNullable(args.message);
-    if (outcome.kind === "dedup") {
-      yield* handleDedupOutcome(outcome.task, messageOpt);
+
+    // 3. Proactive "one DM per pair" dedup (#685), BEFORE create. Reuse an
+    //    existing live conversation for this exact participant set under
+    //    this app instead of minting a duplicate. Best-effort: a transient
+    //    list-scan failure falls through to create. Skipped for zero
+    //    participants (mirrors the P2-B / amendment N7 carve-out).
+    const reuse = yield* findReusableDmConversation(appId, invitedAgentIds).pipe(
+      Effect.orElseSucceed(() => null),
+    );
+    if (reuse !== null) {
+      yield* printTaskReused(reuse.taskId, reuse.conversation);
+      yield* Option.match(messageOpt, {
+        onNone: () => Effect.void,
+        onSome: (m) => sendFirstMessage(reuse.taskId, reuse.conversation.id, m),
+      });
       return;
     }
 
-    // 5. Fresh-create success path.
-    yield* printTaskCreated(outcome.task, outcome.conversation);
+    // 4. TaskRequest atomic. P2-B carve-out: when `invitedAgentIds` is
+    //    empty, omit `participants` from `initialConversation` entirely
+    //    (the schema's `Type.Array(AgentId, { minItems: 1 })` rejects
+    //    `[]`; the server adds the caller to participants implicitly).
+    const { task, conversation } = yield* createTaskAtomic(
+      appId,
+      invitedAgentIds,
+      args.name,
+    );
+    yield* printTaskCreated(task, conversation);
 
-    // 6. Optional MessagesSend. Wrapped in `Effect.either` so a wire
+    // 5. Optional MessagesSend. Wrapped in `Effect.either` so a wire
     //    failure surfaces as inline `process.exit(2)` (preserves the
     //    already-printed `Task started:` stdout line) rather than
     //    routing through `runStartCommand`'s catchAll.
     yield* Option.match(messageOpt, {
       onNone: () => Effect.void,
-      onSome: (m) => sendFirstMessage(outcome.conversation.id, m),
+      onSome: (m) => sendFirstMessage(task.id, conversation.id, m),
     });
   });
 ```
@@ -278,12 +296,16 @@ Spec D2 acceptance criteria → test files:
 | Partial failure | `start.test.ts > partial-success` | `TaskRequest` success + `MessagesSend` fail → assert stdout has `Task started:` line, stderr `Error sending message:`, exit 2 |
 | Unresolved participant | `start.test.ts > unresolved-participant` | `AgentsLookupByName` returns empty agents; assert exit 64, stderr names the token, ZERO `TaskRequest` / `MessagesSend` calls |
 | Help text | `start.test.ts > help` | snapshot `moltzap start --help`; assert presence of synopsis, `--message`, `--app-id`, and the four exit codes |
-| **Dedup hit, single conversation** (P2-A) | `start.test.ts > dedupHitSingleConversation` | `TaskRequest` returns `{ task: existing, conversation: null }`; `TaskConversationList` returns one matching item; assert stdout `Task started: <id> (reusing existing conversation: <id>)` |
-| **Dedup hit, multiple conversations** (P2-A tie-break) | `start.test.ts > dedupHitMultipleConversations` | server-order first match wins (most-recently-active) |
-| **Dedup hit + `--message`** (P2-A reuse-conv MessagesSend route) | `start.test.ts > dedupHitWithMessage` | `MessagesSend.params.conversationId === existing.conversation.id` |
-| **Dedup hit, filtering** (P2-A taskId + archivedAt filter) | `start.test.ts > dedupHitFiltersOtherTaskAndArchived` | items from other tasks AND `archivedAt !== undefined` items are skipped |
-| **Dedup hit, closed task** (P2-A no-usable-conv branch) | `start.test.ts > dedupHitTaskClosedNoUsableConversation` | `findReusableConversation` returns null → stderr `Task already exists but is closed: <taskId>` + exit 1 |
-| **Dedup hit, pagination** (P2-A cursor follow) | `start.test.ts > dedupHitPaginatesUntilFound` | first page has no match → follow `nextCursor` until found |
+| **Proactive dedup, reuse active DM** (#685) | `start.test.ts > dedupReusesActiveDm` | `TaskList` returns the active task; `TaskConversationList` one matching item; assert reuse stdout + NO `TaskRequest` call |
+| **Proactive dedup, tie-break** (#685) | `start.test.ts > dedupPicksFirstActivityOrder` | first match in activity-desc order wins |
+| **Proactive dedup + `--message`** (#685) | `start.test.ts > dedupReuseWithMessage` | `MessagesSend.params.conversationId === reused conversation id`; no `TaskRequest` |
+| **Proactive dedup, filtering** (#685) | `start.test.ts > dedupFiltersArchivedAndOtherTask` | out-of-app-scope tasks AND `archivedAt !== undefined` items skipped |
+| **Proactive dedup, app scoping** (#685) | `start.test.ts > dedupScopesToRequestedApp` | a match under another app is NOT reused → create |
+| **Proactive dedup, participant exactness** (#685) | `start.test.ts > dedupParticipantSetMustMatchExactly` | group request does not reuse a smaller DM → create |
+| **Proactive dedup, zero-participant carve-out** (#685) | `start.test.ts > dedupSkippedForZeroParticipants` | solo `start` makes NO `TaskList`/`TaskConversationList` call → create |
+| **Proactive dedup, best-effort scan** (#685) | `start.test.ts > dedupBestEffortOnScanFailure` | a `TaskList` failure falls through to create, exit 0 |
+| **Proactive dedup, pagination** (#685) | `start.test.ts > dedupPaginatesConversationList` | first page misses → follow `nextCursor` until match |
+| **Proactive dedup, scan cap** (#685) | `start.test.ts > dedupCapsScanAndFallsThroughToCreate` | caps at `DEDUP_SCAN_MAX_PAGES`, then creates |
 | **Zero-participant wire shape** (P2-B carve-out) | `start.test.ts > zeroParticipants` | `TaskRequest.params.initialConversation` deep-equals `{ name }` (no `participants` key) |
 | CHANGELOG | (manual review at PR time) | grep root `CHANGELOG.md` `[Unreleased]` for the new-command entry |
 

--- a/packages/client/src/cli/commands/start.test.ts
+++ b/packages/client/src/cli/commands/start.test.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_APP_ID,
   MessagesSend,
   TaskConversationList,
+  TaskList,
   TaskRequest,
 } from "@moltzap/protocol";
 import { Transport } from "../transport.js";
@@ -97,6 +98,7 @@ interface RespondConfig {
   readonly taskCreate?: () => unknown | Error;
   readonly messagesSend?: () => unknown | Error;
   readonly taskConversationList?: (call: TestTransportCall) => unknown | Error;
+  readonly taskList?: (call: TestTransportCall) => unknown | Error;
 }
 
 const respondLookup = (call: TestTransportCall, config: RespondConfig) => {
@@ -111,21 +113,20 @@ const respondLookup = (call: TestTransportCall, config: RespondConfig) => {
 
 const respondFromConfig =
   (config: RespondConfig) => (call: TestTransportCall) => {
-    if (call.method === AgentsLookupByName.name) {
-      return respondLookup(call, config);
-    }
-    if (call.method === TaskRequest.name) {
-      return (config.taskCreate ?? TASK_CREATE_OK)();
-    }
-    if (call.method === MessagesSend.name) {
-      return (config.messagesSend ?? MESSAGES_SEND_OK)();
-    }
-    if (call.method === TaskConversationList.name) {
-      return (
-        config.taskConversationList ?? (() => ({ items: [] as unknown[] }))
-      )(call);
-    }
-    return new Error(`Unexpected RPC: ${call.method}`);
+    const handlers: Record<string, (c: TestTransportCall) => unknown | Error> =
+      {
+        [AgentsLookupByName.name]: (c) => respondLookup(c, config),
+        [TaskRequest.name]: () => (config.taskCreate ?? TASK_CREATE_OK)(),
+        [MessagesSend.name]: () => (config.messagesSend ?? MESSAGES_SEND_OK)(),
+        [TaskConversationList.name]:
+          config.taskConversationList ?? (() => ({ items: [] as unknown[] })),
+        [TaskList.name]:
+          config.taskList ?? (() => ({ tasks: [] as unknown[] })),
+      };
+    const handler = handlers[call.method];
+    return handler === undefined
+      ? new Error(`Unexpected RPC: ${call.method}`)
+      : handler(call);
   };
 
 const makeTransportWith = (config: RespondConfig) =>
@@ -545,25 +546,25 @@ describe("moltzap start — failure paths", () => {
   );
 });
 
-// ─── Test bodies: dedup hit (P2-A, spec D2 amendment N6) ─────────────────
+// ─── Test bodies: proactive "one DM per pair" dedup (issue #685) ──────────
 
 const EXISTING_TASK_ID = "00000000-0000-4000-8000-0000000000d1";
 const EXISTING_CONV_ID_ACTIVE = "00000000-0000-4000-8000-0000000000d2";
 const EXISTING_CONV_ID_OLDER = "00000000-0000-4000-8000-0000000000d3";
 const OTHER_TASK_ID = "00000000-0000-4000-8000-0000000000e9";
 
-// Widened-status type so active/closed fixtures share a common shape
-// (default + override into `TASK_CREATE_DEDUP` without an `unknown` cast).
-// `satisfies` would be tighter but `taskFixture` itself is loose-typed
-// upstream (string id, no `as Task` cast) — adding a strict satisfies
-// here would propagate that brittleness without the corresponding
-// upstream fix. The widened alias is the local lower bound that the
-// dedup tests need; protocol-schema drift is caught by the protocol
-// type canaries (`task-conversation-family.types-check.ts`), not by
-// fixture site checks.
-type TaskLikeFixture = Omit<typeof taskFixture, "status" | "endedAt"> & {
+// Widened-status type so active/closed/other-app fixtures share a common
+// shape. `taskFixture` is loose-typed upstream (string id, no `as Task`
+// cast); the widened alias is the local lower bound these tests need.
+// Protocol-schema drift is caught by the protocol type canaries
+// (`task-conversation-family.types-check.ts`), not by fixture site checks.
+type TaskLikeFixture = Omit<
+  typeof taskFixture,
+  "status" | "endedAt" | "appId"
+> & {
   status: "active" | "closed";
   endedAt: string | null;
+  appId: string;
 };
 
 const existingTaskFixture: TaskLikeFixture = {
@@ -571,10 +572,10 @@ const existingTaskFixture: TaskLikeFixture = {
   id: EXISTING_TASK_ID,
 };
 
-const existingTaskClosedFixture: TaskLikeFixture = {
+const existingTaskOtherAppFixture: TaskLikeFixture = {
   ...existingTaskFixture,
-  status: "closed",
-  endedAt: NOW_ISO,
+  id: OTHER_TASK_ID,
+  appId: VALID_APP_ID_OVERRIDE,
 };
 
 const conversationFixtureActive = {
@@ -589,27 +590,25 @@ const conversationFixtureOlder = {
   createdAt: "2026-05-18T00:00:00Z",
 };
 
-const TASK_CREATE_DEDUP =
-  (task: TaskLikeFixture = existingTaskFixture) =>
-  () => ({
-    task,
-    conversation: null,
-  });
+const taskListWith =
+  (...tasks: TaskLikeFixture[]) =>
+  () => ({ tasks });
 
 const taskConvListItem = (
   taskId: string,
   conversation: typeof conversationFixture,
+  participants: readonly string[] = [INITIATOR_ID, BOB_AGENT_ID],
 ) => ({
   taskId,
   conversation,
-  participants: [INITIATOR_ID, BOB_AGENT_ID],
+  participants: [...participants],
 });
 
-const dedupHitSingleConversation = () =>
+const dedupReusesActiveDm = () =>
   Effect.gen(function* () {
     const { calls, transport } = makeTransportWith({
       ...onlyBobLookup(),
-      taskCreate: TASK_CREATE_DEDUP(),
+      taskList: taskListWith(existingTaskFixture),
       taskConversationList: () => ({
         items: [taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive)],
       }),
@@ -619,25 +618,24 @@ const dedupHitSingleConversation = () =>
       `Task started: ${EXISTING_TASK_ID} (reusing existing conversation: ${EXISTING_CONV_ID_ACTIVE})`,
     );
     expect(exitSpy).not.toHaveBeenCalled();
-    // Must have called TaskConversationList exactly once (single page,
-    // single match). Cursor MUST NOT be passed on first page.
-    const listCall = findCallOf(calls, TaskConversationList.name);
-    expect(listCall).toBeDefined();
-    expect(listCall!.params).toEqual({ limit: 100 });
+    // Reuse path MUST NOT create a task. App-scoping list uses limit 200;
+    // the conversation list first page MUST NOT pass a cursor.
+    expect(findCallOf(calls, TaskRequest.name)).toBeUndefined();
+    expect(findCallOf(calls, TaskList.name)!.params).toEqual({ limit: 200 });
+    expect(findCallOf(calls, TaskConversationList.name)!.params).toEqual({
+      limit: 100,
+    });
   });
 
-const dedupHitMultipleConversations = () =>
+const dedupPicksFirstActivityOrder = () =>
   Effect.gen(function* () {
-    // Server-side ordering is activity-desc, so the FIRST item under
-    // the target task is the most-recently-active. The handler picks
-    // it without re-sorting (per spec D2 amendment N6 tie-break: "first
-    // match in server iteration order").
+    // Conversations are activity-desc; the handler reuses the FIRST match
+    // under the target task without re-sorting.
     const { transport } = makeTransportWith({
       ...onlyBobLookup(),
-      taskCreate: TASK_CREATE_DEDUP(),
+      taskList: taskListWith(existingTaskFixture),
       taskConversationList: () => ({
         items: [
-          // Server order: active first, older second.
           taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive),
           taskConvListItem(EXISTING_TASK_ID, conversationFixtureOlder),
         ],
@@ -650,11 +648,11 @@ const dedupHitMultipleConversations = () =>
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-const dedupHitWithMessage = () =>
+const dedupReuseWithMessage = () =>
   Effect.gen(function* () {
     const { calls, transport } = makeTransportWith({
       ...onlyBobLookup(),
-      taskCreate: TASK_CREATE_DEDUP(),
+      taskList: taskListWith(existingTaskFixture),
       taskConversationList: () => ({
         items: [taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive)],
       }),
@@ -667,6 +665,8 @@ const dedupHitWithMessage = () =>
       `Task started: ${EXISTING_TASK_ID} (reusing existing conversation: ${EXISTING_CONV_ID_ACTIVE})`,
     );
     expect(stdoutSpy).toHaveBeenCalledWith(`Message sent: ${MESSAGE_ID}`);
+    expect(findCallOf(calls, TaskRequest.name)).toBeUndefined();
+    expect(findCallOf(calls, MessagesSend.name)).toBeDefined();
     // The MessagesSend payload MUST route to the REUSED conversation,
     // not the (null) freshly-created one.
     const sendCall = findCallOf(calls, MessagesSend.name);
@@ -676,18 +676,15 @@ const dedupHitWithMessage = () =>
     ).toBe(EXISTING_CONV_ID_ACTIVE);
   });
 
-const dedupHitFiltersOtherTaskAndArchived = () =>
+const dedupFiltersArchivedAndOtherTask = () =>
   Effect.gen(function* () {
-    // The list mixes items from other tasks AND archived rows under
-    // our task — the handler must skip both and find the lone non-
-    // archived match.
-    const archivedConv = {
-      ...conversationFixtureOlder,
-      archivedAt: NOW_ISO,
-    };
+    // The conversation list mixes an OTHER task (not in the app-scoped
+    // active set) and an archived row under our task — both skipped; the
+    // lone non-archived match under the in-scope task is reused.
+    const archivedConv = { ...conversationFixtureOlder, archivedAt: NOW_ISO };
     const { transport } = makeTransportWith({
       ...onlyBobLookup(),
-      taskCreate: TASK_CREATE_DEDUP(),
+      taskList: taskListWith(existingTaskFixture),
       taskConversationList: () => ({
         items: [
           taskConvListItem(OTHER_TASK_ID, conversationFixtureActive),
@@ -700,54 +697,106 @@ const dedupHitFiltersOtherTaskAndArchived = () =>
     expect(stdoutSpy).toHaveBeenCalledWith(
       `Task started: ${EXISTING_TASK_ID} (reusing existing conversation: ${EXISTING_CONV_ID_ACTIVE})`,
     );
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
-const dedupHitTaskClosedNoUsableConversation = () =>
+const dedupScopesToRequestedApp = () =>
   Effect.gen(function* () {
-    // Existing task is reported by the dedup query but all
-    // conversations under it are archived → `findReusableConversation`
-    // returns null → handler emits closed-task diagnostic + exit 1.
-    const archivedConv = {
-      ...conversationFixtureActive,
-      archivedAt: NOW_ISO,
-    };
-    const { transport } = makeTransportWith({
+    // A conversation under a DIFFERENT-app task with a matching participant
+    // set MUST NOT be reused: `task/list` scopes the active set to the
+    // requested app, and the join drops the other-app task id.
+    const { calls, transport } = makeTransportWith({
       ...onlyBobLookup(),
-      taskCreate: TASK_CREATE_DEDUP(existingTaskClosedFixture),
+      taskList: taskListWith(existingTaskOtherAppFixture),
       taskConversationList: () => ({
-        items: [taskConvListItem(EXISTING_TASK_ID, archivedConv)],
+        items: [taskConvListItem(OTHER_TASK_ID, conversationFixtureActive)],
       }),
     });
     yield* runWith(transport, standardArgs(["agent:bob"]));
-    expect(stderrLines()).toContain(
-      `Task already exists but is closed: ${EXISTING_TASK_ID}`,
+    // No in-scope match → create a fresh task.
+    expect(findCallOf(calls, TaskRequest.name)).toBeDefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${TASK_ID} (conversation: ${CONVERSATION_ID})`,
     );
-    expect(stdoutSpy).not.toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-const dedupHitPaginatesUntilFound = () =>
+const dedupParticipantSetMustMatchExactly = () =>
   Effect.gen(function* () {
-    // First page is full of OTHER tasks → handler must follow
-    // `nextCursor` to find the target on page two. Pin both calls so a
-    // regression that drops pagination support fails the test.
+    // Group request {bob, carol} must NOT reuse a {bob}-only DM: the task
+    // participant set differs in size, so it fails to match → create.
+    const { calls, transport } = makeTransportWith({
+      ...bobCarolLookup(),
+      taskList: taskListWith(existingTaskFixture),
+      taskConversationList: () => ({
+        items: [
+          taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive, [
+            INITIATOR_ID,
+            BOB_AGENT_ID,
+          ]),
+        ],
+      }),
+    });
+    yield* runWith(transport, standardArgs(["agent:bob", "agent:carol"]));
+    expect(findCallOf(calls, TaskRequest.name)).toBeDefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${TASK_ID} (conversation: ${CONVERSATION_ID})`,
+    );
+  });
+
+const dedupSkippedForZeroParticipants = () =>
+  Effect.gen(function* () {
+    // Solo (zero-participant) start: dedup is carved out entirely — no
+    // list scan happens and a fresh task is created.
+    const { calls, transport } = makeTransportWith({
+      taskList: taskListWith(existingTaskFixture),
+    });
+    yield* runWith(transport, standardArgs([]));
+    expect(findCallOf(calls, TaskList.name)).toBeUndefined();
+    expect(findCallOf(calls, TaskConversationList.name)).toBeUndefined();
+    expect(findCallOf(calls, TaskRequest.name)).toBeDefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${TASK_ID} (conversation: ${CONVERSATION_ID})`,
+    );
+  });
+
+const dedupBestEffortOnScanFailure = () =>
+  Effect.gen(function* () {
+    // A transient `task/list` failure MUST NOT block creation: the scan is
+    // best-effort, so the handler falls through to create a fresh task.
+    const { calls, transport } = makeTransportWith({
+      ...onlyBobLookup(),
+      taskList: () => new Error("list temporarily unavailable"),
+    });
+    yield* runWith(transport, standardArgs(["agent:bob"]));
+    expect(findCallOf(calls, TaskRequest.name)).toBeDefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${TASK_ID} (conversation: ${CONVERSATION_ID})`,
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+const dedupPaginatesConversationList = () =>
+  Effect.gen(function* () {
+    // First conversation page misses (OTHER task) → follow `nextCursor` to
+    // page two where the in-scope match lives. Pins cursor forwarding.
     let callCount = 0;
     const { calls, transport } = makeTransportWith({
       ...onlyBobLookup(),
-      taskCreate: TASK_CREATE_DEDUP(),
+      taskList: taskListWith(existingTaskFixture),
       taskConversationList: () => {
         callCount += 1;
-        if (callCount === 1) {
-          return {
-            items: [taskConvListItem(OTHER_TASK_ID, conversationFixtureOlder)],
-            nextCursor: "2026-05-18T12:00:00Z",
-          };
-        }
-        return {
-          items: [
-            taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive),
-          ],
-        };
+        return callCount === 1
+          ? {
+              items: [
+                taskConvListItem(OTHER_TASK_ID, conversationFixtureOlder),
+              ],
+              nextCursor: "2026-05-18T12:00:00Z",
+            }
+          : {
+              items: [
+                taskConvListItem(EXISTING_TASK_ID, conversationFixtureActive),
+              ],
+            };
       },
     });
     yield* runWith(transport, standardArgs(["agent:bob"]));
@@ -755,27 +804,24 @@ const dedupHitPaginatesUntilFound = () =>
     expect(stdoutSpy).toHaveBeenCalledWith(
       `Task started: ${EXISTING_TASK_ID} (reusing existing conversation: ${EXISTING_CONV_ID_ACTIVE})`,
     );
-    // Second call MUST forward the cursor returned by the first page.
     const listCalls = calls.filter(
       (c) => c.method === TaskConversationList.name,
     );
-    expect(listCalls).toHaveLength(2);
     expect(listCalls[1]!.params).toEqual({
       limit: 100,
       cursor: "2026-05-18T12:00:00Z",
     });
   });
 
-const dedupHitCapsAtMaxPages = () =>
+const dedupCapsScanAndFallsThroughToCreate = () =>
   Effect.gen(function* () {
-    // Adversarial server that NEVER returns nextCursor: undefined. The
-    // handler MUST stop at `DEDUP_LOOKUP_MAX_PAGES = 10` and surface
-    // the closed-task diagnostic; without the cap this loops forever
-    // and the test times out. Pins the cap value as a contract.
+    // Adversarial server that never returns `nextCursor: undefined`. The
+    // scan MUST stop at `DEDUP_SCAN_MAX_PAGES = 10`; with no match it falls
+    // through to create rather than looping forever.
     let pageCount = 0;
     const { calls, transport } = makeTransportWith({
       ...onlyBobLookup(),
-      taskCreate: TASK_CREATE_DEDUP(),
+      taskList: taskListWith(existingTaskFixture),
       taskConversationList: () => {
         pageCount += 1;
         return {
@@ -788,102 +834,53 @@ const dedupHitCapsAtMaxPages = () =>
     const listCalls = calls.filter(
       (c) => c.method === TaskConversationList.name,
     );
-    expect(listCalls).toHaveLength(10); // DEDUP_LOOKUP_MAX_PAGES
-    expect(stderrLines()).toContain(
-      `Task already exists but is closed: ${EXISTING_TASK_ID}`,
+    expect(listCalls).toHaveLength(10); // DEDUP_SCAN_MAX_PAGES
+    expect(findCallOf(calls, TaskRequest.name)).toBeDefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `Task started: ${TASK_ID} (conversation: ${CONVERSATION_ID})`,
     );
-    expect(stdoutSpy).not.toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-const dedupHitClosedTaskWithMessage = () =>
-  Effect.gen(function* () {
-    // Partial-failure: TaskRequest dedup-hit + closed-task + --message.
-    // The user's message is intentionally DROPPED — handler exits 1
-    // before reaching `sendFirstMessage`. Pinned so any future change
-    // to add a separate diagnostic ('Message NOT sent: ...') has to
-    // update this test, preventing silent regression.
-    const archivedConv = {
-      ...conversationFixtureActive,
-      archivedAt: NOW_ISO,
-    };
-    const { calls, transport } = makeTransportWith({
-      ...onlyBobLookup(),
-      taskCreate: TASK_CREATE_DEDUP(existingTaskClosedFixture),
-      taskConversationList: () => ({
-        items: [taskConvListItem(EXISTING_TASK_ID, archivedConv)],
-      }),
-    });
-    yield* runWith(
-      transport,
-      standardArgs(["agent:bob"], { message: "hello" }),
-    );
-    expect(calls.filter((c) => c.method === MessagesSend.name)).toEqual([]);
-    expect(stderrLines()).toContain(
-      `Task already exists but is closed: ${EXISTING_TASK_ID}`,
-    );
-    expect(stdoutSpy).not.toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
-
-const dedupHitListRpcFailure = () =>
-  Effect.gen(function* () {
-    // TaskRequest succeeds (dedup hit). TaskConversationList fails with
-    // a wire error (e.g. cursor-format drift). Without the
-    // `DedupListFailedError` remap, the user would see
-    // `Failed: <list-error>` and assume TaskRequest failed → retry →
-    // re-dedup forever. The remap surfaces the existing taskId so the
-    // user knows the task is real.
-    const { transport } = makeTransportWith({
-      ...onlyBobLookup(),
-      taskCreate: TASK_CREATE_DEDUP(),
-      taskConversationList: () => new Error("cursor server-rejected"),
-    });
-    yield* runWith(transport, standardArgs(["agent:bob"]));
-    expect(
-      stderrLines().some(
-        (s) =>
-          s.startsWith(`Task ${EXISTING_TASK_ID} already exists`) &&
-          s.includes("reusable-conversation lookup failed"),
-      ),
-    ).toBe(true);
-    expect(stdoutSpy).not.toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
-
-describe("moltzap start — dedup hit (P2-A / spec D2 amendment N6)", () => {
+describe("moltzap start — proactive DM dedup (#685)", () => {
   beforeEach(installHarness);
   afterEach(restoreHarness);
 
-  it("single existing conversation -> reuses it", dedupHitSingleConversation);
+  it("reuses an existing active DM conversation", dedupReusesActiveDm);
   it(
-    "multiple conversations -> picks first in server iteration order",
-    dedupHitMultipleConversations,
-  );
-  it("with --message -> sends to reused conversation", dedupHitWithMessage);
-  it(
-    "filters items from other tasks and archived rows",
-    dedupHitFiltersOtherTaskAndArchived,
+    "picks the first match in activity-desc order",
+    dedupPicksFirstActivityOrder,
   );
   it(
-    "task closed / all archived -> exit 1 with stderr diagnostic",
-    dedupHitTaskClosedNoUsableConversation,
+    "with --message -> sends to the reused conversation",
+    dedupReuseWithMessage,
   );
   it(
-    "paginates via nextCursor when first page misses",
-    dedupHitPaginatesUntilFound,
+    "filters archived rows and out-of-app-scope tasks",
+    dedupFiltersArchivedAndOtherTask,
   );
   it(
-    "caps at DEDUP_LOOKUP_MAX_PAGES when server never returns final page",
-    dedupHitCapsAtMaxPages,
+    "does not reuse a conversation under another app",
+    dedupScopesToRequestedApp,
   );
   it(
-    "closed task + --message -> message dropped, exit 1",
-    dedupHitClosedTaskWithMessage,
+    "does not reuse when the participant set differs",
+    dedupParticipantSetMustMatchExactly,
   );
   it(
-    "TaskConversationList wire failure -> distinct diagnostic, NOT 'Failed: ...'",
-    dedupHitListRpcFailure,
+    "skips dedup entirely for zero-participant starts",
+    dedupSkippedForZeroParticipants,
+  );
+  it(
+    "falls through to create when the list scan fails",
+    dedupBestEffortOnScanFailure,
+  );
+  it(
+    "paginates the conversation list via nextCursor",
+    dedupPaginatesConversationList,
+  );
+  it(
+    "caps the scan and creates when no match is found",
+    dedupCapsScanAndFallsThroughToCreate,
   );
 });
 

--- a/packages/client/src/cli/commands/start.ts
+++ b/packages/client/src/cli/commands/start.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_APP_ID,
   MessagesSend,
   TaskConversationList,
+  TaskList,
   TaskRequest,
   type AgentId,
   type AppId,
@@ -315,26 +316,13 @@ const printTaskCreated = (
   });
 
 const printTaskReused = (
-  task: Task,
+  taskId: TaskId,
   conversation: Conversation,
 ): Effect.Effect<void> =>
   Effect.sync(() => {
     console.log(
-      `Task started: ${task.id} (reusing existing conversation: ${conversation.id})`,
+      `Task started: ${taskId} (reusing existing conversation: ${conversation.id})`,
     );
-  });
-
-const printTaskAlreadyClosed = (taskId: TaskId): Effect.Effect<void> =>
-  Effect.sync(() => {
-    // WHY this single message covers two distinct conditions:
-    // (a) the existing task has no non-archived conversation, OR
-    // (b) the dedup-lookup window (1000 rows) did not surface one.
-    // (b) is rare per the activity-desc server ordering; if a heavy
-    // user trips it on an active task, the spec D2 amendment N6
-    // diagnostic is intentionally conservative ("closed") rather than
-    // claiming false freshness. The follow-up `moltzap conversations
-    // list` invocation surfaces the real state.
-    console.error(`Task already exists but is closed: ${taskId}`);
   });
 
 const printMessageSent = (messageId: string): Effect.Effect<void> =>
@@ -366,30 +354,15 @@ const sendFirstMessage = (
     ),
   );
 
-/**
- * Outcome of the atomic `TaskRequest` call. The dedup branch fires when
- * `appId === DEFAULT_APP_ID` AND the caller already owns a task with
- * the exact same `{caller} ∪ invitedAgentIds` participant set (see
- * `packages/server/src/task/handlers/tasks.handlers.ts → maybeTaskCreateDedup`
- * and protocol per-flow doc 12 §3). The server returns
- * `{ task: existing, conversation: null }` even when
- * `initialConversation` was supplied — dedup is task-level, not
- * conversation-level — so the CLI MUST treat `conversation === null`
- * as a legitimate outcome rather than a decode error.
- */
-type CreateTaskOutcome =
-  | {
-      readonly kind: "created";
-      readonly task: Task;
-      readonly conversation: Conversation;
-    }
-  | { readonly kind: "dedup"; readonly task: Task };
-
 const createTaskAtomic = (
   appId: AppId,
   invitedAgentIds: readonly AgentId[],
   name: string,
-): Effect.Effect<CreateTaskOutcome, TransportError, Transport> =>
+): Effect.Effect<
+  { readonly task: Task; readonly conversation: Conversation },
+  TransportError,
+  Transport
+> =>
   Effect.gen(function* () {
     // Defensive copies: TaskRequest's params type expects mutable arrays
     // (TypeBox's Static<Array> resolves to T[], not readonly T[]); pass
@@ -412,137 +385,143 @@ const createTaskAtomic = (
       initialConversation,
     });
     if (result.conversation === null) {
-      // Dedup hit (per `tasks.handlers.ts → maybeTaskCreateDedup`): the
-      // server matched an existing task by `{caller} ∪ invitedAgentIds`
-      // and returned it with `conversation: null`. Handler resolves a
-      // reusable conversation via `findReusableConversation` instead of
-      // failing.
-      return { kind: "dedup", task: result.task } as const;
+      // `start` always supplies `initialConversation`, and the D3 server
+      // mints + returns that conversation on accept (it only returns
+      // `conversation: null` when no `initialConversation` was sent). A null
+      // here is therefore a server-contract violation, not a normal outcome —
+      // surface it loudly rather than print a bogus conversation id.
+      return yield* Effect.dieMessage(
+        "task/request returned a null conversation despite an initialConversation request",
+      );
     }
-    return {
-      kind: "created",
-      task: result.task,
-      conversation: result.conversation,
-    } as const;
+    return { task: result.task, conversation: result.conversation };
   });
 
-// ─── Dedup-hit conversation lookup (spec D2 amendment N6) ─────────────────
+// ─── Proactive "one DM per pair" dedup (issue #685) ───────────────────────
+//
+// Server-side `DEFAULT_APP_ID` dedup was retired in #677; the "one DM per
+// pair" UX now lives here. Before creating a task we look for an existing live
+// conversation under this `appId` whose task participant set is exactly the
+// requested pair/group, and reuse it instead of minting a duplicate.
 
 /**
- * Page size + safety cap on `TaskConversationList` follow-up calls. The
- * dedup-hit conversation should appear in the first page for any
- * recently-touched task (server orders by activity desc, see
- * `packages/server/src/task/services/conversation/list-pagination.ts →
- * queryConversationListRows`). The cap protects against pathological
- * cases where the caller has a very long list and the target task is
- * older than the window can see — in which case we surface the closed-
- * task diagnostic rather than spin indefinitely.
+ * Page-count cap on the conversation-list scan. Conversations are returned
+ * activity-desc, so a recently-touched match sits near the top; the cap bounds
+ * work on pathological long lists. A miss degrades to creating a fresh task —
+ * never to incorrectness — so a conservative window is safe.
  */
-const DEDUP_LOOKUP_PAGE_SIZE = 100;
-const DEDUP_LOOKUP_MAX_PAGES = 10;
+const DEDUP_SCAN_PAGE_SIZE = 100;
+const DEDUP_SCAN_MAX_PAGES = 10;
 
 /**
- * P2-A (spec D2 amendment N6) — locate a reusable conversation under a
- * dedup-hit task. Tie-break rule: "first match in server iteration
- * order" — server sorts by activity desc, so this is equivalent to
- * most-recently-active. WHY a small page-count cap: a freshly-touched
- * dedup-hit task lives near the top of the activity-sorted list; the
- * 1000-row ceiling protects against pathological lists where the
- * target is older than the lookup window can see (the closed-task
- * diagnostic is the correct fallback per spec D2 amendment N6).
+ * `task/list` returns at most `limit` (≤ 200) tasks and no continuation
+ * cursor, so the app-scoping window is a single page of the caller's most
+ * recent tasks. Adequate for dedup: a pair you're actively messaging is recent.
  */
+const TASK_LIST_SCAN_LIMIT = 200;
 
 /**
- * Filter rule for the dedup-hit lookup: (a) the item's `taskId` must
- * match the existing task we are reusing (the list is caller-scoped
- * across ALL of the caller's tasks, not task-scoped); (b) the
- * conversation must be non-archived (server includes archived rows
- * unfiltered per `TaskConversationList`'s contract — clients filter
- * `archivedAt !== undefined` locally; archived strings are absent
- * on the wire when the row is active, never `null`, per
- * `ConversationSchema.archivedAt: Type.Optional(DateTimeString)`).
+ * Whether a task's participant set is exactly `{caller} ∪ invited`. The
+ * caller is implicitly a participant of every task the caller-scoped list
+ * returns, so the match is `invited ⊆ participants` and
+ * `|participants| === |unique(invited)| + 1` — no need for the client to know
+ * its own agent id. A degenerate self-invite (caller ∈ invited) simply fails to
+ * match and falls through to create, which is acceptable.
  */
-const pickReusableFromPage = (
-  items: ReadonlyArray<TaskConversationListItem>,
-  taskId: TaskId,
-): Conversation | null => {
-  const match = items.find(
-    (item) =>
-      item.taskId === taskId && item.conversation.archivedAt === undefined,
-  );
-  return match === undefined ? null : match.conversation;
+const participantSetMatchesInvited = (
+  participants: readonly AgentId[],
+  invited: readonly AgentId[],
+): boolean => {
+  const uniqueInvited = new Set(invited);
+  if (participants.length !== uniqueInvited.size + 1) return false;
+  const present = new Set(participants);
+  for (const id of uniqueInvited) {
+    if (!present.has(id)) return false;
+  }
+  return true;
 };
 
-const findReusableConversation = (
-  taskId: TaskId,
-): Effect.Effect<Conversation | null, TransportError, Transport> =>
+/**
+ * First non-archived, in-app-scope conversation in `items` whose task
+ * participant set matches `{caller} ∪ invited`, or `null`. Pulled out of
+ * {@link findReusableDmConversation} to keep that generator's complexity low.
+ */
+const conversationListParams = (
+  cursor: string | undefined,
+): { limit: number; cursor?: string } =>
+  cursor === undefined
+    ? { limit: DEDUP_SCAN_PAGE_SIZE }
+    : { limit: DEDUP_SCAN_PAGE_SIZE, cursor };
+
+const pickReusableFromPage = (
+  items: ReadonlyArray<TaskConversationListItem>,
+  appTaskIds: ReadonlySet<TaskId>,
+  invited: readonly AgentId[],
+): { readonly taskId: TaskId; readonly conversation: Conversation } | null => {
+  for (const item of items) {
+    if (
+      appTaskIds.has(item.taskId) &&
+      item.conversation.archivedAt === undefined &&
+      participantSetMatchesInvited(item.participants, invited)
+    ) {
+      return { taskId: item.taskId, conversation: item.conversation };
+    }
+  }
+  return null;
+};
+
+/**
+ * Caller's ACTIVE task ids under `appId`. `TaskConversationListItem` carries
+ * no `appId`, so we scope the dedup to the requested app via `task/list` and
+ * intersect by `taskId` in {@link findReusableDmConversation}. Only `active`
+ * tasks are reuse targets (a `closed`/`failed` task's conversations are dead).
+ */
+const collectActiveTaskIdsForApp = (
+  appId: AppId,
+): Effect.Effect<ReadonlySet<TaskId>, TransportError, Transport> =>
+  rpc(TaskList, { limit: TASK_LIST_SCAN_LIMIT }).pipe(
+    Effect.map(
+      ({ tasks }) =>
+        new Set(
+          tasks
+            .filter((task) => task.appId === appId && task.status === "active")
+            .map((task) => task.id),
+        ),
+    ),
+  );
+
+/**
+ * Locate a reusable conversation for `{caller} ∪ invited` under `appId`, or
+ * `null` if none. Zero-participant (solo) `start`s are carved out — they never
+ * dedup (mirrors Spec D2 amendment N7). Tie-break: first match in the
+ * activity-desc list order (most-recently-active). The conversation must be
+ * non-archived; archived rows are surfaced unfiltered by `TaskConversationList`
+ * and filtered locally (`archivedAt === undefined`).
+ */
+const findReusableDmConversation = (
+  appId: AppId,
+  invited: readonly AgentId[],
+): Effect.Effect<
+  { readonly taskId: TaskId; readonly conversation: Conversation } | null,
+  TransportError,
+  Transport
+> =>
   Effect.gen(function* () {
+    if (invited.length === 0) return null;
+    const appTaskIds = yield* collectActiveTaskIdsForApp(appId);
+    if (appTaskIds.size === 0) return null;
     let cursor: string | undefined = undefined;
-    for (let page = 0; page < DEDUP_LOOKUP_MAX_PAGES; page++) {
-      const params: { limit: number; cursor?: string } = {
-        limit: DEDUP_LOOKUP_PAGE_SIZE,
-      };
-      if (cursor !== undefined) params.cursor = cursor;
+    for (let page = 0; page < DEDUP_SCAN_MAX_PAGES; page++) {
+      const params: { limit: number; cursor?: string } =
+        conversationListParams(cursor);
       const result = yield* rpc(TaskConversationList, params);
-      const hit = pickReusableFromPage(result.items, taskId);
+      const hit = pickReusableFromPage(result.items, appTaskIds, invited);
       if (hit !== null) return hit;
       if (result.nextCursor === undefined) return null;
       cursor = result.nextCursor;
     }
     return null;
   });
-
-/**
- * Spec D2 amendment N6 — dedup-hit branch. `TaskConversationList`
- * wire failures are captured inline via `Effect.either` (same pattern
- * + same reason as `sendFirstMessage`'s partial-success handling)
- * because `TaskRequest` already succeeded server-side; routing the
- * list error through `runStartCommand`'s `catchAll` would print
- * `Failed: &lt;list-error>`, misleading the user into thinking the
- * create failed.
- */
-const onReuseFound = (
-  task: Task,
-  reuse: Conversation,
-  message: Option.Option<string>,
-): Effect.Effect<void, never, Transport> =>
-  Effect.zipRight(
-    printTaskReused(task, reuse),
-    Option.match(message, {
-      onNone: () => Effect.void,
-      onSome: (m) => sendFirstMessage(task.id, reuse.id, m),
-    }),
-  );
-
-const onReuseNull = (task: Task): Effect.Effect<void, never, Transport> =>
-  Effect.zipRight(
-    printTaskAlreadyClosed(task.id),
-    Effect.sync(() => {
-      process.exit(EXIT_CODES.TASK_CREATE_FAILED);
-    }),
-  );
-
-const handleDedupOutcome = (
-  task: Task,
-  message: Option.Option<string>,
-): Effect.Effect<void, never, Transport> =>
-  Effect.either(findReusableConversation(task.id)).pipe(
-    Effect.flatMap(
-      Either.match({
-        onLeft: (err) =>
-          Effect.sync(() => {
-            console.error(
-              `Task ${task.id} already exists but reusable-conversation lookup failed: ${err.message}`,
-            );
-            process.exit(EXIT_CODES.TASK_CREATE_FAILED);
-          }),
-        onRight: (reuse) =>
-          reuse === null
-            ? onReuseNull(task)
-            : onReuseFound(task, reuse, message),
-      }),
-    ),
-  );
 
 // ─── Handler body ─────────────────────────────────────────────────────────
 
@@ -555,30 +534,26 @@ const handleDedupOutcome = (
  *      batched `AgentsLookupByName` RPC for name-shaped tokens;
  *      UUID-shaped tokens short-circuit). Any token failure ->
  *      `UnresolvedParticipantError` -> exit 64.
- *   3. `rpc(TaskRequest, { appId, invitedAgentIds, initialConversation })`
- *      where `initialConversation` carries `participants` ONLY when
- *      `invitedAgentIds.length > 0` (P2-B). Two success outcomes:
- *      - `created`: server returned a fresh `conversation`. Print
- *        `Task started: &lt;taskId> (conversation: &lt;convId>)`.
- *      - `dedup`: server returned `conversation: null` because
- *        `{caller} ∪ invitedAgentIds` already owned a task on this
- *        appId (P2-A). Auto-fetch the most-recently-active non-
- *        archived conversation under the existing task via
- *        `findReusableConversation` and print
- *        `Task started: &lt;taskId> (reusing existing conversation: &lt;convId>)`.
- *        If no usable conversation exists (closed task, all archived,
- *        or out of dedup-lookup window), print
- *        `Task already exists but is closed: &lt;taskId>` to stderr and
- *        exit 1.
+ *   3. Proactive "one DM per pair" dedup (#685): scan the caller's active
+ *      tasks under `appId` (`task/list`) + their conversations
+ *      (`task/conversation/list`) for a non-archived conversation whose task
+ *      participant set is exactly `{caller} ∪ invitedAgentIds`. If found,
+ *      reuse it — print `Task started: &lt;taskId> (reusing existing
+ *      conversation: &lt;convId>)` — and skip task creation. Solo
+ *      (zero-participant) `start`s never dedup. The scan is best-effort: a
+ *      transient list failure falls through to create rather than aborting.
+ *   4. Otherwise `rpc(TaskRequest, { appId, invitedAgentIds,
+ *      initialConversation })` where `initialConversation` carries
+ *      `participants` ONLY when `invitedAgentIds.length > 0` (P2-B). On
+ *      success print `Task started: &lt;taskId> (conversation: &lt;convId>)`.
  *      `TaskRequest` wire failure -> `TransportError` -> exit 1 via
  *      `runStartCommand`, no stdout.
- *   4. If `args.message` is set AND a conversation was produced (either
- *      kind), call `rpc(MessagesSend, { conversationId, parts: [{ type:
- *      "text", text }] })` wrapped in `Effect.either`. Success -> print
- *      `Message sent: &lt;msgId>`, exit 0. Failure -> print
+ *   5. If `args.message` is set AND a conversation was produced (reuse or
+ *      create), call `rpc(MessagesSend, ...)` wrapped in `Effect.either`.
+ *      Success -> print `Message sent: &lt;msgId>`, exit 0. Failure -> print
  *      `Error sending message: &lt;err>` to stderr, exit 2 via inline
- *      `process.exit` (preserves the already-printed stdout line;
- *      cannot route through `runStartCommand`).
+ *      `process.exit` (preserves the already-printed stdout line; cannot
+ *      route through `runStartCommand`).
  */
 const startCommandHandler = (
   args: StartCommandArgs,
@@ -586,17 +561,32 @@ const startCommandHandler = (
   Effect.gen(function* () {
     const appId = yield* resolveAppId(args.appId);
     const invitedAgentIds = yield* resolveAgentTokens(args.participants);
-    const outcome = yield* createTaskAtomic(appId, invitedAgentIds, args.name);
     const messageOpt = Option.fromNullable(args.message);
-    if (outcome.kind === "dedup") {
-      yield* handleDedupOutcome(outcome.task, messageOpt);
+
+    // Best-effort dedup: a transient list-scan failure must not block creating
+    // the task, so swallow scan errors and fall through to create.
+    const reuse = yield* findReusableDmConversation(
+      appId,
+      invitedAgentIds,
+    ).pipe(Effect.orElseSucceed(() => null));
+    if (reuse !== null) {
+      yield* printTaskReused(reuse.taskId, reuse.conversation);
+      yield* Option.match(messageOpt, {
+        onNone: () => Effect.void,
+        onSome: (m) => sendFirstMessage(reuse.taskId, reuse.conversation.id, m),
+      });
       return;
     }
-    yield* printTaskCreated(outcome.task, outcome.conversation);
+
+    const { task, conversation } = yield* createTaskAtomic(
+      appId,
+      invitedAgentIds,
+      args.name,
+    );
+    yield* printTaskCreated(task, conversation);
     yield* Option.match(messageOpt, {
       onNone: () => Effect.void,
-      onSome: (m) =>
-        sendFirstMessage(outcome.task.id, outcome.conversation.id, m),
+      onSome: (m) => sendFirstMessage(task.id, conversation.id, m),
     });
   }).pipe(Effect.withSpan("startCommandHandler"));
 

--- a/packages/server/src/__tests__/integration/task/task-conversation-family.test.ts
+++ b/packages/server/src/__tests__/integration/task/task-conversation-family.test.ts
@@ -27,7 +27,7 @@
  * | TaskConversationRemoveParticipant | TM-only + idempotency + dual-emit |
  */
 
-import { expect, beforeAll, afterAll, beforeEach, it as vit } from "vitest";
+import { expect, beforeAll, afterAll, beforeEach } from "vitest";
 import * as fc from "fast-check";
 import { Effect, Exit } from "effect";
 import {
@@ -153,10 +153,11 @@ it("TaskRequest (DEFAULT_APP, multi-invitee) mints a fresh task with all partici
     expect(result.conversation).toBeNull();
   }));
 
-// Server-side TaskRequest dedup retired in #677. Re-add coverage as a
-// client-side test once the SDK helper for "list + filter + create-or-use"
-// lands.
-vit.todo("client-side DEFAULT_APP dedup — list + match");
+// Server-side TaskRequest dedup retired in #677; the "one DM per pair" UX is
+// now purely client-side (list active tasks for the app + match the participant
+// set + reuse-or-create). It has no server behavior to assert here — coverage
+// lives in `packages/client/src/cli/commands/start.test.ts` →
+// "moltzap start — proactive DM dedup (#685)".
 
 it("TaskRequest (different appId) does NOT dedup across apps", () =>
   Effect.gen(function* () {

--- a/packages/server/src/__tests__/integration/task/task-stamp-and-dedup.test.ts
+++ b/packages/server/src/__tests__/integration/task/task-stamp-and-dedup.test.ts
@@ -1,4 +1,4 @@
-import { expect, beforeAll, afterAll, beforeEach, it as vit } from "vitest";
+import { expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { Effect } from "effect";
 import {
   it,
@@ -17,10 +17,12 @@ afterAll(() => Effect.runPromise(stopTestServerEffect()));
 
 beforeEach(() => Effect.runPromise(resetTestDbEffect()));
 
-// Pre-#677 the server deduped DEFAULT_APP_ID TaskRequest by participant
-// set. Server dedup retired; the "one DM per pair" UX moves to clients
-// (list + filter + create-or-use). Re-add coverage in the SDK package.
-vit.todo("client-side DEFAULT_APP_ID dedup — list + match");
+// Pre-#677 the server deduped DEFAULT_APP_ID TaskRequest by participant set.
+// Server dedup retired; the "one DM per pair" UX is now purely client-side
+// (list active tasks for the app + match the participant set + reuse-or-create)
+// — no server behavior to assert here. Coverage lives in
+// `packages/client/src/cli/commands/start.test.ts` →
+// "moltzap start — proactive DM dedup (#685)".
 
 it("messages/send stamps task_id matching conversations.task_id", () =>
   Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Implements the client-side "one DM per pair" dedup that #677 moved off the server, and removes the now-dead reactive code it left behind. Closes #685.

- **Proactive dedup before create** (`start.ts → startCommandHandler`): `findReusableDmConversation` scopes to the requested app via one `TaskList` call, then scans `TaskConversationList` (paginated, capped at `DEDUP_SCAN_MAX_PAGES`) for the first non-archived conversation whose task participant set is exactly `{caller} ∪ invitedAgentIds`. Hit → reuse + skip `TaskRequest`; miss (or transient best-effort scan failure) → create.
- **No caller-id needed**: the caller is implicitly in every caller-scoped task, so the match is `invited ⊆ participants` and `|participants| === |unique(invited)| + 1`. Solo (zero-participant) starts are carved out.
- **Dead-code removal** (drift from #677): the reactive `kind:"dedup"` branch, `findReusableConversation`/`pickReusableFromPage`/`DEDUP_LOOKUP_*`/`printTaskAlreadyClosed`, and the stale `maybeTaskCreateDedup` reference. `createTaskAtomic` now returns `{ task, conversation }` directly.
- **Tests**: replaced the reactive dedup suite with proactive coverage (reuse, tie-break, --message routing, archived/other-task filtering, app scoping, participant exactness, zero-participant carve-out, best-effort scan failure, pagination, scan cap). Retired the two server `vit.todo` placeholders (dedup has no server behavior to assert; coverage is in the client suite).
- **Docs**: updated the `moltzap-start-cli` per-flow doc (RPC table, dedup section, sequence diagram, exit-code table, sketch, test map) + fixed a pre-existing `;`-in-Note mermaid render break.

## Design note

Kept entirely client-side (two existing RPCs, joined locally) rather than adding `appId` to `TaskConversationListItem` — smallest blast radius, no protocol/server/conformance change. `TaskList` returns ≤200 tasks with no forward cursor, so the app-scoping window is one page of the caller's most recent tasks; a dedup miss degrades to creating a fresh task (never to incorrectness).

## Test plan

- [x] client build + lint + format
- [x] client unit (`start.test.ts` proactive dedup suite + full suite, 300 pass)
- [x] server lint + integration (148 pass, todo 12→10 after retiring placeholders)
- [x] mermaid parse-validated
- [ ] CI green
- [ ] N=2 review (codex + review-senior), 2 consecutive clean each

🤖 Generated with [Claude Code](https://claude.com/claude-code)