### PR TITLE
ci(publish): stage doc regeneration after version bump (#668 follow-up)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,9 +119,20 @@ jobs:
           # Build all packages so pre-commit typecheck passes
           pnpm -r build
 
+          # Regenerate docs after version bump. PROTOCOL_VERSION change re-bakes
+          # `docs/snippets/constants/values.{mdx,json}` plus the CLI reference +
+          # 20 command pages. Without this, the husky pre-commit drift gate
+          # (`pnpm docs:generate && git diff --quiet`) detects the regen at
+          # commit time and aborts with exit code 1.
+          pnpm docs:generate
+
           git config user.name "moltzap-release[bot]"
           git config user.email "moltzap-release[bot]@users.noreply.github.com"
           git add packages/*/package.json packages/protocol/src/version.ts pnpm-lock.yaml
+          # Stage doc regeneration outputs so the pre-commit drift gate passes.
+          # Mirrors `docs:check:drift` inputs: `docs/`, `packages/**/MODULE.md`,
+          # `README.md`.
+          git add docs/ 'packages/**/MODULE.md' README.md
           if git diff --cached --quiet; then
             echo "No version changes to commit — versions already up to date"
           else


### PR DESCRIPTION
## Summary

The publish-to-npm workflow has been broken since the docs PR #668 landed on main. It fails at the "Commit and push version bump" step because the husky pre-commit hook regenerates docs from the new `PROTOCOL_VERSION` and detects them as unstaged.

**Failing run**: https://github.com/chughtapan/moltzap/actions/runs/26419554378/job/77771229243 (against `54d82ed1`)

**Side effect**: `@moltzap/{protocol,server,client,openclaw-channel}@2026.525.0` are NOT on npm. The publish never executed.

## Root cause

`.github/workflows/publish.yml → Commit and push version bump` step:

1. Patches `PROTOCOL_VERSION` in `packages/protocol/src/version.ts`
2. Stages only `packages/*/package.json`, `packages/protocol/src/version.ts`, `pnpm-lock.yaml`
3. `git commit` triggers `.husky/pre-commit`:
   - `pnpm exec oxfmt .` ✅
   - `pnpm docs:generate` → re-bakes `docs/snippets/constants/values.{mdx,json}` (PROTOCOL_VERSION) + `docs/cli/reference.mdx` + 20 command pages + HelloOk snippet
   - `git diff --quiet` → fails on unstaged regen → exits 1 with "Run: git add -u && git add docs/protocol && git commit"

## Fix

Run `pnpm docs:generate` explicitly in the workflow before staging, and extend `git add` to cover `docs/`, `packages/**/MODULE.md`, `README.md` (mirroring `docs:check:drift` inputs in root `package.json`).

## Test plan

- [ ] Merge this PR. The workflow will run on the merge commit; this PR itself doesn't change packages so it shouldn't trigger a publish.
- [ ] Next push to main that changes `packages/protocol/src/`, `packages/server/src/`, `packages/client/src/`, or `packages/openclaw-channel/src/` should successfully bump versions + publish.
- [ ] Manually re-trigger via `workflow_dispatch` with `packages: "protocol server client openclaw-channel"` to catch up the `@2026.525.0` versions that didn't ship after #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)