### PR TITLE
fix(client,openclaw-channel,protocol): config-home sockets, manifest drift test, shared BoundedMap

### DIFF
--- a/docs/modules/_nav.json
+++ b/docs/modules/_nav.json
@@ -3,6 +3,7 @@
   "pages": [
     "modules/client/src",
     "modules/openclaw-channel/src",
+    "modules/protocol/bounded-map",
     "modules/protocol/conversation",
     "modules/protocol/conversation/requirements",
     "modules/protocol/identity",

--- a/docs/modules/client/src.mdx
+++ b/docs/modules/client/src.mdx
@@ -13,7 +13,7 @@ Public barrel for the MoltZap client package.
 
 ## Public surface
 
-### [`ContextOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/service.ts#L195)
+### [`ContextOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/service.ts#L196)
 
 _Interface_
 
@@ -25,7 +25,7 @@ export interface ContextOptions {
 }
 ```
 
-### [`ConversationMeta`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/service.ts#L188)
+### [`ConversationMeta`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/service.ts#L189)
 
 _Interface_
 
@@ -38,7 +38,7 @@ export interface ConversationMeta {
 }
 ```
 
-### [`MoltZapService`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/service.ts#L324)
+### [`MoltZapService`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/service.ts#L325)
 
 _Class_
 
@@ -93,15 +93,13 @@ export class MoltZapService {
   private readonly archivedConversationIds = new Set<string>();
 
   /**
-   * Insertion-ordered set of recently seen messageIds per conversation.
-   * Bounded at DEDUP_WINDOW_PER_CONV entries per conversation; oldest entry
-   * is evicted when the window is full. Set#keys() preserves insertion
-   * order in V8 / the spec, so eviction via `.next()` is O(1).
-   *
-   * Keyed and valued by their branded ids so the compiler rejects a
-   * `MessageId` accidentally used as a conversation key (or vice versa).
+   * The branded outer and inner keys keep conversation and message ids from
+   * crossing accidentally while each conversation owns its eviction window.
    */
-  private readonly seenMessageIds = new Map<ConversationId, Set<MessageId>>();
+  private readonly seenMessageIds = new Map<
+    ConversationId,
+    BoundedMap<MessageId, true>
+  >();
   private readonly handlers: {
     [K in ServiceHandlerName]: Array<
       NotificationHandler<ServiceHandlerPayloads[K]>
@@ -163,6 +161,8 @@ export class MoltZapService {
   /** Effect-native: compose via `yield*` or bridge at the edge via `Effect.runPromise`. */
   connect(): Effect.Effect<HelloOk, ServiceRpcError> {
     return Effect.gen(this, function* () {
+      const client = new MoltZapAgentClient({
+        serverUrl: this.opts.serverUrl,
 ```
 
 Stateful MoltZap client that manages connection, conversation tracking,
@@ -173,7 +173,7 @@ Promise siblings — async/await consumers run the Effect at the edge
 with `Effect.runPromise`. Keep this class Effect-only so downstream
 callers compose failures and cancellation explicitly.
 
-### [`ServiceRpcError`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/service.ts#L177)
+### [`ServiceRpcError`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/service.ts#L178)
 
 _TypeAlias_
 

--- a/docs/modules/openclaw-channel/src.mdx
+++ b/docs/modules/openclaw-channel/src.mdx
@@ -15,7 +15,7 @@ runtime entries from `index.*` at the extension root only, so the built
 
 ## Public surface
 
-### [`createMoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1244)
+### [`createMoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1268)
 
 _Function_
 
@@ -69,7 +69,7 @@ a throw.
 `task:&lt;taskId>:&lt;conversationId>` (existing conversation). A target
 containing `:` in any other shape is rejected.
 
-### [`default`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1273)
+### [`default`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1297)
 
 _Variable_
 
@@ -77,7 +77,7 @@ _Variable_
 const plugin =
 ```
 
-### [`moltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1270)
+### [`moltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1294)
 
 _Variable_
 
@@ -90,7 +90,7 @@ Shared singleton so a single registration reuses the same `activeClients`
 closure across `startAccount` and `sendText`. Tests import this directly
 to assert against that shared state.
 
-### [`MoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1261)
+### [`MoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1285)
 
 _TypeAlias_
 

--- a/docs/modules/protocol/bounded-map.mdx
+++ b/docs/modules/protocol/bounded-map.mdx
@@ -1,0 +1,106 @@
+---
+title: "protocol/bounded-map"
+description: "Bounded insertion-ordered map shared by endpoint and server caches."
+---
+
+# protocol/bounded-map
+
+_`packages/protocol/src/bounded-map`_
+
+## Purpose
+
+Bounded insertion-ordered map shared by endpoint and server caches.
+
+Protocol is the common dependency leaf for client and server runtime
+packages, so this synchronous store lives in a focused subpath that
+preserves their one-way imports.
+
+## Public surface
+
+### [`BoundedMap`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/bounded-map/index.ts#L25)
+
+_Class_
+
+```ts
+export class BoundedMap<K, V> implements ReadonlyMap<K, V> {
+  readonly #entries = new Map<K, V>();
+
+  constructor(readonly capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+      throw new InvalidBoundedMapCapacity({ capacity });
+    }
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+
+  get(key: K): V | undefined {
+    return this.#entries.get(key);
+  }
+
+  has(key: K): boolean {
+    return this.#entries.has(key);
+  }
+
+  delete(key: K): boolean {
+    return this.#entries.delete(key);
+  }
+
+  clear(): void {
+    this.#entries.clear();
+  }
+
+  set(key: K, value: V): readonly [K, V] | undefined {
+    if (this.#entries.has(key)) {
+      this.#entries.delete(key);
+    }
+    this.#entries.set(key, value);
+
+    if (this.#entries.size <= this.capacity) {
+      return undefined;
+    }
+
+    const oldest = this.#entries.entries().next();
+    if (oldest.done) {
+      return undefined;
+    }
+    this.#entries.delete(oldest.value[0]);
+    return oldest.value;
+  }
+
+  entries(): MapIterator<[K, V]> {
+    return this.#entries.entries();
+  }
+
+  keys(): MapIterator<K> {
+    return this.#entries.keys();
+  }
+
+  values(): MapIterator<V> {
+    return this.#entries.values();
+  }
+
+  forEach(
+    callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
+    thisArg?: unknown,
+  ): void {
+    this.#entries.forEach((value, key) => {
+      callbackfn.call(thisArg, value, key, this);
+    });
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.entries();
+  }
+}
+```
+
+Insertion-ordered map with a fixed entry capacity.
+
+Setting an existing key refreshes its position without evicting another
+entry. Reads preserve insertion order.
+
+## Files
+
+- `index.ts`

--- a/docs/modules/server-core/conversation.mdx
+++ b/docs/modules/server-core/conversation.mdx
@@ -33,14 +33,16 @@ export const conversationList: ServerHandler<typeof ConversationList> = (
 )
 ```
 
-### [`ConversationService`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/conversation/conversation.service.ts#L260)
+### [`ConversationService`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/conversation/conversation.service.ts#L261)
 
 _Class_
 
 ```ts
 export class ConversationService {
   /** In-memory cache for last message previews — avoids decrypting on every list() call */
-  private previewCache = new Map<ConversationId, string>();
+  private readonly previewCache = new BoundedMap<ConversationId, string>(
+    PREVIEW_CACHE_MAX,
+  );
 
   constructor(
     private db: Db,
@@ -53,16 +55,109 @@ export class ConversationService {
     conversationId: ConversationId,
     firstPartText: string,
   ): void {
-    this.previewCache.delete(conversationId);
     this.previewCache.set(
       conversationId,
       firstPartText.slice(0, PREVIEW_CACHE_TEXT_CHARS),
     );
-    if (this.previewCache.size > PREVIEW_CACHE_MAX) {
-      const oldest = this.previewCache.keys().next().value!;
-      this.previewCache.delete(oldest);
-    }
   }
+
+  create<TaskMintError = never>(
+    input: CreateConversationOptions<TaskMintError>,
+  ): Effect.Effect<Conversation, TaskMintError> {
+    return catchSqlErrorAsDefect(this.createConversationEffect(input));
+  }
+
+  private createConversationEffect<TaskMintError>(
+    input: CreateConversationOptions<TaskMintError>,
+  ): Effect.Effect<Conversation, TaskMintError | SqlError> {
+    return Effect.gen(this, function* () {
+      const task = yield* input.mintTask;
+      const created = yield* this.insertConversation(input, task.id);
+      yield* this.subscribeCreatedConversation(input, created.id);
+      yield* this.logConversationCreated(input, created.id);
+      return created;
+    });
+  }
+
+  /** @internal */
+  loadAgentOwners(
+    agentIds: ReadonlyArray<AgentId>,
+  ): Effect.Effect<
+    ReadonlyMap<AgentId, UserId>,
+    AgentNotFoundError | SqlError
+  > {
+    return Effect.gen(this, function* () {
+      const rows =
+        agentIds.length === 0
+          ? []
+          : yield* this.db
+              .selectFrom("agents")
+              .select(["id", "owner_user_id"])
+              .where("id", "in", [...agentIds]);
+      const ownerByAgentId = new Map<AgentId, UserId>();
+      for (const row of rows) {
+        ownerByAgentId.set(row.id, row.owner_user_id);
+      }
+      for (const agentId of agentIds) {
+        if (!ownerByAgentId.has(agentId)) {
+          return yield* Effect.fail(
+            new AgentNotFoundError({ message: `Agent ${agentId} not found` }),
+          );
+        }
+      }
+      return ownerByAgentId;
+    });
+  }
+
+  /** @internal */
+  assertContactPolicyForCreate(
+    creatorAgentId: AgentId,
+    targetAgentIds: ReadonlyArray<AgentId>,
+    ownerByAgentId: ReadonlyMap<AgentId, UserId>,
+  ): Effect.Effect<void, AgentNotFoundError | NotInContactsError> {
+    const policy = this.resolveContactPolicy();
+    if (policy === null || targetAgentIds.length === 0) return Effect.void;
+    return this.assertCreatorContactsAll({
+      creatorAgentId,
+      targetAgentIds,
+      ownerByAgentId,
+      policy,
+    });
+  }
+
+  /**
+   * Reduced-surface participant removal: NO authority gate. Used by
+   * `AppEndpointRegistry.removeDeniedParticipant` for dispatch-deny eviction
+   * (runs server-internally, not via a wire RPC). Broadcasts
+   * `ConversationParticipantsRemoved` with `reason: "app_remove"`
+   * so the evicted agent and the remaining participants observe the
+   * removal.
+   * @internal
+   */
+  removeParticipant(
+    conversationId: ConversationId,
+    agentId: AgentId,
+  ): Effect.Effect<void, NotAParticipantError, NetworkSendServiceTag> {
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        // Snapshot membership BEFORE delete so the evicted agent
+        // is included in the fan-out target list.
+        const participantsSnapshot =
+          yield* this.getParticipantAgentIds(conversationId);
+        const taskRowOpt = yield* takeFirstOption(
+          this.db
+            .selectFrom("conversations")
+            .select("task_id")
+            .where("id", "=", conversationId),
+        );
+        const taskId = Option.match(taskRowOpt, {
+          onNone: () => null,
+          onSome: (row) => row.task_id,
+        });
+        const deleted = yield* this.db
+          .deleteFrom("conversation_participants")
+          .where("conversation_id", "=", conversationId)
+          .where("agent_id", "=", agentId)
 ```
 
 ### [`ConversationServiceLive`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/conversation/layer.ts#L15)

--- a/packages/client/safer-architecture.config.json
+++ b/packages/client/safer-architecture.config.json
@@ -1,6 +1,6 @@
 {
   "minExportedSiblingModules": 6,
-  "maxPublicExports": 28,
+  "maxPublicExports": 29,
   "minPublicFacadeModules": 8,
   "folderChildCountOverrides": [
     {

--- a/packages/client/src/MODULE.md
+++ b/packages/client/src/MODULE.md
@@ -8,7 +8,7 @@ Public barrel for the MoltZap client package.
 
 ## Public surface
 
-### [`ContextOptions`](./service.ts#L195)
+### [`ContextOptions`](./service.ts#L196)
 
 _Interface_
 
@@ -20,7 +20,7 @@ export interface ContextOptions {
 }
 ```
 
-### [`ConversationMeta`](./service.ts#L188)
+### [`ConversationMeta`](./service.ts#L189)
 
 _Interface_
 
@@ -33,7 +33,7 @@ export interface ConversationMeta {
 }
 ```
 
-### [`MoltZapService`](./service.ts#L324)
+### [`MoltZapService`](./service.ts#L325)
 
 _Class_
 
@@ -88,15 +88,13 @@ export class MoltZapService {
   private readonly archivedConversationIds = new Set<string>();
 
   /**
-   * Insertion-ordered set of recently seen messageIds per conversation.
-   * Bounded at DEDUP_WINDOW_PER_CONV entries per conversation; oldest entry
-   * is evicted when the window is full. Set#keys() preserves insertion
-   * order in V8 / the spec, so eviction via `.next()` is O(1).
-   *
-   * Keyed and valued by their branded ids so the compiler rejects a
-   * `MessageId` accidentally used as a conversation key (or vice versa).
+   * The branded outer and inner keys keep conversation and message ids from
+   * crossing accidentally while each conversation owns its eviction window.
    */
-  private readonly seenMessageIds = new Map<ConversationId, Set<MessageId>>();
+  private readonly seenMessageIds = new Map<
+    ConversationId,
+    BoundedMap<MessageId, true>
+  >();
   private readonly handlers: {
     [K in ServiceHandlerName]: Array<
       NotificationHandler<ServiceHandlerPayloads[K]>
@@ -158,6 +156,8 @@ export class MoltZapService {
   /** Effect-native: compose via `yield*` or bridge at the edge via `Effect.runPromise`. */
   connect(): Effect.Effect<HelloOk, ServiceRpcError> {
     return Effect.gen(this, function* () {
+      const client = new MoltZapAgentClient({
+        serverUrl: this.opts.serverUrl,
 ```
 
 Stateful MoltZap client that manages connection, conversation tracking,
@@ -168,7 +168,7 @@ Promise siblings — async/await consumers run the Effect at the edge
 with `Effect.runPromise`. Keep this class Effect-only so downstream
 callers compose failures and cancellation explicitly.
 
-### [`ServiceRpcError`](./service.ts#L177)
+### [`ServiceRpcError`](./service.ts#L178)
 
 _TypeAlias_
 

--- a/packages/client/src/__tests__/service/dedup/unit.test.ts
+++ b/packages/client/src/__tests__/service/dedup/unit.test.ts
@@ -19,6 +19,11 @@ const TASK_DEDUP = testTaskId("dedup-task");
 const ARCHIVED_AT = "2026-05-01T00:00:00.000Z";
 const DEDUP_WINDOW_SIZE = 1000;
 const DEDUP_OVERFLOW_COUNT = DEDUP_WINDOW_SIZE + 1;
+const EMPTY_SEEN_COUNT = 0;
+const SINGLE_SEEN_COUNT = 1;
+const DOUBLE_SEEN_COUNT = 2;
+const OLDEST_EVICTION_MESSAGE_ID = "evict-msg-1";
+const OVERFLOW_EVICTION_MESSAGE_ID = `evict-msg-${DEDUP_OVERFLOW_COUNT}`;
 
 type TestConversationId = ReturnType<typeof testConversationId>;
 
@@ -35,6 +40,10 @@ describe("MoltZapService — inbound messageId dedup", () => {
     scopesIdsByConversation,
   );
   it("evicts the oldest entry when the window is full", evictsOldestMessage);
+  it(
+    "does not refresh a duplicate before the next FIFO eviction",
+    duplicateDoesNotRefresh,
+  );
   it(
     "clears the dedup window when the conversation is archived",
     clearsOnArchive,
@@ -91,11 +100,26 @@ function evictsOldestMessage(): void {
   const { seen, service } = makeObservedService();
   saturateDedupWindow(service);
   seen.length = 0;
-  emitMessage(service, "evict-msg-1", CONV_A);
-  expect(seen).toHaveLength(1);
+  emitMessage(service, OLDEST_EVICTION_MESSAGE_ID, CONV_A);
+  expect(seen).toHaveLength(SINGLE_SEEN_COUNT);
   seen.length = 0;
-  emitMessage(service, "evict-msg-1001", CONV_A);
-  expect(seen).toHaveLength(0);
+  emitMessage(service, OVERFLOW_EVICTION_MESSAGE_ID, CONV_A);
+  expect(seen).toHaveLength(EMPTY_SEEN_COUNT);
+}
+
+function duplicateDoesNotRefresh(): void {
+  const { seen, service } = makeObservedService();
+  for (let i = 1; i <= DEDUP_WINDOW_SIZE; i++) {
+    emitMessage(service, `evict-msg-${i}`, CONV_A);
+  }
+  seen.length = 0;
+
+  emitMessage(service, OLDEST_EVICTION_MESSAGE_ID, CONV_A);
+  expect(seen).toHaveLength(EMPTY_SEEN_COUNT);
+
+  emitMessage(service, OVERFLOW_EVICTION_MESSAGE_ID, CONV_A);
+  emitMessage(service, OLDEST_EVICTION_MESSAGE_ID, CONV_A);
+  expect(seen).toHaveLength(DOUBLE_SEEN_COUNT);
 }
 
 function clearsOnArchive(): void {

--- a/packages/client/src/channel-base/index.ts
+++ b/packages/client/src/channel-base/index.ts
@@ -1,5 +1,8 @@
 /** @file Shared channel-adapter primitives for `@moltzap/client/channel-base`. */
 
+// Channel adapters import per-key store primitives through channel-base.
+export { BoundedMap } from "@moltzap/protocol/bounded-map";
+
 export {
   LeaseAlreadyConsumed,
   projectLeaseInvalid,

--- a/packages/client/src/channel-core.ts
+++ b/packages/client/src/channel-core.ts
@@ -13,6 +13,7 @@ import {
   Queue,
 } from "effect";
 import type { ConversationId, MessageId } from "@moltzap/protocol/conversation";
+import { BoundedMap } from "@moltzap/protocol/bounded-map";
 import type { LeaseId } from "@moltzap/protocol/message/dispatch";
 import type { Message } from "@moltzap/protocol/message";
 import type { TaskId } from "@moltzap/protocol/task";
@@ -317,7 +318,7 @@ interface InboundDispatchWork {
  *   Note over core: consumer fiber — Queue.take; takeDispatchCandidate prefers parked[convId]
  *   core->>server: agent/dispatch/request — dispatchAdmission
  *   server-->>core: ack {leaseId, dispatchId}
- *   Note over server,core: ack/release race absorbed via; pendingDispatchesByLease (Deferred); pendingReleasesByLease (ring 256, soft-TTL 30s)
+ *   Note over server,core: ack/release race absorbed via pendingDispatchesByLease (Deferred) and pendingReleasesByLease (ring 256, soft-TTL 30s)
  *   server->>ws: agent/dispatch/released notification
  *   ws->>core: recordDispatchRelease — settles Deferred or buffers
  *   alt verdict deny
@@ -365,14 +366,15 @@ export class MoltZapChannelCore {
   /**
    * Ring buffer of `dispatchRelease` frames that arrived before the
    * recipient registered its parking Deferred (release-then-ack
-   * race). Bounded LRU via Map insertion-order iteration; soft-TTL
-   * eviction at `DISPATCH_RELEASE_RING_SOFT_TTL_MS` so a release
-   * without a matching ack does not leak memory.
+   * race). `BoundedMap` refreshes insertion order when a lease is set
+   * again and evicts the oldest entry at capacity. Soft-TTL eviction at
+   * `DISPATCH_RELEASE_RING_SOFT_TTL_MS` keeps a release without a matching
+   * ack from retaining memory.
    */
-  private readonly pendingReleasesByLease = new Map<
+  private readonly pendingReleasesByLease = new BoundedMap<
     string,
     PendingReleaseEntry
-  >();
+  >(DISPATCH_RELEASE_RING_CAPACITY);
   private readonly closedConversationIds = new Set<string>();
   private readonly parkedByConversation = new Map<
     string,
@@ -484,10 +486,9 @@ export class MoltZapChannelCore {
    * parking Deferred is registered, settle it inline; otherwise
    * insert into the ring buffer for the future ack-side `consume`.
    * Soft-TTL evicts buffered entries whose age exceeds
-   * `DISPATCH_RELEASE_RING_SOFT_TTL_MS`; the hard-cap at
-   * `DISPATCH_RELEASE_RING_CAPACITY` evicts the oldest entry once
-   * exceeded. Both eviction paths warn-log so operators can spot
-   * release-without-ack adversarial patterns.
+   * `DISPATCH_RELEASE_RING_SOFT_TTL_MS`; insertion at the hard cap
+   * evicts the oldest entry. Both eviction paths warn-log so operators
+   * can spot release-without-ack adversarial patterns.
    */
   private recordDispatchRelease(frame: DispatchReleaseFrame): void {
     const parked = this.pendingDispatchesByLease.get(frame.leaseId);
@@ -502,19 +503,17 @@ export class MoltZapChannelCore {
     }
     const nowMs = Date.now();
     this.evictDispatchReleaseRing(nowMs);
-    this.pendingReleasesByLease.set(frame.leaseId, {
+    const evicted = this.pendingReleasesByLease.set(frame.leaseId, {
       verdict: frame.verdict,
       leaseTimeoutMs: frame.leaseTimeoutMs,
       receivedAtMs: nowMs,
     });
-    while (this.pendingReleasesByLease.size > DISPATCH_RELEASE_RING_CAPACITY) {
-      const oldest = this.pendingReleasesByLease.keys().next().value;
-      if (oldest === undefined) break;
-      this.pendingReleasesByLease.delete(oldest);
+    if (evicted !== undefined) {
+      const [evictedLeaseId] = evicted;
       runBackgroundLog(
         effectLogWarning(
           "MoltZapChannelCore: dispatchRelease ring buffer evicted oldest entry (capacity reached)",
-          { leaseId: oldest },
+          { leaseId: evictedLeaseId },
         ),
       );
     }
@@ -523,8 +522,8 @@ export class MoltZapChannelCore {
   private evictDispatchReleaseRing(nowMs: number): void {
     for (const [leaseId, entry] of this.pendingReleasesByLease) {
       if (nowMs - entry.receivedAtMs <= DISPATCH_RELEASE_RING_SOFT_TTL_MS) {
-        // Map iteration is insertion-order; once one entry is fresh
-        // every subsequent entry is fresher. Stop here.
+        // BoundedMap iterates oldest-set first, so every subsequent entry is
+        // fresher once this one remains inside the TTL.
         return;
       }
       this.pendingReleasesByLease.delete(leaseId);
@@ -678,7 +677,7 @@ export class MoltZapChannelCore {
    * `dispatchRelease` verdict, and return the channel-core
    * `DispatchAdmissionDecision`. Absorbs the ack/release race via
    * `pendingDispatchesByLease` (Deferred) plus
-   * `pendingReleasesByLease` (LRU ring buffer):
+   * `pendingReleasesByLease` (refresh-on-set FIFO ring buffer):
    *   - if release arrives first, the `recordDispatchRelease` event
    *     handler buffers it; this method consumes the buffered entry
    *     after the ack returns.

--- a/packages/client/src/local-paths.ts
+++ b/packages/client/src/local-paths.ts
@@ -35,7 +35,11 @@ export const getMoltZapConfigPath = (): string =>
   pathSync((path) => path.join(getMoltZapConfigDir(), CONFIG_FILE_NAME));
 
 export const getMoltZapServiceSocketPath = (): string =>
-  pathSync((path) => path.join(getMoltZapHomeDir(), SERVICE_SOCKET_FILE_NAME));
+  pathSync((path) =>
+    path.join(getMoltZapConfigDir(), SERVICE_SOCKET_FILE_NAME),
+  );
 
 export const getMoltZapAgentServiceSocketPath = (agentId: string): string =>
-  pathSync((path) => path.join(getMoltZapHomeDir(), `service-${agentId}.sock`));
+  pathSync((path) =>
+    path.join(getMoltZapConfigDir(), `service-${agentId}.sock`),
+  );

--- a/packages/client/src/service-socket-path.test.ts
+++ b/packages/client/src/service-socket-path.test.ts
@@ -1,12 +1,24 @@
-import { describe, expect, it } from "vitest";
-import { getMoltZapAgentServiceSocketPath } from "./local-paths.js";
+import { FileSystem, Path } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { it as effectIt } from "@effect/vitest";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getMoltZapAgentServiceSocketPath,
+  getMoltZapServiceSocketPath,
+} from "./local-paths.js";
 import { FakeMoltZapService } from "./test-utils/fake-service.js";
+
+const scopedIt = effectIt.scoped;
 
 const SAFE_AGENT_ID = "agent-abc_123";
 const DEFAULT_SOCKET_SEGMENT = "default";
 const SAFE_SOCKET_NAME = "service-agent-abc_123.sock";
 const DEFAULT_SOCKET_NAME = "service-default.sock";
+const DISCOVERY_SOCKET_NAME = "service.sock";
 const ETC_PASSWD_SEGMENT = "etc/passwd";
+const CONFIG_HOME_PREFIX = "moltzap-socket-config-";
+const OPERATOR_HOME_PREFIX = "moltzap-socket-operator-";
 const EXPECTED_DEFAULT_SOCKET_PATH = getMoltZapAgentServiceSocketPath(
   DEFAULT_SOCKET_SEGMENT,
 );
@@ -90,6 +102,37 @@ function rejectedSocketPathsStayInMoltzapDir() {
   }
 }
 
+function socketPathsFollowConfigHome() {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const configHome = yield* fileSystem.makeTempDirectoryScoped({
+      prefix: CONFIG_HOME_PREFIX,
+    });
+    const operatorHome = yield* fileSystem.makeTempDirectoryScoped({
+      prefix: OPERATOR_HOME_PREFIX,
+    });
+    vi.stubEnv("HOME", operatorHome);
+    vi.stubEnv("MOLTZAP_CONFIG_HOME", configHome);
+
+    const service = new FakeMoltZapService();
+    setOwnAgentId(service, SAFE_AGENT_ID);
+
+    expect(service.socketPath).toBe(path.join(configHome, SAFE_SOCKET_NAME));
+    expect(getMoltZapServiceSocketPath()).toBe(
+      path.join(configHome, DISCOVERY_SOCKET_NAME),
+    );
+  }).pipe(Effect.provide(NodeContext.layer));
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("MoltZapService.socketPath safe ids", () => {
   it(
     "accepts safe alphanumeric agent ids verbatim",
@@ -127,7 +170,12 @@ describe("MoltZapService.socketPath fallback ids", () => {
 
 describe("MoltZapService.socketPath containment", () => {
   it(
-    "keeps the socket inside ~/.moltzap/ for every rejected id",
+    "keeps the socket inside the configured MoltZap directory",
     rejectedSocketPathsStayInMoltzapDir,
+  );
+
+  scopedIt(
+    "uses MOLTZAP_CONFIG_HOME for agent and discovery sockets",
+    socketPathsFollowConfigHome,
   );
 });

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -60,6 +60,7 @@ import {
 import { AgentCallableGroup } from "@moltzap/protocol/socket/catalog";
 import type { RpcGroup, Rpc } from "@effect/rpc";
 import type { TaskId } from "@moltzap/protocol/task";
+import { BoundedMap } from "@moltzap/protocol/bounded-map";
 import {
   Config,
   ConfigProvider,
@@ -288,10 +289,10 @@ export interface CrossConvMessage {
 const MAX_MESSAGES_PER_CONV = 1000;
 
 /**
- * Per-conversation dedup window. Inbound messageIds are tracked in a
- * Set bounded to this size; once full, the insertion-ordered oldest
- * entry is evicted to make room. 1000 × 36 bytes per UUID ≈ 36 KB per
- * conversation — bounded and negligible for the expected conversation count.
+ * Per-conversation dedup window. `BoundedMap` evicts the oldest message id
+ * when a new id arrives at capacity. 1000 × 36 bytes per UUID ≈ 36 KB per
+ * conversation, which keeps replay protection negligible at the expected
+ * conversation count.
  */
 const DEDUP_WINDOW_PER_CONV = 1000;
 
@@ -371,15 +372,13 @@ export class MoltZapService {
   private readonly archivedConversationIds = new Set<string>();
 
   /**
-   * Insertion-ordered set of recently seen messageIds per conversation.
-   * Bounded at DEDUP_WINDOW_PER_CONV entries per conversation; oldest entry
-   * is evicted when the window is full. Set#keys() preserves insertion
-   * order in V8 / the spec, so eviction via `.next()` is O(1).
-   *
-   * Keyed and valued by their branded ids so the compiler rejects a
-   * `MessageId` accidentally used as a conversation key (or vice versa).
+   * The branded outer and inner keys keep conversation and message ids from
+   * crossing accidentally while each conversation owns its eviction window.
    */
-  private readonly seenMessageIds = new Map<ConversationId, Set<MessageId>>();
+  private readonly seenMessageIds = new Map<
+    ConversationId,
+    BoundedMap<MessageId, true>
+  >();
   private readonly handlers: {
     [K in ServiceHandlerName]: Array<
       NotificationHandler<ServiceHandlerPayloads[K]>
@@ -1279,20 +1278,17 @@ export class MoltZapService {
     convId: ConversationId,
     msgId: MessageId,
   ): boolean {
-    let dedupSet = this.seenMessageIds.get(convId);
-    if (dedupSet === undefined) {
-      dedupSet = new Set<MessageId>();
-      this.seenMessageIds.set(convId, dedupSet);
+    let dedupWindow = this.seenMessageIds.get(convId);
+    if (dedupWindow === undefined) {
+      dedupWindow = new BoundedMap<MessageId, true>(DEDUP_WINDOW_PER_CONV);
+      this.seenMessageIds.set(convId, dedupWindow);
     }
-    if (dedupSet.has(msgId)) {
+    if (dedupWindow.has(msgId)) {
+      // Replays retain their original FIFO age so repeated delivery cannot
+      // keep an old id resident forever.
       return false;
     }
-    if (dedupSet.size >= DEDUP_WINDOW_PER_CONV) {
-      // size >= 1 guaranteed by the guard above; next().value is defined.
-      const oldest = dedupSet.keys().next();
-      if (!oldest.done) dedupSet.delete(oldest.value);
-    }
-    dedupSet.add(msgId);
+    dedupWindow.set(msgId, true);
     return true;
   }
 

--- a/packages/openclaw-channel/src/MODULE.md
+++ b/packages/openclaw-channel/src/MODULE.md
@@ -10,7 +10,7 @@ runtime entries from `index.*` at the extension root only, so the built
 
 ## Public surface
 
-### [`createMoltzapChannelPlugin`](./openclaw-entry.ts#L1244)
+### [`createMoltzapChannelPlugin`](./openclaw-entry.ts#L1268)
 
 _Function_
 
@@ -64,7 +64,7 @@ a throw.
 `task:&lt;taskId>:&lt;conversationId>` (existing conversation). A target
 containing `:` in any other shape is rejected.
 
-### [`default`](./openclaw-entry.ts#L1273)
+### [`default`](./openclaw-entry.ts#L1297)
 
 _Variable_
 
@@ -72,7 +72,7 @@ _Variable_
 const plugin =
 ```
 
-### [`moltzapChannelPlugin`](./openclaw-entry.ts#L1270)
+### [`moltzapChannelPlugin`](./openclaw-entry.ts#L1294)
 
 _Variable_
 
@@ -85,7 +85,7 @@ Shared singleton so a single registration reuses the same `activeClients`
 closure across `startAccount` and `sendText`. Tests import this directly
 to assert against that shared state.
 
-### [`MoltzapChannelPlugin`](./openclaw-entry.ts#L1261)
+### [`MoltzapChannelPlugin`](./openclaw-entry.ts#L1285)
 
 _TypeAlias_
 

--- a/packages/openclaw-channel/src/account.test.ts
+++ b/packages/openclaw-channel/src/account.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import manifest from "../openclaw.plugin.json" with { type: "json" };
+import { makeMoltZapChannelConfigJsonSchema } from "./openclaw-entry.js";
+
+const DRAFT_07_SCHEMA = "http://json-schema.org/draft-07/schema#";
+const EMPTY_REQUIRED_COUNT = 0;
+
+function makeManifestChannelSchema() {
+  const { $schema, ...generated } = makeMoltZapChannelConfigJsonSchema();
+  expect($schema).toBe(DRAFT_07_SCHEMA);
+
+  if (!("required" in generated)) {
+    throw new Error("expected an object schema");
+  }
+  expect(generated.required).toHaveLength(EMPTY_REQUIRED_COUNT);
+
+  const { required, ...embeddedSchema } = generated;
+  return embeddedSchema;
+}
+
+describe("openclaw.plugin.json channel config", () => {
+  it("matches the schema derived from MoltZapAccount", () => {
+    expect(manifest.channelConfigs.moltzap.schema).toEqual(
+      makeManifestChannelSchema(),
+    );
+  });
+});

--- a/packages/openclaw-channel/src/account.test.ts
+++ b/packages/openclaw-channel/src/account.test.ts
@@ -12,9 +12,9 @@ function makeManifestChannelSchema() {
   if (!("required" in generated)) {
     throw new Error("expected an object schema");
   }
-  expect(generated.required).toHaveLength(EMPTY_REQUIRED_COUNT);
 
   const { required, ...embeddedSchema } = generated;
+  expect(required).toHaveLength(EMPTY_REQUIRED_COUNT);
   return embeddedSchema;
 }
 

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -29,7 +29,15 @@ import {
   type EnrichedInboundMessage,
   type GroupFields,
 } from "@moltzap/client/channel-base";
-import { Config, ConfigProvider, Data, Effect, Option, Schema } from "effect";
+import {
+  Config,
+  ConfigProvider,
+  Data,
+  Effect,
+  JSONSchema,
+  Option,
+  Schema,
+} from "effect";
 import {
   writeOpenClawContextLog,
   type OpenClawContextLogInput,
@@ -152,16 +160,30 @@ function writeContextLogOrWarn(
   );
 }
 
-type MoltZapAccount = {
-  id: string;
-  agentName?: string;
-  enabled?: boolean;
-};
+const MoltZapAccountSchema = Schema.Struct({
+  id: Schema.String,
+  agentName: Schema.optional(Schema.String),
+  enabled: Schema.optional(Schema.Boolean),
+});
+
+type MoltZapAccount = Schema.Schema.Type<typeof MoltZapAccountSchema>;
+
+const MoltZapChannelConfigSchema = Schema.Struct({
+  accounts: Schema.optional(Schema.Array(MoltZapAccountSchema)),
+});
+
+/**
+ * The drift test consumes this projection because OpenClaw reads the manifest
+ * from disk.
+ * @internal
+ */
+export const makeMoltZapChannelConfigJsonSchema = () =>
+  JSONSchema.make(MoltZapChannelConfigSchema);
 
 type OpenClawConfig = Record<string, unknown> & {
   channels?: {
     moltzap?: {
-      accounts?: MoltZapAccount[];
+      accounts?: ReadonlyArray<MoltZapAccount>;
     };
   };
 };
@@ -282,7 +304,9 @@ interface InboundRuntimeData {
   readonly groupMembers: string | undefined;
 }
 
-function resolveAccountList(cfg: OpenClawConfig): MoltZapAccount[] {
+function resolveAccountList(
+  cfg: OpenClawConfig,
+): ReadonlyArray<MoltZapAccount> {
   const section = cfg.channels?.moltzap;
   if (!section) return [];
   return Array.isArray(section.accounts) ? section.accounts : [];

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -21,6 +21,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./bounded-map": {
+      "types": "./dist/bounded-map/index.d.ts",
+      "import": "./dist/bounded-map/index.js"
+    },
     "./identity": {
       "types": "./dist/identity/index.d.ts",
       "import": "./dist/identity/index.js"

--- a/packages/protocol/safer-architecture.config.json
+++ b/packages/protocol/safer-architecture.config.json
@@ -1,6 +1,6 @@
 {
   "minExportedSiblingModules": 10,
-  "maxSubpathExports": 10,
+  "maxSubpathExports": 11,
   "maxPublicExports": 42,
   "maxPublicReexports": 13,
   "minPublicFacadeModules": 14,

--- a/packages/protocol/src/bounded-map/MODULE.md
+++ b/packages/protocol/src/bounded-map/MODULE.md
@@ -1,0 +1,101 @@
+# protocol/bounded-map
+
+_`packages/protocol/src/bounded-map`_
+
+## Purpose
+
+Bounded insertion-ordered map shared by endpoint and server caches.
+
+Protocol is the common dependency leaf for client and server runtime
+packages, so this synchronous store lives in a focused subpath that
+preserves their one-way imports.
+
+## Public surface
+
+### [`BoundedMap`](./index.ts#L25)
+
+_Class_
+
+```ts
+export class BoundedMap<K, V> implements ReadonlyMap<K, V> {
+  readonly #entries = new Map<K, V>();
+
+  constructor(readonly capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+      throw new InvalidBoundedMapCapacity({ capacity });
+    }
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+
+  get(key: K): V | undefined {
+    return this.#entries.get(key);
+  }
+
+  has(key: K): boolean {
+    return this.#entries.has(key);
+  }
+
+  delete(key: K): boolean {
+    return this.#entries.delete(key);
+  }
+
+  clear(): void {
+    this.#entries.clear();
+  }
+
+  set(key: K, value: V): readonly [K, V] | undefined {
+    if (this.#entries.has(key)) {
+      this.#entries.delete(key);
+    }
+    this.#entries.set(key, value);
+
+    if (this.#entries.size <= this.capacity) {
+      return undefined;
+    }
+
+    const oldest = this.#entries.entries().next();
+    if (oldest.done) {
+      return undefined;
+    }
+    this.#entries.delete(oldest.value[0]);
+    return oldest.value;
+  }
+
+  entries(): MapIterator<[K, V]> {
+    return this.#entries.entries();
+  }
+
+  keys(): MapIterator<K> {
+    return this.#entries.keys();
+  }
+
+  values(): MapIterator<V> {
+    return this.#entries.values();
+  }
+
+  forEach(
+    callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
+    thisArg?: unknown,
+  ): void {
+    this.#entries.forEach((value, key) => {
+      callbackfn.call(thisArg, value, key, this);
+    });
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.entries();
+  }
+}
+```
+
+Insertion-ordered map with a fixed entry capacity.
+
+Setting an existing key refreshes its position without evicting another
+entry. Reads preserve insertion order.
+
+## Files
+
+- `index.ts`

--- a/packages/protocol/src/bounded-map/bounded-map.test.ts
+++ b/packages/protocol/src/bounded-map/bounded-map.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { BoundedMap } from "./index.js";
+
+const CAPACITY = 2;
+const EMPTY_SIZE = 0;
+const SINGLE_ENTRY_SIZE = 1;
+const FULL_SIZE = 2;
+
+const KEY_ALPHA = "alpha";
+const KEY_BETA = "beta";
+const KEY_GAMMA = "gamma";
+const VALUE_ALPHA = "value-alpha";
+const VALUE_ALPHA_REFRESHED = "value-alpha-refreshed";
+const VALUE_BETA = "value-beta";
+const VALUE_GAMMA = "value-gamma";
+
+const ALPHA_ENTRY: readonly [string, string] = [KEY_ALPHA, VALUE_ALPHA];
+const ALPHA_REFRESHED_ENTRY: readonly [string, string] = [
+  KEY_ALPHA,
+  VALUE_ALPHA_REFRESHED,
+];
+const BETA_ENTRY: readonly [string, string] = [KEY_BETA, VALUE_BETA];
+const GAMMA_ENTRY: readonly [string, string] = [KEY_GAMMA, VALUE_GAMMA];
+const EMPTY_ENTRIES: ReadonlyArray<readonly [string, string]> = [];
+const FIFO_ENTRIES: ReadonlyArray<readonly [string, string]> = [
+  BETA_ENTRY,
+  GAMMA_ENTRY,
+];
+const REFRESHED_ENTRIES: ReadonlyArray<readonly [string, string]> = [
+  ALPHA_REFRESHED_ENTRY,
+  GAMMA_ENTRY,
+];
+const EXPECTED_KEYS: ReadonlyArray<string> = [KEY_BETA, KEY_GAMMA];
+const EXPECTED_VALUES: ReadonlyArray<string> = [VALUE_BETA, VALUE_GAMMA];
+const INVALID_CAPACITY_MESSAGE =
+  "BoundedMap capacity must be a positive safe integer";
+
+const INVALID_CAPACITIES: ReadonlyArray<number> = [
+  0,
+  -1,
+  1.5,
+  Number.NaN,
+  Number.POSITIVE_INFINITY,
+  Number.MAX_SAFE_INTEGER + 1,
+];
+
+function makeMap(): BoundedMap<string, string> {
+  return new BoundedMap<string, string>(CAPACITY);
+}
+
+describe("BoundedMap", () => {
+  it("keeps at most capacity entries and evicts in FIFO order", boundsFifo);
+  it(
+    "refreshes an existing key on set before choosing the next eviction",
+    refreshesOnSet,
+  );
+  it("does not refresh insertion order on get", getDoesNotRefresh);
+  it("supports deletion and clearing", supportsDeleteAndClear);
+  it("iterates entries, keys, and values in insertion order", iteratesInOrder);
+  it("visits entries through ReadonlyMap-compatible forEach", visitsForEach);
+  it("rejects capacities that are not positive safe integers", rejectsInvalid);
+});
+
+function boundsFifo(): void {
+  const entries = makeMap();
+
+  expect(entries.set(KEY_ALPHA, VALUE_ALPHA)).toBeUndefined();
+  expect(entries.set(KEY_BETA, VALUE_BETA)).toBeUndefined();
+  expect(entries.size).toBe(FULL_SIZE);
+
+  expect(entries.set(KEY_GAMMA, VALUE_GAMMA)).toEqual(ALPHA_ENTRY);
+  expect(entries.size).toBe(FULL_SIZE);
+  expect(entries.has(KEY_ALPHA)).toBe(false);
+  expect(entries.get(KEY_BETA)).toBe(VALUE_BETA);
+  expect([...entries]).toEqual(FIFO_ENTRIES);
+}
+
+function refreshesOnSet(): void {
+  const entries = makeMap();
+  entries.set(KEY_ALPHA, VALUE_ALPHA);
+  entries.set(KEY_BETA, VALUE_BETA);
+
+  expect(entries.set(KEY_ALPHA, VALUE_ALPHA_REFRESHED)).toBeUndefined();
+  expect(entries.set(KEY_GAMMA, VALUE_GAMMA)).toEqual(BETA_ENTRY);
+  expect(entries.get(KEY_ALPHA)).toBe(VALUE_ALPHA_REFRESHED);
+  expect([...entries]).toEqual(REFRESHED_ENTRIES);
+}
+
+function getDoesNotRefresh(): void {
+  const entries = makeMap();
+  entries.set(KEY_ALPHA, VALUE_ALPHA);
+  entries.set(KEY_BETA, VALUE_BETA);
+
+  expect(entries.get(KEY_ALPHA)).toBe(VALUE_ALPHA);
+  expect(entries.set(KEY_GAMMA, VALUE_GAMMA)).toEqual(ALPHA_ENTRY);
+  expect([...entries]).toEqual(FIFO_ENTRIES);
+}
+
+function supportsDeleteAndClear(): void {
+  const entries = makeMap();
+  entries.set(KEY_ALPHA, VALUE_ALPHA);
+  entries.set(KEY_BETA, VALUE_BETA);
+
+  expect(entries.delete(KEY_ALPHA)).toBe(true);
+  expect(entries.delete(KEY_ALPHA)).toBe(false);
+  expect(entries.size).toBe(SINGLE_ENTRY_SIZE);
+
+  entries.clear();
+  expect(entries.size).toBe(EMPTY_SIZE);
+  expect([...entries]).toEqual(EMPTY_ENTRIES);
+}
+
+function iteratesInOrder(): void {
+  const entries = makeMap();
+  entries.set(KEY_BETA, VALUE_BETA);
+  entries.set(KEY_GAMMA, VALUE_GAMMA);
+
+  expect([...entries.entries()]).toEqual(FIFO_ENTRIES);
+  expect([...entries.keys()]).toEqual(EXPECTED_KEYS);
+  expect([...entries.values()]).toEqual(EXPECTED_VALUES);
+}
+
+function visitsForEach(): void {
+  const entries = makeMap();
+  const visited: Array<readonly [string, string]> = [];
+  entries.set(KEY_BETA, VALUE_BETA);
+  entries.set(KEY_GAMMA, VALUE_GAMMA);
+
+  entries.forEach((value, key, map) => {
+    expect(map).toBe(entries);
+    visited.push([key, value]);
+  });
+
+  expect(visited).toEqual(FIFO_ENTRIES);
+}
+
+function rejectsInvalid(): void {
+  for (const capacity of INVALID_CAPACITIES) {
+    expect(() => new BoundedMap(capacity)).toThrow(INVALID_CAPACITY_MESSAGE);
+  }
+}

--- a/packages/protocol/src/bounded-map/index.ts
+++ b/packages/protocol/src/bounded-map/index.ts
@@ -1,0 +1,96 @@
+/**
+ * @file Bounded insertion-ordered map shared by endpoint and server caches.
+ *
+ * Protocol is the common dependency leaf for client and server runtime
+ * packages, so this synchronous store lives in a focused subpath that
+ * preserves their one-way imports.
+ */
+
+import { Data } from "effect";
+
+class InvalidBoundedMapCapacity extends Data.TaggedError(
+  "InvalidBoundedMapCapacity",
+)<{ readonly capacity: number }> {
+  override get message(): string {
+    return `BoundedMap capacity must be a positive safe integer: ${this.capacity}`;
+  }
+}
+
+/**
+ * Insertion-ordered map with a fixed entry capacity.
+ *
+ * Setting an existing key refreshes its position without evicting another
+ * entry. Reads preserve insertion order.
+ */
+export class BoundedMap<K, V> implements ReadonlyMap<K, V> {
+  readonly #entries = new Map<K, V>();
+
+  constructor(readonly capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+      throw new InvalidBoundedMapCapacity({ capacity });
+    }
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+
+  get(key: K): V | undefined {
+    return this.#entries.get(key);
+  }
+
+  has(key: K): boolean {
+    return this.#entries.has(key);
+  }
+
+  delete(key: K): boolean {
+    return this.#entries.delete(key);
+  }
+
+  clear(): void {
+    this.#entries.clear();
+  }
+
+  set(key: K, value: V): readonly [K, V] | undefined {
+    if (this.#entries.has(key)) {
+      this.#entries.delete(key);
+    }
+    this.#entries.set(key, value);
+
+    if (this.#entries.size <= this.capacity) {
+      return undefined;
+    }
+
+    const oldest = this.#entries.entries().next();
+    if (oldest.done) {
+      return undefined;
+    }
+    this.#entries.delete(oldest.value[0]);
+    return oldest.value;
+  }
+
+  entries(): MapIterator<[K, V]> {
+    return this.#entries.entries();
+  }
+
+  keys(): MapIterator<K> {
+    return this.#entries.keys();
+  }
+
+  values(): MapIterator<V> {
+    return this.#entries.values();
+  }
+
+  forEach(
+    callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
+    thisArg?: unknown,
+  ): void {
+    this.#entries.forEach((value, key) => {
+      callbackfn.call(thisArg, value, key, this);
+    });
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.entries();
+  }
+}

--- a/packages/server/src/conversation/MODULE.md
+++ b/packages/server/src/conversation/MODULE.md
@@ -28,14 +28,16 @@ export const conversationList: ServerHandler<typeof ConversationList> = (
 )
 ```
 
-### [`ConversationService`](./conversation.service.ts#L260)
+### [`ConversationService`](./conversation.service.ts#L261)
 
 _Class_
 
 ```ts
 export class ConversationService {
   /** In-memory cache for last message previews — avoids decrypting on every list() call */
-  private previewCache = new Map<ConversationId, string>();
+  private readonly previewCache = new BoundedMap<ConversationId, string>(
+    PREVIEW_CACHE_MAX,
+  );
 
   constructor(
     private db: Db,
@@ -48,16 +50,109 @@ export class ConversationService {
     conversationId: ConversationId,
     firstPartText: string,
   ): void {
-    this.previewCache.delete(conversationId);
     this.previewCache.set(
       conversationId,
       firstPartText.slice(0, PREVIEW_CACHE_TEXT_CHARS),
     );
-    if (this.previewCache.size > PREVIEW_CACHE_MAX) {
-      const oldest = this.previewCache.keys().next().value!;
-      this.previewCache.delete(oldest);
-    }
   }
+
+  create<TaskMintError = never>(
+    input: CreateConversationOptions<TaskMintError>,
+  ): Effect.Effect<Conversation, TaskMintError> {
+    return catchSqlErrorAsDefect(this.createConversationEffect(input));
+  }
+
+  private createConversationEffect<TaskMintError>(
+    input: CreateConversationOptions<TaskMintError>,
+  ): Effect.Effect<Conversation, TaskMintError | SqlError> {
+    return Effect.gen(this, function* () {
+      const task = yield* input.mintTask;
+      const created = yield* this.insertConversation(input, task.id);
+      yield* this.subscribeCreatedConversation(input, created.id);
+      yield* this.logConversationCreated(input, created.id);
+      return created;
+    });
+  }
+
+  /** @internal */
+  loadAgentOwners(
+    agentIds: ReadonlyArray<AgentId>,
+  ): Effect.Effect<
+    ReadonlyMap<AgentId, UserId>,
+    AgentNotFoundError | SqlError
+  > {
+    return Effect.gen(this, function* () {
+      const rows =
+        agentIds.length === 0
+          ? []
+          : yield* this.db
+              .selectFrom("agents")
+              .select(["id", "owner_user_id"])
+              .where("id", "in", [...agentIds]);
+      const ownerByAgentId = new Map<AgentId, UserId>();
+      for (const row of rows) {
+        ownerByAgentId.set(row.id, row.owner_user_id);
+      }
+      for (const agentId of agentIds) {
+        if (!ownerByAgentId.has(agentId)) {
+          return yield* Effect.fail(
+            new AgentNotFoundError({ message: `Agent ${agentId} not found` }),
+          );
+        }
+      }
+      return ownerByAgentId;
+    });
+  }
+
+  /** @internal */
+  assertContactPolicyForCreate(
+    creatorAgentId: AgentId,
+    targetAgentIds: ReadonlyArray<AgentId>,
+    ownerByAgentId: ReadonlyMap<AgentId, UserId>,
+  ): Effect.Effect<void, AgentNotFoundError | NotInContactsError> {
+    const policy = this.resolveContactPolicy();
+    if (policy === null || targetAgentIds.length === 0) return Effect.void;
+    return this.assertCreatorContactsAll({
+      creatorAgentId,
+      targetAgentIds,
+      ownerByAgentId,
+      policy,
+    });
+  }
+
+  /**
+   * Reduced-surface participant removal: NO authority gate. Used by
+   * `AppEndpointRegistry.removeDeniedParticipant` for dispatch-deny eviction
+   * (runs server-internally, not via a wire RPC). Broadcasts
+   * `ConversationParticipantsRemoved` with `reason: "app_remove"`
+   * so the evicted agent and the remaining participants observe the
+   * removal.
+   * @internal
+   */
+  removeParticipant(
+    conversationId: ConversationId,
+    agentId: AgentId,
+  ): Effect.Effect<void, NotAParticipantError, NetworkSendServiceTag> {
+    return catchSqlErrorAsDefect(
+      Effect.gen(this, function* () {
+        // Snapshot membership BEFORE delete so the evicted agent
+        // is included in the fan-out target list.
+        const participantsSnapshot =
+          yield* this.getParticipantAgentIds(conversationId);
+        const taskRowOpt = yield* takeFirstOption(
+          this.db
+            .selectFrom("conversations")
+            .select("task_id")
+            .where("id", "=", conversationId),
+        );
+        const taskId = Option.match(taskRowOpt, {
+          onNone: () => null,
+          onSome: (row) => row.task_id,
+        });
+        const deleted = yield* this.db
+          .deleteFrom("conversation_participants")
+          .where("conversation_id", "=", conversationId)
+          .where("agent_id", "=", agentId)
 ```
 
 ### [`ConversationServiceLive`](./layer.ts#L15)

--- a/packages/server/src/conversation/conversation.service.ts
+++ b/packages/server/src/conversation/conversation.service.ts
@@ -7,6 +7,7 @@ import type {
 import type { AgentId, UserId } from "@moltzap/protocol/identity";
 import type { ConversationId } from "@moltzap/protocol/conversation";
 import type { TaskId } from "@moltzap/protocol/task";
+import { BoundedMap } from "@moltzap/protocol/bounded-map";
 import type { SqlError } from "@effect/sql/SqlError";
 import { Effect, Option } from "effect";
 import { InvalidParamsError } from "@moltzap/protocol/rpc";
@@ -259,7 +260,9 @@ const nextConversationListCursor = (
 
 export class ConversationService {
   /** In-memory cache for last message previews — avoids decrypting on every list() call */
-  private previewCache = new Map<ConversationId, string>();
+  private readonly previewCache = new BoundedMap<ConversationId, string>(
+    PREVIEW_CACHE_MAX,
+  );
 
   constructor(
     private db: Db,
@@ -272,15 +275,10 @@ export class ConversationService {
     conversationId: ConversationId,
     firstPartText: string,
   ): void {
-    this.previewCache.delete(conversationId);
     this.previewCache.set(
       conversationId,
       firstPartText.slice(0, PREVIEW_CACHE_TEXT_CHARS),
     );
-    if (this.previewCache.size > PREVIEW_CACHE_MAX) {
-      const oldest = this.previewCache.keys().next().value!;
-      this.previewCache.delete(oldest);
-    }
   }
 
   create<TaskMintError = never>(

--- a/scripts/check-architecture-boundaries.js
+++ b/scripts/check-architecture-boundaries.js
@@ -107,6 +107,7 @@ for (const file of v2Files) {
 
 assertExportMap("packages/protocol", [
   ".",
+  "./bounded-map",
   "./conversation",
   "./identity",
   "./message",

--- a/scripts/gen-architecture-configs.mjs
+++ b/scripts/gen-architecture-configs.mjs
@@ -64,7 +64,7 @@ const packageDefinitions = {
   client: {
     beforeShared: {
       minExportedSiblingModules: 6,
-      maxPublicExports: 28,
+      maxPublicExports: 29,
       minPublicFacadeModules: 8,
       folderChildCountOverrides: [
         {
@@ -119,7 +119,7 @@ const packageDefinitions = {
   protocol: {
     config: {
       minExportedSiblingModules: 10,
-      maxSubpathExports: 10,
+      maxSubpathExports: 11,
       maxPublicExports: 42,
       maxPublicReexports: 13,
       minPublicFacadeModules: 14,


### PR DESCRIPTION
Codex-dispatched debt batch, reviewed and simplified. Fixes #783 (agent service socket honors MOLTZAP_CONFIG_HOME), fixes #805 (plugin manifest pinned against the MoltZapAccount schema via a JSONSchema.make drift test), and consolidates the repo's three hand-rolled capped-map evictions behind one BoundedMap primitive in @moltzap/protocol (placed there because server-core must not depend on the client), with a channel-base re-export for adapter authors. Verified: 582 tests green across client/protocol/server-core/openclaw-channel; root lint fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)