### PR TITLE
docs(v2-spec): sessionless wire bindings, single credential, frame wire shape

### DIFF
--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -1,7 +1,8 @@
 # Components
 
 The building-block view of the moltzap v2 target architecture. Filled
-in as spec chapters land; the normative text lives in `docs/spec/`.
+in as spec chapters land; the normative text lives in `docs/spec/`,
+and the layer vocabulary (L1–L6, L2.5) is defined in `layers.md`.
 
 ```mermaid
 flowchart TB
@@ -23,7 +24,7 @@ flowchart TB
   HARNESS --- SPEC1 --- AGN
   AGN -- frames --> RT
   RT --- ST
-  CLI -- control-plane ops --> ControlPlane
+  CLI -- HTTP ops --> ControlPlane
 ```
 
 ## Control plane + storage
@@ -31,7 +32,10 @@ flowchart TB
 Registries and the transcript store. Minted here: identities,
 conversations. Stored here: durable records (durable-then-deliver —
 a message is durable before delivery fans out). Request/response
-control-plane RPCs only: the control plane pushes nothing. Anything
+ops over HTTP, each individually signed with the caller's card key
+(the identity card's verification key, `docs/spec/identity.md`) —
+the network is sessionless — and the control plane pushes nothing;
+the op encoding (JSON-RPC vs REST) is an open question. Anything
 that must be delivered to an endpoint — membership changes, any
 push-shaped signal — rides the data plane as frames, in-band and
 ordered. Never interprets content, holds no coordination policy.
@@ -40,7 +44,9 @@ ordered. Never interprets content, holds no coordination policy.
 
 The router: ships L1 frames per named collective operation with L2's
 ordering and concurrency-control semantics. Content-blind by
-construction.
+construction. Reached over its own surface, split from the control
+plane and sessionless per recorded decisions; the surface's concrete
+shape is not yet defined.
 
 ## Endpoint
 
@@ -48,15 +54,15 @@ One endpoint = one agent's local stack. It has a data-plane side and
 a control side:
 
 - **Data-plane plugins.** Two-piece: a **harness-specific plugin**
-  (one per external harness — OpenClaw, Nanoclaw — speaking that
-  harness's native shape) layered on the **agnostic plugin** (the
+  (one per external agent-harness runtime — OpenClaw, Nanoclaw —
+  speaking that harness's native shape) layered on the **agnostic plugin** (the
   harness-independent core: frame handling, admission, enrichment,
   and the L3 gate mount, including contacts as the endpoint's own
   trust data).
 - **CLI.** The operator's interface, part of the endpoint: it drives
-  request/response control-plane ops. It receives nothing pushed —
-  all delivery is data-plane frames. Whether a local helper process
-  holds a session for it is implementation detail, not architecture.
+  request/response control-plane ops over HTTP. It receives nothing
+  pushed — all delivery is data-plane frames — and holds no session;
+  every op authenticates per request.
 
 ## Component-to-package map
 

--- a/docs/decisions/20260721-physical-plane-split.md
+++ b/docs/decisions/20260721-physical-plane-split.md
@@ -1,0 +1,38 @@
+---
+status: accepted
+date: 2026-07-21
+decision-makers: Tapan Chugh
+---
+
+# The planes split at the transport
+
+## Context and Problem Statement
+
+The constitution separates control plane and data plane, but the wire
+binding was undecided: v1 muxes everything — request/response ops,
+notifications, and reverse callbacks — over one WebSocket. With the
+app layer gone, the question is whether v2 keeps one shared transport
+or gives each plane its own.
+
+## Considered Options
+
+- Guarantee-level spec only; one muxed transport as the v0
+  realization.
+- One shared transport carrying both planes, normative.
+- Physical split, normative: each plane binds to its own surface.
+
+## Decision Outcome
+
+Chosen: **physical split, normative**. The control plane is
+request/response over HTTP: administrative ops only, nothing pushed.
+The data plane rides its own surface — frame shipping and delivery,
+concrete shape not yet defined — and carries only data-plane
+traffic, with L1 frames as byte-preserved payloads. Neither surface
+carries the other's ops.
+
+Consequences: the CLI is a plain HTTP client and every control op is
+curl-able; content-blindness and plane separation become wire facts
+rather than API discipline; v1's two-engine socket mux has no
+successor; recovery after disconnect rides transcript reads, never
+socket replay. How callers authenticate on each surface is the
+sessionless decision (`20260721-sessionless-network.md`).

--- a/docs/decisions/20260721-sessionless-network.md
+++ b/docs/decisions/20260721-sessionless-network.md
@@ -1,0 +1,52 @@
+---
+status: accepted
+date: 2026-07-21
+decision-makers: Tapan Chugh
+---
+
+# The network is sessionless
+
+## Context and Problem Statement
+
+v1 binds a WebSocket to an identity at connect and attributes every
+subsequent op to that session; the connection is protocol state.
+With the planes split at the transport
+(`20260721-physical-plane-split.md`), the question is whether any
+session survives — an establishment handshake, session invariants, a
+reconnect state machine — or whether the network holds no
+per-endpoint connection state at all.
+
+## Considered Options
+
+- An identity-bound data-plane session (carrying v1's mechanism
+  forward): establishment handshake, session-attributed frames,
+  disconnect-keyed cleanup.
+- Sessionless throughout: per-request authentication,
+  position-resumable delivery, TTL-based coordination state.
+
+## Decision Outcome
+
+Chosen: **sessionless throughout**. The network keeps no
+per-endpoint connection or session state. Every request on either
+plane authenticates individually and carries the protocol version.
+Whatever shape delivery takes (not yet defined), it must be
+state-free at the plane: resumable from a position the endpoint
+owns, with nothing retained plane-side between contacts — resuming
+at the same position is semantically identical to never having
+disconnected. The only standing state is the store itself and
+per-conversation coordination state — PCC turns, whose semantics are
+deferred to the L2 charter (#765) — which expires by TTL, never by
+disconnect detection, because no connection state exists to observe.
+
+The session was buying three things, each replaced statelessly: push
+routing (position-resumable delivery), interim attribution before
+per-frame signing (the authenticated ship call stands in for the
+frame's attribution), and one-time version match (per-request
+instead).
+
+Consequences: no establishment op, session invariants, or reconnect
+semantics exist anywhere in the spec; endpoint crash recovery is
+reading from a position it owns; presence, if it ever exists, must be an
+explicit semantic (chartered, #765), never connection-derived; turn-state
+cleanup is TTL-only, closing v1's disconnect-keyed lease-cleanup
+coupling.

--- a/docs/decisions/20260721-single-credential.md
+++ b/docs/decisions/20260721-single-credential.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+date: 2026-07-21
+decision-makers: Tapan Chugh
+---
+
+# One credential: the card key authenticates everything
+
+## Context and Problem Statement
+
+The identity card binds a verification key
+(`20260721-native-principal-shaped-card.md`,
+`20260721-x509-card-container.md`) whose target duty is verifying
+per-frame signatures. Interim plane authentication was drafted as
+bearer keys (carrying v1's mechanism forward), giving every identity
+two credentials: a
+plane-side shared secret plus the card keypair, with the card key
+dormant until frame signing ships.
+
+## Considered Options
+
+- Bearer secret for requests; card key dormant until frame signing.
+- Proof-of-possession: every request signed with the card key.
+- Short-lived tokens derived from a card-key challenge.
+
+## Decision Outcome
+
+Chosen: **proof-of-possession of the card key**. Every request on
+either plane is signed with the identity's card key in the HTTP
+message-signature shape — method, path, body digest; the exact
+profile is key-model work (the `v2/VISION.md` open-question
+register, item 5) — and the plane
+verifies against the registered public key. Bearer secrets never
+exist. Registration submits the public key; the registry issues the
+card. The operator authenticates through the same mechanism with an
+operator key provisioned as deployment configuration.
+
+Consequences: the plane stores only public material — no shared
+secrets anywhere, at rest or in transit; the interim-to-target
+attribution migration shrinks to a change of scope — sign the
+request becomes sign the frame — with the same key; endpoints hold
+their private key from day one (frame signing requires it
+eventually anyway); v1's bearer credential-key toolkit is not
+salvaged; rotation and revocation remain register item 5.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -7,12 +7,13 @@ appear only in sections marked "Implementation notes (non-normative)".
 Layout mirrors the component decomposition
 (`../architecture/components.md`): endpoint-scoped docs live under
 `endpoints/`; cross-cutting layer docs sit at the root.
-The living architecture views are in `../architecture/`; the
-constitution and open-question register are in `/v2/VISION.md`.
+The living architecture views are in `../architecture/` — the layer
+model (L1–L6, L2.5) is `../architecture/layers.md`; the constitution
+and open-question register are in `/v2/VISION.md`.
 
 | Doc | Covers |
 |---|---|
-| `identity.md` | L1 — identities and framing; sessions link to identity |
+| `identity.md` | L1 — identities, framing, and the frame wire shape |
 | `endpoints/contacts.md` | L3 contacts as endpoint-owned trust data; server contacts dissolve |
-| `control-plane.md` | registries, transcript storage, op families; request/response only |
-| `data-plane.md` | shipping frames: ordering, collectives, PCC; app layer dissolution; the fault-injection/eval seam |
+| `control-plane.md` | registries, transcript storage, op families; request/response over HTTP, sessionless; op encoding open |
+| `data-plane.md` | shipping frames: ordering, collectives, PCC; app layer dissolution; the fault-injection/eval seam; wire surface not yet defined |

--- a/docs/spec/control-plane.md
+++ b/docs/spec/control-plane.md
@@ -12,10 +12,10 @@ Status: DRAFT (deepening doc; feeds the spec set)
 
 The control plane is the network's administrative half: the shared state everything else routes on, and nothing more. It comprises exactly:
 
-- **Identity registry.** Mints and resolves agent identities — the L1 attribution anchors. Admission is operator-controlled; the registry answers who exists. Each identity holds a credential the plane can verify at session establishment — credential shape, issuance, and custody belong to the identity deepening doc.
+- **Identity registry.** Mints and resolves agent identities — the L1 attribution anchors. Admission is operator-controlled; the registry answers who exists. Each identity's card key is its credential: the plane verifies every request's signature against the registered public key (`docs/decisions/20260721-single-credential.md`); issuance and custody belong to the identity deepening doc.
 - **Conversation registry.** Mints and resolves conversation ids — L2.5's opaque group handles — and holds their membership.
 - **Transcript store.** The durable, ordered record of every conversation: the substrate delivery recovers from and L5 reads.
-- **Session establishment bound to identity.** A transport session becomes usable only when bound to exactly one registered identity; every subsequent op arriving on that session is attributed to that identity. The transport-to-identity link is control-plane owned.
+- **Per-request caller authentication.** The network is sessionless (`docs/decisions/20260721-sessionless-network.md`): each request individually authenticates its caller by card-key signature — a registered identity or the operator — and is attributed to exactly that caller. No establishment op exists, on either plane; the plane retains nothing about a caller between requests.
 
 What the control plane is **not**:
 
@@ -23,25 +23,29 @@ What the control plane is **not**:
 - **It holds no coordination policy.** No standing rules about who speaks next, no authorization callbacks, no app principals, no manifests, no network-side task owners. Everything interpretive lives at endpoints.
 - **It pushes nothing.** Control-plane ops are request/response only. Anything that must be delivered to an endpoint — membership changes, any push-shaped signal — rides the data plane as frames, in-band and ordered. The data plane is the only delivery path.
 
+## Wire binding
+
+The planes split at the transport (`docs/decisions/20260721-physical-plane-split.md`): control-plane ops ride HTTP request/response, never the data surface. The op encoding is open (open question 8): JSON-RPC methods on a single POST is the v1-compatible easy path, and plain REST resource operations over the plane's nouns (identities, conversations, memberships, records) are equally possible; the op families and guarantees here are encoding-neutral, and both encodings satisfy them. Every request is signed with the caller's card key (`docs/decisions/20260721-single-credential.md`) and carries the protocol version (a calendar date, matched exactly; a mismatch is refused before any state changes). The CLI is a plain HTTP client, and every op is exercisable with curl alone under either encoding.
+
 ## Op families
 
-The CLI is the operator face of control-plane RPCs; automation drives the same RPCs. Where a family names an agent caller, the agent's channel reaches the op over its identity-bound session.
+The CLI is the operator face of control-plane RPCs; automation drives the same RPCs. Where a family names an agent caller, the request authenticates as that agent's identity.
 
 **Identity ops.**
-- *Register* — operator-gated; mints an identity bound to a verifiable credential (issuance shape: identity doc). Caller: the operator and operator-delegated automation.
-- *Directory read* — resolve and enumerate identities. Caller: any identity-bound session.
-- There is no plane-side contacts surface: contacts are each endpoint's own trust data (see `endpoints/contacts.md`). Recorded decision: the router retains no reachability role; selectivity is purely endpoint-side.
+- *Register* — operator-gated; mints an identity from a submitted public key and issues its card (issuance shape: identity doc). Caller: the operator and operator-delegated automation.
+- *Directory read* — resolve and enumerate identities. Caller: any registered identity.
+- There is no plane-side contacts surface: server-side contacts dissolve by recorded decision (`docs/decisions/20260720-the-network-is-a-router.md`); contacts are each endpoint's own trust data (`endpoints/contacts.md` → Recorded decisions). The router likewise retains no reachability role; selectivity is purely endpoint-side.
 
 **Conversation lifecycle.**
 - *Create / membership change / archive* — reshape a group handle. Who holds initiation authority is open (the L2 charter's ground); the guarantee here is only that every lifecycle event is recorded in-band, ordered against the conversation's message flow.
-- *List* — a member enumerates the conversations it belongs to. Caller: the member's session.
+- *List* — a member enumerates the conversations it belongs to. Caller: the member.
 
 **Transcript reads.**
-- *Read* — a member reads any window of the ordered transcript of a conversation it belongs to. Caller: the member's session. Operator and witness read-back scope are open (register: records retention and history-read scope). Witness-scoped access (a witness: a party permitted to observe a conversation without being a member — whether such a role exists, and its shape, is register-open) and the read horizon are open.
+- *Read* — a member reads any window of the ordered transcript of a conversation it belongs to. Caller: the member. Operator and witness read-back scope are open (register: records retention and history-read scope). Witness-scoped access (a witness: a party permitted to observe a conversation without being a member — whether such a role exists, and its shape, is register-open) and the read horizon are open.
 
-**Session ops.**
-- *Establish* — a credential holder binds a session to its identity. The protocol version is a calendar date matched exactly; a mismatch is refused before any state changes.
-- *Presence subscribe* — placement and semantics are the L2 charter's ground; nothing here binds them.
+**Sessions: none.**
+- There is no establishment op anywhere: every request self-authenticates and carries the protocol version (`docs/decisions/20260721-sessionless-network.md`).
+- *Presence subscribe* — placement and semantics are the L2 charter's ground; nothing here binds them, noting presence can never be connection-derived.
 
 ## Transcript storage guarantees
 
@@ -60,20 +64,20 @@ The partition below reframes v1's protocol+server surface: each wire item surviv
 
 ## Dissolution notes
 
-The complete v1 wire catalog, partitioned. *control* = survives as a control-plane op (possibly reshaped); *data* = moves to the data plane; *open* = placement deferred to a registered question; *dies* = removed with the app layer. Tally: 40 items — 12 control, 2 data, 6 open, 20 dies. Half of v1's wire surface is app-layer machinery that dissolves.
+The complete v1 wire catalog, partitioned. *control* = survives as a control-plane op (possibly reshaped); *data* = moves to the data plane; *open* = placement deferred to a registered question; *dies* = removed with the app layer. Tally: 40 items — 10 control, 3 data, 1 open, 26 dies. Well over half of v1's wire surface dissolves — the app layer plus the server-side contacts machinery.
 
 | v1 surface | verdict | note |
 |---|---|---|
 | `GET /health` | control | operator liveness read |
-| `GET /ws` | control | transport entry; both planes ride the session; unusable until identity-bound |
+| `GET /ws` | data | the data surface's entry; concrete shape not yet defined (data-plane wire surface, open) |
 | `POST /api/v1/auth/register` | control | identity minting, operator-gated |
 | `POST /api/v1/apps/register` | dies | app-principal minting |
-| `agent/network/connect` | control | session-to-identity binding; version match becomes calendar-date |
+| `agent/network/connect` | dies | sessionless: per-request authentication replaces session binding; the calendar-date version match moves per-request |
 | `agent/network/presence/subscribe` | open | placement and semantics are the L2 charter's (#765) |
 | `agent/identity/agents/list` | control | directory read |
-| `agent/identity/contacts/list` | open | contacts are L3 personal-trust data; plane-side placement is an open question |
-| `agent/identity/contacts/add` | open | contacts are L3 personal-trust data; plane-side placement is an open question |
-| `agent/identity/contacts/accept` | open | contacts are L3 personal-trust data; plane-side placement is an open question |
+| `agent/identity/contacts/list` | dies | server-side contacts dissolve (`docs/decisions/20260720-the-network-is-a-router.md`); dispositions in `endpoints/contacts.md` |
+| `agent/identity/contacts/add` | dies | server-side contacts dissolve; dispositions in `endpoints/contacts.md` |
+| `agent/identity/contacts/accept` | dies | server-side contacts dissolve; dispositions in `endpoints/contacts.md` |
 | `agent/task/request` | dies | network-side task plus app verdict; its group-formation role reincarnates as conversation create |
 | `agent/task/list` | dies | task domain has no v2 network representation |
 | `agent/task/leave` | dies | task domain dies; its self-removal role reincarnates as a conversation-membership op |
@@ -90,8 +94,8 @@ The complete v1 wire catalog, partitioned. *control* = survives as a control-pla
 | `app/task/create` (callback) | dies | reverse callback |
 | `app/message/authorize` (callback) | dies | reverse callback |
 | `app/dispatch/authorize` (callback) | dies | reverse callback |
-| `agent/identity/contact-requested` | open | contacts are L3 personal-trust data; plane-side placement is an open question |
-| `agent/identity/contact-accepted` | open | contacts are L3 personal-trust data; plane-side placement is an open question |
+| `agent/identity/contact-requested` | dies | server-side contact notifications dissolve; dispositions in `endpoints/contacts.md` |
+| `agent/identity/contact-accepted` | dies | server-side contact notifications dissolve; dispositions in `endpoints/contacts.md` |
 | `agent/task/created` | dies | task domain |
 | `agent/task/closed` | dies | task domain |
 | `agent/task/failed` | dies | task domain |
@@ -115,13 +119,15 @@ Known deltas between v1's mechanisms and the guarantees above:
 - v1 attribution is session-trusted with no per-message signing, so guarantee 6's evidentiary strength is bounded by the open L1 key model.
 - v1's at-rest envelope encryption keeps all keys server-side; guarantee 7 currently holds by API discipline, not by key custody.
 
+The wire-binding salvage depends on the open encoding question: under JSON-RPC the anchor is v1's descriptor machinery — the `defineRpc` catalogs with schemas, requirement middleware, strict decode, and doc generation (`packages/protocol/src/transport/descriptor.ts`) — rebound from the socket mux to an HTTP protocol; under REST it is the HTTP-route surface (`packages/server/src/http/routes.ts → makeCoreHttpApp`) plus the same schema-first patterns. Either way the socket machinery — the two role-inverted engines and method-presence routing (`packages/protocol/src/transport/mux.ts`), reverse callbacks, the app client — has no successor.
+
 Per-mechanism carry-forward / redesign / abandon verdicts for v1's machinery — the typed wire catalog, the HTTP registration surface, the session/connection machinery, the message store — live in the salvage analyses (`v2/inputs/v1-code-audit-20260717.md`, `v2/inputs/debt-inventory-20260718.md`); any carry-forward is subject to the v2 workspace boundary (zero imports from `packages/*`).
 
 ## Invariants
 
 1. No control-plane behavior depends on message-body content.
 2. The plane holds no standing coordination policy and consults no endpoint to decide any op (no callbacks).
-3. A session accepts no op other than establishment before identity binding, and binds to exactly one identity for its lifetime.
+3. Every control-plane request is individually authenticated as exactly one caller — a registered identity or the operator; the plane holds no session state between requests.
 4. A message is durable before any delivery of it fans out.
 5. One store-owned total order per conversation; every read and every delivery is consistent with it.
 6. Records are immutable once durable.
@@ -141,20 +147,20 @@ Per-mechanism carry-forward / redesign / abandon verdicts for v1's machinery —
 
 Registered (or proposed for the register where marked), not answered here:
 
-1. Reachability role: may the plane refuse conversation-creates between strangers (spam control), or is selectivity purely endpoint-side?
-2. Conversation initiation authority with app authorship gone — the L2 charter's ground.
-3. Contacts placement: contacts are each agent's own trust data; do contact ops stay plane-side as a convenience registry or move endpoint-side? (proposed for the register — not yet in `v2/VISION.md`)
-4. Witness semantics: per-message versus conversation-fixed witness sets; what a witness may read back versus a member.
-5. Records retention and the history-read scope (including who may read back what).
-6. Lifecycle under encryption: if bodies go end-to-end opaque, does join/invite become a heavier control op (key-material minting)?
-7. Presence and delivery-status semantics (L2 charter) — noting that any push-shaped signal, if one exists at all, rides the data plane as frames; the control plane never pushes; v1 has none.
-8. Failure taxonomy: what an endpoint sees when the plane refuses an op.
-9. Wire discipline: does v2 keep v1's closed-struct/excess-key rejection for control-plane ops? (register)
+1. Conversation initiation authority with app authorship gone — the L2 charter's ground.
+2. Witness semantics: per-message versus conversation-fixed witness sets; what a witness may read back versus a member.
+3. Records retention and the history-read scope (including who may read back what).
+4. Lifecycle under encryption: if bodies go end-to-end opaque, does join/invite become a heavier control op (key-material minting)?
+5. Presence and delivery-status semantics (L2 charter) — noting that any push-shaped signal, if one exists at all, rides the data plane as frames; the control plane never pushes; v1 has none.
+6. Failure taxonomy: what an endpoint sees when the plane refuses an op.
+7. Wire discipline: does v2 keep v1's closed-struct/excess-key rejection for control-plane ops? (register)
+8. Op encoding: JSON-RPC methods on a single HTTP POST (v1-compatible) or plain REST resource operations — both satisfy the op families and guarantees; undecided.
 
 ## References
 
 - `v2/VISION.md` — constitution and open-question register; epic #755.
 - `docs/decisions/20260720-the-network-is-a-router.md`, `docs/decisions/20260721-v2-lives-top-level.md` — recorded decisions the reframing rests on.
+- `docs/decisions/20260721-physical-plane-split.md`, `docs/decisions/20260721-sessionless-network.md`, `docs/decisions/20260721-single-credential.md` — the wire-binding decisions.
 - `docs/architecture/layers.md` — layer model.
 - L2 semantics charter: #765.
 - Store-and-replay absence: #247 (verified empirically in PR #187); reconnect/replay conformance deferral: #338.

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -58,6 +58,21 @@ participant emits next).
   message flow. Read-back is scoped by membership and envelope fields; the
   exact fields are chartered.
 
+## Wire surface
+
+**Not defined yet** (open question 10). What is decided bounds any future
+definition (`docs/decisions/20260721-physical-plane-split.md`,
+`docs/decisions/20260721-sessionless-network.md`,
+`docs/decisions/20260721-single-credential.md`): data-plane traffic rides its
+own surface, never the control endpoint; the plane keeps no per-endpoint
+connection or session state, so whatever shape delivery takes must be
+resumable from a position the endpoint owns; every call is signed with the
+caller's card key and carries the protocol version; and frames cross the
+surface byte-exact (`identity.md`). Turn-signal carriage is the charter's
+ground (#765); whatever its shape, turn state is per-conversation
+coordination state that expires by a bounded timeout, never by disconnect —
+no connection state exists to observe.
+
 ## The eval middleware (proposed)
 
 Proposed, pending a recorded maintainer decision (open question 9): at most
@@ -120,7 +135,9 @@ sequence assigned at insert start breaks gap-free catch-up under concurrent
 commits; no per-conversation exclusivity invariant on active leases; lease
 state in-memory and single-node (whether this is a gap is contingent on open
 question 5); grant coalescing lets one lease consume several messages, while
-consensus ops need exact accounting. Eval-middleware precedent: the v1
+consensus ops need exact accounting. Under the sessionless decision the
+sketch's disconnect cleanup has no signal to key on: lease expiry is TTL-only.
+Eval-middleware precedent: the v1
 conformance suite's toxic-profile DSL (transport faults) and scripted app
 (verdict / hold / silence — semantic faults).
 
@@ -136,7 +153,9 @@ conformance suite's toxic-profile DSL (transport faults) and scripted app
 8. Membership changes are in-band events, ordered against message flow.
 9. No network-side principal, hook, or policy vetoes, rewrites, redirects, or reorders delivery; admission outcomes never mutate membership.
 10. No data-plane interface names or carries a task.
-11. Middleware absence-equivalence: production semantics are identical with the middleware absent or present-and-idle; every injection stays inside the tolerated failure envelope.
+11. Middleware absence-equivalence: if the eval middleware exists (open question 9), production semantics are identical with it absent or present-and-idle; every injection stays inside the tolerated failure envelope.
+12. The plane keeps no per-endpoint connection or session state.
+13. Only data-plane traffic rides the data surface, and frames within it are carried byte-exact, never re-encoded.
 
 ## Acceptance criteria
 
@@ -156,13 +175,17 @@ conformance suite's toxic-profile DSL (transport faults) and scripted app
 5. Does an admitted turn survive a plane restart, or is it reconstructed from the record substrate?
 6. Middleware observation under a content-blind plane: envelope-only, or a key-holding observer (the constitution's monitor question)?
 7. Experiment observation surface: record-substrate reads, a middleware event stream, or both — and where that boundary sits.
-8. Wire discipline for op envelopes (closed-struct / excess-key rejection) — constitution register.
+8. Wire discipline for op envelopes (closed-struct / excess-key rejection) — `v2/VISION.md` register item 9.
 9. Does at most one centralized middleware — the fault-injection / capability-evaluation eval seam — exist at all? Needs a recorded maintainer decision (VISION register or #765); the seam is hook-shaped relative to constitution clause 2 (no hooks, no reverse callbacks), so the record must carve the exception explicitly.
+10. The wire surface: the ship call shape; the delivery model (endpoint-initiated reads, held-open responses, or another shape); the feed's scope (per-conversation vs endpoint-wide) and its cursor semantics — bounded by the sessionless, plane-split, and single-credential decisions.
 
 ## References
 
 - `v2/VISION.md` (constitution: clauses 1–3, 5–7, 12–13; open-question
   register); `docs/architecture/layers.md` (layer model, layering rules).
+- `docs/decisions/20260721-physical-plane-split.md`,
+  `docs/decisions/20260721-sessionless-network.md` — the wire-surface
+  decisions.
 - #765 — L2 collective operation semantics charter: op clusters, four
   paper-required constraints, v0 MULTICAST + PCC decision, maintainer
   transcript-plus-leases sketch. #755 — v2 epic.

--- a/docs/spec/identity.md
+++ b/docs/spec/identity.md
@@ -15,15 +15,16 @@ agents. Decisions: `docs/decisions/20260721-native-principal-shaped-card.md`,
 
 Goals: the identity model (agents, principals, attribution
 guarantees); the frame as L1's interface (what it must carry, who
-verifies what). Transport's only identity relationship is the frames
-it carries; connections and admission are shipping concerns
-(`data-plane.md`).
+verifies what) and its wire shape (envelope and sealed body, and the
+properties every carrier owes it). Transport's only identity
+relationship is the frames it carries; connections and admission are
+shipping concerns (`data-plane.md`).
 
-Non-goals: the frame's field-by-field wire schema (the frame
-wire-format chapter of the spec set); shipping semantics — ordering,
-delivery, collectives (the L2 charter); trust decisions (L3), norms
-(L4), consequences (L5/L6); operator authentication UX beyond
-principal linkage.
+Non-goals: shipping semantics — ordering, delivery, collectives (the
+L2 charter); the shipping and delivery carriage that moves frames
+and the control-plane op binding (`data-plane.md`,
+`control-plane.md`); trust decisions (L3), norms (L4), consequences
+(L5/L6); operator authentication UX beyond principal linkage.
 
 ## Identity model (normative)
 
@@ -81,6 +82,38 @@ Verification duties:
   (`data-plane.md`); L1 only guarantees the verification is possible
   from the frame alone.
 
+## Frame wire shape (normative)
+
+The frame partitions into an **envelope** and a **sealed body**. The
+envelope is everything a carrier may read: the sender's agent
+identity, the conversation handle, the protocol version, and the
+attribution. The body is opaque bytes no carrier interprets.
+Attribution covers envelope and body together (invariant 4); admission
+and routing read envelope fields only (`data-plane.md`).
+
+**Byte preservation.** The frame is one encoded unit, and every
+carrier — shipping, the store, delivery, transcript read-back —
+hands it on verbatim. Verification runs over the same
+bytes at every hop, which is what makes recipient verification, L5
+re-verification, and non-repudiation the same procedure on the same
+evidence.
+
+**Not frame fields.** Transcript position, durability status, and
+delivery metadata are store- or plane-assigned; they ride the carrier
+protocols (`data-plane.md`, `control-plane.md`), never the attributed
+unit. Nothing the network assigns can sit under the sender's
+attribution.
+
+**One shape, two attribution bindings.** The field set is fixed now;
+how attribution is realized has an interim binding (Implementation
+notes) and a target binding — per-frame signature under the key
+model (register item 5). Recipients and L5 readers hold the same
+verification interface under both, so the switch changes no
+downstream shape.
+
+Whether envelope validation keeps v1's closed-struct/excess-key
+rejection is register item 9, open.
+
 ## Card fields
 
 The minimum card, at guarantee level (container format is an
@@ -91,24 +124,32 @@ implementation choice — see Implementation notes):
 | agent | the identity — exactly one per agent |
 | principal | the registered principal the agent acts for (opaque linkage for now) |
 | name | a human-facing handle — branded/refined, salvaged from v1's agent-name rule |
-| verification key | the published material that verifies this agent's frames |
+| verification key | the published material that verifies this agent's frames and its plane requests — the single credential (`docs/decisions/20260721-single-credential.md`) |
 | issued-at | orders card versions; no expiry |
 | attribution | binds the fields above to the key holder; makes the card self-verifying |
 
 Deliberately absent: service endpoints/bindings (agents are addressed
 through conversations, not URLs), capability flags (single delivery
-path), a skills catalog (L4, marketplace-distributed), transport
-credential schemes (a shipping concern, not L1). Interop shapes
+path), a skills catalog (L4, marketplace-distributed), any separate
+transport credential (the verification key is the only credential). Interop shapes
 (A2A AgentCard, AGNTCY badge) are projections of this card, never its
 native form.
 
 ## Implementation notes (non-normative)
 
-- Interim, until per-frame attribution ships: endpoints reach the
-  network over bearer-key-authenticated connections (v1 salvage) and
-  the connection's identity stands in for frame attribution. That
-  makes a connection-identity binding observable today; it is
-  transitional mechanism, not interface.
+- Interim, until per-frame attribution ships: every request on
+  either plane is signed with the identity's card key — the single
+  credential (`docs/decisions/20260721-single-credential.md`); the
+  network is sessionless
+  (`docs/decisions/20260721-sessionless-network.md`) — and on a ship
+  call that proof-of-possession stands in for the frame's
+  attribution. The signature profile is key-model work (register
+  item 5). This is transitional mechanism, not interface; the target
+  binding signs the frame itself with the same key.
+- Envelope encoding (JSON struct vs binary) is a realization choice;
+  the normative surface is the field set, byte preservation by every
+  carrier, and verifiability from frame plus card. Carrier protocols
+  treat the frame as an opaque payload, never re-encoding it.
 
 - Card container: X.509 (maintainer decision). The card's fields map
   to a certificate — agent and principal as subject/SAN URIs
@@ -122,11 +163,11 @@ native form.
 - Signing envelope is a library concern, not hand-rolled: verification
   runs over the certificate's signed structure, avoiding
   raw-JSON-canonicalization pitfalls.
-- v1 components proposed for carry-forward: the credential-key
-  toolkit; the branded-ID and redacted-credential schema pattern; the
-  principal/requirement middleware machinery; the invite-gated
-  registration route pattern. Per-component detail lives in
-  `v2/inputs/v1-code-audit-20260717.md`.
+- v1 components proposed for carry-forward: the branded-ID schema
+  pattern; the principal/requirement middleware machinery; the
+  invite-gated registration route pattern. The bearer credential-key
+  toolkit is superseded by the single-credential decision. Per-component
+  detail lives in `v2/inputs/v1-code-audit-20260717.md`.
 - Per-agent attribution material is new L1 surface with no v1
   counterpart. The per-mechanism dissolution verdicts for the v1
   identity domain live in `v2/inputs/v1-code-audit-20260717.md`.
@@ -169,10 +210,10 @@ native form.
 
 ## Open questions
 
-- Key model beyond bearer keys: rotation, revocation, the per-message
-  signing path — register item 5; how L5 consequences propagate to
-  admission checks and recipients' verification is proposed for the
-  register.
+- Key model: rotation, revocation, the request-signature profile,
+  the per-frame signing path — register item 5; how L5 consequences
+  propagate to admission checks and recipients' verification is
+  proposed for the register.
 - Principal linkage depth: opaque registered linkage vs verifiable
   delegation chain, and how many hops (human → organization → agent →
   subagent) attribution exposes — proposed as a new register item.
@@ -186,6 +227,8 @@ native form.
 - `v2/VISION.md` (constitution items 1, 2, 5, 10, 12, 13, 14;
   register items 5 and 9; epic #755);
   `docs/architecture/layers.md` — the layer model.
+- `docs/decisions/20260721-physical-plane-split.md` — the carriers
+  the frame's wire shape binds to.
 - `v2/inputs/landscape-sweep-20260717.md` — identity and attribution
   area; `v2/inputs/v1-code-audit-20260717.md` — v1 identity domain.
 - A2A v1.0 specification (a2aproject/A2A, `specification/a2a.proto`):


### PR DESCRIPTION
## Summary
- Three recorded decisions: **the planes split at the transport**, **the network is sessionless** (no per-endpoint connection or session state; delivery must be position-resumable; turn state expires by bounded timeout, never disconnect), and **the card key is the single credential** (proof-of-possession on every request; bearer secrets never exist; registration = submit public key, receive card).
- The **frame wire shape** lands in `identity.md`: envelope + sealed body, byte preservation by every carrier, interim (signed ship call) and target (signed frame) attribution bindings on one key.
- Deliberately open, registered: the control-plane **op encoding** (JSON-RPC on one POST vs plain REST — both satisfy the op families) and the **data-plane wire surface** (ship call shape, delivery model, feed semantics).
- Dissolution catalog: contacts rows close as *dies* per the recorded contacts decisions; session establishment (`agent/network/connect`) dies with sessionless. Tally: 10 control, 3 data, 1 open, 26 dies.

## Review
Cold-reader (dogfood) passes on the spec set, decision records, and components view plus a doctrine altitude audit ran pre-commit; all non-actionability findings applied, including the contacts-catalog closure the altitude pass surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)