### PR TITLE
perf(wire): decode hot-path benchmark (de-risks #723 Effect-Schema migration)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -51,6 +51,7 @@
       "entry": [
         "src/**/*.test.ts",
         "src/**/*.types-check.ts",
+        "src/**/__benchmarks__/*.bench.ts",
         "src/testing/conformance/**/*.ts",
         "scripts/check-mermaid.ts",
         "vitest*.config.ts"

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -48,7 +48,9 @@
     "lint": "eslint src scripts *.ts --cache --max-warnings=0",
     "docs:generate": "tsx scripts/generate-docs.ts && (cd ../.. && pnpm exec typedoc) && tsx scripts/generate-modules.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "bench": "vitest bench --run src/transport/__benchmarks__/wire-decode.bench.ts",
+    "bench:typecheck": "tsc --noEmit -p tsconfig.bench.json"
   },
   "dependencies": {
     "@effect/platform": "^0.96.1",

--- a/packages/protocol/src/transport/__benchmarks__/effect-schema-prototype.ts
+++ b/packages/protocol/src/transport/__benchmarks__/effect-schema-prototype.ts
@@ -1,0 +1,201 @@
+/**
+ * @file Effect-Schema PROTOTYPE for the #723 wire-validation migration.
+ *
+ * THROWAWAY SPIKE CODE — bench-only. Not on any barrel, not imported by
+ * production. It exists to A/B the per-frame decode cost of `effect/Schema`
+ * (AST-interpreted) against the shipping TypeBox+AJV (compiled) path, in the
+ * EXACT shape #723 would ship per the #720 spike verdict:
+ *
+ *   - one `Schema.Struct` per wire method, discriminated on the `method`
+ *     literal (the migration's `Match.discriminator("method")` ground), with
+ *     the same `jsonrpc`/`id`/`method`/`params` envelope the real
+ *     `RequestFrameSchema` carries;
+ *   - all ~34 server-inbound methods folded into one `Schema.Union` so the
+ *     union arm-select cost matches the real catalog the AJV `.find()` scans;
+ *   - decoded via `Schema.decodeUnknownEither(Union, { onExcessProperty:
+ *     "error" })` — `onExcessProperty: "error"` is REQUIRED to match the
+ *     shipping `new Ajv({ strict: true })` + `additionalProperties: false`,
+ *     which rejects excess keys everywhere (effect's default silently STRIPS
+ *     them — see #723 plan revision r4 B1).
+ *
+ * The three representative methods (`agents/list`, `messages/send`,
+ * `task/conversation/create`) carry their FULL production param shapes,
+ * including branded-UUID `Schema.pattern(UUID_RE)` fields (mirroring the
+ * AJV `format: "uuid"` FormatRegistry check) and the nested text-part /
+ * participants arrays. The remaining catalog methods carry a minimal params
+ * struct: their param SHAPE does not affect the measured frames, but their
+ * PRESENCE in the union is what makes the arm-select cost realistic.
+ */
+import { Schema } from "effect";
+import type { Either } from "effect";
+
+// Same UUID regex the production `schema-primitives.ts` FormatRegistry uses.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const BrandedId = (brand: string) =>
+  Schema.String.pipe(Schema.pattern(UUID_RE), Schema.brand(brand));
+
+const TaskId = BrandedId("TaskId");
+const ConversationId = BrandedId("ConversationId");
+const MessageId = BrandedId("MessageId");
+const AgentId = BrandedId("AgentId");
+const LeaseId = BrandedId("LeaseId");
+
+// ── Representative param shapes (full fidelity to production) ─────────
+
+// `agents/list` — ListLimitSchema (optional int 1..200) + optional cursor.
+const AgentsListParams = Schema.Struct({
+  limit: Schema.optional(
+    Schema.Int.pipe(
+      Schema.greaterThanOrEqualTo(1),
+      Schema.lessThanOrEqualTo(200),
+    ),
+  ),
+  cursor: Schema.optional(Schema.String),
+});
+
+// `messages/send` — MessagePartsSchema is a union of text/image/file parts;
+// the bench frame uses a text part, so the prototype mirrors the text arm
+// (the discriminated part-union cost is part of params decode for this
+// method, same as AJV runs the `PartSchema` union per element).
+const TextPart = Schema.Struct({
+  type: Schema.Literal("text"),
+  text: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(32768)),
+});
+const ImagePart = Schema.Struct({
+  type: Schema.Literal("image"),
+  url: Schema.String.pipe(Schema.minLength(1)),
+  altText: Schema.optional(Schema.String.pipe(Schema.maxLength(256))),
+});
+const FilePart = Schema.Struct({
+  type: Schema.Literal("file"),
+  url: Schema.String.pipe(Schema.minLength(1)),
+  name: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(256)),
+  mimeType: Schema.optional(
+    Schema.String.pipe(Schema.minLength(1), Schema.maxLength(128)),
+  ),
+  size: Schema.optional(Schema.Int.pipe(Schema.greaterThanOrEqualTo(0))),
+});
+const PartSchema = Schema.Union(TextPart, ImagePart, FilePart);
+const MessagesSendParams = Schema.Struct({
+  taskId: TaskId,
+  conversationId: ConversationId,
+  parts: Schema.Array(PartSchema).pipe(Schema.minItems(1), Schema.maxItems(10)),
+  replyToId: Schema.optional(MessageId),
+  dispatchLeaseId: Schema.optional(LeaseId),
+});
+
+// `task/conversation/create` — branded UUID + participants[] of UUIDs.
+const TaskConversationCreateParams = Schema.Struct({
+  taskId: TaskId,
+  name: Schema.optional(
+    Schema.String.pipe(Schema.minLength(1), Schema.maxLength(100)),
+  ),
+  participants: Schema.Array(AgentId).pipe(Schema.minItems(1)),
+});
+
+// Minimal filler params for the non-measured catalog methods — present so
+// the union arm count matches the real ~34-method `serverRpcMethods`.
+const FillerParams = Schema.Struct({});
+
+// One frame schema per method, discriminated on the `method` literal.
+const frame = <P extends Schema.Schema.AnyNoContext>(
+  method: string,
+  params: P,
+) =>
+  Schema.Struct({
+    jsonrpc: Schema.Literal("2.0"),
+    id: Schema.String,
+    method: Schema.Literal(method),
+    params,
+  });
+
+// The remaining server-inbound RPC methods — exactly the 28 names in the
+// real `serverRpcMethods` catalog MINUS the 3 modeled in full above, so the
+// union has the same 31 arms `serverRpcMethods` has (verified against
+// `serverRpcMethods.map(d => d.name)` at the base tree). They carry filler
+// params: their SHAPE does not affect the measured frames, but their
+// PRESENCE is what makes the discriminated-union arm-select cost realistic.
+// If a method is added to / removed from the wire, this list drifts from the
+// real catalog by one arm — a tolerable bench-fidelity rounding, not a
+// correctness bug (the AJV side always scans the live `serverRpcMethods`).
+const FILLER_METHODS = [
+  "agents/claim",
+  "agents/invite",
+  "agents/lookup",
+  "agents/lookupByName",
+  "agents/register",
+  "apps/register",
+  "contacts/accept",
+  "contacts/add",
+  "contacts/byId",
+  "contacts/list",
+  "dispatch/request",
+  "dispatches/get",
+  "invites/createAgent",
+  "messages/list",
+  "network/connect",
+  "network/ping",
+  "presence/subscribe",
+  "task/addParticipant",
+  "task/close",
+  "task/conversation/archive",
+  "task/conversation/list",
+  "task/conversation/participants/add",
+  "task/conversation/participants/remove",
+  "task/conversation/unarchive",
+  "task/leave",
+  "task/list",
+  "task/removeParticipant",
+  "task/request",
+] as const;
+
+const fillerFrames = FILLER_METHODS.map((m) => frame(m, FillerParams));
+
+/**
+ * The discriminated `WireFrame` union — the migration's
+ * `Schema.Union(...perMethodStructs)`. Arm count == real catalog size (31) so
+ * the decode pays a representative discriminator-narrow + params-decode.
+ */
+const WireRequestUnion = Schema.Union(
+  frame("agents/list", AgentsListParams),
+  frame("messages/send", MessagesSendParams),
+  frame("task/conversation/create", TaskConversationCreateParams),
+  ...fillerFrames,
+);
+
+/**
+ * Number of arms in the prototype union (3 fully-modeled + the fillers).
+ * The sibling `frames.test.ts` asserts this equals the live
+ * `serverRpcMethods` catalog size so the method-selection cost stays a fair
+ * A/B — if the wire gains/loses a method, the test fails and the filler list
+ * gets re-synced before the bench numbers are trusted again.
+ */
+export const PROTOTYPE_UNION_ARM_COUNT = 3 + fillerFrames.length;
+
+// `onExcessProperty: "error"` to match AJV strict + additionalProperties:false.
+const decoder = Schema.decodeUnknownEither(WireRequestUnion, {
+  onExcessProperty: "error",
+});
+
+/**
+ * Full inbound decode in ONE pass: the union decode subsumes the AJV
+ * `decodeFrame` 3-arm envelope classify AND the `decodeRpcRequest` linear
+ * `.find()` method-select AND the per-method params validation.
+ */
+export function decodeWireRequest(
+  frameValue: unknown,
+): Either.Either<unknown, unknown> {
+  return decoder(frameValue);
+}
+
+/**
+ * Method-selection isolation: the same union decode. Effect has no separate
+ * "select arm then validate params" stage — the discriminated-union decode
+ * does both in one walk, so this is identical to `decodeWireRequest`. Kept as
+ * a named entry to mirror the AJV `selectAjvMethod` measurement.
+ */
+export function selectMethodArm(frameValue: unknown): void {
+  decoder(frameValue);
+}

--- a/packages/protocol/src/transport/__benchmarks__/frames.test.ts
+++ b/packages/protocol/src/transport/__benchmarks__/frames.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @file Validity guard for the wire-decode benchmark fixtures.
+ *
+ * The benchmark (`wire-decode.bench.ts`) is only meaningful if BOTH engines
+ * ACCEPT all three representative frames — timing a rejection path would
+ * measure the wrong thing. This test runs in the normal suite and fails
+ * loudly if a production schema drifts out from under a fixture (e.g. a new
+ * required param on `messages/send`), forcing the bench fixtures back into
+ * sync before the canary's numbers are trusted.
+ */
+import { describe, it, expect } from "vitest";
+import { Effect, Either, Exit } from "effect";
+import type { RequestFrame } from "../wire.js";
+import { serverRpcMethods } from "../../rpc-registry.js";
+import {
+  smallFrame,
+  typicalFrame,
+  nestedFrame,
+  decodeAjvFull,
+} from "./frames.js";
+import {
+  decodeWireRequest,
+  PROTOTYPE_UNION_ARM_COUNT,
+} from "./effect-schema-prototype.js";
+
+const FRAMES = [
+  ["small · agents/list", smallFrame],
+  ["typical · messages/send", typicalFrame],
+  ["nested · task/conversation/create", nestedFrame],
+] as const;
+
+describe("wire-decode bench fixtures", () => {
+  for (const [name, frame] of FRAMES) {
+    it(`AJV (shipping path) accepts the ${name} frame`, () => {
+      const exit = Effect.runSyncExit(decodeAjvFull(frame as RequestFrame));
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+
+    it(`Effect Schema prototype accepts the ${name} frame`, () => {
+      const accepted = Either.match(decodeWireRequest(frame), {
+        onLeft: () => false,
+        onRight: () => true,
+      });
+      expect(accepted).toBe(true);
+    });
+  }
+
+  it("Schema prototype union has the same arm count as serverRpcMethods", () => {
+    // Method-selection is only a fair A/B if both engines weigh the same
+    // catalog. If the wire gains/loses a method, this fails and the prototype
+    // filler list must be re-synced before the bench numbers are trusted.
+    expect(PROTOTYPE_UNION_ARM_COUNT).toBe(serverRpcMethods.length);
+  });
+});

--- a/packages/protocol/src/transport/__benchmarks__/frames.ts
+++ b/packages/protocol/src/transport/__benchmarks__/frames.ts
@@ -1,0 +1,86 @@
+/**
+ * @file Representative real RPC frames + the two decode compositions the
+ * benchmark times. Bench-only fixtures — not on any barrel.
+ *
+ * The frames carry REAL params matching the production schemas:
+ *   - `agents/list`              — `AgentsList.paramsSchema` (limit + cursor)
+ *   - `messages/send`            — `MessagesSend.paramsSchema` (4 branded
+ *                                  UUIDs + a text-part array)
+ *   - `task/conversation/create` — `TaskConversationCreate.paramsSchema`
+ *                                  (branded UUID + participants[] of UUIDs)
+ *
+ * AJV path (`decodeAjvFull`): the EXACT shipping composition —
+ * `decodeFrame` (3-arm envelope) → `decodeRpcRequest(serverRpcMethods, …)`
+ * (linear `.find()` + the matched method's compiled `validateParams`).
+ *
+ * The Effect-Schema side of the A/B (the single-pass union decode the #723
+ * migration would ship) lives in `./effect-schema-prototype.ts`.
+ */
+import { Effect } from "effect";
+import { decodeFrame, type RequestFrame, type DecodedFrame } from "../wire.js";
+import { decodeRpcRequest } from "../rpc-groups.js";
+import { serverRpcMethods } from "../../rpc-registry.js";
+
+// ── Valid fixtures (canonical UUIDs so the format check passes) ──────
+const TASK_ID = "11111111-1111-1111-1111-111111111111";
+const CONV_ID = "22222222-2222-2222-2222-222222222222";
+const AGENT_A = "33333333-3333-3333-3333-333333333333";
+const AGENT_B = "44444444-4444-4444-4444-444444444444";
+
+export const smallFrame = {
+  jsonrpc: "2.0" as const,
+  id: "req-1",
+  method: "agents/list",
+  params: { limit: 25 },
+};
+
+export const typicalFrame = {
+  jsonrpc: "2.0" as const,
+  id: "req-2",
+  method: "messages/send",
+  params: {
+    taskId: TASK_ID,
+    conversationId: CONV_ID,
+    parts: [{ type: "text", text: "hello from the benchmark harness" }],
+  },
+};
+
+export const nestedFrame = {
+  jsonrpc: "2.0" as const,
+  id: "req-3",
+  method: "task/conversation/create",
+  params: {
+    taskId: TASK_ID,
+    name: "bench conversation",
+    participants: [AGENT_A, AGENT_B],
+  },
+};
+
+// ── AJV: the full shipping inbound-decode composition ────────────────
+// `decodeFrame` classifies the envelope (Request arm), then
+// `decodeRpcRequest` selects the method out of the real catalog and runs
+// its compiled params validator. This is precisely what the dispatcher
+// pays per inbound request, isolated from socket read + JSON.parse.
+export function decodeAjvFull(
+  frame: RequestFrame,
+): Effect.Effect<unknown, unknown> {
+  return decodeFrame(frame).pipe(
+    Effect.flatMap((decoded: DecodedFrame) =>
+      decoded._tag === "Request"
+        ? decodeRpcRequest(serverRpcMethods, decoded.frame)
+        : // Bench frames are always Request; a non-Request classification
+          // means the fixture is wrong, so fail loudly rather than time a
+          // mis-shaped path.
+          Effect.die(new Error(`bench frame classified as ${decoded._tag}`)),
+    ),
+  );
+}
+
+// AJV method-selection only: skip the envelope classifier, time the linear
+// `.find()` scan over `serverRpcMethods` + the matched `validateParams`.
+export function selectAjvMethod(frame: RequestFrame): void {
+  Effect.runSyncExit(decodeRpcRequest(serverRpcMethods, frame));
+}
+
+// The Effect-Schema side of the A/B lives in `./effect-schema-prototype.ts`
+// (`decodeWireRequest` / `selectMethodArm`); the bench imports it directly.

--- a/packages/protocol/src/transport/__benchmarks__/wire-decode.bench.ts
+++ b/packages/protocol/src/transport/__benchmarks__/wire-decode.bench.ts
@@ -1,0 +1,124 @@
+/**
+ * @file Inbound wire-decode hot-path benchmark — perf canary for the
+ * dispatcher's per-frame decode cost.
+ *
+ * WHAT THIS GUARDS
+ * ----------------
+ * Every inbound JSON-RPC request the server accepts pays a fixed decode
+ * tax before any handler runs. That tax is two stages, both measured here
+ * against the REAL shipping schemas (no toy schemas):
+ *
+ *   1. `decodeFrame` — the 3-arm envelope classifier in `wire.ts`. It runs
+ *      the compiled AJV `validateRequestFrame` -> `validateResponseFrame` ->
+ *      `validateNotificationFrame` guards in order until one matches.
+ *   2. `decodeRpcRequest` — the per-method selection + params validation in
+ *      `rpc-groups.ts`. It linear-scans the ~34-method `serverRpcMethods`
+ *      catalog (`.find(d => d.name === frame.method)`) then runs that
+ *      method's compiled AJV `validateParams`.
+ *
+ * The full inbound decode a request frame pays is `decodeFrame` +
+ * `decodeRpcRequest` composed. This file measures that full path, isolated
+ * from socket I/O and JSON parsing (frames are pre-parsed plain objects),
+ * across three representative frame classes:
+ *
+ *   - small:   `agents/list`               (1 optional integer param)
+ *   - typical: `messages/send`             (4 branded-UUID + 1 text-part array)
+ *   - nested:  `task/conversation/create`  (branded UUID + participants[] array)
+ *
+ * The fixtures' validity (both engines ACCEPT all three frames) is asserted
+ * in the sibling `frames.test.ts` so this file stays a pure timing harness —
+ * a bench that silently times a rejection path would be worthless, and that
+ * test fails loudly if a schema drifts out from under the fixtures.
+ *
+ * WHY IT EXISTS (de-risks #723)
+ * -----------------------------
+ * #723 migrates wire validation from TypeBox+AJV (compiled validators) to
+ * `effect/Schema` (AST-interpreted decode). The #720 spike flagged per-frame
+ * `Schema.decode` cost as the one UNPROVEN risk on this hot path. This
+ * benchmark is BOTH:
+ *   (a) the AJV baseline the migration must not regress — a standing perf
+ *       canary on the decode hot path, useful regardless of #723; and
+ *   (b) a side-by-side A/B against an `effect/Schema` PROTOTYPE built in the
+ *       exact shape the migration would ship (a `Schema.Union` of per-method
+ *       structs discriminated on the `method` literal, decoded via
+ *       `Schema.decodeUnknownEither` with `onExcessProperty: "error"` to match
+ *       AJV `strict` + `additionalProperties: false`).
+ *
+ * The Effect-Schema prototype is bench-only spike code — clearly fenced in
+ * `./effect-schema-prototype.ts`, imported here ONLY for the A/B variants.
+ * It ships no production surface and is not on any barrel.
+ *
+ * RUN
+ * ---
+ * From the protocol package: `pnpm bench` (or, from the repo root,
+ * `pnpm --filter ./packages/protocol bench`).
+ */
+import { bench, describe } from "vitest";
+import { Effect } from "effect";
+import type { RequestFrame } from "../wire.js";
+import {
+  smallFrame,
+  typicalFrame,
+  nestedFrame,
+  decodeAjvFull,
+  selectAjvMethod,
+} from "./frames.js";
+import {
+  decodeWireRequest,
+  selectMethodArm,
+} from "./effect-schema-prototype.js";
+
+// ── (1) FULL inbound decode: decodeFrame + decodeRpcRequest ──────────
+// This is the tax every accepted request frame pays. AJV path runs the
+// real shipping `decodeFrame` (3-arm envelope) + `decodeRpcRequest`
+// (linear find + per-method validateParams) over the real
+// `serverRpcMethods` catalog. Schema path runs the single-pass union
+// decode that subsumes all three.
+
+describe("full inbound decode — AJV (shipping path)", () => {
+  bench("small  · agents/list", () => {
+    Effect.runSyncExit(decodeAjvFull(smallFrame as RequestFrame));
+  });
+  bench("typical · messages/send", () => {
+    Effect.runSyncExit(decodeAjvFull(typicalFrame as RequestFrame));
+  });
+  bench("nested · task/conversation/create", () => {
+    Effect.runSyncExit(decodeAjvFull(nestedFrame as RequestFrame));
+  });
+});
+
+describe("full inbound decode — Effect Schema (prototype)", () => {
+  bench("small  · agents/list", () => {
+    decodeWireRequest(smallFrame);
+  });
+  bench("typical · messages/send", () => {
+    decodeWireRequest(typicalFrame);
+  });
+  bench("nested · task/conversation/create", () => {
+    decodeWireRequest(nestedFrame);
+  });
+});
+
+// ── (2) METHOD-SELECTION cost over the ~34-method catalog ────────────
+// AJV: the linear `.find()` scan + the matched method's validateParams.
+// Schema: the discriminated-union arm select (same union decode, isolated
+// to the selection+params cost). We measure the `messages/send` / nested
+// cases which sit mid/late in the catalog.
+
+describe("method-selection — AJV linear find + validateParams", () => {
+  bench("typical · messages/send", () => {
+    selectAjvMethod(typicalFrame as RequestFrame);
+  });
+  bench("nested · task/conversation/create", () => {
+    selectAjvMethod(nestedFrame as RequestFrame);
+  });
+});
+
+describe("method-selection — Effect Schema union arm-select", () => {
+  bench("typical · messages/send", () => {
+    selectMethodArm(typicalFrame);
+  });
+  bench("nested · task/conversation/create", () => {
+    selectMethodArm(nestedFrame);
+  });
+});

--- a/packages/protocol/tsconfig.bench.json
+++ b/packages/protocol/tsconfig.bench.json
@@ -1,0 +1,17 @@
+{
+  // Type-checks the wire-decode benchmark (`src/**/__benchmarks__/**`) WITHOUT
+  // emitting it into the published `dist/`. The main `tsconfig.json` excludes
+  // `__benchmarks__` so the bench + its throwaway Effect-Schema prototype never
+  // ship; this config keeps them honest at compile time (same role `vitest`
+  // type-stripping plays for `*.test.ts`). Wired into `pnpm bench:typecheck`.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  // Re-include the bench tree the base config deliberately excludes; the
+  // bench imports production source under `src/`, so keep `src/**/*.ts`
+  // visible to the program but drop the base `__benchmarks__` exclude.
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -9,5 +9,5 @@
     "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts", "dist"]
+  "exclude": ["src/**/*.test.ts", "src/**/__benchmarks__/**", "dist"]
 }


### PR DESCRIPTION
## What

Adds an inbound **wire-decode micro-benchmark** over real RPC frames that measures the full per-frame decode tax the dispatcher pays, and A/Bs it against an Effect-Schema prototype to answer the one open perf risk gating the #723 migration.

The decode tax is two stages, both timed against the **real shipping schemas** (no toy schemas):
1. `decodeFrame` (`wire.ts`) — the 3-arm envelope classifier (compiled AJV `validateRequestFrame` → `validateResponseFrame` → `validateNotificationFrame`).
2. `decodeRpcRequest` (`rpc-groups.ts`) — the linear `.find()` method-select over the live 31-method `serverRpcMethods` catalog + that method's compiled AJV `validateParams`.

Frames span three classes: **small** (`agents/list`), **typical** (`messages/send`, branded UUIDs + text-part array), **nested** (`task/conversation/create`, branded UUID + `participants[]`). Decode is isolated from socket I/O and JSON parsing (pre-parsed plain objects).

## Why (de-risks #723)

The [#720 spike](https://github.com/chughtapan/moltzap/issues/720) flagged per-frame `Schema.decode` (AST-interpreted) vs AJV (compiled) as the **one UNPROVEN risk** on this hot path. The [#723 P6 gate](https://github.com/chughtapan/moltzap/issues/723) is locked at **≤5× AJV / ≤50µs per frame**. This PR answers it with numbers.

The Effect-Schema prototype is built in the **exact shape the migration would ship**: a `Schema.Union` of per-method structs discriminated on the `method` literal, decoded via `Schema.decodeUnknownEither(..., { onExcessProperty: "error" })` — `onExcessProperty: "error"` matches the shipping `new Ajv({ strict: true })` + `additionalProperties: false` (effect's default silently strips excess keys; see #723 r4 B1). The union has exactly 31 arms = the live `serverRpcMethods` size, so the method-selection cost is a fair A/B. The 3 measured methods carry full param fidelity (branded-UUID `Schema.pattern(UUID_RE)`, nested arrays); the other 28 are fillers.

## Numbers (mean ns/decode, vitest bench, ~150k-260k samples/frame, rme <5%)

**Full inbound decode** — `decodeFrame` + `decodeRpcRequest` (the number that gates the hot path):

| Frame | AJV (shipping) | Effect Schema (proto) | Ratio | Schema absolute |
|---|---|---|---|---|
| small · agents/list | ~1.9 µs | ~3.6 µs | **1.9×** | 3.6 µs |
| typical · messages/send | ~2.6 µs | ~8.5 µs | **3.2×** | 8.5 µs |
| nested · task/conversation/create | ~2.4 µs | ~8.0 µs | **3.3×** | 8.0 µs |

Schema p99 tails stay ~20-30µs worst-case, still under the 50µs ceiling.

**Method-selection only** (AJV linear `.find()` + `validateParams` vs Schema union arm-select): AJV ~0.7µs, Schema ~8-9µs. The high ratio here is structural — AJV's `.find()` is a trivial string scan while Schema has no separate "select then validate" stage; the union decode does method-select AND full params validation in one walk. The composite (full inbound decode) is what matters and is the table above.

## Verdict: ACCEPTABLE

Schema's full per-frame decode is **~1.9-3.3× AJV, worst-case ~8.5µs/frame** — inside #723's locked P6 gate (≤5× AJV / ≤50µs) with large headroom. At 8.5µs/frame the decode stage alone tops out near ~118k frames/sec single-threaded before decode becomes the bottleneck — orders of magnitude above any realistic JSON-RPC frame rate moltzap sees. **Perf is not a blocker for the #723 migration**; no mitigation (precompiled Schema, ParseResult caching) is needed at current frame rates. The migration is de-risked on this axis.

## What this PR actually merges

The **AJV-baseline benchmark is the mergeable artifact**: a standing perf canary on the decode hot path, useful regardless of #723, and the baseline the migration must not regress.

- `wire-decode.bench.ts` — the harness (AJV + Schema variants).
- `frames.ts` — real fixtures + the exact shipping AJV decode composition.
- `frames.test.ts` — runs in the normal suite; asserts both engines accept all three fixtures AND that the prototype union arm count tracks `serverRpcMethods`, so the canary can't silently drift.
- `effect-schema-prototype.ts` — clearly-fenced throwaway spike code (not on any barrel, not imported by production), kept as a bench variant so the A/B is reproducible.

Bench files live under `src/**/__benchmarks__/`, **excluded from the published build** (`tsconfig.json`) so nothing ships to `dist/`, but **typechecked** via `tsconfig.bench.json` (`pnpm bench:typecheck`) and run via `pnpm bench`. Registered as a knip entry.

## Gates

`pnpm check` (lint + format), `pnpm build`, `pnpm typecheck`, `pnpm bench:typecheck`, sloppy-code-guard, knip, oxlint, and the full protocol suite (220 tests) all green. Pre-commit hook ran clean (no `--no-verify`). Ran `/simplify` + `/review` on the diff; review caught and fixed a union-arm-count drift (prototype had 35 arms vs the real 31) and added the parity test that locks it.

Refs #723, #705, #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)