### PR TITLE
fix(testbed): bump bundled client/protocol pins to the published BoundedMap release

### DIFF
--- a/packages/testbed/nanoclaw-assets/package-lock.json
+++ b/packages/testbed/nanoclaw-assets/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@clack/core": "^1.2.0",
         "@clack/prompts": "^1.2.0",
-        "@moltzap/client": "2026.723.0",
-        "@moltzap/protocol": "2026.721.1",
+        "@moltzap/client": "2026.724.2",
+        "@moltzap/protocol": "2026.724.2",
         "@onecli-sh/sdk": "2.2.1",
         "better-sqlite3": "12.11.1",
         "chat": "4.29.0",
@@ -954,9 +954,9 @@
       "license": "MIT"
     },
     "node_modules/@moltzap/client": {
-      "version": "2026.723.0",
-      "resolved": "https://registry.npmjs.org/@moltzap/client/-/client-2026.723.0.tgz",
-      "integrity": "sha512-E6GXn5Jzeqxs57uwAl0N6vGmrgDIV9KdxGLgz0NrVMVhzhh8RmvuZ29w/htKSfDDkKqOmAyDslboYZXkY8xiqg==",
+      "version": "2026.724.2",
+      "resolved": "https://registry.npmjs.org/@moltzap/client/-/client-2026.724.2.tgz",
+      "integrity": "sha512-rHAl5F9QPM5r04med6LZzC1fonCSk0Y0aA6hyVnQZpgNfSMrV68+orYkmm7Zava6aSsMl63g3hOKZsrzV1hQVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@effect/cli": "^0.76.0",
@@ -966,7 +966,7 @@
         "@effect/printer-ansi": "0.50.0",
         "@effect/rpc": "0.76.0",
         "@effect/typeclass": "0.41.0",
-        "@moltzap/protocol": "2026.721.1",
+        "@moltzap/protocol": "2026.724.2",
         "effect": "3.22.0"
       },
       "bin": {
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/@moltzap/protocol": {
-      "version": "2026.721.1",
-      "resolved": "https://registry.npmjs.org/@moltzap/protocol/-/protocol-2026.721.1.tgz",
-      "integrity": "sha512-atpGbJOyhq2d/h+WFLQcNJD/1lESSyQsIlxGqpfUK0bDc4vivHxBBufkR8IbPIBeAegO5pacWs7vCeBEJGBiGQ==",
+      "version": "2026.724.2",
+      "resolved": "https://registry.npmjs.org/@moltzap/protocol/-/protocol-2026.724.2.tgz",
+      "integrity": "sha512-d9ph2NNWheyPo4qo8/bAWVanXI1lPMn+kJcKq57vPT45c2JyQNB3eBAdVBmmqhx6z+PcipT2z0VMMOxbyetFgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@effect/platform": "^0.97.0",
@@ -5322,9 +5322,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/packages/testbed/nanoclaw-assets/package.json
+++ b/packages/testbed/nanoclaw-assets/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
-    "@moltzap/client": "2026.723.0",
-    "@moltzap/protocol": "2026.721.1",
+    "@moltzap/client": "2026.724.2",
+    "@moltzap/protocol": "2026.724.2",
     "@onecli-sh/sdk": "2.2.1",
     "better-sqlite3": "12.11.1",
     "chat": "4.29.0",


### PR DESCRIPTION
The #824 channel asset imports BoundedMap via channel-base; the bundled manifest still pinned @moltzap/client@2026.723.0 (pre-export), so cold installs failed at the pinned checkout's tsc. Pins move to 2026.724.2. Verified by a full cold install + live-model E2E round-trip (real gateway-credentialed reply in ~12s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)