### PR TITLE
test(apps): finish v1 app-boundary cleanup

### DIFF
--- a/docs/modules/server-core/dispatch.mdx
+++ b/docs/modules/server-core/dispatch.mdx
@@ -474,19 +474,19 @@ Mint + claim + finalize sequence (recipient + moderator round-trip):
 ```mermaid
 sequenceDiagram
   participant Recv as Recipient (client)
-  participant AH as apps.handlers
+  participant DA as DispatchAdmissionService
   participant LR as LeaseRegistry
   participant Mod as Moderator
   participant MS as MessageService
 
-  Recv->>AH: agent/dispatch/request (C→S)
-  AH->>LR: mint(binding) — PENDING
-  LR-->>AH: {leaseId, dispatchId}
-  AH-->>Recv: ack returned immediately
-  AH->>Mod: Effect.fork — dispatchAuthorizeHook
-  Mod-->>AH: verdict
-  AH->>LR: resolve(leaseId, verdict) — GRANTED | DENIED | HOLD
-  AH->>Recv: agent/dispatch/released {verdict}
+  Recv->>DA: agent/dispatch/request (C→S)
+  DA->>LR: mint(binding) — PENDING
+  LR-->>DA: {leaseId, dispatchId}
+  DA-->>Recv: ack returned immediately
+  DA->>Mod: Effect.forkDaemon — app/dispatch/authorize
+  Mod-->>DA: verdict
+  DA->>LR: resolve(leaseId, verdict) — GRANTED | DENIED | HOLD
+  LR->>Recv: agent/dispatch/released {verdict}
   Recv->>MS: agent/message/send with dispatchLeaseId
   MS->>LR: claim(leaseId) — GRANTED → CLAIMED
   Note over MS: Effect.acquireUseRelease; use sendInsert returns carrier; release Exit success → claim.finalize CLAIMED → CONSUMED; release Exit failure → claim.rollback CLAIMED → GRANTED

--- a/packages/server/src/__tests__/integration/app/app-session-scoping.integration.test.ts
+++ b/packages/server/src/__tests__/integration/app/app-session-scoping.integration.test.ts
@@ -14,7 +14,8 @@
  *
  * The hijack rejection (a second connection cannot steal a live app's
  * moderator-endpoint binding) is covered at the unit level by
- * `app-host.remote.test.ts` — the registry's strict no-overwrite invariant.
+ * `identity/apps/endpoint-registry.test.ts` — the registry's strict
+ * no-overwrite invariant.
  * At the integration level the Connect rejection is swallowed by the test
  * client's auto-connect, so a meaningful assertion there is not available
  * without a raw Connect-frame driver; the unit test is the canonical proof.

--- a/packages/server/src/dispatch/MODULE.md
+++ b/packages/server/src/dispatch/MODULE.md
@@ -469,19 +469,19 @@ Mint + claim + finalize sequence (recipient + moderator round-trip):
 ```mermaid
 sequenceDiagram
   participant Recv as Recipient (client)
-  participant AH as apps.handlers
+  participant DA as DispatchAdmissionService
   participant LR as LeaseRegistry
   participant Mod as Moderator
   participant MS as MessageService
 
-  Recv->>AH: agent/dispatch/request (C→S)
-  AH->>LR: mint(binding) — PENDING
-  LR-->>AH: {leaseId, dispatchId}
-  AH-->>Recv: ack returned immediately
-  AH->>Mod: Effect.fork — dispatchAuthorizeHook
-  Mod-->>AH: verdict
-  AH->>LR: resolve(leaseId, verdict) — GRANTED | DENIED | HOLD
-  AH->>Recv: agent/dispatch/released {verdict}
+  Recv->>DA: agent/dispatch/request (C→S)
+  DA->>LR: mint(binding) — PENDING
+  LR-->>DA: {leaseId, dispatchId}
+  DA-->>Recv: ack returned immediately
+  DA->>Mod: Effect.forkDaemon — app/dispatch/authorize
+  Mod-->>DA: verdict
+  DA->>LR: resolve(leaseId, verdict) — GRANTED | DENIED | HOLD
+  LR->>Recv: agent/dispatch/released {verdict}
   Recv->>MS: agent/message/send with dispatchLeaseId
   MS->>LR: claim(leaseId) — GRANTED → CLAIMED
   Note over MS: Effect.acquireUseRelease; use sendInsert returns carrier; release Exit success → claim.finalize CLAIMED → CONSUMED; release Exit failure → claim.rollback CLAIMED → GRANTED

--- a/packages/server/src/dispatch/lease-registry.ts
+++ b/packages/server/src/dispatch/lease-registry.ts
@@ -244,19 +244,19 @@ interface Claim {
  * ```mermaid
  * sequenceDiagram
  *   participant Recv as Recipient (client)
- *   participant AH as apps.handlers
+ *   participant DA as DispatchAdmissionService
  *   participant LR as LeaseRegistry
  *   participant Mod as Moderator
  *   participant MS as MessageService
  *
- *   Recv->>AH: agent/dispatch/request (C→S)
- *   AH->>LR: mint(binding) — PENDING
- *   LR-->>AH: {leaseId, dispatchId}
- *   AH-->>Recv: ack returned immediately
- *   AH->>Mod: Effect.fork — dispatchAuthorizeHook
- *   Mod-->>AH: verdict
- *   AH->>LR: resolve(leaseId, verdict) — GRANTED | DENIED | HOLD
- *   AH->>Recv: agent/dispatch/released {verdict}
+ *   Recv->>DA: agent/dispatch/request (C→S)
+ *   DA->>LR: mint(binding) — PENDING
+ *   LR-->>DA: {leaseId, dispatchId}
+ *   DA-->>Recv: ack returned immediately
+ *   DA->>Mod: Effect.forkDaemon — app/dispatch/authorize
+ *   Mod-->>DA: verdict
+ *   DA->>LR: resolve(leaseId, verdict) — GRANTED | DENIED | HOLD
+ *   LR->>Recv: agent/dispatch/released {verdict}
  *   Recv->>MS: agent/message/send with dispatchLeaseId
  *   MS->>LR: claim(leaseId) — GRANTED → CLAIMED
  *   Note over MS: Effect.acquireUseRelease; use sendInsert returns carrier; release Exit success → claim.finalize CLAIMED → CONSUMED; release Exit failure → claim.rollback CLAIMED → GRANTED

--- a/packages/server/src/identity/apps/endpoint-registry.test.ts
+++ b/packages/server/src/identity/apps/endpoint-registry.test.ts
@@ -13,6 +13,9 @@ const APP_ID = makeAppId("00000000-0000-4000-8000-000000000560");
 const CONN_ID = Schema.decodeUnknownSync(ConnectionId)(
   "00000000-0000-4000-8000-00000000c001",
 );
+const OTHER_CONN_ID = Schema.decodeUnknownSync(ConnectionId)(
+  "00000000-0000-4000-8000-00000000c002",
+);
 
 const APP_MANIFEST = {
   appId: APP_ID,
@@ -24,26 +27,40 @@ const APP_MANIFEST = {
   },
 } satisfies AppManifest;
 
+function makeTestEndpoint(id: typeof CONN_ID) {
+  return makeHandlerAppEndpoint({
+    id,
+    handlers: {
+      [DispatchAuthorize.name]: () =>
+        Effect.succeed({ admission: { decision: "grant" } }),
+      [MessagesAuthorize.name]: () =>
+        Effect.succeed({
+          verdict: {
+            decision: "Forward",
+            recipients: [],
+          },
+        }),
+      [TaskCreate.name]: () =>
+        Effect.succeed({ verdict: { decision: "accept" } }),
+    },
+  });
+}
+
 describe("AppEndpointRegistry.registerApp", () => {
   it("registers the app, keying the registration by the bound conn", () => {
     const registry = new AppEndpointRegistry();
-    const connection = makeHandlerAppEndpoint({
-      id: CONN_ID,
-      handlers: {
-        [DispatchAuthorize.name]: () =>
-          Effect.succeed({ admission: { decision: "grant" } }),
-        [MessagesAuthorize.name]: () =>
-          Effect.succeed({
-            verdict: {
-              decision: "Forward",
-              recipients: [],
-            },
-          }),
-        [TaskCreate.name]: () =>
-          Effect.succeed({ verdict: { decision: "accept" } }),
-      },
-    });
+    const connection = makeTestEndpoint(CONN_ID);
     registry.registerApp(APP_ID, APP_MANIFEST, connection);
     expect(registry.lookupApp(APP_ID)?.endpoint.connId).toBe(CONN_ID);
+  });
+
+  it("does not replace a live app registration", () => {
+    const registry = new AppEndpointRegistry();
+    const original = makeTestEndpoint(CONN_ID);
+    const replacement = makeTestEndpoint(OTHER_CONN_ID);
+
+    expect(registry.registerApp(APP_ID, APP_MANIFEST, original)).toBe(true);
+    expect(registry.registerApp(APP_ID, APP_MANIFEST, replacement)).toBe(false);
+    expect(registry.lookupApp(APP_ID)?.endpoint).toBe(original);
   });
 });


### PR DESCRIPTION
## Summary

- pin duplicate app registration as strict no-overwrite behavior
- replace the stale app-host test reference
- update dispatch flow docs to current service ownership and regenerate the published module docs

Closes #724

## Validation

- `pnpm exec nx run @moltzap/server-core:test`
- `pnpm exec nx run @moltzap/server-core:typecheck:tests`
- `pnpm exec nx run @moltzap/server-core:lint`
- `pnpm format:check`
- `pnpm docs:check:drift`
- `git diff --check`