### PR TITLE
fix(dispatch): make lease transitions atomic

### DIFF
--- a/docs/modules/server-core/dispatch.mdx
+++ b/docs/modules/server-core/dispatch.mdx
@@ -257,7 +257,7 @@ export interface EnqueueDispatchRequestArgs {
 }
 ```
 
-### [`LeaseInvalidError`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L162)
+### [`LeaseInvalidError`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L170)
 
 _Class_
 
@@ -280,7 +280,7 @@ surface a precise wire-error code, e.g. typed-CONSUMED /
 typed-EXPIRED) and `expected` carries the set of states the
 operation would have accepted.
 
-### [`LeaseRecord`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L131)
+### [`LeaseRecord`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L139)
 
 _Interface_
 
@@ -304,7 +304,7 @@ Snapshot of a lease for `app/dispatch/lease/get` and observability tests.
 Mirrors the wire `LeaseRecordSchema` shape; ISO-8601 timestamps for
 cross-boundary stability.
 
-### [`leaseRecordToWire`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L487)
+### [`leaseRecordToWire`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L536)
 
 _Function_
 
@@ -315,7 +315,7 @@ export function leaseRecordToWire(record: LeaseRecord): LeaseRecordWire
 Translation point between the in-process nested `LeaseRecord` and the wire
 `LeaseRecordSchema` shape.
 
-### [`LeaseRegistry`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L281)
+### [`LeaseRegistry`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L288)
 
 _Interface_
 
@@ -391,7 +391,7 @@ export interface LeaseRegistry {
    *   forked fiber catches and discards). No `agent/dispatch/released`
    *   notification fires (the recipient is gone).
    *
-   * - **GRANTED → EXPIRED-on-disconnect**: terminal state; emits
+   * - **GRANTED / HOLD → EXPIRED-on-disconnect**: terminal state; emits
    *   `app/dispatch/lease-expired` to the moderator. Cancels the post-grant TTL
    *   fiber. The recipient won't observe; the moderator's view stays
    *   consistent.
@@ -402,13 +402,12 @@ export interface LeaseRegistry {
    *   release-arm of the acquireUseRelease is responsible. Otherwise a
    *   committed durable row could be retried into a duplicate.
    *
-   * - **HOLD / DENIED / EXPIRED / ABANDONED / CONSUMED**: no-op (already
-   *   terminal-or-near-terminal; no recipient-binding work to do).
+   * - **DENIED / EXPIRED / ABANDONED / CONSUMED**: no-op (already terminal;
+   *   no recipient-binding work to do).
    *
-   * Errors are absorbed: connection-close cleanup is fire-and-forget;
-   * any per-lease transition failure is logged-and-dropped (the
-   * disconnect path must complete even if a single lease's state is
-   * unexpected). Public error channel is `never`.
+   * The matching transitions commit as one atomic batch. Notification
+   * failures are absorbed so disconnect cleanup always completes; the public
+   * error channel is `never`.
    */
   abandon(connId: ConnectionId): Effect.Effect<void, never, never>;
 
@@ -416,9 +415,11 @@ export interface LeaseRegistry {
    * Internal — record the forked moderator round-trip fiber so
    * {@link abandon} can interrupt it on recipient disconnect. The
    * caller forks the round-trip immediately after `mint`; the registry
-   * interrupts the fiber when the binding's recipient connection
-   * closes (PENDING → ABANDONED transition). No-op if the lease is no
-   * longer in PENDING when the fiber is attached. Idempotent.
+   * interrupts the fiber when the binding's recipient connection closes
+   * (PENDING → ABANDONED). If the child already resolved the lease, attachment
+   * leaves that winning child alive to finish its post-commit work. If the
+   * lease was abandoned or removed, attachment interrupts the orphaned child.
+   * Reattaching the same fiber is idempotent.
    */
   attachRoundTripFiber(
     leaseId: LeaseId,
@@ -439,13 +440,12 @@ export interface LeaseRegistry {
    * closed, so the cross-connection write SUSPENDS forever — inside the
    * uninterruptible region — and `Scope.close` blocks awaiting that
    * fiber. That is the teardown deadlock this method prevents.
-   *
 ```
 
 Public contract of the lease registry. One instance per server lifetime,
 shared by dispatch admission and message send. Backed by an in-process
-`Ref&lt;Map&lt;LeaseId, LeaseEntry>>` with per-lease TTL fibers — no DB row.
-State transitions are atomic via `Ref.modify`.
+`Ref&lt;LeaseRegistryData>` containing entries, dispatch index, and the closed
+flag — no DB row. State transitions are atomic via `Ref.modify`.
 
 Lease state machine (eight states; `LeaseState` in this file is the
 normative enumeration):
@@ -457,7 +457,6 @@ stateDiagram-v2
   PENDING --> DENIED : verdict deny
   PENDING --> HOLD : verdict hold
   PENDING --> ABANDONED : conn close
-  HOLD --> PENDING : retry on next inbound message in same conv
   GRANTED --> CLAIMED : agent/message/send claim
   GRANTED --> EXPIRED : TTL fires OR conn close
   HOLD --> EXPIRED : conn close
@@ -503,12 +502,12 @@ no-op. The CLAIMED no-op is load-bearing — without it, a recipient
 disconnect mid-insert could roll back a committed durable row,
 permitting a duplicate retry.
 
-Timer wheel / min-heap for TTLs runs on a single fiber; per-lease
-scheduler fibers are forbidden. Manifest TTLs come from the
-`dispatch_authorize` `{ kind: "hook", timeoutMs }` policy (moderator
-response) and the verdict's `leaseTimeoutMs` (post-grant lease).
+Each timed GRANTED lease owns one daemon TTL fiber. The fiber is bound to
+the immutable record version that created it, so a stale pre-rollback timer
+cannot expire a newer GRANTED epoch. The timeout comes from the grant
+verdict's `leaseTimeoutMs`.
 
-### [`LeaseRegistryDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L430)
+### [`LeaseRegistryDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L438)
 
 _Interface_
 
@@ -525,8 +524,8 @@ Constructor dependencies for the lease registry.
   helper to find the recipient and at `app/dispatch/lease-consumed` /
   `app/dispatch/lease-expired` emission to find the moderator's connection.
 - `leaseRetentionMs`: terminal-state retention window (CONSUMED /
-  DENIED / EXPIRED / ABANDONED). Live states (PENDING / GRANTED /
-  HOLD / CLAIMED) age out on their own TTLs.
+  DENIED / EXPIRED / ABANDONED). A GRANTED lease may separately carry the
+  verdict's `leaseTimeoutMs`.
 - `transitionObserver`: called at every transition that crosses the
   lease's "active for presence" boundary (PENDING → GRANTED, exits
   from GRANTED|CLAIMED). Feeds presence emission. **Required, not
@@ -568,7 +567,7 @@ export class LeaseRegistryTag extends Context.Tag("moltzap/LeaseRegistry")<
 >() {}
 ```
 
-### [`LeaseState`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L110)
+### [`LeaseState`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L118)
 
 _TypeAlias_
 
@@ -592,7 +591,7 @@ Discriminated state of a lease. The registry's `Ref.modify`
 transitions read this discriminator and reject illegal transitions
 with a typed error (see LeaseInvalidError).
 
-### [`LeaseVerdict`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L121)
+### [`LeaseVerdict`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L129)
 
 _TypeAlias_
 
@@ -618,7 +617,7 @@ Dispatch admission is only defined for app-bound, non-archived
 conversations. The success type deliberately has no non-app-bound arm, so
 downstream lease minting cannot accidentally handle one as a lease binding.
 
-### [`makeLeaseRegistry`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L1226)
+### [`makeLeaseRegistry`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L1421)
 
 _Function_
 
@@ -631,15 +630,13 @@ export function makeLeaseRegistry(
 Construct the registry. The constructor is the only public factory
 — `LeaseRegistry` is referenced as an interface from call sites.
 
-Implementation: a `Ref&lt;Map&lt;LeaseId, LeaseEntry>>` plus a per-lease
-scheduled TTL fiber (Effect-managed; safe to interrupt). Every state
-transition is a `Ref.modify` predicate that returns the new entry +
-a description of the side-effect (notification to emit, fiber to
-cancel). The side-effects run AFTER the predicate commits — so the
-state change is visible to concurrent readers before the
-notification fires, satisfying the "first writer wins" invariant.
+Implementation: one `Ref&lt;LeaseRegistryData>` atomically owns entries,
+dispatch index, and closed state. A narrow semaphore orders each state
+commit with its presence observer callback; network notifications and fiber
+interruption run after that critical section. A shared shutdown signal
+cancels parked notification and retention effects.
 
-### [`ModeratorBoundLeaseBinding`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L95)
+### [`ModeratorBoundLeaseBinding`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L103)
 
 _Interface_
 

--- a/docs/modules/server-core/dispatch.mdx
+++ b/docs/modules/server-core/dispatch.mdx
@@ -304,7 +304,7 @@ Snapshot of a lease for `app/dispatch/lease/get` and observability tests.
 Mirrors the wire `LeaseRecordSchema` shape; ISO-8601 timestamps for
 cross-boundary stability.
 
-### [`leaseRecordToWire`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L536)
+### [`leaseRecordToWire`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L526)
 
 _Function_
 
@@ -430,16 +430,16 @@ export interface LeaseRegistry {
    * Deterministic shutdown drain — invoked by `CoreApp.close`
    * (`core/app.ts -> closeCoreAppEffect`) BEFORE `Scope.close(appScope)`.
    *
-   * Closing the app scope interrupts every per-connection WebSocket fiber.
-   * Each interrupted fiber runs its disconnect cleanup
-   * (`MoltZapServer`/`moltzap/server-socket.ts` close cleanup) in an UNINTERRUPTIBLE
-   * `onExit` region, and that cleanup calls {@link abandon}. For a recipient
-   * connection holding a GRANTED lease, `abandon` emits a `app/dispatch/lease-expired`
-   * frame to the MODERATOR connection via {@link fireNotification}. When the
-   * moderator socket is being torn down concurrently its write-latch is
-   * closed, so the cross-connection write SUSPENDS forever — inside the
-   * uninterruptible region — and `Scope.close` blocks awaiting that
-   * fiber. That is the teardown deadlock this method prevents.
+   * Atomically closes and drains the registry, completes the shared signal
+   * observed by background notification and retention fibers, then interrupts
+   * live TTL and moderator round-trip fibers. No concurrent transition can
+   * repopulate the registry after the drain.
+   *
+   * Idempotent; safe to call when no leases are live. Error channel `never` —
+   * shutdown is best-effort.
+   */
+  shutdown(): Effect.Effect<void, never, never>;
+}
 ```
 
 Public contract of the lease registry. One instance per server lifetime,
@@ -507,7 +507,7 @@ the immutable record version that created it, so a stale pre-rollback timer
 cannot expire a newer GRANTED epoch. The timeout comes from the grant
 verdict's `leaseTimeoutMs`.
 
-### [`LeaseRegistryDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L438)
+### [`LeaseRegistryDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L428)
 
 _Interface_
 
@@ -617,7 +617,7 @@ Dispatch admission is only defined for app-bound, non-archived
 conversations. The success type deliberately has no non-app-bound arm, so
 downstream lease minting cannot accidentally handle one as a lease binding.
 
-### [`makeLeaseRegistry`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L1421)
+### [`makeLeaseRegistry`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/dispatch/lease-registry.ts#L1346)
 
 _Function_
 

--- a/docs/modules/server-core/network/presence.mdx
+++ b/docs/modules/server-core/network/presence.mdx
@@ -143,7 +143,7 @@ connections. Single source of truth for the lease-count-to-status
 mapping; walks `leasesByConn` and returns `working` for any non-zero
 count, else `online`.
 
-### [`LeaseTransitionObserver`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/network/presence/presence-types.ts#L162)
+### [`LeaseTransitionObserver`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/network/presence/presence-types.ts#L160)
 
 _Interface_
 
@@ -170,10 +170,8 @@ means GRANTED or CLAIMED — the two states that count toward
 This is the NARROW contract `LeaseRegistry` depends on. The registry
 sees only these two methods, not the full `PresenceService` surface.
 
-- `onLeaseActiveBegin` fires on `PENDING → GRANTED` only. `HOLD →
-  PENDING → GRANTED` (verdict re-try) eventually reaches GRANTED, at
-  which point this fires; the intermediate HOLD never enters the
-  active set.
+- `onLeaseActiveBegin` fires on `PENDING → GRANTED` only. `HOLD` is not
+  retried and never enters the active set.
 - `onLeaseActiveEnd` fires on the lease's first exit from
   GRANTED-or-CLAIMED into a terminal state — `CLAIMED → CONSUMED`,
   `GRANTED → EXPIRED` (TTL), `GRANTED → EXPIRED-on-disconnect`. A
@@ -195,7 +193,7 @@ ghost callbacks. The fast-reconnect race: agent A disconnects on
 threading, those callbacks would mutate against the surviving
 connection; the check makes them no-op audits instead.
 
-### [`noopLeaseTransitionObserver`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/network/presence/presence-types.ts#L184)
+### [`noopLeaseTransitionObserver`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/network/presence/presence-types.ts#L182)
 
 _Variable_
 
@@ -203,9 +201,9 @@ _Variable_
 export const noopLeaseTransitionObserver: LeaseTransitionObserver =
 ```
 
-Default observer used by `LeaseRegistry`'s `transitionObserver`
-when the registry is constructed without a presence service (e.g. in
-`lease-registry.test.ts` unit tests that do not exercise presence).
+Explicit no-op value for callers that do not exercise presence, such as
+`lease-registry.test.ts`. It is passed as the required
+`LeaseRegistry.transitionObserver`; the registry has no implicit default.
 
 The default discipline (Principle 4) is to have a value that does the
 right thing rather than a `null` branch every call site has to

--- a/packages/server/src/__tests__/integration/app/dispatch-flow/concurrency.test.ts
+++ b/packages/server/src/__tests__/integration/app/dispatch-flow/concurrency.test.ts
@@ -12,10 +12,7 @@
  * claim, sendInsert+commit, finalize|rollback)`.
  */
 import { it as effectIt } from "@effect/vitest";
-import {
-  DispatchRelease,
-  type LeaseId,
-} from "@moltzap/protocol/message/dispatch";
+import { DispatchRelease } from "@moltzap/protocol/message/dispatch";
 import type { AppManifest } from "@moltzap/protocol/identity";
 import type { ConversationId } from "@moltzap/protocol/conversation";
 import { Chunk, Duration, Effect, Either, Fiber, Stream } from "effect";
@@ -34,7 +31,6 @@ import {
   startDispatchFlowServer,
   stopDispatchFlowServer,
   waitForDispatchRelease,
-  type ConversationBinding,
 } from "./fixture.js";
 import {
   getKyselyDb,
@@ -157,20 +153,6 @@ function requestGrantedDispatchLease(
   });
 }
 
-function sendTwiceWithLease(
-  bob: ConnectedAgent,
-  binding: ConversationBinding,
-  leaseId: LeaseId,
-) {
-  return Effect.all(
-    [
-      sendMessageWithLease(bob, binding, leaseId, "first").pipe(Effect.either),
-      sendMessageWithLease(bob, binding, leaseId, "second").pipe(Effect.either),
-    ],
-    { concurrency: 2 },
-  );
-}
-
 function readMessageIds(conversationId: ConversationId) {
   return Effect.tryPromise(() =>
     getKyselyDb()
@@ -185,13 +167,18 @@ function sameLeaseSendsCommitExactlyOnce() {
   return Effect.gen(function* () {
     const { alice, bob } = yield* setupAgentPair();
     const { binding, leaseId } = yield* requestGrantedDispatchLease(alice, bob);
-    const outcomes = yield* sendTwiceWithLease(bob, binding, leaseId);
-    const successes = outcomes.flatMap(
-      Either.match({
-        onLeft: () => [],
-        onRight: (result) => [result],
-      }),
+    const outcomes = yield* Effect.all(
+      [
+        sendMessageWithLease(bob, binding, leaseId, "first").pipe(
+          Effect.either,
+        ),
+        sendMessageWithLease(bob, binding, leaseId, "second").pipe(
+          Effect.either,
+        ),
+      ],
+      { concurrency: 2 },
     );
+    const successes = outcomes.filter(Either.isRight);
 
     expect(successes).toHaveLength(1);
     expect(outcomes.filter(Either.isLeft)).toHaveLength(1);
@@ -202,11 +189,11 @@ function sameLeaseSendsCommitExactlyOnce() {
 
     const rows = yield* readMessageIds(binding.conversationId);
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.id).toBe(success.message.id);
+    expect(rows[0]?.id).toBe(success.right.message.id);
 
     const record = yield* readLeaseByLeaseId(leaseId);
     expect(record.state).toBe(DISPATCH_STATE_CONSUMED);
-    expect(record.consumedMessageId).toBe(success.message.id);
+    expect(record.consumedMessageId).toBe(success.right.message.id);
   });
 }
 

--- a/packages/server/src/__tests__/integration/app/dispatch-flow/concurrency.test.ts
+++ b/packages/server/src/__tests__/integration/app/dispatch-flow/concurrency.test.ts
@@ -12,28 +12,41 @@
  * claim, sendInsert+commit, finalize|rollback)`.
  */
 import { it as effectIt } from "@effect/vitest";
-import { DispatchRelease } from "@moltzap/protocol/message/dispatch";
+import {
+  DispatchRelease,
+  type LeaseId,
+} from "@moltzap/protocol/message/dispatch";
 import type { AppManifest } from "@moltzap/protocol/identity";
 import type { ConversationId } from "@moltzap/protocol/conversation";
-import { Chunk, Duration, Effect, Fiber, Stream } from "effect";
+import { Chunk, Duration, Effect, Either, Fiber, Stream } from "effect";
 import { afterAll, beforeAll, beforeEach, describe, expect } from "vitest";
 import {
   DISPATCH_RELEASE_TIMEOUT_MS,
   DISPATCH_REQUEST_CONCURRENCY,
+  DISPATCH_STATE_CONSUMED,
   attachDispatchAuthorizeHook,
   createConversationOnApp,
   createDispatchFlowFixture,
   MODERATED_HOOKS,
+  readLeaseByLeaseId,
   requestDispatch,
+  sendMessageWithLease,
   startDispatchFlowServer,
   stopDispatchFlowServer,
+  waitForDispatchRelease,
+  type ConversationBinding,
 } from "./fixture.js";
-import { setupAgentPair, type ConnectedAgent } from "../../helpers.js";
+import {
+  getKyselyDb,
+  setupAgentPair,
+  type ConnectedAgent,
+} from "../../helpers.js";
 
 const it = effectIt.live;
 
 const TEST_APP_ID = "00000000-0000-4000-8000-000000010001";
 const EXPECTED_HOOK_CALLS = 2;
+const LEASE_TTL_MS = 60_000;
 
 const TEST_APP_MANIFEST: AppManifest = {
   appId: TEST_APP_ID,
@@ -117,6 +130,86 @@ function sameConversationRequestsRunConcurrently() {
   });
 }
 
+function requestGrantedDispatchLease(
+  alice: ConnectedAgent,
+  bob: ConnectedAgent,
+) {
+  return Effect.gen(function* () {
+    fixture.setNextHookVerdict({
+      decision: "grant",
+      leaseTimeoutMs: LEASE_TTL_MS,
+    });
+    yield* attachDispatchAuthorizeHook(alice, fixture);
+    const binding = yield* createConversationOnApp(
+      alice,
+      bob,
+      TEST_APP_MANIFEST,
+    );
+    const releaseFiber = yield* waitForDispatchRelease(bob);
+    const ack = yield* requestDispatch(
+      bob,
+      binding.conversationId,
+      alice,
+      "same lease",
+    );
+    yield* Fiber.join(releaseFiber);
+    return { binding, leaseId: ack.leaseId };
+  });
+}
+
+function sendTwiceWithLease(
+  bob: ConnectedAgent,
+  binding: ConversationBinding,
+  leaseId: LeaseId,
+) {
+  return Effect.all(
+    [
+      sendMessageWithLease(bob, binding, leaseId, "first").pipe(Effect.either),
+      sendMessageWithLease(bob, binding, leaseId, "second").pipe(Effect.either),
+    ],
+    { concurrency: 2 },
+  );
+}
+
+function readMessageIds(conversationId: ConversationId) {
+  return Effect.tryPromise(() =>
+    getKyselyDb()
+      .selectFrom("messages")
+      .select("id")
+      .where("conversation_id", "=", conversationId)
+      .execute(),
+  );
+}
+
+function sameLeaseSendsCommitExactlyOnce() {
+  return Effect.gen(function* () {
+    const { alice, bob } = yield* setupAgentPair();
+    const { binding, leaseId } = yield* requestGrantedDispatchLease(alice, bob);
+    const outcomes = yield* sendTwiceWithLease(bob, binding, leaseId);
+    const successes = outcomes.flatMap(
+      Either.match({
+        onLeft: () => [],
+        onRight: (result) => [result],
+      }),
+    );
+
+    expect(successes).toHaveLength(1);
+    expect(outcomes.filter(Either.isLeft)).toHaveLength(1);
+    const success = successes[0];
+    if (success === undefined) {
+      return yield* Effect.dieMessage("expected one successful lease send");
+    }
+
+    const rows = yield* readMessageIds(binding.conversationId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(success.message.id);
+
+    const record = yield* readLeaseByLeaseId(leaseId);
+    expect(record.state).toBe(DISPATCH_STATE_CONSUMED);
+    expect(record.consumedMessageId).toBe(success.message.id);
+  });
+}
+
 describe("dispatch/* — concurrency", () => {
   it(
     "cross-conversation concurrency: two agent/dispatch/request in different (taskId, conversationId) run concurrently",
@@ -127,6 +220,12 @@ describe("dispatch/* — concurrency", () => {
   it(
     "same-conversation concurrency: two agent/dispatch/request in same (taskId, conversationId) run concurrently",
     sameConversationRequestsRunConcurrently,
+    25_000,
+  );
+
+  it(
+    "same-lease concurrency: exactly one message send commits",
+    sameLeaseSendsCommitExactlyOnce,
     25_000,
   );
 });

--- a/packages/server/src/core/app.ts
+++ b/packages/server/src/core/app.ts
@@ -226,28 +226,19 @@ function makeCoreAppApi(options: CoreAppApiOptions): CoreApp {
  * do not race the HTTP server teardown.
  *
  * `leaseRegistry.shutdown()` runs BEFORE `Scope.close(appScope)`:
- * closing the app scope interrupts every per-connection WS fiber, and each
- * runs its disconnect cleanup UNINTERRUPTIBLY. For a recipient holding a
- * GRANTED lease that cleanup emits a `app/dispatch/lease-expired` frame to the
- * moderator connection; when the moderator socket is torn down concurrently
- * the cross-connection write parks on its closed write-latch forever,
- * deadlocking `Scope.close`. Draining the registry first (fail-closed every
- * lease so notifications drop, interrupt the live TTL/round-trip fibers)
- * removes the parked write. See
+ * it atomically closes and drains lease state, stops background notification
+ * and retention work, and interrupts live TTL/moderator round-trip fibers.
+ * Later per-connection disconnect cleanup therefore observes an empty,
+ * closed registry and cannot schedule new lease work during scope teardown.
+ * See
  * `dispatch/lease-registry.ts → LeaseRegistry.shutdown`.
  */
 function closeCoreAppEffect(options: CoreAppApiOptions) {
   const { services } = options;
   return Effect.gen(function* () {
-    // Drain the lease runtime FIRST, before any socket teardown. Both
-    // the explicit `conn.socket.shutdown` loop below AND `Scope.close`'s
-    // interrupt of the WS fibers trigger each connection's disconnect cleanup
-    // (`MoltZapServer`/`moltzap/server-socket.ts -> leaseRegistry.abandon`),
-    // which for a recipient holding a GRANTED lease emits a cross-connection
-    // `app/dispatch/lease-expired` frame to the moderator. If the moderator socket is
-    // closing concurrently that write parks forever on its closed write-latch.
-    // Flipping the registry closed up front makes every such notification drop
-    // instead of park; it also interrupts the live TTL/round-trip fibers.
+    // Drain the lease runtime before socket teardown. Subsequent disconnect
+    // cleanup observes an empty, closed registry; background notification,
+    // retention, TTL, and moderator round-trip work is stopped first.
     yield* services.leaseRegistry.shutdown();
     yield* services.messageService.close();
     for (const conn of yield* services.connections.allConnections()) {

--- a/packages/server/src/dispatch/MODULE.md
+++ b/packages/server/src/dispatch/MODULE.md
@@ -299,7 +299,7 @@ Snapshot of a lease for `app/dispatch/lease/get` and observability tests.
 Mirrors the wire `LeaseRecordSchema` shape; ISO-8601 timestamps for
 cross-boundary stability.
 
-### [`leaseRecordToWire`](./lease-registry.ts#L536)
+### [`leaseRecordToWire`](./lease-registry.ts#L526)
 
 _Function_
 
@@ -425,16 +425,16 @@ export interface LeaseRegistry {
    * Deterministic shutdown drain — invoked by `CoreApp.close`
    * (`core/app.ts -> closeCoreAppEffect`) BEFORE `Scope.close(appScope)`.
    *
-   * Closing the app scope interrupts every per-connection WebSocket fiber.
-   * Each interrupted fiber runs its disconnect cleanup
-   * (`MoltZapServer`/`moltzap/server-socket.ts` close cleanup) in an UNINTERRUPTIBLE
-   * `onExit` region, and that cleanup calls {@link abandon}. For a recipient
-   * connection holding a GRANTED lease, `abandon` emits a `app/dispatch/lease-expired`
-   * frame to the MODERATOR connection via {@link fireNotification}. When the
-   * moderator socket is being torn down concurrently its write-latch is
-   * closed, so the cross-connection write SUSPENDS forever — inside the
-   * uninterruptible region — and `Scope.close` blocks awaiting that
-   * fiber. That is the teardown deadlock this method prevents.
+   * Atomically closes and drains the registry, completes the shared signal
+   * observed by background notification and retention fibers, then interrupts
+   * live TTL and moderator round-trip fibers. No concurrent transition can
+   * repopulate the registry after the drain.
+   *
+   * Idempotent; safe to call when no leases are live. Error channel `never` —
+   * shutdown is best-effort.
+   */
+  shutdown(): Effect.Effect<void, never, never>;
+}
 ```
 
 Public contract of the lease registry. One instance per server lifetime,
@@ -502,7 +502,7 @@ the immutable record version that created it, so a stale pre-rollback timer
 cannot expire a newer GRANTED epoch. The timeout comes from the grant
 verdict's `leaseTimeoutMs`.
 
-### [`LeaseRegistryDeps`](./lease-registry.ts#L438)
+### [`LeaseRegistryDeps`](./lease-registry.ts#L428)
 
 _Interface_
 
@@ -612,7 +612,7 @@ Dispatch admission is only defined for app-bound, non-archived
 conversations. The success type deliberately has no non-app-bound arm, so
 downstream lease minting cannot accidentally handle one as a lease binding.
 
-### [`makeLeaseRegistry`](./lease-registry.ts#L1421)
+### [`makeLeaseRegistry`](./lease-registry.ts#L1346)
 
 _Function_
 

--- a/packages/server/src/dispatch/MODULE.md
+++ b/packages/server/src/dispatch/MODULE.md
@@ -252,7 +252,7 @@ export interface EnqueueDispatchRequestArgs {
 }
 ```
 
-### [`LeaseInvalidError`](./lease-registry.ts#L162)
+### [`LeaseInvalidError`](./lease-registry.ts#L170)
 
 _Class_
 
@@ -275,7 +275,7 @@ surface a precise wire-error code, e.g. typed-CONSUMED /
 typed-EXPIRED) and `expected` carries the set of states the
 operation would have accepted.
 
-### [`LeaseRecord`](./lease-registry.ts#L131)
+### [`LeaseRecord`](./lease-registry.ts#L139)
 
 _Interface_
 
@@ -299,7 +299,7 @@ Snapshot of a lease for `app/dispatch/lease/get` and observability tests.
 Mirrors the wire `LeaseRecordSchema` shape; ISO-8601 timestamps for
 cross-boundary stability.
 
-### [`leaseRecordToWire`](./lease-registry.ts#L487)
+### [`leaseRecordToWire`](./lease-registry.ts#L536)
 
 _Function_
 
@@ -310,7 +310,7 @@ export function leaseRecordToWire(record: LeaseRecord): LeaseRecordWire
 Translation point between the in-process nested `LeaseRecord` and the wire
 `LeaseRecordSchema` shape.
 
-### [`LeaseRegistry`](./lease-registry.ts#L281)
+### [`LeaseRegistry`](./lease-registry.ts#L288)
 
 _Interface_
 
@@ -386,7 +386,7 @@ export interface LeaseRegistry {
    *   forked fiber catches and discards). No `agent/dispatch/released`
    *   notification fires (the recipient is gone).
    *
-   * - **GRANTED → EXPIRED-on-disconnect**: terminal state; emits
+   * - **GRANTED / HOLD → EXPIRED-on-disconnect**: terminal state; emits
    *   `app/dispatch/lease-expired` to the moderator. Cancels the post-grant TTL
    *   fiber. The recipient won't observe; the moderator's view stays
    *   consistent.
@@ -397,13 +397,12 @@ export interface LeaseRegistry {
    *   release-arm of the acquireUseRelease is responsible. Otherwise a
    *   committed durable row could be retried into a duplicate.
    *
-   * - **HOLD / DENIED / EXPIRED / ABANDONED / CONSUMED**: no-op (already
-   *   terminal-or-near-terminal; no recipient-binding work to do).
+   * - **DENIED / EXPIRED / ABANDONED / CONSUMED**: no-op (already terminal;
+   *   no recipient-binding work to do).
    *
-   * Errors are absorbed: connection-close cleanup is fire-and-forget;
-   * any per-lease transition failure is logged-and-dropped (the
-   * disconnect path must complete even if a single lease's state is
-   * unexpected). Public error channel is `never`.
+   * The matching transitions commit as one atomic batch. Notification
+   * failures are absorbed so disconnect cleanup always completes; the public
+   * error channel is `never`.
    */
   abandon(connId: ConnectionId): Effect.Effect<void, never, never>;
 
@@ -411,9 +410,11 @@ export interface LeaseRegistry {
    * Internal — record the forked moderator round-trip fiber so
    * {@link abandon} can interrupt it on recipient disconnect. The
    * caller forks the round-trip immediately after `mint`; the registry
-   * interrupts the fiber when the binding's recipient connection
-   * closes (PENDING → ABANDONED transition). No-op if the lease is no
-   * longer in PENDING when the fiber is attached. Idempotent.
+   * interrupts the fiber when the binding's recipient connection closes
+   * (PENDING → ABANDONED). If the child already resolved the lease, attachment
+   * leaves that winning child alive to finish its post-commit work. If the
+   * lease was abandoned or removed, attachment interrupts the orphaned child.
+   * Reattaching the same fiber is idempotent.
    */
   attachRoundTripFiber(
     leaseId: LeaseId,
@@ -434,13 +435,12 @@ export interface LeaseRegistry {
    * closed, so the cross-connection write SUSPENDS forever — inside the
    * uninterruptible region — and `Scope.close` blocks awaiting that
    * fiber. That is the teardown deadlock this method prevents.
-   *
 ```
 
 Public contract of the lease registry. One instance per server lifetime,
 shared by dispatch admission and message send. Backed by an in-process
-`Ref&lt;Map&lt;LeaseId, LeaseEntry>>` with per-lease TTL fibers — no DB row.
-State transitions are atomic via `Ref.modify`.
+`Ref&lt;LeaseRegistryData>` containing entries, dispatch index, and the closed
+flag — no DB row. State transitions are atomic via `Ref.modify`.
 
 Lease state machine (eight states; `LeaseState` in this file is the
 normative enumeration):
@@ -452,7 +452,6 @@ stateDiagram-v2
   PENDING --> DENIED : verdict deny
   PENDING --> HOLD : verdict hold
   PENDING --> ABANDONED : conn close
-  HOLD --> PENDING : retry on next inbound message in same conv
   GRANTED --> CLAIMED : agent/message/send claim
   GRANTED --> EXPIRED : TTL fires OR conn close
   HOLD --> EXPIRED : conn close
@@ -498,12 +497,12 @@ no-op. The CLAIMED no-op is load-bearing — without it, a recipient
 disconnect mid-insert could roll back a committed durable row,
 permitting a duplicate retry.
 
-Timer wheel / min-heap for TTLs runs on a single fiber; per-lease
-scheduler fibers are forbidden. Manifest TTLs come from the
-`dispatch_authorize` `{ kind: "hook", timeoutMs }` policy (moderator
-response) and the verdict's `leaseTimeoutMs` (post-grant lease).
+Each timed GRANTED lease owns one daemon TTL fiber. The fiber is bound to
+the immutable record version that created it, so a stale pre-rollback timer
+cannot expire a newer GRANTED epoch. The timeout comes from the grant
+verdict's `leaseTimeoutMs`.
 
-### [`LeaseRegistryDeps`](./lease-registry.ts#L430)
+### [`LeaseRegistryDeps`](./lease-registry.ts#L438)
 
 _Interface_
 
@@ -520,8 +519,8 @@ Constructor dependencies for the lease registry.
   helper to find the recipient and at `app/dispatch/lease-consumed` /
   `app/dispatch/lease-expired` emission to find the moderator's connection.
 - `leaseRetentionMs`: terminal-state retention window (CONSUMED /
-  DENIED / EXPIRED / ABANDONED). Live states (PENDING / GRANTED /
-  HOLD / CLAIMED) age out on their own TTLs.
+  DENIED / EXPIRED / ABANDONED). A GRANTED lease may separately carry the
+  verdict's `leaseTimeoutMs`.
 - `transitionObserver`: called at every transition that crosses the
   lease's "active for presence" boundary (PENDING → GRANTED, exits
   from GRANTED|CLAIMED). Feeds presence emission. **Required, not
@@ -563,7 +562,7 @@ export class LeaseRegistryTag extends Context.Tag("moltzap/LeaseRegistry")<
 >() {}
 ```
 
-### [`LeaseState`](./lease-registry.ts#L110)
+### [`LeaseState`](./lease-registry.ts#L118)
 
 _TypeAlias_
 
@@ -587,7 +586,7 @@ Discriminated state of a lease. The registry's `Ref.modify`
 transitions read this discriminator and reject illegal transitions
 with a typed error (see LeaseInvalidError).
 
-### [`LeaseVerdict`](./lease-registry.ts#L121)
+### [`LeaseVerdict`](./lease-registry.ts#L129)
 
 _TypeAlias_
 
@@ -613,7 +612,7 @@ Dispatch admission is only defined for app-bound, non-archived
 conversations. The success type deliberately has no non-app-bound arm, so
 downstream lease minting cannot accidentally handle one as a lease binding.
 
-### [`makeLeaseRegistry`](./lease-registry.ts#L1226)
+### [`makeLeaseRegistry`](./lease-registry.ts#L1421)
 
 _Function_
 
@@ -626,15 +625,13 @@ export function makeLeaseRegistry(
 Construct the registry. The constructor is the only public factory
 — `LeaseRegistry` is referenced as an interface from call sites.
 
-Implementation: a `Ref&lt;Map&lt;LeaseId, LeaseEntry>>` plus a per-lease
-scheduled TTL fiber (Effect-managed; safe to interrupt). Every state
-transition is a `Ref.modify` predicate that returns the new entry +
-a description of the side-effect (notification to emit, fiber to
-cancel). The side-effects run AFTER the predicate commits — so the
-state change is visible to concurrent readers before the
-notification fires, satisfying the "first writer wins" invariant.
+Implementation: one `Ref&lt;LeaseRegistryData>` atomically owns entries,
+dispatch index, and closed state. A narrow semaphore orders each state
+commit with its presence observer callback; network notifications and fiber
+interruption run after that critical section. A shared shutdown signal
+cancels parked notification and retention effects.
 
-### [`ModeratorBoundLeaseBinding`](./lease-registry.ts#L95)
+### [`ModeratorBoundLeaseBinding`](./lease-registry.ts#L103)
 
 _Interface_
 

--- a/packages/server/src/dispatch/lease-registry.test.ts
+++ b/packages/server/src/dispatch/lease-registry.test.ts
@@ -1,0 +1,293 @@
+import { it as effectIt } from "@effect/vitest";
+import type { RpcSerialization } from "@effect/rpc";
+import type { LeaseId } from "@moltzap/protocol/message/dispatch";
+import {
+  agentId,
+  appId,
+  connectionId,
+  conversationId,
+  messageId,
+  taskId,
+} from "@moltzap/protocol/testing";
+import {
+  Deferred,
+  Effect,
+  Either,
+  Exit,
+  Fiber,
+  Option,
+  TestClock,
+} from "effect";
+import { describe, expect } from "vitest";
+import type { LeaseTransitionObserver } from "../network/presence/presence-types.js";
+import { noopLeaseTransitionObserver } from "../network/presence/presence-types.js";
+import {
+  ConnectionManager,
+  type Originator,
+  type WebSocketRef,
+} from "../socket/connection.js";
+import {
+  makeLeaseRegistry,
+  type LeaseRegistry,
+  type ModeratorBoundLeaseBinding,
+} from "./lease-registry.js";
+
+const TEST_TTL_MS = 1_000;
+const OLD_TTL_ELAPSED_MS = 900;
+const OLD_TTL_REMAINING_MS = TEST_TTL_MS - OLD_TTL_ELAPSED_MS;
+const STATE_CLAIMED = "CLAIMED";
+const STATE_CONSUMED = "CONSUMED";
+const STATE_DENIED = "DENIED";
+const STATE_EXPIRED = "EXPIRED";
+const STATE_GRANTED = "GRANTED";
+const MESSAGE_ID = messageId("00000000-0000-4000-8000-00000000b737");
+
+const BINDING = {
+  _tag: "ModeratorBound",
+  recipientAgentId: agentId("00000000-0000-4000-8000-00000000a737"),
+  recipientConnectionId: connectionId("00000000-0000-4000-8000-00000000c737"),
+  moderatorConnectionId: connectionId("00000000-0000-4000-8000-00000000c738"),
+  conversationId: conversationId("00000000-0000-4000-8000-00000000d737"),
+  taskId: taskId("00000000-0000-4000-8000-00000000e737"),
+  appId: appId("00000000-0000-4000-8000-00000000f737"),
+} satisfies ModeratorBoundLeaseBinding;
+
+const it = effectIt.effect;
+
+function withRegistry<A, E>(
+  use: (registry: LeaseRegistry) => Effect.Effect<A, E, never>,
+  transitionObserver = noopLeaseTransitionObserver,
+  connections = new ConnectionManager(),
+): Effect.Effect<A, E, never> {
+  return Effect.gen(function* () {
+    const registry = yield* makeLeaseRegistry({
+      connections,
+      leaseRetentionMs: TEST_TTL_MS,
+      transitionObserver,
+    });
+    return yield* use(registry).pipe(Effect.ensuring(registry.shutdown()));
+  });
+}
+
+const unusedOriginatorOperation = () =>
+  Effect.dieMessage("unused test originator operation");
+
+function makeUnusedParser(): RpcSerialization.Parser {
+  const fail = () =>
+    Effect.runSync(Effect.dieMessage("unused test originator parser"));
+  return { decode: fail, encode: fail };
+}
+
+function hangingOriginator(notifyStarted: Deferred.Deferred<void>): Originator {
+  return {
+    call: unusedOriginatorOperation,
+    callback: unusedOriginatorOperation,
+    notify: () =>
+      Deferred.succeed(notifyStarted, void 0).pipe(
+        Effect.zipRight(Effect.never),
+      ),
+    sink: {
+      parser: makeUnusedParser(),
+      inject: unusedOriginatorOperation,
+    },
+  };
+}
+
+const UNUSED_SOCKET: WebSocketRef = {
+  write: () => Effect.void,
+  shutdown: Effect.void,
+};
+
+function mintLease(registry: LeaseRegistry): Effect.Effect<LeaseId> {
+  return registry.mint(BINDING).pipe(Effect.map(({ leaseId }) => leaseId));
+}
+
+function grantLease(registry: LeaseRegistry, leaseId: LeaseId) {
+  return registry.resolve(leaseId, {
+    _tag: "grant",
+    leaseTimeoutMs: TEST_TTL_MS,
+  });
+}
+
+function expectSingleWinner(
+  outcomes: ReadonlyArray<Either.Either<unknown, unknown>>,
+): void {
+  expect(outcomes.filter(Either.isRight)).toHaveLength(1);
+  expect(outcomes.filter(Either.isLeft)).toHaveLength(1);
+}
+
+function concurrentClaimsAreSingleUse() {
+  return withRegistry((registry) =>
+    Effect.gen(function* () {
+      const leaseId = yield* mintLease(registry);
+      yield* grantLease(registry, leaseId);
+      const outcomes = yield* Effect.all(
+        [
+          registry.claim(leaseId).pipe(Effect.either),
+          registry.claim(leaseId).pipe(Effect.either),
+        ],
+        { concurrency: 2 },
+      );
+      expectSingleWinner(outcomes);
+      expect(
+        (yield* registry.read({ _tag: "leaseId", value: leaseId })).state,
+      ).toBe(STATE_CLAIMED);
+    }),
+  );
+}
+
+function concurrentResolutionsAreSingleUse() {
+  return withRegistry((registry) =>
+    Effect.gen(function* () {
+      const leaseId = yield* mintLease(registry);
+      const outcomes = yield* Effect.all(
+        [
+          registry.resolve(leaseId, { _tag: "grant" }).pipe(Effect.either),
+          registry.resolve(leaseId, { _tag: "deny" }).pipe(Effect.either),
+        ],
+        { concurrency: 2 },
+      );
+      expectSingleWinner(outcomes);
+      const expectedState = Either.match(outcomes[0], {
+        onLeft: () => STATE_DENIED,
+        onRight: () => STATE_GRANTED,
+      });
+      expect(
+        (yield* registry.read({ _tag: "leaseId", value: leaseId })).state,
+      ).toBe(expectedState);
+    }),
+  );
+}
+
+function finalizeAndRollbackAreSingleUse() {
+  return withRegistry((registry) =>
+    Effect.gen(function* () {
+      const leaseId = yield* mintLease(registry);
+      yield* grantLease(registry, leaseId);
+      const claim = yield* registry.claim(leaseId);
+      const outcomes = yield* Effect.all(
+        [
+          claim.finalize(MESSAGE_ID).pipe(Effect.either),
+          claim.rollback.pipe(Effect.either),
+        ],
+        { concurrency: 2 },
+      );
+      expectSingleWinner(outcomes);
+      const expectedState = Either.match(outcomes[0], {
+        onLeft: () => STATE_GRANTED,
+        onRight: () => STATE_CONSUMED,
+      });
+      expect(
+        (yield* registry.read({ _tag: "leaseId", value: leaseId })).state,
+      ).toBe(expectedState);
+    }),
+  );
+}
+
+function resolveBeforeAttachStaysAlive() {
+  return Effect.gen(function* () {
+    const beginEntered = yield* Deferred.make<void>();
+    const releaseBegin = yield* Deferred.make<void>();
+    const observer: LeaseTransitionObserver = {
+      onLeaseActiveBegin: () =>
+        Deferred.succeed(beginEntered, void 0).pipe(
+          Effect.zipRight(Deferred.await(releaseBegin)),
+        ),
+      onLeaseActiveEnd: () => Effect.void,
+    };
+    return yield* withRegistry(
+      (registry) =>
+        asyncObserverScenario(registry, { beginEntered, releaseBegin }).pipe(
+          Effect.ensuring(Deferred.succeed(releaseBegin, void 0)),
+        ),
+      observer,
+    );
+  });
+}
+
+interface BeginGate {
+  readonly beginEntered: Deferred.Deferred<void>;
+  readonly releaseBegin: Deferred.Deferred<void>;
+}
+
+function asyncObserverScenario(registry: LeaseRegistry, gate: BeginGate) {
+  return Effect.gen(function* () {
+    const leaseId = yield* mintLease(registry);
+    const resolveFiber = yield* Effect.fork(grantLease(registry, leaseId));
+    yield* Deferred.await(gate.beginEntered);
+    yield* registry.attachRoundTripFiber(leaseId, resolveFiber);
+    const claimFiber = yield* Effect.fork(registry.claim(leaseId));
+    expect(Option.isNone(yield* Fiber.poll(claimFiber))).toBe(true);
+    yield* Deferred.succeed(gate.releaseBegin, void 0);
+    expect(Exit.isSuccess(yield* Fiber.await(resolveFiber))).toBe(true);
+    expect(Exit.isSuccess(yield* Fiber.await(claimFiber))).toBe(true);
+  });
+}
+
+function rollbackStartsANewTtlEpoch() {
+  return withRegistry((registry) =>
+    Effect.gen(function* () {
+      const leaseId = yield* mintLease(registry);
+      yield* grantLease(registry, leaseId);
+      yield* TestClock.adjust(OLD_TTL_ELAPSED_MS);
+      const claim = yield* registry.claim(leaseId);
+      yield* claim.rollback;
+      yield* TestClock.adjust(OLD_TTL_REMAINING_MS);
+      expect(
+        (yield* registry.read({ _tag: "leaseId", value: leaseId })).state,
+      ).toBe(STATE_GRANTED);
+      yield* TestClock.adjust(OLD_TTL_ELAPSED_MS);
+      expect(
+        (yield* registry.read({ _tag: "leaseId", value: leaseId })).state,
+      ).toBe(STATE_EXPIRED);
+    }),
+  );
+}
+
+function shutdownReleasesPendingNotifications() {
+  return Effect.gen(function* () {
+    const notifyStarted = yield* Deferred.make<void>();
+    const connections = new ConnectionManager();
+    yield* connections.addUnauthenticated(
+      BINDING.moderatorConnectionId,
+      UNUSED_SOCKET,
+      hangingOriginator(notifyStarted),
+    );
+    return yield* withRegistry(
+      (registry) =>
+        Effect.gen(function* () {
+          const leaseId = yield* mintLease(registry);
+          yield* grantLease(registry, leaseId);
+          const claim = yield* registry.claim(leaseId);
+          const finalizeFiber = yield* Effect.fork(claim.finalize(MESSAGE_ID));
+          yield* Deferred.await(notifyStarted);
+          yield* registry.shutdown();
+          const completed = yield* Fiber.await(finalizeFiber);
+          expect(Exit.isSuccess(completed)).toBe(true);
+        }),
+      noopLeaseTransitionObserver,
+      connections,
+    );
+  });
+}
+
+describe("LeaseRegistry", () => {
+  it("allows exactly one concurrent claim", concurrentClaimsAreSingleUse);
+  it(
+    "allows exactly one concurrent resolution",
+    concurrentResolutionsAreSingleUse,
+  );
+  it(
+    "allows exactly one finalize or rollback",
+    finalizeAndRollbackAreSingleUse,
+  );
+  it(
+    "keeps a fast resolver alive and orders activation",
+    resolveBeforeAttachStaysAlive,
+  );
+  it("starts a fresh TTL after rollback", rollbackStartsANewTtlEpoch);
+  it(
+    "releases pending notifications at shutdown",
+    shutdownReleasesPendingNotifications,
+  );
+});

--- a/packages/server/src/dispatch/lease-registry.test.ts
+++ b/packages/server/src/dispatch/lease-registry.test.ts
@@ -1,5 +1,5 @@
 import { it as effectIt } from "@effect/vitest";
-import type { RpcSerialization } from "@effect/rpc";
+import { RpcSerialization } from "@effect/rpc";
 import type { LeaseId } from "@moltzap/protocol/message/dispatch";
 import {
   agentId,
@@ -9,15 +9,7 @@ import {
   messageId,
   taskId,
 } from "@moltzap/protocol/testing";
-import {
-  Deferred,
-  Effect,
-  Either,
-  Exit,
-  Fiber,
-  Option,
-  TestClock,
-} from "effect";
+import { Deferred, Effect, Either, Fiber, Option, TestClock } from "effect";
 import { describe, expect } from "vitest";
 import type { LeaseTransitionObserver } from "../network/presence/presence-types.js";
 import { noopLeaseTransitionObserver } from "../network/presence/presence-types.js";
@@ -72,22 +64,20 @@ function withRegistry<A, E>(
 const unusedOriginatorOperation = () =>
   Effect.dieMessage("unused test originator operation");
 
-function makeUnusedParser(): RpcSerialization.Parser {
-  const fail = () =>
-    Effect.runSync(Effect.dieMessage("unused test originator parser"));
-  return { decode: fail, encode: fail };
-}
-
-function hangingOriginator(notifyStarted: Deferred.Deferred<void>): Originator {
+function hangingOriginator(
+  notifyStarted: Deferred.Deferred<void>,
+  notifyStopped: Deferred.Deferred<void>,
+): Originator {
   return {
     call: unusedOriginatorOperation,
     callback: unusedOriginatorOperation,
     notify: () =>
       Deferred.succeed(notifyStarted, void 0).pipe(
         Effect.zipRight(Effect.never),
+        Effect.ensuring(Deferred.succeed(notifyStopped, void 0)),
       ),
     sink: {
-      parser: makeUnusedParser(),
+      parser: RpcSerialization.jsonRpc().unsafeMake(),
       inject: unusedOriginatorOperation,
     },
   };
@@ -113,7 +103,17 @@ function expectSingleWinner(
   outcomes: ReadonlyArray<Either.Either<unknown, unknown>>,
 ): void {
   expect(outcomes.filter(Either.isRight)).toHaveLength(1);
-  expect(outcomes.filter(Either.isLeft)).toHaveLength(1);
+  const failures = outcomes.filter(Either.isLeft);
+  expect(failures).toHaveLength(1);
+  expect(failures[0]?.left).toMatchObject({ _tag: "LeaseInvalidError" });
+}
+
+function expectLeaseNotFound(result: Either.Either<unknown, unknown>): void {
+  Either.match(result, {
+    onLeft: (error) =>
+      expect(error).toMatchObject({ _tag: "LeaseNotFoundError" }),
+    onRight: () => expect.fail("expected retained lease to be removed"),
+  });
 }
 
 function concurrentClaimsAreSingleUse() {
@@ -219,8 +219,8 @@ function asyncObserverScenario(registry: LeaseRegistry, gate: BeginGate) {
     const claimFiber = yield* Effect.fork(registry.claim(leaseId));
     expect(Option.isNone(yield* Fiber.poll(claimFiber))).toBe(true);
     yield* Deferred.succeed(gate.releaseBegin, void 0);
-    expect(Exit.isSuccess(yield* Fiber.await(resolveFiber))).toBe(true);
-    expect(Exit.isSuccess(yield* Fiber.await(claimFiber))).toBe(true);
+    yield* Fiber.join(resolveFiber);
+    yield* Fiber.join(claimFiber);
   });
 }
 
@@ -231,7 +231,7 @@ function rollbackStartsANewTtlEpoch() {
       yield* grantLease(registry, leaseId);
       yield* TestClock.adjust(OLD_TTL_ELAPSED_MS);
       const claim = yield* registry.claim(leaseId);
-      yield* claim.rollback;
+      yield* claim.rollback.pipe(Effect.uninterruptible);
       yield* TestClock.adjust(OLD_TTL_REMAINING_MS);
       expect(
         (yield* registry.read({ _tag: "leaseId", value: leaseId })).state,
@@ -244,14 +244,15 @@ function rollbackStartsANewTtlEpoch() {
   );
 }
 
-function shutdownReleasesPendingNotifications() {
+function hangingNotificationDoesNotBlockFinalizeOrRetention() {
   return Effect.gen(function* () {
     const notifyStarted = yield* Deferred.make<void>();
+    const notifyStopped = yield* Deferred.make<void>();
     const connections = new ConnectionManager();
     yield* connections.addUnauthenticated(
       BINDING.moderatorConnectionId,
       UNUSED_SOCKET,
-      hangingOriginator(notifyStarted),
+      hangingOriginator(notifyStarted, notifyStopped),
     );
     return yield* withRegistry(
       (registry) =>
@@ -259,11 +260,18 @@ function shutdownReleasesPendingNotifications() {
           const leaseId = yield* mintLease(registry);
           yield* grantLease(registry, leaseId);
           const claim = yield* registry.claim(leaseId);
-          const finalizeFiber = yield* Effect.fork(claim.finalize(MESSAGE_ID));
+          const finalizeFiber = yield* Effect.fork(
+            claim.finalize(MESSAGE_ID).pipe(Effect.uninterruptible),
+          );
           yield* Deferred.await(notifyStarted);
+          yield* Fiber.join(finalizeFiber);
+          yield* TestClock.adjust(TEST_TTL_MS);
+          const retained = yield* registry
+            .read({ _tag: "leaseId", value: leaseId })
+            .pipe(Effect.either);
+          expectLeaseNotFound(retained);
           yield* registry.shutdown();
-          const completed = yield* Fiber.await(finalizeFiber);
-          expect(Exit.isSuccess(completed)).toBe(true);
+          yield* Deferred.await(notifyStopped);
         }),
       noopLeaseTransitionObserver,
       connections,
@@ -287,7 +295,7 @@ describe("LeaseRegistry", () => {
   );
   it("starts a fresh TTL after rollback", rollbackStartsANewTtlEpoch);
   it(
-    "releases pending notifications at shutdown",
-    shutdownReleasesPendingNotifications,
+    "does not let a hanging notification block finalize or retention",
+    hangingNotificationDoesNotBlockFinalizeOrRetention,
   );
 });

--- a/packages/server/src/dispatch/lease-registry.ts
+++ b/packages/server/src/dispatch/lease-registry.ts
@@ -395,21 +395,11 @@ export interface LeaseRegistry {
    * Deterministic shutdown drain — invoked by `CoreApp.close`
    * (`core/app.ts -> closeCoreAppEffect`) BEFORE `Scope.close(appScope)`.
    *
-   * Closing the app scope interrupts every per-connection WebSocket fiber.
-   * Each interrupted fiber runs its disconnect cleanup
-   * (`MoltZapServer`/`moltzap/server-socket.ts` close cleanup) in an UNINTERRUPTIBLE
-   * `onExit` region, and that cleanup calls {@link abandon}. For a recipient
-   * connection holding a GRANTED lease, `abandon` emits a `app/dispatch/lease-expired`
-   * frame to the MODERATOR connection via {@link fireNotification}. When the
-   * moderator socket is being torn down concurrently its write-latch is
-   * closed, so the cross-connection write SUSPENDS forever — inside the
-   * uninterruptible region — and `Scope.close` blocks awaiting that
-   * fiber. That is the teardown deadlock this method prevents.
+   * Atomically closes and drains the registry, completes the shared signal
+   * observed by background notification and retention fibers, then interrupts
+   * live TTL and moderator round-trip fibers. No concurrent transition can
+   * repopulate the registry after the drain.
    *
-   * `shutdown` breaks the deadlock at its source: it flips the registry into
-   * a closed state and completes a shared shutdown signal. New notifications
-   * drop, in-flight notifications and retention sleepers lose their race with
-   * that signal, and live TTL/round-trip fibers are interrupted.
    * Idempotent; safe to call when no leases are live. Error channel `never` —
    * shutdown is best-effort.
    */
@@ -610,11 +600,13 @@ function fireNotification<D extends AnyNotificationDefinition>(
   return Ref.get(state.dataRef).pipe(
     Effect.flatMap((data) => {
       if (data.closed) return Effect.void;
-      return Effect.raceFirst(
-        Effect.disconnect(
-          fireNotificationToConnection(state, connId, definition, params),
-        ),
-        Deferred.await(state.shutdownSignal),
+      return Effect.forkDaemon(
+        Effect.raceFirst(
+          Effect.disconnect(
+            fireNotificationToConnection(state, connId, definition, params),
+          ),
+          Deferred.await(state.shutdownSignal),
+        ).pipe(Effect.interruptible),
       ).pipe(Effect.asVoid);
     }),
   );
@@ -633,8 +625,8 @@ function fireNotificationToConnection<D extends AnyNotificationDefinition>(
           "lease-registry: target connection gone; dropping notification",
         ).pipe(Effect.annotateLogs({ connId }));
       }
-      // Fire the notification over the target connection's reverse client; the
-      // void result settles on the client's ack.
+      // The forked reverse-client effect settles on the client's ack; lease
+      // transitions never wait for that acknowledgement.
       return connOpt.value.originator
         .notify(definition, params)
         .pipe(
@@ -735,7 +727,7 @@ function scheduleRetention(
         Effect.flatMap(() => removeEntry(state, leaseId, dispatchId)),
       ),
       Deferred.await(state.shutdownSignal),
-    ),
+    ).pipe(Effect.interruptible),
   ).pipe(Effect.asVoid);
 }
 
@@ -743,14 +735,9 @@ function isTtlExpirableState(state: LeaseState): boolean {
   return state === "GRANTED";
 }
 
-function isDisconnectExpirableState(state: LeaseState): boolean {
-  return state === "GRANTED" || state === "HOLD";
-}
-
 interface ExpiredLeaseTransition {
   readonly record: LeaseRecord;
   readonly expiredAt: string;
-  readonly wasActive: boolean;
 }
 
 function observeLeaseActiveEnd(
@@ -771,14 +758,14 @@ function commitTtlExpiry(
   expectedRecord: LeaseRecord,
 ): Effect.Effect<ExpiredLeaseTransition | null, never, never> {
   const expiredAt = new Date().toISOString();
-  return modifyRegistry(state, (data) => {
+  return Ref.modify(state.dataRef, (data) => {
     const entry = data.entries.get(leaseId);
     if (
       !entry ||
       entry.record !== expectedRecord ||
       !isTtlExpirableState(entry.record.state)
     ) {
-      return [Either.right(null), data];
+      return [null, data];
     }
     const record: LeaseRecord = {
       ...entry.record,
@@ -790,14 +777,7 @@ function commitTtlExpiry(
       ttlFiber: null,
       roundTripFiber: null,
     };
-    return [
-      Either.right({
-        record,
-        expiredAt,
-        wasActive: entry.record.state === "GRANTED",
-      }),
-      withLeaseEntry(data, leaseId, nextEntry),
-    ];
+    return [{ record, expiredAt }, withLeaseEntry(data, leaseId, nextEntry)];
   });
 }
 
@@ -814,7 +794,7 @@ function expireLeaseFromTtl(
           leaseId,
           expectedRecord,
         );
-        if (committed?.wasActive) {
+        if (committed !== null) {
           yield* observeLeaseActiveEnd(state, leaseId, committed.record);
         }
         return committed;
@@ -822,40 +802,12 @@ function expireLeaseFromTtl(
     );
 
     if (transition === null) return;
+    yield* scheduleRetention(state, leaseId, transition.record.dispatchId);
     yield* emitDispatchLeaseExpired(
       state,
       transition.record,
       transition.expiredAt,
     );
-    yield* scheduleRetention(state, leaseId, transition.record.dispatchId);
-  });
-}
-
-function scheduleTtl(
-  state: LeaseRegistryState,
-  leaseId: LeaseId,
-  timeoutMs: number,
-  expectedRecord: LeaseRecord,
-): Effect.Effect<Fiber.RuntimeFiber<unknown, unknown>, never, never> {
-  return Effect.forkDaemon(
-    Effect.sleep(`${timeoutMs} millis`).pipe(
-      Effect.flatMap(() => expireLeaseFromTtl(state, leaseId, expectedRecord)),
-    ),
-  );
-}
-
-function attachTtlFiber(
-  state: LeaseRegistryState,
-  leaseId: LeaseId,
-  expectedRecord: LeaseRecord,
-  fiber: Fiber.RuntimeFiber<unknown, unknown>,
-): Effect.Effect<boolean, never, never> {
-  return Ref.modify(state.dataRef, (data) => {
-    const entry = data.entries.get(leaseId);
-    if (!entry || entry.record !== expectedRecord || entry.ttlFiber !== null) {
-      return [false, data];
-    }
-    return [true, withLeaseEntry(data, leaseId, { ...entry, ttlFiber: fiber })];
   });
 }
 
@@ -869,24 +821,28 @@ function scheduleTtlForEntry(
     return Effect.void;
   }
   return Effect.gen(function* () {
-    const fiber = yield* scheduleTtl(state, leaseId, timeoutMs, entry.record);
-    const attached = yield* attachTtlFiber(state, leaseId, entry.record, fiber);
+    const fiber = yield* Effect.forkDaemon(
+      Effect.sleep(`${timeoutMs} millis`).pipe(
+        Effect.flatMap(() => expireLeaseFromTtl(state, leaseId, entry.record)),
+        Effect.interruptible,
+      ),
+    );
+    const attached = yield* Ref.modify(state.dataRef, (data) => {
+      const current = data.entries.get(leaseId);
+      if (
+        !current ||
+        current.record !== entry.record ||
+        current.ttlFiber !== null
+      ) {
+        return [false, data];
+      }
+      return [
+        true,
+        withLeaseEntry(data, leaseId, { ...current, ttlFiber: fiber }),
+      ];
+    });
     if (!attached) yield* Fiber.interruptFork(fiber);
   });
-}
-
-function getExistingLeaseEntry(
-  state: LeaseRegistryState,
-  leaseId: LeaseId,
-): Effect.Effect<LeaseEntry, LeaseNotFoundError, never> {
-  return Ref.get(state.dataRef).pipe(
-    Effect.flatMap((data) => {
-      const entry = data.entries.get(leaseId);
-      return entry
-        ? Effect.succeed(entry)
-        : Effect.fail(leaseNotFound(leaseId, "leaseId"));
-    }),
-  );
 }
 
 function modifyClaimedEntry<A>(
@@ -942,13 +898,13 @@ function finalizeClaim(
       }),
     );
 
+    yield* scheduleRetention(state, leaseId, consumedRecord.dispatchId);
     yield* emitDispatchLeaseConsumed(
       state,
       consumedRecord,
       messageId,
       consumedAt,
     );
-    yield* scheduleRetention(state, leaseId, consumedRecord.dispatchId);
   });
 }
 
@@ -1078,7 +1034,6 @@ function resolveLease(
   verdict: LeaseVerdict,
 ): Effect.Effect<void, LeaseInvalidError | LeaseNotFoundError, never> {
   return Effect.gen(function* () {
-    const nextState = leaseStateForVerdict(verdict);
     const nextEntry = yield* state.transitionPermit.withPermits(1)(
       Effect.gen(function* () {
         const committed = yield* commitResolvedLease(state, leaseId, verdict);
@@ -1094,10 +1049,10 @@ function resolveLease(
     );
 
     yield* scheduleTtlForEntry(state, leaseId, nextEntry);
-    yield* emitDispatchRelease(state, nextEntry.record, verdict);
-    if (nextState === "DENIED") {
+    if (nextEntry.record.state === "DENIED") {
       yield* scheduleRetention(state, leaseId, nextEntry.record.dispatchId);
     }
+    yield* emitDispatchRelease(state, nextEntry.record, verdict);
   });
 }
 
@@ -1150,45 +1105,24 @@ function claimLease(
   });
 }
 
-function readLeaseByLeaseId(
-  state: LeaseRegistryState,
-  leaseId: LeaseId,
-): Effect.Effect<LeaseRecord, LeaseNotFoundError, never> {
-  return getExistingLeaseEntry(state, leaseId).pipe(
-    Effect.map((entry) => entry.record),
-  );
-}
-
-function readLeaseByDispatchId(
-  state: LeaseRegistryState,
-  dispatchId: DispatchId,
-): Effect.Effect<LeaseRecord, LeaseNotFoundError, never> {
-  return Effect.gen(function* () {
-    const data = yield* Ref.get(state.dataRef);
-    const leaseId = data.dispatchIndex.get(dispatchId);
-    if (!leaseId) {
-      return yield* Effect.fail(leaseNotFound(dispatchId, "dispatchId"));
-    }
-    const entry = data.entries.get(leaseId);
-    if (!entry) {
-      return yield* Effect.fail(leaseNotFound(dispatchId, "dispatchId"));
-    }
-    return entry.record;
-  });
-}
-
 function readLease(
   state: LeaseRegistryState,
   id:
     | { readonly _tag: "leaseId"; readonly value: LeaseId }
     | { readonly _tag: "dispatchId"; readonly value: DispatchId },
 ): Effect.Effect<LeaseRecord, LeaseNotFoundError, never> {
-  return id._tag === "leaseId"
-    ? readLeaseByLeaseId(state, id.value)
-    : readLeaseByDispatchId(state, id.value);
+  return Ref.get(state.dataRef).pipe(
+    Effect.flatMap((data) => {
+      const leaseId =
+        id._tag === "leaseId" ? id.value : data.dispatchIndex.get(id.value);
+      const entry =
+        leaseId === undefined ? undefined : data.entries.get(leaseId);
+      return entry
+        ? Effect.succeed(entry.record)
+        : Effect.fail(leaseNotFound(id.value, id._tag));
+    }),
+  );
 }
-
-type RoundTripAttachOutcome = "Attached" | "Cancel" | "Settled";
 
 function attachRoundTripFiberToLease(
   state: LeaseRegistryState,
@@ -1196,28 +1130,25 @@ function attachRoundTripFiberToLease(
   fiber: Fiber.RuntimeFiber<unknown, unknown>,
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
-    const outcome = yield* Ref.modify(
-      state.dataRef,
-      (data): readonly [RoundTripAttachOutcome, LeaseRegistryData] => {
-        const entry = data.entries.get(leaseId);
-        if (!entry || entry.record.state === "ABANDONED") {
-          return ["Cancel", data];
-        }
-        if (entry.record.state !== "PENDING") {
-          // The child can resolve before its parent attaches the handle. It must
-          // be allowed to finish post-commit work (presence, TTL, notification).
-          return ["Settled", data];
-        }
-        if (entry.roundTripFiber !== null) {
-          return [entry.roundTripFiber === fiber ? "Attached" : "Cancel", data];
-        }
-        return [
-          "Attached",
-          withLeaseEntry(data, leaseId, { ...entry, roundTripFiber: fiber }),
-        ];
-      },
-    );
-    if (outcome === "Cancel") yield* Fiber.interruptFork(fiber);
+    const shouldCancel = yield* Ref.modify(state.dataRef, (data) => {
+      const entry = data.entries.get(leaseId);
+      if (!entry || entry.record.state === "ABANDONED") {
+        return [true, data];
+      }
+      if (entry.record.state !== "PENDING") {
+        // The child can resolve before its parent attaches the handle. It must
+        // be allowed to finish post-commit work (presence, TTL, notification).
+        return [false, data];
+      }
+      if (entry.roundTripFiber !== null) {
+        return [entry.roundTripFiber !== fiber, data];
+      }
+      return [
+        false,
+        withLeaseEntry(data, leaseId, { ...entry, roundTripFiber: fiber }),
+      ];
+    });
+    if (shouldCancel) yield* Fiber.interruptFork(fiber);
   });
 }
 
@@ -1256,14 +1187,15 @@ function makeDisconnectTransition(
       roundTripFiber: entry.roundTripFiber,
     };
   }
-  if (!isDisconnectExpirableState(entry.record.state)) return null;
+  const wasActive = entry.record.state === "GRANTED";
+  if (!wasActive && entry.record.state !== "HOLD") return null;
   return {
     _tag: "Expired",
     leaseId,
     record: { ...entry.record, state: "EXPIRED", expiredAt: transitionedAt },
     expiredAt: transitionedAt,
     ttlFiber: entry.ttlFiber,
-    wasActive: entry.record.state === "GRANTED",
+    wasActive,
   };
 }
 
@@ -1295,20 +1227,6 @@ function commitDisconnectTransitions(
   });
 }
 
-function observeDisconnectTransitions(
-  state: LeaseRegistryState,
-  transitions: ReadonlyArray<DisconnectTransition>,
-): Effect.Effect<void, never, never> {
-  return Effect.forEach(
-    transitions,
-    (transition) =>
-      transition._tag === "Expired" && transition.wasActive
-        ? observeLeaseActiveEnd(state, transition.leaseId, transition.record)
-        : Effect.void,
-    { concurrency: 1, discard: true },
-  );
-}
-
 function runDisconnectTransition(
   state: LeaseRegistryState,
   transition: DisconnectTransition,
@@ -1318,25 +1236,21 @@ function runDisconnectTransition(
       if (transition.roundTripFiber) {
         yield* Fiber.interruptFork(transition.roundTripFiber);
       }
-      yield* scheduleRetention(
-        state,
-        transition.leaseId,
-        transition.record.dispatchId,
-      );
-      return;
+    } else {
+      if (transition.ttlFiber) yield* Fiber.interruptFork(transition.ttlFiber);
     }
-
-    if (transition.ttlFiber) yield* Fiber.interruptFork(transition.ttlFiber);
-    yield* emitDispatchLeaseExpired(
-      state,
-      transition.record,
-      transition.expiredAt,
-    );
     yield* scheduleRetention(
       state,
       transition.leaseId,
       transition.record.dispatchId,
     );
+    if (transition._tag === "Expired") {
+      yield* emitDispatchLeaseExpired(
+        state,
+        transition.record,
+        transition.expiredAt,
+      );
+    }
   });
 }
 
@@ -1348,7 +1262,18 @@ function abandonConnectionLeases(
     const transitions = yield* state.transitionPermit.withPermits(1)(
       Effect.gen(function* () {
         const committed = yield* commitDisconnectTransitions(state, connId);
-        yield* observeDisconnectTransitions(state, committed);
+        yield* Effect.forEach(
+          committed,
+          (transition) =>
+            transition._tag === "Expired" && transition.wasActive
+              ? observeLeaseActiveEnd(
+                  state,
+                  transition.leaseId,
+                  transition.record,
+                )
+              : Effect.void,
+          { concurrency: 1, discard: true },
+        );
         return committed;
       }),
     );

--- a/packages/server/src/dispatch/lease-registry.ts
+++ b/packages/server/src/dispatch/lease-registry.ts
@@ -1,4 +1,13 @@
-import { Data, Effect, Fiber, Option, Ref, Schema } from "effect";
+import {
+  Data,
+  Deferred,
+  Effect,
+  Either,
+  Fiber,
+  Option,
+  Ref,
+  Schema,
+} from "effect";
 import type { AgentId, AppId } from "@moltzap/protocol/identity";
 import type { ConnectionId } from "@moltzap/protocol/socket";
 import type { ConversationId, MessageId } from "@moltzap/protocol/conversation";
@@ -48,8 +57,8 @@ const decodeLeaseId = Schema.decodeUnknownSync(LeaseIdSchema);
  *           │                              │                       │
  *           │ resolve(deny)                │ TTL                   │ finalize(messageId)
  *           ├────────────▶ DENIED          ├────────────▶ EXPIRED  ├─────────────▶ CONSUMED
- *           │ resolve(hold)                │   ▲                   │
- *           ├────────────▶ HOLD ── TTL ────┘   │                   │ rollback
+ *           │ resolve(hold)                │                       │
+ *           ├────────────▶ HOLD            │                       │ rollback
  *           │ connection-close                 │                   └─────────────▶ GRANTED
  *           ├────────────▶ ABANDONED           │
  *           │ moderator timeout                │
@@ -59,9 +68,9 @@ const decodeLeaseId = Schema.decodeUnknownSync(LeaseIdSchema);
  *                                                              (terminal)
  * ```
  *
- * Note: HOLD inherits the same post-grant TTL as GRANTED — both age out
- * to EXPIRED. CLAIMED and terminal states (CONSUMED / DENIED / EXPIRED /
- * ABANDONED) skip TTL.
+ * Only a GRANTED lease carrying `leaseTimeoutMs` owns a TTL. HOLD has no
+ * timeout in the wire verdict and remains until recipient disconnect or
+ * registry shutdown. CLAIMED and terminal states skip TTL.
  *
  * Two load-bearing rules:
  *
@@ -83,8 +92,7 @@ const decodeLeaseId = Schema.decodeUnknownSync(LeaseIdSchema);
  *    create a duplicate message.
  *
  * Terminal states (CONSUMED / DENIED / EXPIRED / ABANDONED) age out
- * of the registry on the same `leaseRetentionMs` clock; HOLD inherits
- * the post-grant TTL.
+ * of the registry on the same `leaseRetentionMs` clock.
  */
 
 /**
@@ -197,8 +205,8 @@ interface Claim {
   readonly leaseId: LeaseId;
 
   /**
-   * CLAIMED → CONSUMED. Idempotent with respect to a successful durable
-   * insert — calling twice on the same handle is a typed defect.
+   * CLAIMED → CONSUMED. Calling twice on the same handle returns a typed
+   * `LeaseInvalidError` because the first call already left CLAIMED.
    */
   readonly finalize: (
     messageId: MessageId,
@@ -214,8 +222,8 @@ interface Claim {
 /**
  * Public contract of the lease registry. One instance per server lifetime,
  * shared by dispatch admission and message send. Backed by an in-process
- * `Ref&lt;Map&lt;LeaseId, LeaseEntry>>` with per-lease TTL fibers — no DB row.
- * State transitions are atomic via `Ref.modify`.
+ * `Ref&lt;LeaseRegistryData>` containing entries, dispatch index, and the closed
+ * flag — no DB row. State transitions are atomic via `Ref.modify`.
  *
  * Lease state machine (eight states; `LeaseState` in this file is the
  * normative enumeration):
@@ -227,7 +235,6 @@ interface Claim {
  *   PENDING --> DENIED : verdict deny
  *   PENDING --> HOLD : verdict hold
  *   PENDING --> ABANDONED : conn close
- *   HOLD --> PENDING : retry on next inbound message in same conv
  *   GRANTED --> CLAIMED : agent/message/send claim
  *   GRANTED --> EXPIRED : TTL fires OR conn close
  *   HOLD --> EXPIRED : conn close
@@ -273,10 +280,10 @@ interface Claim {
  * disconnect mid-insert could roll back a committed durable row,
  * permitting a duplicate retry.
  *
- * Timer wheel / min-heap for TTLs runs on a single fiber; per-lease
- * scheduler fibers are forbidden. Manifest TTLs come from the
- * `dispatch_authorize` `{ kind: "hook", timeoutMs }` policy (moderator
- * response) and the verdict's `leaseTimeoutMs` (post-grant lease).
+ * Each timed GRANTED lease owns one daemon TTL fiber. The fiber is bound to
+ * the immutable record version that created it, so a stale pre-rollback timer
+ * cannot expire a newer GRANTED epoch. The timeout comes from the grant
+ * verdict's `leaseTimeoutMs`.
  */
 export interface LeaseRegistry {
   /**
@@ -349,7 +356,7 @@ export interface LeaseRegistry {
    *   forked fiber catches and discards). No `agent/dispatch/released`
    *   notification fires (the recipient is gone).
    *
-   * - **GRANTED → EXPIRED-on-disconnect**: terminal state; emits
+   * - **GRANTED / HOLD → EXPIRED-on-disconnect**: terminal state; emits
    *   `app/dispatch/lease-expired` to the moderator. Cancels the post-grant TTL
    *   fiber. The recipient won't observe; the moderator's view stays
    *   consistent.
@@ -360,13 +367,12 @@ export interface LeaseRegistry {
    *   release-arm of the acquireUseRelease is responsible. Otherwise a
    *   committed durable row could be retried into a duplicate.
    *
-   * - **HOLD / DENIED / EXPIRED / ABANDONED / CONSUMED**: no-op (already
-   *   terminal-or-near-terminal; no recipient-binding work to do).
+   * - **DENIED / EXPIRED / ABANDONED / CONSUMED**: no-op (already terminal;
+   *   no recipient-binding work to do).
    *
-   * Errors are absorbed: connection-close cleanup is fire-and-forget;
-   * any per-lease transition failure is logged-and-dropped (the
-   * disconnect path must complete even if a single lease's state is
-   * unexpected). Public error channel is `never`.
+   * The matching transitions commit as one atomic batch. Notification
+   * failures are absorbed so disconnect cleanup always completes; the public
+   * error channel is `never`.
    */
   abandon(connId: ConnectionId): Effect.Effect<void, never, never>;
 
@@ -374,9 +380,11 @@ export interface LeaseRegistry {
    * Internal — record the forked moderator round-trip fiber so
    * {@link abandon} can interrupt it on recipient disconnect. The
    * caller forks the round-trip immediately after `mint`; the registry
-   * interrupts the fiber when the binding's recipient connection
-   * closes (PENDING → ABANDONED transition). No-op if the lease is no
-   * longer in PENDING when the fiber is attached. Idempotent.
+   * interrupts the fiber when the binding's recipient connection closes
+   * (PENDING → ABANDONED). If the child already resolved the lease, attachment
+   * leaves that winning child alive to finish its post-commit work. If the
+   * lease was abandoned or removed, attachment interrupts the orphaned child.
+   * Reattaching the same fiber is idempotent.
    */
   attachRoundTripFiber(
     leaseId: LeaseId,
@@ -399,9 +407,9 @@ export interface LeaseRegistry {
    * fiber. That is the teardown deadlock this method prevents.
    *
    * `shutdown` breaks the deadlock at its source: it flips the registry into
-   * a closed state so {@link fireNotification} drops (rather than parks on) every
-   * subsequent cross-connection notification, and it interrupts the live
-   * per-lease TTL/round-trip fibers so none survive into `Scope.close`.
+   * a closed state and completes a shared shutdown signal. New notifications
+   * drop, in-flight notifications and retention sleepers lose their race with
+   * that signal, and live TTL/round-trip fibers are interrupted.
    * Idempotent; safe to call when no leases are live. Error channel `never` —
    * shutdown is best-effort.
    */
@@ -414,8 +422,8 @@ export interface LeaseRegistry {
  *   helper to find the recipient and at `app/dispatch/lease-consumed` /
  *   `app/dispatch/lease-expired` emission to find the moderator's connection.
  * - `leaseRetentionMs`: terminal-state retention window (CONSUMED /
- *   DENIED / EXPIRED / ABANDONED). Live states (PENDING / GRANTED /
- *   HOLD / CLAIMED) age out on their own TTLs.
+ *   DENIED / EXPIRED / ABANDONED). A GRANTED lease may separately carry the
+ *   verdict's `leaseTimeoutMs`.
  * - `transitionObserver`: called at every transition that crosses the
  *   lease's "active for presence" boundary (PENDING → GRANTED, exits
  *   from GRANTED|CLAIMED). Feeds presence emission. **Required, not
@@ -453,15 +461,56 @@ interface LeaseEntry {
   readonly roundTripFiber: Fiber.RuntimeFiber<unknown, unknown> | null;
 }
 
-function setReadonlyMapValue<K, V>(
-  key: K,
-  value: V,
-): (map: ReadonlyMap<K, V>) => ReadonlyMap<K, V> {
-  return (map) => {
-    const next = new Map(map);
-    next.set(key, value);
-    return next;
-  };
+interface LeaseRegistryData {
+  readonly entries: ReadonlyMap<LeaseId, LeaseEntry>;
+  readonly dispatchIndex: ReadonlyMap<DispatchId, LeaseId>;
+
+  /**
+   * Set by {@link shutdownRegistry} at `CoreApp.close`. Once `true`, new
+   * registry state cannot be repopulated and notifications are dropped.
+   */
+  readonly closed: boolean;
+}
+
+interface LeaseRegistryState {
+  readonly deps: LeaseRegistryDeps;
+  readonly dataRef: Ref.Ref<LeaseRegistryData>;
+  /** Cancels in-flight notification and retention effects at shutdown. */
+  readonly shutdownSignal: Deferred.Deferred<void>;
+
+  /**
+   * `Ref.modify` makes each state change atomic. This permit additionally
+   * serializes a state commit with its presence observer callback, preventing
+   * a concurrent begin/end transition from overtaking that callback. Network
+   * notifications and fiber interruption stay outside the permit.
+   */
+  readonly transitionPermit: Effect.Semaphore;
+}
+
+function withLeaseEntry(
+  data: LeaseRegistryData,
+  leaseId: LeaseId,
+  entry: LeaseEntry,
+): LeaseRegistryData {
+  const entries = new Map(data.entries);
+  entries.set(leaseId, entry);
+  return { ...data, entries };
+}
+
+function modifyRegistry<A, E>(
+  state: LeaseRegistryState,
+  transition: (
+    data: LeaseRegistryData,
+  ) => readonly [Either.Either<A, E>, LeaseRegistryData],
+): Effect.Effect<A, E, never> {
+  return Ref.modify(state.dataRef, transition).pipe(
+    Effect.flatMap(
+      Either.match({
+        onLeft: (error) => Effect.fail(error),
+        onRight: (value) => Effect.succeed(value),
+      }),
+    ),
+  );
 }
 
 function leaseStateForVerdict(verdict: LeaseVerdict): LeaseState {
@@ -533,24 +582,6 @@ function leaseVerdictToWire(
   }
 }
 
-interface LeaseRegistryState {
-  readonly deps: LeaseRegistryDeps;
-  readonly entriesRef: Ref.Ref<ReadonlyMap<LeaseId, LeaseEntry>>;
-  readonly dispatchIndexRef: Ref.Ref<ReadonlyMap<DispatchId, LeaseId>>;
-
-  /**
-   * Set by {@link shutdownRegistry} at `CoreApp.close`. Once `true`,
-   * {@link fireNotification} drops cross-connection notifications instead of
-   * parking on a dead peer's closed write-latch — see {@link LeaseRegistry.shutdown}.
-   */
-  readonly closedRef: Ref.Ref<boolean>;
-}
-
-interface LeaseConnectionTarget {
-  readonly leaseId: LeaseId;
-  readonly entry: LeaseEntry;
-}
-
 function leaseNotFound(
   id: LeaseId | DispatchId,
   kind: "leaseId" | "dispatchId",
@@ -576,12 +607,16 @@ function fireNotification<D extends AnyNotificationDefinition>(
   // Once the registry is shutting down, every connection is being torn down
   // concurrently. Drop the notification deterministically — no consumer
   // remains at shutdown.
-  return Ref.get(state.closedRef).pipe(
-    Effect.flatMap((closed) =>
-      closed
-        ? Effect.void
-        : fireNotificationToConnection(state, connId, definition, params),
-    ),
+  return Ref.get(state.dataRef).pipe(
+    Effect.flatMap((data) => {
+      if (data.closed) return Effect.void;
+      return Effect.raceFirst(
+        Effect.disconnect(
+          fireNotificationToConnection(state, connId, definition, params),
+        ),
+        Deferred.await(state.shutdownSignal),
+      ).pipe(Effect.asVoid);
+    }),
   );
 }
 
@@ -673,35 +708,20 @@ function emitDispatchLeaseExpired(
   );
 }
 
-function replaceEntry(
-  state: LeaseRegistryState,
-  leaseId: LeaseId,
-  next: LeaseEntry,
-): Effect.Effect<void, never, never> {
-  return Ref.update(state.entriesRef, (m) => {
-    const out = new Map(m);
-    out.set(leaseId, next);
-    return out;
-  });
-}
-
 function removeEntry(
   state: LeaseRegistryState,
   leaseId: LeaseId,
   dispatchId: DispatchId,
 ): Effect.Effect<void, never, never> {
-  return Effect.zip(
-    Ref.update(state.entriesRef, (m) => {
-      const out = new Map(m);
-      out.delete(leaseId);
-      return out;
-    }),
-    Ref.update(state.dispatchIndexRef, (m) => {
-      const out = new Map(m);
-      out.delete(dispatchId);
-      return out;
-    }),
-  ).pipe(Effect.asVoid);
+  return Ref.update(state.dataRef, (data) => {
+    const entry = data.entries.get(leaseId);
+    if (!entry || entry.record.dispatchId !== dispatchId) return data;
+    const entries = new Map(data.entries);
+    const dispatchIndex = new Map(data.dispatchIndex);
+    entries.delete(leaseId);
+    dispatchIndex.delete(dispatchId);
+    return { ...data, entries, dispatchIndex };
+  });
 }
 
 function scheduleRetention(
@@ -710,48 +730,104 @@ function scheduleRetention(
   dispatchId: DispatchId,
 ): Effect.Effect<void, never, never> {
   return Effect.forkDaemon(
-    Effect.sleep(`${state.deps.leaseRetentionMs} millis`).pipe(
-      Effect.flatMap(() => removeEntry(state, leaseId, dispatchId)),
+    Effect.raceFirst(
+      Effect.sleep(`${state.deps.leaseRetentionMs} millis`).pipe(
+        Effect.flatMap(() => removeEntry(state, leaseId, dispatchId)),
+      ),
+      Deferred.await(state.shutdownSignal),
     ),
   ).pipe(Effect.asVoid);
 }
 
 function isTtlExpirableState(state: LeaseState): boolean {
+  return state === "GRANTED";
+}
+
+function isDisconnectExpirableState(state: LeaseState): boolean {
   return state === "GRANTED" || state === "HOLD";
+}
+
+interface ExpiredLeaseTransition {
+  readonly record: LeaseRecord;
+  readonly expiredAt: string;
+  readonly wasActive: boolean;
+}
+
+function observeLeaseActiveEnd(
+  state: LeaseRegistryState,
+  leaseId: LeaseId,
+  record: LeaseRecord,
+): Effect.Effect<void, never, never> {
+  return state.deps.transitionObserver.onLeaseActiveEnd(
+    leaseId,
+    record.binding.recipientAgentId,
+    record.binding.recipientConnectionId,
+  );
+}
+
+function commitTtlExpiry(
+  state: LeaseRegistryState,
+  leaseId: LeaseId,
+  expectedRecord: LeaseRecord,
+): Effect.Effect<ExpiredLeaseTransition | null, never, never> {
+  const expiredAt = new Date().toISOString();
+  return modifyRegistry(state, (data) => {
+    const entry = data.entries.get(leaseId);
+    if (
+      !entry ||
+      entry.record !== expectedRecord ||
+      !isTtlExpirableState(entry.record.state)
+    ) {
+      return [Either.right(null), data];
+    }
+    const record: LeaseRecord = {
+      ...entry.record,
+      state: "EXPIRED",
+      expiredAt,
+    };
+    const nextEntry: LeaseEntry = {
+      record,
+      ttlFiber: null,
+      roundTripFiber: null,
+    };
+    return [
+      Either.right({
+        record,
+        expiredAt,
+        wasActive: entry.record.state === "GRANTED",
+      }),
+      withLeaseEntry(data, leaseId, nextEntry),
+    ];
+  });
 }
 
 function expireLeaseFromTtl(
   state: LeaseRegistryState,
   leaseId: LeaseId,
+  expectedRecord: LeaseRecord,
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
-    const current = yield* Ref.get(state.entriesRef);
-    const entry = current.get(leaseId);
-    if (!entry || !isTtlExpirableState(entry.record.state)) return;
-    // Capture the pre-expire state so we know whether to fire the
-    // active-end observer call. GRANTED is in the active set; HOLD never
-    // entered it.
-    const wasActive = entry.record.state === "GRANTED";
-    const expiredAt = new Date().toISOString();
-    const nextRecord: LeaseRecord = {
-      ...entry.record,
-      state: "EXPIRED",
-      expiredAt,
-    };
-    yield* replaceEntry(state, leaseId, {
-      record: nextRecord,
-      ttlFiber: null,
-      roundTripFiber: null,
-    });
-    yield* emitDispatchLeaseExpired(state, nextRecord, expiredAt);
-    yield* scheduleRetention(state, leaseId, nextRecord.dispatchId);
-    if (wasActive) {
-      yield* state.deps.transitionObserver.onLeaseActiveEnd(
-        leaseId,
-        nextRecord.binding.recipientAgentId,
-        nextRecord.binding.recipientConnectionId,
-      );
-    }
+    const transition = yield* state.transitionPermit.withPermits(1)(
+      Effect.gen(function* () {
+        const committed = yield* commitTtlExpiry(
+          state,
+          leaseId,
+          expectedRecord,
+        );
+        if (committed?.wasActive) {
+          yield* observeLeaseActiveEnd(state, leaseId, committed.record);
+        }
+        return committed;
+      }),
+    );
+
+    if (transition === null) return;
+    yield* emitDispatchLeaseExpired(
+      state,
+      transition.record,
+      transition.expiredAt,
+    );
+    yield* scheduleRetention(state, leaseId, transition.record.dispatchId);
   });
 }
 
@@ -759,21 +835,53 @@ function scheduleTtl(
   state: LeaseRegistryState,
   leaseId: LeaseId,
   timeoutMs: number,
+  expectedRecord: LeaseRecord,
 ): Effect.Effect<Fiber.RuntimeFiber<unknown, unknown>, never, never> {
   return Effect.forkDaemon(
     Effect.sleep(`${timeoutMs} millis`).pipe(
-      Effect.flatMap(() => expireLeaseFromTtl(state, leaseId)),
+      Effect.flatMap(() => expireLeaseFromTtl(state, leaseId, expectedRecord)),
     ),
   );
+}
+
+function attachTtlFiber(
+  state: LeaseRegistryState,
+  leaseId: LeaseId,
+  expectedRecord: LeaseRecord,
+  fiber: Fiber.RuntimeFiber<unknown, unknown>,
+): Effect.Effect<boolean, never, never> {
+  return Ref.modify(state.dataRef, (data) => {
+    const entry = data.entries.get(leaseId);
+    if (!entry || entry.record !== expectedRecord || entry.ttlFiber !== null) {
+      return [false, data];
+    }
+    return [true, withLeaseEntry(data, leaseId, { ...entry, ttlFiber: fiber })];
+  });
+}
+
+function scheduleTtlForEntry(
+  state: LeaseRegistryState,
+  leaseId: LeaseId,
+  entry: LeaseEntry,
+): Effect.Effect<void, never, never> {
+  const timeoutMs = entry.record.leaseTimeoutMs;
+  if (timeoutMs === null || !isTtlExpirableState(entry.record.state)) {
+    return Effect.void;
+  }
+  return Effect.gen(function* () {
+    const fiber = yield* scheduleTtl(state, leaseId, timeoutMs, entry.record);
+    const attached = yield* attachTtlFiber(state, leaseId, entry.record, fiber);
+    if (!attached) yield* Fiber.interruptFork(fiber);
+  });
 }
 
 function getExistingLeaseEntry(
   state: LeaseRegistryState,
   leaseId: LeaseId,
 ): Effect.Effect<LeaseEntry, LeaseNotFoundError, never> {
-  return Ref.get(state.entriesRef).pipe(
-    Effect.flatMap((entries) => {
-      const entry = entries.get(leaseId);
+  return Ref.get(state.dataRef).pipe(
+    Effect.flatMap((data) => {
+      const entry = data.entries.get(leaseId);
       return entry
         ? Effect.succeed(entry)
         : Effect.fail(leaseNotFound(leaseId, "leaseId"));
@@ -781,37 +889,25 @@ function getExistingLeaseEntry(
   );
 }
 
-function assertLeaseState(
-  leaseId: LeaseId,
-  state: LeaseState,
-  expected: ReadonlyArray<LeaseState>,
-  operation: LeaseInvalidError["operation"],
-): Effect.Effect<void, LeaseInvalidError, never> {
-  return expected.includes(state)
-    ? Effect.void
-    : Effect.fail(invalidLeaseState(leaseId, state, expected, operation));
-}
-
-function getClaimedEntry(
+function modifyClaimedEntry<A>(
   state: LeaseRegistryState,
   leaseId: LeaseId,
   operation: "finalize" | "rollback",
-): Effect.Effect<LeaseEntry, LeaseInvalidError, never> {
-  return Effect.gen(function* () {
-    const current = yield* Ref.get(state.entriesRef);
-    const entry = current.get(leaseId);
-    if (!entry) {
-      return yield* Effect.fail(
-        invalidLeaseState(leaseId, "EXPIRED", ["CLAIMED"], operation),
-      );
+  transition: (entry: LeaseEntry) => readonly [A, LeaseEntry],
+): Effect.Effect<A, LeaseInvalidError, never> {
+  return modifyRegistry(state, (data) => {
+    const entry = data.entries.get(leaseId);
+    const currentState = entry?.record.state ?? "EXPIRED";
+    if (!entry || currentState !== "CLAIMED") {
+      return [
+        Either.left(
+          invalidLeaseState(leaseId, currentState, ["CLAIMED"], operation),
+        ),
+        data,
+      ];
     }
-    yield* assertLeaseState(
-      leaseId,
-      entry.record.state,
-      ["CLAIMED"],
-      operation,
-    );
-    return entry;
+    const [value, nextEntry] = transition(entry);
+    return [Either.right(value), withLeaseEntry(data, leaseId, nextEntry)];
   });
 }
 
@@ -821,19 +917,31 @@ function finalizeClaim(
   messageId: MessageId,
 ): Effect.Effect<void, LeaseInvalidError, never> {
   return Effect.gen(function* () {
-    const entry = yield* getClaimedEntry(state, leaseId, "finalize");
     const consumedAt = new Date().toISOString();
-    const consumedRecord: LeaseRecord = {
-      ...entry.record,
-      state: "CONSUMED",
-      consumedAt,
-      consumedMessageId: messageId,
-    };
-    yield* replaceEntry(state, leaseId, {
-      record: consumedRecord,
-      ttlFiber: null,
-      roundTripFiber: null,
-    });
+    const consumedRecord = yield* state.transitionPermit.withPermits(1)(
+      Effect.gen(function* () {
+        const record = yield* modifyClaimedEntry(
+          state,
+          leaseId,
+          "finalize",
+          (entry) => {
+            const consumed: LeaseRecord = {
+              ...entry.record,
+              state: "CONSUMED",
+              consumedAt,
+              consumedMessageId: messageId,
+            };
+            return [
+              consumed,
+              { record: consumed, ttlFiber: null, roundTripFiber: null },
+            ];
+          },
+        );
+        yield* observeLeaseActiveEnd(state, leaseId, record);
+        return record;
+      }),
+    );
+
     yield* emitDispatchLeaseConsumed(
       state,
       consumedRecord,
@@ -841,26 +949,7 @@ function finalizeClaim(
       consumedAt,
     );
     yield* scheduleRetention(state, leaseId, consumedRecord.dispatchId);
-    // CLAIMED → CONSUMED exits the active set; fire onLeaseActiveEnd so
-    // the presence service re-derives the recipient's status (working →
-    // online if this was the last active lease).
-    yield* state.deps.transitionObserver.onLeaseActiveEnd(
-      leaseId,
-      consumedRecord.binding.recipientAgentId,
-      consumedRecord.binding.recipientConnectionId,
-    );
   });
-}
-
-function rescheduleRollbackTtl(
-  state: LeaseRegistryState,
-  leaseId: LeaseId,
-  entry: LeaseEntry,
-): Effect.Effect<Fiber.RuntimeFiber<unknown, unknown> | null, never, never> {
-  if (entry.record.leaseTimeoutMs === null) {
-    return Effect.succeed(null);
-  }
-  return scheduleTtl(state, leaseId, entry.record.leaseTimeoutMs);
 }
 
 function rollbackClaim(
@@ -868,13 +957,17 @@ function rollbackClaim(
   leaseId: LeaseId,
 ): Effect.Effect<void, LeaseInvalidError, never> {
   return Effect.gen(function* () {
-    const entry = yield* getClaimedEntry(state, leaseId, "rollback");
-    const ttlFiber = yield* rescheduleRollbackTtl(state, leaseId, entry);
-    yield* replaceEntry(state, leaseId, {
-      record: { ...entry.record, state: "GRANTED" },
-      ttlFiber,
-      roundTripFiber: null,
-    });
+    const grantedEntry = yield* state.transitionPermit.withPermits(1)(
+      modifyClaimedEntry(state, leaseId, "rollback", (entry) => {
+        const nextEntry: LeaseEntry = {
+          record: { ...entry.record, state: "GRANTED" },
+          ttlFiber: null,
+          roundTripFiber: null,
+        };
+        return [nextEntry, nextEntry];
+      }),
+    );
+    yield* scheduleTtlForEntry(state, leaseId, grantedEntry);
   });
 }
 
@@ -921,25 +1014,62 @@ function mintLease(
       new Date().toISOString(),
     );
     const entry: LeaseEntry = { record, ttlFiber: null, roundTripFiber: null };
-    yield* Ref.update(state.entriesRef, setReadonlyMapValue(leaseId, entry));
-    yield* Ref.update(
-      state.dispatchIndexRef,
-      setReadonlyMapValue(dispatchId, leaseId),
-    );
+    const inserted = yield* Ref.modify(state.dataRef, (data) => {
+      if (data.closed) return [false, data];
+      const entries = new Map(data.entries);
+      const dispatchIndex = new Map(data.dispatchIndex);
+      entries.set(leaseId, entry);
+      dispatchIndex.set(dispatchId, leaseId);
+      return [true, { ...data, entries, dispatchIndex }];
+    });
+    if (!inserted) return yield* Effect.interrupt;
     return { leaseId, dispatchId };
   });
 }
 
-function scheduleResolvedTtl(
+function commitResolvedLease(
   state: LeaseRegistryState,
   leaseId: LeaseId,
-  leaseState: LeaseState,
-  timeoutMs: number | null,
-): Effect.Effect<Fiber.RuntimeFiber<unknown, unknown> | null, never, never> {
-  if (timeoutMs === null || !isTtlExpirableState(leaseState)) {
-    return Effect.succeed(null);
-  }
-  return scheduleTtl(state, leaseId, timeoutMs);
+  verdict: LeaseVerdict,
+): Effect.Effect<LeaseEntry, LeaseInvalidError | LeaseNotFoundError, never> {
+  return modifyRegistry<LeaseEntry, LeaseInvalidError | LeaseNotFoundError>(
+    state,
+    (data) => {
+      const entry = data.entries.get(leaseId);
+      if (!entry) {
+        return [Either.left(leaseNotFound(leaseId, "leaseId")), data];
+      }
+      if (entry.record.state !== "PENDING") {
+        return [
+          Either.left(
+            invalidLeaseState(
+              leaseId,
+              entry.record.state,
+              ["PENDING"],
+              "resolve",
+            ),
+          ),
+          data,
+        ];
+      }
+      const record: LeaseRecord = {
+        ...entry.record,
+        state: leaseStateForVerdict(verdict),
+        verdict,
+        resolvedAt: new Date().toISOString(),
+        leaseTimeoutMs: leaseTimeoutForVerdict(verdict),
+      };
+      const resolvedEntry: LeaseEntry = {
+        record,
+        ttlFiber: null,
+        roundTripFiber: null,
+      };
+      return [
+        Either.right(resolvedEntry),
+        withLeaseEntry(data, leaseId, resolvedEntry),
+      ];
+    },
+  );
 }
 
 function resolveLease(
@@ -948,53 +1078,62 @@ function resolveLease(
   verdict: LeaseVerdict,
 ): Effect.Effect<void, LeaseInvalidError | LeaseNotFoundError, never> {
   return Effect.gen(function* () {
-    const entry = yield* getExistingLeaseEntry(state, leaseId);
-    yield* assertLeaseState(
-      leaseId,
-      entry.record.state,
-      ["PENDING"],
-      "resolve",
-    );
     const nextState = leaseStateForVerdict(verdict);
-    const leaseTimeoutMs = leaseTimeoutForVerdict(verdict);
-    const nextRecord: LeaseRecord = {
-      ...entry.record,
-      state: nextState,
-      verdict,
-      resolvedAt: new Date().toISOString(),
-      leaseTimeoutMs,
-    };
-    const ttlFiber = yield* scheduleResolvedTtl(
-      state,
-      leaseId,
-      nextState,
-      leaseTimeoutMs,
+    const nextEntry = yield* state.transitionPermit.withPermits(1)(
+      Effect.gen(function* () {
+        const committed = yield* commitResolvedLease(state, leaseId, verdict);
+        if (committed.record.state === "GRANTED") {
+          yield* state.deps.transitionObserver.onLeaseActiveBegin(
+            leaseId,
+            committed.record.binding.recipientAgentId,
+            committed.record.binding.recipientConnectionId,
+          );
+        }
+        return committed;
+      }),
     );
-    yield* replaceEntry(state, leaseId, {
-      record: nextRecord,
-      ttlFiber,
-      roundTripFiber: null,
-    });
-    // GRANTED enters the active set. The begin callback fires before
-    // emitDispatchRelease because that helper awaits an inline socket
-    // write, which is a suspension window the forked TTL fiber can wake
-    // inside (leaseTimeoutMs minimum is 1ms). If the TTL fiber observed
-    // GRANTED and fired onLeaseActiveEnd before begin ran, the end would
-    // no-op on a not-yet-present lease and presence would strand at
-    // working. Firing begin first — on this fiber, before any await —
-    // guarantees the active-set add precedes any TTL-driven end. DENIED /
-    // HOLD do NOT enter the active set; no observer call.
-    if (nextState === "GRANTED") {
-      yield* state.deps.transitionObserver.onLeaseActiveBegin(
-        leaseId,
-        nextRecord.binding.recipientAgentId,
-        nextRecord.binding.recipientConnectionId,
-      );
-    }
-    yield* emitDispatchRelease(state, nextRecord, verdict);
+
+    yield* scheduleTtlForEntry(state, leaseId, nextEntry);
+    yield* emitDispatchRelease(state, nextEntry.record, verdict);
     if (nextState === "DENIED") {
-      yield* scheduleRetention(state, leaseId, nextRecord.dispatchId);
+      yield* scheduleRetention(state, leaseId, nextEntry.record.dispatchId);
     }
+  });
+}
+
+function commitClaimedLease(
+  state: LeaseRegistryState,
+  leaseId: LeaseId,
+): Effect.Effect<
+  Fiber.RuntimeFiber<unknown, unknown> | null,
+  LeaseInvalidError | LeaseNotFoundError,
+  never
+> {
+  return modifyRegistry<
+    Fiber.RuntimeFiber<unknown, unknown> | null,
+    LeaseInvalidError | LeaseNotFoundError
+  >(state, (data) => {
+    const entry = data.entries.get(leaseId);
+    if (!entry) {
+      return [Either.left(leaseNotFound(leaseId, "leaseId")), data];
+    }
+    if (entry.record.state !== "GRANTED") {
+      return [
+        Either.left(
+          invalidLeaseState(leaseId, entry.record.state, ["GRANTED"], "claim"),
+        ),
+        data,
+      ];
+    }
+    const claimedEntry: LeaseEntry = {
+      record: { ...entry.record, state: "CLAIMED" },
+      ttlFiber: null,
+      roundTripFiber: null,
+    };
+    return [
+      Either.right(entry.ttlFiber),
+      withLeaseEntry(data, leaseId, claimedEntry),
+    ];
   });
 }
 
@@ -1003,16 +1142,10 @@ function claimLease(
   leaseId: LeaseId,
 ): Effect.Effect<Claim, LeaseInvalidError | LeaseNotFoundError, never> {
   return Effect.gen(function* () {
-    const entry = yield* getExistingLeaseEntry(state, leaseId);
-    yield* assertLeaseState(leaseId, entry.record.state, ["GRANTED"], "claim");
-    if (entry.ttlFiber) {
-      yield* Fiber.interrupt(entry.ttlFiber);
-    }
-    yield* replaceEntry(state, leaseId, {
-      record: { ...entry.record, state: "CLAIMED" },
-      ttlFiber: null,
-      roundTripFiber: null,
-    });
+    const ttlFiber = yield* state.transitionPermit.withPermits(1)(
+      commitClaimedLease(state, leaseId),
+    );
+    if (ttlFiber) yield* Fiber.interruptFork(ttlFiber);
     return makeClaim(state, leaseId);
   });
 }
@@ -1031,13 +1164,12 @@ function readLeaseByDispatchId(
   dispatchId: DispatchId,
 ): Effect.Effect<LeaseRecord, LeaseNotFoundError, never> {
   return Effect.gen(function* () {
-    const dispatchIndex = yield* Ref.get(state.dispatchIndexRef);
-    const leaseId = dispatchIndex.get(dispatchId);
+    const data = yield* Ref.get(state.dataRef);
+    const leaseId = data.dispatchIndex.get(dispatchId);
     if (!leaseId) {
       return yield* Effect.fail(leaseNotFound(dispatchId, "dispatchId"));
     }
-    const entries = yield* Ref.get(state.entriesRef);
-    const entry = entries.get(leaseId);
+    const entry = data.entries.get(leaseId);
     if (!entry) {
       return yield* Effect.fail(leaseNotFound(dispatchId, "dispatchId"));
     }
@@ -1056,106 +1188,156 @@ function readLease(
     : readLeaseByDispatchId(state, id.value);
 }
 
+type RoundTripAttachOutcome = "Attached" | "Cancel" | "Settled";
+
 function attachRoundTripFiberToLease(
   state: LeaseRegistryState,
   leaseId: LeaseId,
   fiber: Fiber.RuntimeFiber<unknown, unknown>,
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
-    const entries = yield* Ref.get(state.entriesRef);
-    const entry = entries.get(leaseId);
-    if (!entry || entry.record.state !== "PENDING") return;
-    yield* replaceEntry(state, leaseId, { ...entry, roundTripFiber: fiber });
+    const outcome = yield* Ref.modify(
+      state.dataRef,
+      (data): readonly [RoundTripAttachOutcome, LeaseRegistryData] => {
+        const entry = data.entries.get(leaseId);
+        if (!entry || entry.record.state === "ABANDONED") {
+          return ["Cancel", data];
+        }
+        if (entry.record.state !== "PENDING") {
+          // The child can resolve before its parent attaches the handle. It must
+          // be allowed to finish post-commit work (presence, TTL, notification).
+          return ["Settled", data];
+        }
+        if (entry.roundTripFiber !== null) {
+          return [entry.roundTripFiber === fiber ? "Attached" : "Cancel", data];
+        }
+        return [
+          "Attached",
+          withLeaseEntry(data, leaseId, { ...entry, roundTripFiber: fiber }),
+        ];
+      },
+    );
+    if (outcome === "Cancel") yield* Fiber.interruptFork(fiber);
   });
 }
 
-function leaseTargetsForConnection(
-  entries: ReadonlyMap<LeaseId, LeaseEntry>,
+type DisconnectTransition =
+  | {
+      readonly _tag: "Abandoned";
+      readonly leaseId: LeaseId;
+      readonly record: LeaseRecord;
+      readonly roundTripFiber: Fiber.RuntimeFiber<unknown, unknown> | null;
+    }
+  | {
+      readonly _tag: "Expired";
+      readonly leaseId: LeaseId;
+      readonly record: LeaseRecord;
+      readonly expiredAt: string;
+      readonly ttlFiber: Fiber.RuntimeFiber<unknown, unknown> | null;
+      readonly wasActive: boolean;
+    };
+
+function makeDisconnectTransition(
   connId: ConnectionId,
-): ReadonlyArray<LeaseConnectionTarget> {
-  return Array.from(entries, ([leaseId, entry]) => ({
+  leaseId: LeaseId,
+  entry: LeaseEntry,
+  transitionedAt: string,
+): DisconnectTransition | null {
+  if (entry.record.binding.recipientConnectionId !== connId) return null;
+  if (entry.record.state === "PENDING") {
+    return {
+      _tag: "Abandoned",
+      leaseId,
+      record: {
+        ...entry.record,
+        state: "ABANDONED",
+        resolvedAt: transitionedAt,
+      },
+      roundTripFiber: entry.roundTripFiber,
+    };
+  }
+  if (!isDisconnectExpirableState(entry.record.state)) return null;
+  return {
+    _tag: "Expired",
     leaseId,
-    entry,
-  })).filter(
-    ({ entry }) => entry.record.binding.recipientConnectionId === connId,
+    record: { ...entry.record, state: "EXPIRED", expiredAt: transitionedAt },
+    expiredAt: transitionedAt,
+    ttlFiber: entry.ttlFiber,
+    wasActive: entry.record.state === "GRANTED",
+  };
+}
+
+function commitDisconnectTransitions(
+  state: LeaseRegistryState,
+  connId: ConnectionId,
+): Effect.Effect<ReadonlyArray<DisconnectTransition>, never, never> {
+  const transitionedAt = new Date().toISOString();
+  return Ref.modify(state.dataRef, (data) => {
+    const entries = new Map(data.entries);
+    const actions: Array<DisconnectTransition> = [];
+    for (const [leaseId, entry] of data.entries) {
+      const action = makeDisconnectTransition(
+        connId,
+        leaseId,
+        entry,
+        transitionedAt,
+      );
+      if (action !== null) {
+        actions.push(action);
+        entries.set(leaseId, {
+          record: action.record,
+          ttlFiber: null,
+          roundTripFiber: null,
+        });
+      }
+    }
+    return [actions, actions.length === 0 ? data : { ...data, entries }];
+  });
+}
+
+function observeDisconnectTransitions(
+  state: LeaseRegistryState,
+  transitions: ReadonlyArray<DisconnectTransition>,
+): Effect.Effect<void, never, never> {
+  return Effect.forEach(
+    transitions,
+    (transition) =>
+      transition._tag === "Expired" && transition.wasActive
+        ? observeLeaseActiveEnd(state, transition.leaseId, transition.record)
+        : Effect.void,
+    { concurrency: 1, discard: true },
   );
 }
 
-function abandonPendingLease(
+function runDisconnectTransition(
   state: LeaseRegistryState,
-  target: LeaseConnectionTarget,
+  transition: DisconnectTransition,
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
-    const { leaseId, entry } = target;
-    const abandonedRecord: LeaseRecord = {
-      ...entry.record,
-      state: "ABANDONED",
-      resolvedAt: new Date().toISOString(),
-    };
-    yield* replaceEntry(state, leaseId, {
-      record: abandonedRecord,
-      ttlFiber: null,
-      roundTripFiber: null,
-    });
-    const roundTripFiber = entry.roundTripFiber;
-    if (roundTripFiber) {
-      yield* Fiber.interruptFork(roundTripFiber);
-    }
-    yield* scheduleRetention(state, leaseId, abandonedRecord.dispatchId);
-  });
-}
-
-function expireLeaseOnDisconnect(
-  state: LeaseRegistryState,
-  target: LeaseConnectionTarget,
-): Effect.Effect<void, never, never> {
-  return Effect.gen(function* () {
-    const { leaseId, entry } = target;
-    const ttlFiber = entry.ttlFiber;
-    if (ttlFiber) {
-      yield* Fiber.interruptFork(ttlFiber);
-    }
-    // Capture the pre-expire state to decide whether to fire the
-    // active-end observer call. The disconnect-driven expiry handles
-    // GRANTED (active set) AND CLAIMED (also active); the presence
-    // service's connId-mismatch guard handles the fast-reconnect race so
-    // this callback is safe to fire even after the agent has reconnected
-    // on a new connId.
-    const wasActive =
-      entry.record.state === "GRANTED" || entry.record.state === "CLAIMED";
-    const expiredAt = new Date().toISOString();
-    const expiredRecord: LeaseRecord = {
-      ...entry.record,
-      state: "EXPIRED",
-      expiredAt,
-    };
-    yield* replaceEntry(state, leaseId, {
-      record: expiredRecord,
-      ttlFiber: null,
-      roundTripFiber: null,
-    });
-    yield* emitDispatchLeaseExpired(state, expiredRecord, expiredAt);
-    yield* scheduleRetention(state, leaseId, expiredRecord.dispatchId);
-    if (wasActive) {
-      yield* state.deps.transitionObserver.onLeaseActiveEnd(
-        leaseId,
-        expiredRecord.binding.recipientAgentId,
-        expiredRecord.binding.recipientConnectionId,
+    if (transition._tag === "Abandoned") {
+      if (transition.roundTripFiber) {
+        yield* Fiber.interruptFork(transition.roundTripFiber);
+      }
+      yield* scheduleRetention(
+        state,
+        transition.leaseId,
+        transition.record.dispatchId,
       );
+      return;
     }
-  });
-}
 
-function abandonLeaseForConnection(
-  state: LeaseRegistryState,
-  target: LeaseConnectionTarget,
-): Effect.Effect<void, never, never> {
-  const leaseState = target.entry.record.state;
-  if (leaseState === "PENDING") return abandonPendingLease(state, target);
-  if (isTtlExpirableState(leaseState)) {
-    return expireLeaseOnDisconnect(state, target);
-  }
-  return Effect.void;
+    if (transition.ttlFiber) yield* Fiber.interruptFork(transition.ttlFiber);
+    yield* emitDispatchLeaseExpired(
+      state,
+      transition.record,
+      transition.expiredAt,
+    );
+    yield* scheduleRetention(
+      state,
+      transition.leaseId,
+      transition.record.dispatchId,
+    );
+  });
 }
 
 function abandonConnectionLeases(
@@ -1163,11 +1345,16 @@ function abandonConnectionLeases(
   connId: ConnectionId,
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
-    const entries = yield* Ref.get(state.entriesRef);
-    const targets = leaseTargetsForConnection(entries, connId);
+    const transitions = yield* state.transitionPermit.withPermits(1)(
+      Effect.gen(function* () {
+        const committed = yield* commitDisconnectTransitions(state, connId);
+        yield* observeDisconnectTransitions(state, committed);
+        return committed;
+      }),
+    );
     yield* Effect.forEach(
-      targets,
-      (target) => abandonLeaseForConnection(state, target),
+      transitions,
+      (transition) => runDisconnectTransition(state, transition),
       { concurrency: 1, discard: true },
     );
   }).pipe(Effect.asVoid);
@@ -1176,26 +1363,36 @@ function abandonConnectionLeases(
 /**
  * Drain the registry at app shutdown (see {@link LeaseRegistry.shutdown}).
  *
- * Order matters: flip `closedRef` FIRST so any disconnect-driven
- * {@link fireNotification} that races this (the WS-interruption cascade may already
- * be running) drops instead of parking on a dead peer. Then snapshot the live
- * entries, clear them, and interrupt the per-lease TTL + round-trip fibers so
- * none survive into `Scope.close(appScope)`. `Fiber.interruptFork` is
- * fire-and-forget — shutdown itself never blocks on an interrupt completing.
+ * The closed flag, entries, and dispatch index change in one atomic update.
+ * Any concurrent registry transition therefore linearizes entirely before or
+ * after shutdown; no writer can repopulate a partially drained registry.
+ * `Fiber.interruptFork` is fire-and-forget, so shutdown never blocks on an
+ * interrupt completing.
  */
 function shutdownRegistry(
   state: LeaseRegistryState,
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
-    yield* Ref.set(state.closedRef, true);
-    const entries = yield* Ref.getAndSet(state.entriesRef, new Map());
-    yield* Ref.set(state.dispatchIndexRef, new Map());
+    const entries = yield* state.transitionPermit.withPermits(1)(
+      Effect.gen(function* () {
+        const drained = yield* Ref.modify(state.dataRef, (data) => [
+          data.entries,
+          {
+            entries: new Map(),
+            dispatchIndex: new Map(),
+            closed: true,
+          },
+        ]);
+        yield* Deferred.succeed(state.shutdownSignal, void 0);
+        return drained;
+      }),
+    );
     for (const entry of entries.values()) {
       if (entry.ttlFiber) yield* Fiber.interruptFork(entry.ttlFiber);
       if (entry.roundTripFiber)
         yield* Fiber.interruptFork(entry.roundTripFiber);
     }
-  }).pipe(Effect.withSpan("leaseRegistry.shutdown"));
+  }).pipe(Effect.uninterruptible, Effect.withSpan("leaseRegistry.shutdown"));
 }
 
 function makeLeaseRegistryFromState(state: LeaseRegistryState): LeaseRegistry {
@@ -1215,30 +1412,28 @@ function makeLeaseRegistryFromState(state: LeaseRegistryState): LeaseRegistry {
  * Construct the registry. The constructor is the only public factory
  * — `LeaseRegistry` is referenced as an interface from call sites.
  *
- * Implementation: a `Ref&lt;Map&lt;LeaseId, LeaseEntry>>` plus a per-lease
- * scheduled TTL fiber (Effect-managed; safe to interrupt). Every state
- * transition is a `Ref.modify` predicate that returns the new entry +
- * a description of the side-effect (notification to emit, fiber to
- * cancel). The side-effects run AFTER the predicate commits — so the
- * state change is visible to concurrent readers before the
- * notification fires, satisfying the "first writer wins" invariant.
+ * Implementation: one `Ref&lt;LeaseRegistryData>` atomically owns entries,
+ * dispatch index, and closed state. A narrow semaphore orders each state
+ * commit with its presence observer callback; network notifications and fiber
+ * interruption run after that critical section. A shared shutdown signal
+ * cancels parked notification and retention effects.
  */
 export function makeLeaseRegistry(
   deps: LeaseRegistryDeps,
 ): Effect.Effect<LeaseRegistry, never, never> {
   return Effect.gen(function* () {
-    const entriesRef = yield* Ref.make<ReadonlyMap<LeaseId, LeaseEntry>>(
-      new Map(),
-    );
-    const dispatchIndexRef = yield* Ref.make<ReadonlyMap<DispatchId, LeaseId>>(
-      new Map(),
-    );
-    const closedRef = yield* Ref.make(false);
+    const dataRef = yield* Ref.make<LeaseRegistryData>({
+      entries: new Map(),
+      dispatchIndex: new Map(),
+      closed: false,
+    });
+    const shutdownSignal = yield* Deferred.make<void>();
+    const transitionPermit = yield* Effect.makeSemaphore(1);
     return makeLeaseRegistryFromState({
       deps,
-      entriesRef,
-      dispatchIndexRef,
-      closedRef,
+      dataRef,
+      shutdownSignal,
+      transitionPermit,
     });
   }).pipe(Effect.withSpan("makeLeaseRegistry"));
 }

--- a/packages/server/src/network/presence/MODULE.md
+++ b/packages/server/src/network/presence/MODULE.md
@@ -138,7 +138,7 @@ connections. Single source of truth for the lease-count-to-status
 mapping; walks `leasesByConn` and returns `working` for any non-zero
 count, else `online`.
 
-### [`LeaseTransitionObserver`](./presence-types.ts#L162)
+### [`LeaseTransitionObserver`](./presence-types.ts#L160)
 
 _Interface_
 
@@ -165,10 +165,8 @@ means GRANTED or CLAIMED — the two states that count toward
 This is the NARROW contract `LeaseRegistry` depends on. The registry
 sees only these two methods, not the full `PresenceService` surface.
 
-- `onLeaseActiveBegin` fires on `PENDING → GRANTED` only. `HOLD →
-  PENDING → GRANTED` (verdict re-try) eventually reaches GRANTED, at
-  which point this fires; the intermediate HOLD never enters the
-  active set.
+- `onLeaseActiveBegin` fires on `PENDING → GRANTED` only. `HOLD` is not
+  retried and never enters the active set.
 - `onLeaseActiveEnd` fires on the lease's first exit from
   GRANTED-or-CLAIMED into a terminal state — `CLAIMED → CONSUMED`,
   `GRANTED → EXPIRED` (TTL), `GRANTED → EXPIRED-on-disconnect`. A
@@ -190,7 +188,7 @@ ghost callbacks. The fast-reconnect race: agent A disconnects on
 threading, those callbacks would mutate against the surviving
 connection; the check makes them no-op audits instead.
 
-### [`noopLeaseTransitionObserver`](./presence-types.ts#L184)
+### [`noopLeaseTransitionObserver`](./presence-types.ts#L182)
 
 _Variable_
 
@@ -198,9 +196,9 @@ _Variable_
 export const noopLeaseTransitionObserver: LeaseTransitionObserver =
 ```
 
-Default observer used by `LeaseRegistry`'s `transitionObserver`
-when the registry is constructed without a presence service (e.g. in
-`lease-registry.test.ts` unit tests that do not exercise presence).
+Explicit no-op value for callers that do not exercise presence, such as
+`lease-registry.test.ts`. It is passed as the required
+`LeaseRegistry.transitionObserver`; the registry has no implicit default.
 
 The default discipline (Principle 4) is to have a value that does the
 right thing rather than a `null` branch every call site has to

--- a/packages/server/src/network/presence/presence-types.ts
+++ b/packages/server/src/network/presence/presence-types.ts
@@ -134,10 +134,8 @@ export type PresenceAuditEvent =
  * This is the NARROW contract `LeaseRegistry` depends on. The registry
  * sees only these two methods, not the full `PresenceService` surface.
  *
- * - `onLeaseActiveBegin` fires on `PENDING → GRANTED` only. `HOLD →
- *   PENDING → GRANTED` (verdict re-try) eventually reaches GRANTED, at
- *   which point this fires; the intermediate HOLD never enters the
- *   active set.
+ * - `onLeaseActiveBegin` fires on `PENDING → GRANTED` only. `HOLD` is not
+ *   retried and never enters the active set.
  * - `onLeaseActiveEnd` fires on the lease's first exit from
  *   GRANTED-or-CLAIMED into a terminal state — `CLAIMED → CONSUMED`,
  *   `GRANTED → EXPIRED` (TTL), `GRANTED → EXPIRED-on-disconnect`. A
@@ -173,9 +171,9 @@ export interface LeaseTransitionObserver {
 }
 
 /**
- * Default observer used by `LeaseRegistry`'s `transitionObserver`
- * when the registry is constructed without a presence service (e.g. in
- * `lease-registry.test.ts` unit tests that do not exercise presence).
+ * Explicit no-op value for callers that do not exercise presence, such as
+ * `lease-registry.test.ts`. It is passed as the required
+ * `LeaseRegistry.transitionObserver`; the registry has no implicit default.
  *
  * The default discipline (Principle 4) is to have a value that does the
  * right thing rather than a `null` branch every call site has to


### PR DESCRIPTION
## Summary

- store lease entries, the dispatch index, and shutdown state in one atomic registry state
- linearize competing grant/deny, claim, finalize, rollback, expiry, disconnect, and shutdown transitions
- prevent stale TTL fibers from expiring a newer lease epoch and ensure shutdown releases parked notifications
- add race-focused unit coverage and an integration regression proving concurrent sends produce exactly one durable message

## Why

The lease lifecycle was spread across independent refs and multi-step reads/writes. Competing fibers could both observe the same pre-transition state, allowing duplicate claims and inconsistent registry/index state. Observer callbacks, TTL fibers, and shutdown also had ordering windows around those transitions.

This makes the lease state machine first-writer-wins and preserves its invariants under concurrency.

Refs #737.

## Validation

- server unit suite: 20 files, 159 tests
- dispatch-flow integration suite: 6 files, 20 tests
- source and test TypeScript checks
- server lint and formatting checks
- generated module documentation refreshed
- independent concurrency review: no blockers