### PR TITLE
chore(testbed,ci): harness type seam, guard-dep centralization, nx release detection, gated install coverage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,24 +59,23 @@ jobs:
             BASE=$(git hash-object -t tree /dev/null)
           fi
 
+          AFFECTED_PROJECTS=$(pnpm exec nx show projects \
+            --affected \
+            --withTarget=build \
+            --base="$BASE" \
+            --head=HEAD \
+            --json)
+          echo "Affected build projects since $BASE: $AFFECTED_PROJECTS"
+
           CHANGED=""
           REQUESTED_PACKAGES=" ${REQUESTED_PACKAGES} "
           for pkg in protocol server client openclaw-channel testbed; do
+            PROJECT_NAME=$(node -p "require('./packages/$pkg/package.json').name")
             if [[ "$REQUESTED_PACKAGES" == *" $pkg "* ]]; then
               SHOULD_RELEASE=1
               echo "Package $pkg requested by workflow_dispatch input"
-            elif git diff --name-only "$BASE"..HEAD -- \
-              "packages/$pkg/src/" \
-              "packages/$pkg/bin/" \
-              "packages/$pkg/scripts/" \
-              "packages/$pkg/package.json" \
-              "packages/$pkg/README.md" \
-              "packages/$pkg/tsconfig.json" \
-              "packages/$pkg/openclaw.plugin.json" | grep -q .; then
-              SHOULD_RELEASE=1
-            elif [ "$pkg" = "testbed" ] && git diff --name-only "$BASE"..HEAD -- \
-              "packages/nanoclaw-channel/src/channels/moltzap.ts" \
-              "packages/testbed/nanoclaw-assets/" | grep -q .; then
+            elif jq -e --arg project "$PROJECT_NAME" \
+              'index($project) != null' <<< "$AFFECTED_PROJECTS" >/dev/null; then
               SHOULD_RELEASE=1
             else
               SHOULD_RELEASE=0

--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -1,3 +1,4 @@
+// Package ESLint configs load this shared module, so the root owns its plugins.
 import guard from "eslint-plugin-agent-code-guard";
 import tsParser from "@typescript-eslint/parser";
 import comments from "@eslint-community/eslint-plugin-eslint-comments";
@@ -28,14 +29,11 @@ const packageIgnores = {
   ignores: ["**/dist/**", "**/node_modules/**", "**/*.d.ts"],
 };
 
-// Effect.gen abandons the generator when a yielded effect fails: NO code in
-// a `finally` block runs on that path — not even synchronous statements —
-// so cleanup written as try/finally silently leaks (#791's root cause).
-// Flags any try/finally whose nearest enclosing function is a generator
-// driven by Effect (`Effect.gen(...)` / `Effect.fn(...)(...)`); plain
-// generators, where real iteration does run finally via `.return()`, are
-// not flagged. The fix is Effect.ensuring / Effect.acquireRelease.
-// Inline pending upstream adoption: agent-code-guard#81.
+// Effect.gen abandons its generator when a yielded effect fails, so a
+// `finally` block cannot provide reliable cleanup on that path. This rule
+// flags try/finally inside Effect-driven generators while leaving plain
+// generators alone, where iteration runs finally through `.return()`.
+// Effect.ensuring and Effect.acquireRelease preserve cleanup on every path.
 const genFinallyRule = {
   meta: {
     type: "problem",

--- a/knip.json
+++ b/knip.json
@@ -14,8 +14,7 @@
         "src/**/__tests__/**/*.ts",
         "vitest*.config.ts"
       ],
-      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"],
-      "ignoreDependencies": ["eslint-plugin-agent-code-guard"]
+      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"]
     },
     "packages/nanoclaw-channel": {
       "entry": [
@@ -23,8 +22,7 @@
         "src/**/__tests__/**/*.ts",
         "vitest*.config.ts"
       ],
-      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"],
-      "ignoreDependencies": ["eslint-plugin-agent-code-guard"]
+      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"]
     },
     "packages/openclaw-channel": {
       "entry": [
@@ -33,8 +31,7 @@
         "src/**/__tests__/**/*.ts",
         "vitest*.config.ts"
       ],
-      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"],
-      "ignoreDependencies": ["eslint-plugin-agent-code-guard"]
+      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"]
     },
     "packages/protocol": {
       "entry": [
@@ -44,8 +41,7 @@
         "scripts/check-mermaid.ts",
         "vitest*.config.ts"
       ],
-      "project": ["scripts/**/*.ts", "src/**/*.ts", "*.mjs", "vitest*.config.ts"],
-      "ignoreDependencies": ["eslint-plugin-agent-code-guard"]
+      "project": ["scripts/**/*.ts", "src/**/*.ts", "*.mjs", "vitest*.config.ts"]
     },
     "packages/testbed": {
       "entry": [
@@ -53,8 +49,7 @@
         "src/**/*.test.ts",
         "vitest*.config.ts"
       ],
-      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"],
-      "ignoreDependencies": ["eslint-plugin-agent-code-guard"]
+      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"]
     },
     "packages/server": {
       "entry": [
@@ -64,8 +59,7 @@
         "src/**/__tests__/**/*.ts",
         "vitest*.config.ts"
       ],
-      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"],
-      "ignoreDependencies": ["eslint-plugin-agent-code-guard"]
+      "project": ["src/**/*.ts", "*.mjs", "vitest*.config.ts"]
     }
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -91,7 +91,6 @@
     "@effect/vitest": "^0.30.0",
     "@moltzap/server-core": "workspace:*",
     "eslint": "^9",
-    "eslint-plugin-agent-code-guard": "0.0.14",
     "fast-check": "^3.23.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",

--- a/packages/nanoclaw-channel/package.json
+++ b/packages/nanoclaw-channel/package.json
@@ -63,7 +63,6 @@
     "@effect/platform-node": "^0.108.0",
     "@effect/vitest": "^0.30.0",
     "eslint": "^9",
-    "eslint-plugin-agent-code-guard": "0.0.14",
     "typescript": "^5.7.0",
     "vitest": "^3.2.0"
   }

--- a/packages/openclaw-channel/package.json
+++ b/packages/openclaw-channel/package.json
@@ -67,7 +67,6 @@
     "@types/node": "^25.5.0",
     "@types/pg": "^8.11.0",
     "eslint": "^9",
-    "eslint-plugin-agent-code-guard": "0.0.14",
     "fast-check": "^3.23.1",
     "pg": "^8.13.0",
     "typescript": "^5.7.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -131,7 +131,6 @@
   },
   "devDependencies": {
     "eslint": "^9",
-    "eslint-plugin-agent-code-guard": "0.0.14",
     "fast-check": "^3.23.1",
     "tsc-alias": "^1.8.17",
     "tsx": "^4.19.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -92,7 +92,6 @@
     "@effect/vitest": "^0.30.0",
     "@types/pg": "^8.11.0",
     "eslint": "^9",
-    "eslint-plugin-agent-code-guard": "0.0.14",
     "fast-check": "^3.23.1",
     "kysely-codegen": "^0.20.0",
     "tsc-alias": "^1.8.17",

--- a/packages/testbed/package.json
+++ b/packages/testbed/package.json
@@ -24,6 +24,7 @@
     "build": "nx run @moltzap/testbed:build",
     "lint": "nx run @moltzap/testbed:lint",
     "test": "vitest run --passWithNoTests",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "typecheck:tests": "tsc -p tsconfig.test.json"
   },
   "nx": {
@@ -47,6 +48,23 @@
           "cwd": "packages/testbed",
           "command": "eslint src *.ts --cache --max-warnings=0"
         }
+      },
+      "test:integration": {
+        "dependsOn": [
+          "build"
+        ],
+        "inputs": [
+          "default",
+          "^production",
+          {
+            "env": "MOLTZAP_NANOCLAW_ITEST"
+          }
+        ]
+      },
+      "typecheck:tests": {
+        "dependsOn": [
+          "build"
+        ]
       },
       "arch:check": {
         "executor": "nx:run-commands",

--- a/packages/testbed/package.json
+++ b/packages/testbed/package.json
@@ -70,7 +70,6 @@
     "@moltzap/server-core": "workspace:*",
     "@types/node": "^25.5.0",
     "eslint": "^9",
-    "eslint-plugin-agent-code-guard": "0.0.14",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/packages/testbed/package.json
+++ b/packages/testbed/package.json
@@ -66,6 +66,8 @@
     "openclaw": "2026.6.33"
   },
   "devDependencies": {
+    "@moltzap/client": "workspace:*",
+    "@moltzap/server-core": "workspace:*",
     "@types/node": "^25.5.0",
     "eslint": "^9",
     "eslint-plugin-agent-code-guard": "0.0.14",

--- a/packages/testbed/src/nanoclaw-install.integration.test.ts
+++ b/packages/testbed/src/nanoclaw-install.integration.test.ts
@@ -1,0 +1,71 @@
+import { basename, join } from "node:path";
+import { Command, FileSystem } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Config, Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import {
+  ensureNanoclawRuntimeInstalledEffect,
+  findWarmNanoclawRuntimeInstallEffect,
+} from "./nanoclaw-install.js";
+
+const CACHE_GENERATION_PREFIX = "generation-";
+const READY_MARKER = ".ready";
+const DOCKER_COMMAND = "docker";
+const DOCKER_IMAGE_SUBCOMMAND = "image";
+const DOCKER_INSPECT_SUBCOMMAND = "inspect";
+const SUCCESS_EXIT_CODE = 0;
+
+// The no-process-env-at-runtime guard applies to test files, so the gate
+// reads the flag through Config under the default env-backed provider.
+const NANOCLAW_INSTALL_INTEGRATION_ENABLED = Effect.runSync(
+  Config.string("MOLTZAP_NANOCLAW_ITEST").pipe(
+    Config.withDefault("0"),
+    Config.map((value) => value === "1"),
+  ),
+);
+
+describe.skipIf(!NANOCLAW_INSTALL_INTEGRATION_ENABLED)(
+  "NanoClaw real install cache",
+  () => {
+    it(
+      "reuses a fingerprint-matched generation with its existing image",
+      reusesWarmInstall,
+    );
+  },
+);
+
+function reusesWarmInstall() {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const warmCandidate = yield* findWarmNanoclawRuntimeInstallEffect();
+      expect(warmCandidate).not.toBeNull();
+      if (warmCandidate === null) return;
+
+      const fileSystem = yield* FileSystem.FileSystem;
+      const readyFingerprint = yield* fileSystem.readFileString(
+        join(warmCandidate.cacheDir, READY_MARKER),
+        "utf8",
+      );
+      expect(readyFingerprint).toBe(warmCandidate.cacheFingerprint);
+      expect(
+        basename(warmCandidate.cacheDir).startsWith(CACHE_GENERATION_PREFIX),
+      ).toBeTruthy();
+
+      const imageExitCode = yield* Command.exitCode(
+        Command.make(
+          DOCKER_COMMAND,
+          DOCKER_IMAGE_SUBCOMMAND,
+          DOCKER_INSPECT_SUBCOMMAND,
+          warmCandidate.containerImage,
+        ),
+      );
+      expect(Number(imageExitCode)).toBe(SUCCESS_EXIT_CODE);
+
+      const firstInstall = yield* ensureNanoclawRuntimeInstalledEffect();
+      expect(firstInstall).toEqual(warmCandidate);
+      const secondInstall = yield* ensureNanoclawRuntimeInstalledEffect();
+      expect(secondInstall).toBe(firstInstall);
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
+}

--- a/packages/testbed/src/nanoclaw-install.ts
+++ b/packages/testbed/src/nanoclaw-install.ts
@@ -130,6 +130,24 @@ function resolveCacheTarget() {
   return cachedCacheTarget;
 }
 
+/**
+ * Resolves a ready generation without building so integration probes can
+ * guarantee they exercise the warm install path.
+ * @internal
+ */
+export function findWarmNanoclawRuntimeInstallEffect() {
+  return Effect.gen(function* () {
+    const target = yield* resolveCacheTarget();
+    const generationDir = yield* findNanoclawCacheGeneration(
+      target.cacheRoot,
+      target.cacheFingerprint,
+    );
+    return generationDir === null
+      ? null
+      : runtimeInstall(generationDir, target.cacheFingerprint);
+  }).pipe(Effect.withSpan("findWarmNanoclawRuntimeInstallEffect"));
+}
+
 function runtimeInstall(
   cacheDir: string,
   cacheFingerprint: string,

--- a/packages/testbed/src/trace-capture-harness.ts
+++ b/packages/testbed/src/trace-capture-harness.ts
@@ -1,5 +1,7 @@
 import { Path } from "@effect/platform";
+import type * as ClientTestUtils from "@moltzap/client/test-utils";
 import { Data, Duration, Effect, Fiber, Option, Stream } from "effect";
+import type * as ServerTestUtils from "@moltzap/server-core/test-utils";
 import { startRuntimeAgent, type RuntimeKind } from "./testbed.js";
 import { RuntimeReadyTimedOut, SpawnFailed } from "./errors.js";
 import type { Runtime } from "./runtime.js";
@@ -16,17 +18,11 @@ import {
   type TraceCaptureEvent,
 } from "./trace-capture-bundle.js";
 
-import type { AnyServerRpcDefinition } from "@moltzap/protocol/socket/catalog";
 import type { AgentId, AgentKey } from "@moltzap/protocol/identity";
 import {
   MessageReceivedNotificationDefinition,
   MessagesSend,
 } from "@moltzap/protocol/message";
-import type {
-  NotificationParamsOf,
-  ParamsOf,
-  ResultOf,
-} from "@moltzap/protocol/rpc";
 import {
   DEFAULT_APP_ID,
   TaskRequest,
@@ -99,91 +95,17 @@ interface MessagePart {
   readonly text?: string;
 }
 
-interface HarnessClient {
-  close(): Effect.Effect<void, never, never>;
-
-  /**
-   * Typed-payload Stream subscription. The harness subscribes BEFORE
-   * issuing each `MessagesSend` (`sendMessageAndWait`'s fork → trigger →
-   * join pattern) so the response notification is never dropped between
-   * the request and the Stream materialisation. Structural shape mirrors
-   * `MoltZapAgentClient.subscribe`.
-   */
-  subscribe<D extends typeof MessageReceivedNotificationDefinition>(
-    definition: D,
-    refinement?: (params: NotificationParamsOf<D>) => boolean,
-  ): Stream.Stream<NotificationParamsOf<D>, Error, never>;
-  sendRpc<D extends AnyServerRpcDefinition>(
-    method: D,
-    payload: ParamsOf<D>,
-  ): Effect.Effect<ResultOf<D>, Error, never>;
-}
+// Type-only namespaces keep the dynamic loaders aligned with their published
+// test surfaces without introducing client or server runtime imports.
+type ClientTestModule = typeof ClientTestUtils;
+type HarnessClient = ClientTestUtils.HarnessAgentClient;
+type ServerTestModule = typeof ServerTestUtils;
+type CoreTestServer = ServerTestUtils.CoreTestServer;
 
 interface ConnectedActor {
   readonly agentId: AgentId;
   readonly name: string;
   readonly client: HarnessClient;
-}
-
-// Structural shape of the dynamically loaded `@moltzap/client` test-utils
-// barrel; the canonical implementation is `test-utils/harness.ts →
-// registerAndConnect` there. Loaded by path so the published testbed
-// package never takes a static dependency on the client.
-interface ClientTestModule {
-  registerAgent(
-    baseUrl: string,
-    name: string,
-  ): Effect.Effect<
-    {
-      readonly agentId: AgentId;
-      readonly apiKey: AgentKey;
-    },
-    Error,
-    never
-  >;
-  registerAndConnect(
-    baseUrl: string,
-    name: string,
-  ): Effect.Effect<
-    {
-      readonly agentId: AgentId;
-      readonly apiKey: AgentKey;
-      readonly client: HarnessClient;
-    },
-    Error,
-    never
-  >;
-  stripWsPath(wsUrl: string): string;
-}
-
-// Structural view of the server-owned runtime test port. The concrete
-// implementation lives in @moltzap/server-core's test-utils.
-interface RuntimeServerLike {
-  awaitAgentReady(
-    agentId: AgentId,
-    timeoutMs: number,
-  ): Effect.Effect<
-    | { readonly _tag: "Ready" }
-    | { readonly _tag: "Timeout"; readonly timeoutMs: number }
-    | {
-        readonly _tag: "ProcessExited";
-        readonly exitCode: number | null;
-        readonly stderr: string;
-      },
-    never,
-    never
-  >;
-}
-
-interface CoreTestServer {
-  readonly baseUrl: string;
-  readonly wsUrl: string;
-  readonly runtimeServer: RuntimeServerLike;
-}
-
-interface ServerTestModule {
-  startCoreTestServer(opts: Readonly<Record<string, never>>): unknown;
-  stopCoreTestServer(): unknown;
 }
 
 interface ConversationExecutionState {
@@ -833,10 +755,7 @@ function startCoreTraceServer(
   serverTestModule: ServerTestModule,
 ): Effect.Effect<CoreTestServer, HarnessFailure> {
   return Effect.tryPromise({
-    try: () =>
-      Promise.resolve(
-        serverTestModule.startCoreTestServer({}),
-      ) as Promise<CoreTestServer>,
+    try: () => serverTestModule.startCoreTestServer({}),
     catch: (error) =>
       failHarness(error instanceof Error ? error.message : String(error)),
   });

--- a/packages/testbed/tsconfig.json
+++ b/packages/testbed/tsconfig.json
@@ -17,7 +17,13 @@
   ],
   "references": [
     {
+      "path": "../client"
+    },
+    {
       "path": "../protocol"
+    },
+    {
+      "path": "../server"
     }
   ]
 }

--- a/packages/testbed/vitest.integration.config.ts
+++ b/packages/testbed/vitest.integration.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+const NANOCLAW_INSTALL_TEST_TIMEOUT_MS = 30_000;
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.integration.test.ts"],
+    fileParallelism: false,
+    testTimeout: NANOCLAW_INSTALL_TEST_TIMEOUT_MS,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
-      eslint-plugin-agent-code-guard:
-        specifier: 0.0.14
-        version: 0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       fast-check:
         specifier: ^3.23.1
         version: 3.23.2
@@ -130,9 +127,6 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
-      eslint-plugin-agent-code-guard:
-        specifier: 0.0.14
-        version: 0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -176,9 +170,6 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
-      eslint-plugin-agent-code-guard:
-        specifier: 0.0.14
-        version: 0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       fast-check:
         specifier: ^3.23.1
         version: 3.23.2
@@ -210,9 +201,6 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
-      eslint-plugin-agent-code-guard:
-        specifier: 0.0.14
-        version: 0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       fast-check:
         specifier: ^3.23.1
         version: 3.23.2
@@ -301,9 +289,6 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
-      eslint-plugin-agent-code-guard:
-        specifier: 0.0.14
-        version: 0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       fast-check:
         specifier: ^3.23.1
         version: 3.23.2
@@ -356,9 +341,6 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
-      eslint-plugin-agent-code-guard:
-        specifier: 0.0.14
-        version: 0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -13658,17 +13640,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/visitor-keys@8.58.2':
     dependencies:
       '@typescript-eslint/types': 8.58.2
@@ -15336,19 +15307,6 @@ snapshots:
       - '@emnapi/runtime'
       - supports-color
 
-  eslint-plugin-agent-code-guard@0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-plugin-jsdoc: 62.9.0(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-sonarjs: 4.0.3(eslint@9.39.4(jiti@2.7.0))
-      knip: 6.14.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - supports-color
-
   eslint-plugin-jsdoc@62.9.0(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@es-joy/jsdoccomment': 0.86.0
@@ -15369,48 +15327,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsdoc@62.9.0(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@es-joy/jsdoccomment': 0.86.0
-      '@es-joy/resolve.exports': 1.2.0
-      are-docs-informative: 0.0.2
-      comment-parser: 1.4.6
-      debug: 4.4.3(supports-color@8.1.1)
-      escape-string-regexp: 4.0.0
-      eslint: 9.39.4(jiti@2.7.0)
-      espree: 11.2.0
-      esquery: 1.7.0
-      html-entities: 2.6.0
-      object-deep-merge: 2.0.0
-      parse-imports-exports: 0.2.4
-      semver: 7.8.0
-      spdx-expression-parse: 4.0.0
-      to-valid-identifier: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-sonarjs@4.0.3(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       builtin-modules: 3.3.0
       bytes: 3.1.2
       eslint: 9.39.4(jiti@1.21.7)
-      functional-red-black-tree: 1.0.1
-      globals: 17.6.0
-      jsx-ast-utils-x: 0.1.0
-      lodash.merge: 4.6.2
-      minimatch: 10.2.5
-      scslre: 0.3.0
-      semver: 7.8.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-
-  eslint-plugin-sonarjs@4.0.3(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      builtin-modules: 3.3.0
-      bytes: 3.1.2
-      eslint: 9.39.4(jiti@2.7.0)
       functional-red-black-tree: 1.0.1
       globals: 17.6.0
       jsx-ast-utils-x: 0.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,12 @@ importers:
         specifier: 2026.6.33
         version: 2026.6.33(@cfworker/json-schema@4.1.1)
     devDependencies:
+      '@moltzap/client':
+        specifier: workspace:*
+        version: link:../client
+      '@moltzap/server-core':
+        specifier: workspace:*
+        version: link:../server
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0


### PR DESCRIPTION
Codex-dispatched debt batch, reviewed and simplified. Fixes #796 (trace harness module shapes derive from type-only imports; runtime loading stays dynamic), fixes #786 (agent-code-guard ownership centralized at the workspace root; stale knip exemptions removed), fixes #794 (publish change-detection driven by nx show projects --affected with release-base and empty-tree handling, empirically probed on five change classes), fixes #800 (env-gated integration coverage for the warm NanoClaw install path). Verified: testbed matrix green; integration target skips cleanly when ungated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)