### PR TITLE
perf(testbed): bound adapter log buffers; cap the channel conversation map

### DIFF
--- a/docs/modules/testbed/src.mdx
+++ b/docs/modules/testbed/src.mdx
@@ -42,7 +42,7 @@ export function awaitAgentReadyByPolling(
 ): Effect.Effect<ReadyOutcome, never, never>
 ```
 
-### [`createOpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L509)
+### [`createOpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L508)
 
 _Function_
 
@@ -179,9 +179,7 @@ export class NanoclawAdapter implements Runtime {
 
   getLogs(offset: number): LogSlice {
     if (!this.state) return { text: "", nextOffset: 0 };
-    const full = getNanoclawRuntimeLogs(this.state.handle);
-    const text = full.slice(offset);
-    return { text, nextOffset: full.length };
+    return this.state.handle.logs.read(offset);
   }
 
   getInboundMarker(): string {
@@ -270,7 +268,7 @@ export interface NanoclawAdapterOptions {
 }
 ```
 
-### [`OpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L429)
+### [`OpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L430)
 
 _Class_
 
@@ -301,7 +299,7 @@ export class OpenClawAdapter implements Runtime {
       ),
       source: {
         pollExitCode: () => pollExitCode(proc),
-        stderr: () => logBuffer.value,
+        stderr: () => logBuffer.text,
         timeoutMs,
       },
       teardown: () => this.teardown(),
@@ -331,9 +329,7 @@ export class OpenClawAdapter implements Runtime {
 
   getLogs(offset: number): LogSlice {
     if (!this.state) return { text: "", nextOffset: 0 };
-    const full = this.state.logBuffer.value;
-    const text = full.slice(offset);
-    return { text, nextOffset: full.length };
+    return this.state.logBuffer.read(offset);
   }
 
   getInboundMarker(): string {
@@ -367,7 +363,7 @@ Readiness signal: server-side WS authentication event surfaces via
 (boot) or `RuntimeExitedBeforeReady` / `RuntimeReadyTimedOut`
 (post-spawn, surfaced by `processExitLoop`).
 
-### [`OpenClawAdapterDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L152)
+### [`OpenClawAdapterDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L153)
 
 _Interface_
 
@@ -379,7 +375,7 @@ export interface OpenClawAdapterDeps {
 }
 ```
 
-### [`OpenClawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L158)
+### [`OpenClawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L159)
 
 _Interface_
 

--- a/docs/modules/testbed/src.mdx
+++ b/docs/modules/testbed/src.mdx
@@ -130,14 +130,21 @@ _Interface_
 
 ```ts
 export interface LogSlice {
-  /** stdout+stderr bytes starting from the requested offset. */
+  /**
+   * stdout+stderr from the requested offset. Adapters retain a bounded
+   * window (startup head + rolling tail); when the offset falls into a
+   * dropped region, the missing middle is replaced by a
+   * `[... log window elided ...]` marker, so a stale cursor can observe
+   * non-contiguous text and marker-matching consumers must poll faster
+   * than the tail window fills.
+   */
   readonly text: string;
   /** Byte offset to pass on the next call to continue reading. */
   readonly nextOffset: number;
 }
 ```
 
-### [`NanoclawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/nanoclaw-adapter.ts#L97)
+### [`NanoclawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/nanoclaw-adapter.ts#L96)
 
 _Class_
 
@@ -166,7 +173,7 @@ export class NanoclawAdapter implements Runtime {
       ),
       source: {
         pollExitCode: () => pollFiberExitCode(handle.exitFiber),
-        stderr: () => getNanoclawRuntimeLogs(handle),
+        stderr: () => handle.logs.text,
         timeoutMs,
       },
       teardown: () => this.teardown(),
@@ -251,7 +258,7 @@ flowchart TD
 Inbound marker: `New messages`. The immutable cache key covers the pinned
 NanoClaw source, dependency lock, bundled channel/skill, and host ABI.
 
-### [`NanoclawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/nanoclaw-adapter.ts#L23)
+### [`NanoclawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/nanoclaw-adapter.ts#L22)
 
 _Interface_
 
@@ -387,7 +394,7 @@ export interface OpenClawAdapterOptions {
 }
 ```
 
-### [`ReadyOutcome`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L56)
+### [`ReadyOutcome`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L63)
 
 _TypeAlias_
 
@@ -396,7 +403,7 @@ export type ReadyOutcome =
   | { readonly _tag: "Ready" }
 ```
 
-### [`Runtime`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L75)
+### [`Runtime`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L82)
 
 _Interface_
 

--- a/packages/nanoclaw-channel/src/channels/moltzap.ts
+++ b/packages/nanoclaw-channel/src/channels/moltzap.ts
@@ -48,6 +48,7 @@ class MoltZapChannelError extends Data.TaggedError("MoltZapChannelError")<{
 const MOLTZAP_CHANNEL = "moltzap";
 const MOLTZAP_JID_PREFIX = "mz:";
 const EVAL_NAME_ID_CHARS = 8;
+const MAX_TRACKED_CONVERSATIONS = 4096;
 export const EVAL_AGENT_GROUP_ID = "eval-agent";
 
 // Harness runs start from an empty database, so eval mode also provisions
@@ -170,7 +171,9 @@ export class MoltZapAdapter implements ChannelAdapter {
   private readonly dispatchLeases = new LeaseStore<string, LeaseId>();
   // Per-jid memory of the task and branded conversation id from the most
   // recent inbound. `agent/message/send` requires both; keeping the branded
-  // id avoids re-decoding it on every reply.
+  // id avoids re-decoding it on every reply. Bounded FIFO: an evicted
+  // conversation degrades to the existing "no taskId" deliver error until
+  // its next inbound refreshes the entry.
   private readonly conversationsByJid = new Map<
     string,
     { readonly taskId: TaskId; readonly conversationId: ConversationId }
@@ -355,6 +358,21 @@ export class MoltZapAdapter implements ChannelAdapter {
     });
   }
 
+  private rememberConversation(
+    jid: string,
+    enriched: EnrichedInboundMessage,
+  ): void {
+    this.conversationsByJid.delete(jid);
+    if (this.conversationsByJid.size >= MAX_TRACKED_CONVERSATIONS) {
+      const oldest = this.conversationsByJid.keys().next().value;
+      if (oldest !== undefined) this.conversationsByJid.delete(oldest);
+    }
+    this.conversationsByJid.set(jid, {
+      taskId: enriched.taskId,
+      conversationId: enriched.conversationId,
+    });
+  }
+
   private handleInbound(enriched: EnrichedInboundMessage): void {
     // Own outbound replies echo back through the notification stream; the
     // router has no is-from-me concept, so they are dropped here.
@@ -363,10 +381,7 @@ export class MoltZapAdapter implements ChannelAdapter {
     if (config === null) return;
     const jid = jidFromConversationId(enriched.conversationId);
     this.rememberDispatchLease(jid, enriched);
-    this.conversationsByJid.set(jid, {
-      taskId: enriched.taskId,
-      conversationId: enriched.conversationId,
-    });
+    this.rememberConversation(jid, enriched);
     const isGroup = enriched.conversationMeta?.type === "group";
     if (this.evalMode) {
       this.ensureEvalWiring(jid, enriched, isGroup);

--- a/packages/testbed/src/MODULE.md
+++ b/packages/testbed/src/MODULE.md
@@ -37,7 +37,7 @@ export function awaitAgentReadyByPolling(
 ): Effect.Effect<ReadyOutcome, never, never>
 ```
 
-### [`createOpenClawAdapter`](./openclaw-adapter.ts#L509)
+### [`createOpenClawAdapter`](./openclaw-adapter.ts#L508)
 
 _Function_
 
@@ -174,9 +174,7 @@ export class NanoclawAdapter implements Runtime {
 
   getLogs(offset: number): LogSlice {
     if (!this.state) return { text: "", nextOffset: 0 };
-    const full = getNanoclawRuntimeLogs(this.state.handle);
-    const text = full.slice(offset);
-    return { text, nextOffset: full.length };
+    return this.state.handle.logs.read(offset);
   }
 
   getInboundMarker(): string {
@@ -265,7 +263,7 @@ export interface NanoclawAdapterOptions {
 }
 ```
 
-### [`OpenClawAdapter`](./openclaw-adapter.ts#L429)
+### [`OpenClawAdapter`](./openclaw-adapter.ts#L430)
 
 _Class_
 
@@ -296,7 +294,7 @@ export class OpenClawAdapter implements Runtime {
       ),
       source: {
         pollExitCode: () => pollExitCode(proc),
-        stderr: () => logBuffer.value,
+        stderr: () => logBuffer.text,
         timeoutMs,
       },
       teardown: () => this.teardown(),
@@ -326,9 +324,7 @@ export class OpenClawAdapter implements Runtime {
 
   getLogs(offset: number): LogSlice {
     if (!this.state) return { text: "", nextOffset: 0 };
-    const full = this.state.logBuffer.value;
-    const text = full.slice(offset);
-    return { text, nextOffset: full.length };
+    return this.state.logBuffer.read(offset);
   }
 
   getInboundMarker(): string {
@@ -362,7 +358,7 @@ Readiness signal: server-side WS authentication event surfaces via
 (boot) or `RuntimeExitedBeforeReady` / `RuntimeReadyTimedOut`
 (post-spawn, surfaced by `processExitLoop`).
 
-### [`OpenClawAdapterDeps`](./openclaw-adapter.ts#L152)
+### [`OpenClawAdapterDeps`](./openclaw-adapter.ts#L153)
 
 _Interface_
 
@@ -374,7 +370,7 @@ export interface OpenClawAdapterDeps {
 }
 ```
 
-### [`OpenClawAdapterOptions`](./openclaw-adapter.ts#L158)
+### [`OpenClawAdapterOptions`](./openclaw-adapter.ts#L159)
 
 _Interface_
 

--- a/packages/testbed/src/MODULE.md
+++ b/packages/testbed/src/MODULE.md
@@ -125,14 +125,21 @@ _Interface_
 
 ```ts
 export interface LogSlice {
-  /** stdout+stderr bytes starting from the requested offset. */
+  /**
+   * stdout+stderr from the requested offset. Adapters retain a bounded
+   * window (startup head + rolling tail); when the offset falls into a
+   * dropped region, the missing middle is replaced by a
+   * `[... log window elided ...]` marker, so a stale cursor can observe
+   * non-contiguous text and marker-matching consumers must poll faster
+   * than the tail window fills.
+   */
   readonly text: string;
   /** Byte offset to pass on the next call to continue reading. */
   readonly nextOffset: number;
 }
 ```
 
-### [`NanoclawAdapter`](./nanoclaw-adapter.ts#L97)
+### [`NanoclawAdapter`](./nanoclaw-adapter.ts#L96)
 
 _Class_
 
@@ -161,7 +168,7 @@ export class NanoclawAdapter implements Runtime {
       ),
       source: {
         pollExitCode: () => pollFiberExitCode(handle.exitFiber),
-        stderr: () => getNanoclawRuntimeLogs(handle),
+        stderr: () => handle.logs.text,
         timeoutMs,
       },
       teardown: () => this.teardown(),
@@ -246,7 +253,7 @@ flowchart TD
 Inbound marker: `New messages`. The immutable cache key covers the pinned
 NanoClaw source, dependency lock, bundled channel/skill, and host ABI.
 
-### [`NanoclawAdapterOptions`](./nanoclaw-adapter.ts#L23)
+### [`NanoclawAdapterOptions`](./nanoclaw-adapter.ts#L22)
 
 _Interface_
 
@@ -382,7 +389,7 @@ export interface OpenClawAdapterOptions {
 }
 ```
 
-### [`ReadyOutcome`](./runtime.ts#L56)
+### [`ReadyOutcome`](./runtime.ts#L63)
 
 _TypeAlias_
 
@@ -391,7 +398,7 @@ export type ReadyOutcome =
   | { readonly _tag: "Ready" }
 ```
 
-### [`Runtime`](./runtime.ts#L75)
+### [`Runtime`](./runtime.ts#L82)
 
 _Interface_
 

--- a/packages/testbed/src/child-process.ts
+++ b/packages/testbed/src/child-process.ts
@@ -96,7 +96,12 @@ export class BoundedLogBuffer {
       rest = rest.slice(take);
     }
     if (rest.length === 0) return;
-    this.tail = (this.tail + rest).slice(-this.tailCapacity);
+    // Compact only past 2x capacity: V8 rope concatenation keeps `+=` cheap,
+    // so the flatten amortizes to O(1)/char at a 2x memory high-water mark.
+    this.tail += rest;
+    if (this.tail.length >= 2 * this.tailCapacity) {
+      this.tail = this.tail.slice(-this.tailCapacity);
+    }
   }
 
   /**
@@ -107,14 +112,16 @@ export class BoundedLogBuffer {
     const tailStart = this.total - this.tail.length;
     if (offset >= tailStart) {
       return {
-        text: this.tail.slice(this.tail.length - (this.total - offset)),
+        text: this.tail.slice(offset - tailStart),
         nextOffset: this.total,
       };
     }
-    const headPart = offset < this.head.length ? this.head.slice(offset) : "";
-    const elided = tailStart > Math.max(offset, this.head.length);
+    const elided = tailStart > this.head.length;
     return {
-      text: headPart + (elided ? LOG_ELISION_MARKER : "") + this.tail,
+      text:
+        this.head.slice(offset) +
+        (elided ? LOG_ELISION_MARKER : "") +
+        this.tail,
       nextOffset: this.total,
     };
   }

--- a/packages/testbed/src/child-process.ts
+++ b/packages/testbed/src/child-process.ts
@@ -67,6 +67,64 @@ export function makeCommandHelpers<E>(makeError: ErrorFactory<E>) {
 
 const UTF8_DECODER = new TextDecoder("utf-8");
 
+const LOG_HEAD_CAPACITY = 64 * 1024;
+const LOG_TAIL_CAPACITY = 256 * 1024;
+const LOG_ELISION_MARKER = "\n[... log window elided ...]\n";
+
+/**
+ * Append-only process log window: the first `headCapacity` chars (startup
+ * diagnostics) plus a rolling tail, so a chatty long-lived agent cannot
+ * grow memory unbounded. Offsets are positions in the ORIGINAL stream —
+ * pollers keep monotonic cursors even after the middle is elided.
+ */
+export class BoundedLogBuffer {
+  private head = "";
+  private tail = "";
+  private total = 0;
+
+  constructor(
+    private readonly headCapacity = LOG_HEAD_CAPACITY,
+    private readonly tailCapacity = LOG_TAIL_CAPACITY,
+  ) {}
+
+  append(chunk: string): void {
+    this.total += chunk.length;
+    let rest = chunk;
+    if (this.head.length < this.headCapacity) {
+      const take = Math.min(this.headCapacity - this.head.length, rest.length);
+      this.head += rest.slice(0, take);
+      rest = rest.slice(take);
+    }
+    if (rest.length === 0) return;
+    this.tail = (this.tail + rest).slice(-this.tailCapacity);
+  }
+
+  /**
+   * Text from `offset` (original-stream position) to the current end;
+   * regions no longer retained collapse into an elision marker.
+   */
+  read(offset: number): { readonly text: string; readonly nextOffset: number } {
+    const tailStart = this.total - this.tail.length;
+    if (offset >= tailStart) {
+      return {
+        text: this.tail.slice(this.tail.length - (this.total - offset)),
+        nextOffset: this.total,
+      };
+    }
+    const headPart = offset < this.head.length ? this.head.slice(offset) : "";
+    const elided = tailStart > Math.max(offset, this.head.length);
+    return {
+      text: headPart + (elided ? LOG_ELISION_MARKER : "") + this.tail,
+      nextOffset: this.total,
+    };
+  }
+
+  /** The full retained window (head + elision marker + tail). */
+  get text(): string {
+    return this.read(0).text;
+  }
+}
+
 /** Drains a child stdout/stderr stream into the caller's log accumulator. */
 function consumeProcessStream(
   stream: Stream.Stream<Uint8Array, unknown>,

--- a/packages/testbed/src/nanoclaw-adapter.ts
+++ b/packages/testbed/src/nanoclaw-adapter.ts
@@ -131,9 +131,7 @@ export class NanoclawAdapter implements Runtime {
 
   getLogs(offset: number): LogSlice {
     if (!this.state) return { text: "", nextOffset: 0 };
-    const full = getNanoclawRuntimeLogs(this.state.handle);
-    const text = full.slice(offset);
-    return { text, nextOffset: full.length };
+    return this.state.handle.logs.read(offset);
   }
 
   getInboundMarker(): string {

--- a/packages/testbed/src/nanoclaw-adapter.ts
+++ b/packages/testbed/src/nanoclaw-adapter.ts
@@ -15,7 +15,6 @@ import { pollFiberExitCode } from "./child-process.js";
 import {
   startNanoclawRuntimeEffect,
   stopNanoclawRuntimeEffect,
-  getNanoclawRuntimeLogs,
   type NanoclawRuntimeHandle,
 } from "./nanoclaw-process.js";
 import { ensureNanoclawRuntimeInstalledEffect } from "./nanoclaw-install.js";
@@ -118,7 +117,7 @@ export class NanoclawAdapter implements Runtime {
       ),
       source: {
         pollExitCode: () => pollFiberExitCode(handle.exitFiber),
-        stderr: () => getNanoclawRuntimeLogs(handle),
+        stderr: () => handle.logs.text,
         timeoutMs,
       },
       teardown: () => this.teardown(),

--- a/packages/testbed/src/nanoclaw-process.ts
+++ b/packages/testbed/src/nanoclaw-process.ts
@@ -27,6 +27,7 @@ import {
   type NanoclawRuntimeInstall,
 } from "./nanoclaw-install.js";
 import {
+  BoundedLogBuffer,
   escalatingKill,
   makeCommandHelpers,
   startSupervisedProcess,
@@ -53,7 +54,7 @@ export interface NanoclawRuntimeHandle {
   scope: Scope.CloseableScope;
   exitFiber: Fiber.RuntimeFiber<number, never>;
   runtimeDir: string;
-  capturedLogs: string[];
+  logs: BoundedLogBuffer;
 }
 
 interface StartNanoclawRuntimeOptions {
@@ -362,14 +363,14 @@ function startNanoclawProcess(
   opts: StartNanoclawRuntimeOptions,
   runtimeDir: string,
   install: NanoclawRuntimeInstall,
-  capturedLogs: string[],
+  logs: BoundedLogBuffer,
 ) {
   const command = makeNanoclawCommand(opts, runtimeDir, install);
   return Effect.uninterruptibleMask((restore) =>
     Effect.gen(function* () {
       const scope = yield* Scope.make();
       return yield* restore(
-        initializeNanoclawProcess(command, scope, capturedLogs),
+        initializeNanoclawProcess(command, scope, logs),
       ).pipe(
         Effect.onError((cause) => Scope.close(scope, Exit.failCause(cause))),
       );
@@ -383,10 +384,10 @@ function startNanoclawProcess(
 function initializeNanoclawProcess(
   command: ReturnType<typeof makeNanoclawCommand>,
   scope: Scope.CloseableScope,
-  capturedLogs: string[],
+  logs: BoundedLogBuffer,
 ) {
   return startSupervisedProcess(command, scope, (chunk) => {
-    capturedLogs.push(chunk);
+    logs.append(chunk);
   }).pipe(
     Effect.map(
       ({ proc, exitFiber }) =>
@@ -409,14 +410,14 @@ function startConfiguredNanoclawRuntime(
     yield* writeRuntimeWorkspaceFiles(runtimeDir, opts.workspaceFiles);
     yield* writeNanoclawMoltZapProfileConfig(opts, runtimeDir);
 
-    const capturedLogs: string[] = [];
+    const logs = new BoundedLogBuffer();
     const started = yield* startNanoclawProcess(
       opts,
       runtimeDir,
       install,
-      capturedLogs,
+      logs,
     );
-    return { ...started, runtimeDir, capturedLogs };
+    return { ...started, runtimeDir, logs };
   });
 }
 
@@ -482,5 +483,5 @@ function removeNanoclawRuntimeDir(runtimeDir: string) {
 }
 
 export function getNanoclawRuntimeLogs(handle: NanoclawRuntimeHandle): string {
-  return handle.capturedLogs.join("");
+  return handle.logs.text;
 }

--- a/packages/testbed/src/nanoclaw-process.ts
+++ b/packages/testbed/src/nanoclaw-process.ts
@@ -481,7 +481,3 @@ function removeNanoclawRuntimeDir(runtimeDir: string) {
     ),
   );
 }
-
-export function getNanoclawRuntimeLogs(handle: NanoclawRuntimeHandle): string {
-  return handle.logs.text;
-}

--- a/packages/testbed/src/openclaw-adapter.ts
+++ b/packages/testbed/src/openclaw-adapter.ts
@@ -19,6 +19,7 @@ import type {
 import { SpawnFailed, spawnFailed } from "./errors.js";
 import { raceReadiness } from "./adapter-readiness.js";
 import {
+  BoundedLogBuffer,
   escalatingKill,
   pollFiberExitCode,
   startSupervisedProcess,
@@ -75,11 +76,11 @@ function stopSpawnedOpenClawProcess(
 
 function initializeOpenClawProcess(
   command: Command.Command,
-  logBuffer: { value: string },
+  logBuffer: BoundedLogBuffer,
   scope: Scope.CloseableScope,
 ) {
   return startSupervisedProcess(command, scope, (chunk) => {
-    logBuffer.value += chunk;
+    logBuffer.append(chunk);
   }).pipe(
     Effect.map(
       ({ proc, exitFiber }) =>
@@ -117,7 +118,7 @@ function spawnOpenClawProcess(opts: {
   readonly args: ReadonlyArray<string>;
   readonly cwd: string;
   readonly env: Readonly<Record<string, string>>;
-  readonly logBuffer: { value: string };
+  readonly logBuffer: BoundedLogBuffer;
   readonly onStarted: (
     process: SpawnedProcess,
   ) => Effect.Effect<void, never, never>;
@@ -164,7 +165,7 @@ export interface OpenClawAdapterOptions {
 interface AdapterState {
   process: SpawnedProcess;
   stateDir: string;
-  logBuffer: { value: string };
+  logBuffer: BoundedLogBuffer;
   spawnInput: SpawnInput;
   tornDown: boolean;
 }
@@ -320,7 +321,7 @@ function spawnConfiguredOpenClaw(options: {
   readonly stateDir: string;
   readonly input: SpawnInput;
   readonly port: number;
-  readonly logBuffer: { value: string };
+  readonly logBuffer: BoundedLogBuffer;
   readonly onStarted: (
     process: SpawnedProcess,
   ) => Effect.Effect<void, never, never>;
@@ -371,7 +372,7 @@ function startOpenClawAdapter(
               : removeOpenClawStateDir(leasedStateDir),
         );
         yield* restore(configureOpenClawStateDir(deps, input, stateDir));
-        const logBuffer = { value: "" };
+        const logBuffer = new BoundedLogBuffer();
         const child = yield* restore(
           Effect.acquireReleaseInterruptible(
             spawnConfiguredOpenClaw({
@@ -452,7 +453,7 @@ export class OpenClawAdapter implements Runtime {
       ),
       source: {
         pollExitCode: () => pollExitCode(proc),
-        stderr: () => logBuffer.value,
+        stderr: () => logBuffer.text,
         timeoutMs,
       },
       teardown: () => this.teardown(),
@@ -482,9 +483,7 @@ export class OpenClawAdapter implements Runtime {
 
   getLogs(offset: number): LogSlice {
     if (!this.state) return { text: "", nextOffset: 0 };
-    const full = this.state.logBuffer.value;
-    const text = full.slice(offset);
-    return { text, nextOffset: full.length };
+    return this.state.logBuffer.read(offset);
   }
 
   getInboundMarker(): string {

--- a/packages/testbed/src/runtime.ts
+++ b/packages/testbed/src/runtime.ts
@@ -47,7 +47,14 @@ export interface SpawnInput {
 }
 
 export interface LogSlice {
-  /** stdout+stderr bytes starting from the requested offset. */
+  /**
+   * stdout+stderr from the requested offset. Adapters retain a bounded
+   * window (startup head + rolling tail); when the offset falls into a
+   * dropped region, the missing middle is replaced by a
+   * `[... log window elided ...]` marker, so a stale cursor can observe
+   * non-contiguous text and marker-matching consumers must poll faster
+   * than the tail window fills.
+   */
   readonly text: string;
   /** Byte offset to pass on the next call to continue reading. */
   readonly nextOffset: number;

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -25,6 +25,7 @@ import {
   type OpenClawAdapterDeps,
 } from "./openclaw-adapter.js";
 import { TESTBED_PROFILE_NAME } from "./channel-plugin-install.js";
+import { BoundedLogBuffer } from "./child-process.js";
 import {
   NanoclawAdapter,
   type NanoclawAdapterOptions,
@@ -546,7 +547,7 @@ function openClawTeardownSendsTerminateThenKill() {
           scope,
         },
         stateDir: TEARDOWN_STATE_DIR,
-        logBuffer: { value: "" },
+        logBuffer: new BoundedLogBuffer(),
         spawnInput: stubSpawnInput(),
         tornDown: false,
       });
@@ -602,7 +603,7 @@ function openClawTeardownInterruptionFinishesCleanup() {
           scope,
         },
         stateDir: TEARDOWN_STATE_DIR,
-        logBuffer: { value: "" },
+        logBuffer: new BoundedLogBuffer(),
         spawnInput: stubSpawnInput(),
         tornDown: false,
       });
@@ -675,7 +676,7 @@ interface InjectedOpenClawAdapterState {
     readonly scope: Scope.CloseableScope;
   };
   readonly stateDir: string;
-  readonly logBuffer: { readonly value: string };
+  readonly logBuffer: BoundedLogBuffer;
   readonly spawnInput: SpawnInput;
   tornDown: boolean;
 }


### PR DESCRIPTION
Fixes #801. Stacked on #815 (the connect-marker scan bullet died there when the gate was deleted); GitHub retargets to main when #815 merges.

- **Shared `BoundedLogBuffer`** (`child-process.ts`): first 64KB + rolling 256KB tail per agent, replacing openclaw's unbounded string and nanoclaw's unbounded chunk array. Offsets stay in original-stream positions, so `getLogs(offset)` pollers keep monotonic cursors even after the middle is elided (an elision marker stands in for dropped regions). This also aligns the two representations: both sides now pay O(window) reads instead of nanoclaw's per-call full re-join.
- **Channel conversation map capped** (nanoclaw-channel `moltzap.ts`): `conversationsByJid` is FIFO-capped at 4096; an evicted conversation degrades to the existing "no taskId" deliver error until its next inbound refreshes it.
- **Deliberately out of scope**: the channel-base `LeaseStore` — evicting a pending lease would break an in-flight dispatch (it's production-shared with openclaw-channel); bounded eviction there needs its own design if it ever matters at real scale.

Verified: build, lint, tests (68 testbed + 26 nanoclaw-channel), typecheck all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)