### PR TITLE
ci: connect CI to the self-hosted Nx remote cache (#808)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,14 @@ on:
     branches: [main, v2]
   pull_request:
 
+# Self-hosted Nx remote cache (Railway). Trusted events -- pushes to main/v2 and
+# same-repo pull requests -- read and populate the shared cache. Fork PRs receive
+# no repository secrets and a writable shared cache is a poisoning vector, so they
+# skip the remote cache and run cold.
 env:
-  NX_SKIP_REMOTE_CACHE: "true"
+  NX_SELF_HOSTED_REMOTE_CACHE_SERVER: https://nx-cache-server-production.up.railway.app
+  NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+  NX_SKIP_REMOTE_CACHE: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'true' || 'false' }}
 
 jobs:
   ci:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,8 +13,14 @@ on:
       - "docker-compose.conformance.yml"
       - ".github/workflows/conformance.yml"
 
+# Self-hosted Nx remote cache (Railway). Trusted events -- pushes to main/v2 and
+# same-repo pull requests -- read and populate the shared cache. Fork PRs receive
+# no repository secrets and a writable shared cache is a poisoning vector, so they
+# skip the remote cache and run cold.
 env:
-  NX_SKIP_REMOTE_CACHE: "true"
+  NX_SELF_HOSTED_REMOTE_CACHE_SERVER: https://nx-cache-server-production.up.railway.app
+  NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+  NX_SKIP_REMOTE_CACHE: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'true' || 'false' }}
 
 jobs:
   conformance:


### PR DESCRIPTION
## What

Re-connects CI to the self-hosted Railway Nx remote cache. Drops
`NX_SKIP_REMOTE_CACHE: "true"` from both `.github/workflows/ci.yml` and
`.github/workflows/conformance.yml` and wires the self-hosted cache env vars,
so `nx run-many` / `nx affected` (which back `pnpm build`, `typecheck`, `lint`,
`test`, and conformance) reuse task outputs across runs instead of recomputing
everything cold.

Closes #808 (once the secret below is added and the change is approved).

## Why it was disabled (investigation)

`1bcedbac` "Disable remote Nx cache in CI" (2026-06-05) has a **bare, one-line
message with no stated reason**, no linked issue, and no discussion. It was
authored on the big apps-as-principals cutover branch and swept into PR #722.
The cache had been stood up only 3 days earlier (`3a2a310f`, 2026-06-02, "cut Nx
remote cache over to self-hosted server on Railway").

I found **no evidence of a cache-correctness incident, a Railway reliability
problem, or a cost blow-up.** The repo's own debt inventory
(`v2/inputs/debt-inventory-20260718.md`) and `TRIAGE-arch.md` both treat the cold
CI simply as debt to reverse — `TRIAGE-arch.md` even notes the disabled cache is
why the `arch:check` gate OOM-killed protocol's cold analysis. So the disable
reads as a **precautionary "park it" during a large, churny cutover**, not a real
technical blocker. Re-enabling is wiring the secret back + your go-ahead, not
fixing an underlying defect. Since it was your deliberate call, this PR stays a
draft pending your confirmation.

## Configuration (verified, not guessed)

The cache is Nx's **custom self-hosted remote cache server** contract (no
`@nx/s3-cache`/`@nx/gcs-cache` plugin is installed; `nx@^22.7.5`). The server is
`ghcr.io/ikatsuba/nx-cache-server` on Railway at
`https://nx-cache-server-production.up.railway.app`, backed by a Railway
Bucket. The correct env var names for this mode (confirmed against Nx's official
self-hosted-caching docs and the server implementation) are:

- `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` — the cache server URL (committed in the
  workflow; not a secret).
- `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` — the bearer token (a secret).

These are the exact two vars the original pre-disable config used, so this PR
restores that wiring rather than inventing a new scheme.

## Required GitHub repository secret (you must add — I cannot set secrets)

| Secret name | Value |
|---|---|
| `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` | The read+write bearer token for the `nx-cache-server` on Railway (its `NX_CACHE_ACCESS_TOKEN`). Get it from the Railway `nx-remote-cache` project → `nx-cache-server` service env. |

That is the **only** secret needed for this PR as written. The server URL is
committed in the workflow (it is not sensitive).

## Fork-PR security handling

`NX_SKIP_REMOTE_CACHE` is now computed per event instead of a hard `"true"`:

```
NX_SKIP_REMOTE_CACHE: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'true' || 'false' }}
```

- **push to `main`/`v2`** and **same-repo (non-fork) PRs** → cache active,
  read + write. GitHub exposes repo secrets to these trusted events.
- **fork PRs** → skip the remote cache and run cold. GitHub does not expose repo
  secrets to fork PRs (the token would be empty), and a writable shared cache
  reachable from an untrusted fork is a **cache-poisoning vector**. Skipping
  closes that off while keeping fork PRs runnable.

### Optional hardening (not in this PR)

If you want even same-repo PRs to be unable to write (strict "writes only on
`push`"), provision a **second, read-only token** on the `nx-cache-server` and
feed it to `pull_request` events (Nx swallows the server's `403` on write for a
read-only token). That needs server-side token work and a second secret, so I
left it out; say the word and I will wire it.

## Verification plan (after the secret is added)

1. Merge/allow one `push` to `main` → populates the cache.
2. Re-run CI on an unchanged commit → expect `nx` "read from remote cache" / a
   cache-hit run instead of cold recompute (issue #808 acceptance).

## Blocked on

- [ ] `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN` repo secret added.
- [ ] Your go-ahead to re-enable (it was disabled deliberately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
