### PR TITLE
feat(testbed): dual-mode channel install across both runtime adapters

### DIFF
--- a/docs/modules/testbed/src.mdx
+++ b/docs/modules/testbed/src.mdx
@@ -42,7 +42,7 @@ export function awaitAgentReadyByPolling(
 ): Effect.Effect<ReadyOutcome, never, never>
 ```
 
-### [`createOpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L527)
+### [`createOpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L586)
 
 _Function_
 
@@ -61,11 +61,26 @@ flowchart TD
   OCWF["createOpenClawAdapter(input)"]
   OCBIN["openclawBin = input.openclawBin ??<br>resolveInstalledPackageBin('openclaw')"]
   OCCH["channelDistDir = input.channelDistDir ??<br>resolveInstalledPackageRoot('@moltzap/openclaw-channel')/dist"]
-  OCOUT["new OpenClawAdapter({ server, openclawBin, channelDistDir })"]
+  OCOUT["new OpenClawAdapter({ server, openclawBin,<br>channelDistDir, installMode })"]
   OCWF --> OCBIN --> OCCH --> OCOUT
 ```
 
-### [`launchTestbed`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L337)
+### [`InstallMode`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/install-mode.ts#L6)
+
+_TypeAlias_
+
+```ts
+export type InstallMode = "published" | "workspace";
+
+const CHANNEL_PACKAGE_NAME = "@moltzap/openclaw-channel";
+
+interface InstallModeResolverDeps {
+  readonly resolveChannelPackageRoot: () => string;
+  readonly workspacePackagesDir: string | null;
+}
+```
+
+### [`launchTestbed`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L370)
 
 _Function_
 
@@ -90,7 +105,7 @@ Sibling: launchTestbedWithProcessSignals adds SIGINT
 / SIGTERM handlers so Ctrl-C during startup interrupts cleanly via
 `TestbedStartupInterrupted`.
 
-### [`launchTestbedWithProcessSignals`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L439)
+### [`launchTestbedWithProcessSignals`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L476)
 
 _Function_
 
@@ -144,7 +159,7 @@ export interface LogSlice {
 }
 ```
 
-### [`NanoclawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/nanoclaw-adapter.ts#L98)
+### [`NanoclawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/nanoclaw-adapter.ts#L114)
 
 _Class_
 
@@ -203,6 +218,7 @@ export class NanoclawAdapter implements Runtime {
               acquireNanoclawRuntime(
                 input,
                 this.options.autoRegisterConversations ?? false,
+                this.options.installMode,
               ),
             ),
             (acquired) =>
@@ -238,11 +254,21 @@ runtime cache is installed, then launch.
 flowchart TD
   NS["NanoclawAdapter.spawn(input)"]
   subgraph P1["Install pinned NanoClaw runtime"]
+    P1M{"install mode"}
+    P1P["published<br>hash bundled exact registry lock"]
+    P1WSRC["workspace<br>pack built client + protocol<br>hash exact tarball bytes"]
     P1C{"matching immutable generation exists?"}
     P1WARM["reuse immutable generation"]
-    P1COLD["preflightDocker → download pinned tarball<br>→ copy bundled channel + skill + eval provisioner<br>→ install pinned client + build<br>→ publish immutable generation"]
+    P1COLD["preflight Docker → download pinned source<br>→ copy bundled channel + skill + eval provisioner"]
+    P1CM{"workspace?"}
+    P1VENDOR["copy tarballs into vendor<br>rewrite both direct deps to file paths<br>refresh + assert package lock"]
+    P1BUILD["npm ci + build<br>build fingerprinted Docker image<br>publish immutable generation"]
+    P1M -->|published| P1P --> P1C
+    P1M -->|workspace| P1WSRC --> P1C
     P1C -->|yes| P1WARM
-    P1C -->|no| P1COLD
+    P1C -->|no| P1COLD --> P1CM
+    P1CM -->|yes| P1VENDOR --> P1BUILD
+    P1CM -->|no| P1BUILD
   end
   subgraph P2["Start isolated agent runtime"]
     P2DIR["create isolated runtime dir<br>copy container + scripts"]
@@ -253,20 +279,24 @@ flowchart TD
     P2OC --> P2DIR --> P2WS --> P2EVAL --> P2SP
   end
   NCR["waitUntilReady — server.awaitAgentReady (WS auth)<br>raced against subprocess exit,<br>bounded by the caller's readyTimeoutMs"]
-  NS --> P1 --> P2 --> NCR
+  NS --> P1M
+  P1WARM --> P2OC
+  P1BUILD --> P2OC
+  P2SP --> NCR
 ```
 
 Inbound marker: `New messages`. The immutable cache key covers the pinned
-NanoClaw source, dependency lock, bundled channel/skill/provisioner, and
-host ABI.
+NanoClaw source, dependency lock, bundled channel/skill/provisioner, host
+ABI, and workspace tarball bytes when workspace mode is selected.
 
-### [`NanoclawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/nanoclaw-adapter.ts#L22)
+### [`NanoclawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/nanoclaw-adapter.ts#L23)
 
 _Interface_
 
 ```ts
 export interface NanoclawAdapterOptions {
   readonly server: RuntimeServerHandle;
+  readonly installMode: InstallMode;
 
   /**
    * Registers conversations on first delivery so NanoClaw will process them.
@@ -277,7 +307,7 @@ export interface NanoclawAdapterOptions {
 }
 ```
 
-### [`OpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L449)
+### [`OpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L508)
 
 _Class_
 
@@ -355,14 +385,22 @@ readiness via the server-side WS authentication event.
 flowchart TD
   OCS["OpenClawAdapter.spawn(input)"]
   OC1["1. allocateFreePort()<br>NodeSocketServer.make({ port: 0 })"]
-  OC2["2. lease + configure state dir<br>makeTempDirectory, writeOpenClawConfig,<br>seedWorkspaceFiles, installChannelPlugin"]
+  OC2["2. lease + configure state dir<br>makeTempDirectory, writeOpenClawConfig,<br>seed workspace + model auth"]
+  OCM{"install mode"}
+  OCW["workspace<br>validate local channel build<br>copy channel dist + dependency links<br>pin plugins.allow"]
+  OCP["published<br>reuse or build pinned npm project cache<br>materialize project + OpenClaw peer link<br>omit plugins.allow"]
   OC3["3. buildOpenClawProcessPlan(openclawBin, port)<br>(handles .mjs vs binary entry)"]
   OC4["4. lease spawnOpenClawProcess<br>exact child environment<br>exitFiber + log buffer"]
   OC5["5. commit process + state-dir leases<br>to adapter state"]
   OCF["failed or interrupted handoff<br>stops child + removes state dir"]
   OCR["waitUntilReady<br>race(server.awaitAgentReady, processExitLoop)<br>inbound marker: 'inbound from agent:'"]
-  OCS --> OC1 --> OC2 --> OC3 --> OC4 --> OC5 --> OCR
+  OCS --> OC1 --> OC2 --> OCM
+  OCM -->|workspace| OCW --> OC3
+  OCM -->|published| OCP --> OC3
+  OC3 --> OC4 --> OC5 --> OCR
   OC2 -.->|failure| OCF
+  OCW -.->|failure| OCF
+  OCP -.->|failure| OCF
   OC4 -.->|failure or interruption| OCF
 ```
 
@@ -372,7 +410,7 @@ Readiness signal: server-side WS authentication event surfaces via
 (boot) or `RuntimeExitedBeforeReady` / `RuntimeReadyTimedOut`
 (post-spawn, surfaced by `processExitLoop`).
 
-### [`OpenClawAdapterDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L166)
+### [`OpenClawAdapterDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L176)
 
 _Interface_
 
@@ -381,10 +419,11 @@ export interface OpenClawAdapterDeps {
   readonly server: RuntimeServerHandle;
   readonly openclawBin: string;
   readonly channelDistDir: string;
+  readonly installMode: InstallMode;
 }
 ```
 
-### [`OpenClawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L172)
+### [`OpenClawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L183)
 
 _Interface_
 
@@ -393,6 +432,7 @@ export interface OpenClawAdapterOptions {
   readonly server: RuntimeServerHandle;
   readonly openclawBin?: string;
   readonly channelDistDir?: string;
+  readonly installMode: InstallMode;
 }
 ```
 
@@ -463,7 +503,7 @@ Raised by `startPendingRuntimeAgent` when `waitUntilReady` returns
 `exitCode` is `null` only if the process exited via signal.
 Caller action: inspect `stderr`; check binary auth config.
 
-### [`RuntimeKind`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L56)
+### [`RuntimeKind`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L65)
 
 _TypeAlias_
 
@@ -536,7 +576,7 @@ export interface RuntimeServerHandle {
 }
 ```
 
-### [`RuntimeStartOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L58)
+### [`RuntimeStartOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L67)
 
 _TypeAlias_
 
@@ -601,7 +641,7 @@ export interface SpawnInput {
 }
 ```
 
-### [`startRuntimeAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L309)
+### [`startRuntimeAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L339)
 
 _Function_
 
@@ -635,7 +675,7 @@ coordinated startup.
 - `RuntimeReadyTimedOut` — `waitUntilReady` exceeds `readyTimeoutMs`
 - `RuntimeExitedBeforeReady` — the process exits before signaling ready (inspect `stderr`)
 
-### [`Testbed`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L78)
+### [`Testbed`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L87)
 
 _Interface_
 
@@ -647,7 +687,7 @@ export interface Testbed {
 }
 ```
 
-### [`TestbedAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L73)
+### [`TestbedAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L82)
 
 _Interface_
 
@@ -658,7 +698,7 @@ export interface TestbedAgent {
 }
 ```
 
-### [`TestbedAgentSpec`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L29)
+### [`TestbedAgentSpec`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L32)
 
 _Interface_
 
@@ -673,7 +713,7 @@ export interface TestbedAgentSpec {
 }
 ```
 
-### [`TestbedLaunchOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L67)
+### [`TestbedLaunchOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L76)
 
 _TypeAlias_
 
@@ -685,7 +725,7 @@ export type TestbedProcessSignalOptions = TestbedLaunchOptions & {
 };
 ```
 
-### [`TestbedProcessSignalOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L69)
+### [`TestbedProcessSignalOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L78)
 
 _TypeAlias_
 
@@ -695,7 +735,7 @@ export type TestbedProcessSignalOptions = TestbedLaunchOptions & {
 };
 ```
 
-### [`TestbedStartupInterrupted`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L84)
+### [`TestbedStartupInterrupted`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L93)
 
 _Class_
 
@@ -723,6 +763,7 @@ export interface WorkspaceFile {
 
 - `await-agent-ready.ts`
 - `errors.ts`
+- `install-mode.ts`
 - `nanoclaw-adapter.ts`
 - `openclaw-adapter.ts`
 - `runtime.ts`

--- a/packages/testbed/AGENTS.md
+++ b/packages/testbed/AGENTS.md
@@ -14,8 +14,18 @@ Single-tier `src/` — no subdirectories; each adapter is a peer.
 - `{openclaw,nanoclaw}-adapter.ts` — one adapter per runtime; installed
   runtime packages are the defaults and explicit binary/plugin paths remain
   available for tests and custom installations
+- `install-mode.ts` — one fleet-wide `published` / `workspace` artifact
+  decision, inferred from package resolution or selected explicitly
+- `immutable-cache.ts` — generic building-directory, ready-marker, and
+  immutable-generation lifecycle shared by runtime installers, plus the
+  fingerprint envelope and the process-wide cold-build permit
+- `json-guards.ts` — `makeJsonGuards`, manifest/lockfile shape checks bound to
+  one module's error factory
+- `openclaw-plugin-cache.ts` — pinned npm plugin installation, provenance
+  validation, immutable project caching, and per-agent materialization
 - `nanoclaw-install.ts` — pinned source/assets, deterministic dependency
-  lock, immutable cache promotion, and Docker image build
+  lock, workspace package packing, immutable cache promotion, and Docker
+  image build
 - `nanoclaw-process.ts` — per-agent runtime directory, process lifecycle,
   logs, and teardown; container isolation comes from NanoClaw's own
   cwd-derived install slug
@@ -41,6 +51,10 @@ Single-tier `src/` — no subdirectories; each adapter is a peer.
   arises only when SIGINT/SIGTERM interrupts startup in
   `launchTestbedWithProcessSignals`. A testbed currently uses one runtime kind
   for the whole agent collection.
+- **Install mode** — one decision applies to the whole testbed and each
+  adapter interprets it. `published` runs every `@moltzap` artifact from the
+  npm registry at the testbed's exact installed pins; `workspace` runs every
+  `@moltzap` artifact from the current workspace build. Columns never mix.
 - **Trace-capture harness** — `trace-capture-{bundle,harness,payload}.ts`,
   compiled by this package, loaded from `dist/` by the external `cc-judge`
   runner (its only consumer), and run against `packages/evals/scenarios/*.yaml`.

--- a/packages/testbed/package.json
+++ b/packages/testbed/package.json
@@ -58,6 +58,9 @@
           "^production",
           {
             "env": "MOLTZAP_NANOCLAW_ITEST"
+          },
+          {
+            "env": "MOLTZAP_OPENCLAW_ITEST"
           }
         ]
       },

--- a/packages/testbed/safer-architecture.config.json
+++ b/packages/testbed/safer-architecture.config.json
@@ -1,15 +1,19 @@
 {
   "packageRuntime": "node",
-  "maxPublicExports": 30,
+  "maxPublicExports": 32,
   "minPublicFacadeModules": 7,
   "folderChildCountOverrides": [
     {
       "folder": ".",
-      "maxChildren": 13,
-      "reason": "The testbed keeps runtime adapters, orchestration, readiness, process support, locking, and trace-capture modules as deliberate peers in its documented single-tier source layout"
+      "maxChildren": 16,
+      "reason": "The testbed keeps runtime adapters, orchestration, readiness, process support, locking, install-mode resolution, cache lifecycle, and trace-capture modules as deliberate peers in its documented single-tier source layout"
     }
   ],
   "facadeFiles": [
+    {
+      "file": "nanoclaw-install.ts",
+      "reason": "NanoClaw install boundary composing pinned-source download, bundled-asset injection, and dual-mode dependency materialization behind one immutable cache"
+    },
     {
       "file": "channel-plugin-install.ts",
       "reason": "Shared plugin-install and workspace-seed boundary both runtime adapters compose for on-disk channel provisioning"

--- a/packages/testbed/src/MODULE.md
+++ b/packages/testbed/src/MODULE.md
@@ -37,7 +37,7 @@ export function awaitAgentReadyByPolling(
 ): Effect.Effect<ReadyOutcome, never, never>
 ```
 
-### [`createOpenClawAdapter`](./openclaw-adapter.ts#L527)
+### [`createOpenClawAdapter`](./openclaw-adapter.ts#L586)
 
 _Function_
 
@@ -56,11 +56,26 @@ flowchart TD
   OCWF["createOpenClawAdapter(input)"]
   OCBIN["openclawBin = input.openclawBin ??<br>resolveInstalledPackageBin('openclaw')"]
   OCCH["channelDistDir = input.channelDistDir ??<br>resolveInstalledPackageRoot('@moltzap/openclaw-channel')/dist"]
-  OCOUT["new OpenClawAdapter({ server, openclawBin, channelDistDir })"]
+  OCOUT["new OpenClawAdapter({ server, openclawBin,<br>channelDistDir, installMode })"]
   OCWF --> OCBIN --> OCCH --> OCOUT
 ```
 
-### [`launchTestbed`](./testbed.ts#L337)
+### [`InstallMode`](./install-mode.ts#L6)
+
+_TypeAlias_
+
+```ts
+export type InstallMode = "published" | "workspace";
+
+const CHANNEL_PACKAGE_NAME = "@moltzap/openclaw-channel";
+
+interface InstallModeResolverDeps {
+  readonly resolveChannelPackageRoot: () => string;
+  readonly workspacePackagesDir: string | null;
+}
+```
+
+### [`launchTestbed`](./testbed.ts#L370)
 
 _Function_
 
@@ -85,7 +100,7 @@ Sibling: launchTestbedWithProcessSignals adds SIGINT
 / SIGTERM handlers so Ctrl-C during startup interrupts cleanly via
 `TestbedStartupInterrupted`.
 
-### [`launchTestbedWithProcessSignals`](./testbed.ts#L439)
+### [`launchTestbedWithProcessSignals`](./testbed.ts#L476)
 
 _Function_
 
@@ -139,7 +154,7 @@ export interface LogSlice {
 }
 ```
 
-### [`NanoclawAdapter`](./nanoclaw-adapter.ts#L98)
+### [`NanoclawAdapter`](./nanoclaw-adapter.ts#L114)
 
 _Class_
 
@@ -198,6 +213,7 @@ export class NanoclawAdapter implements Runtime {
               acquireNanoclawRuntime(
                 input,
                 this.options.autoRegisterConversations ?? false,
+                this.options.installMode,
               ),
             ),
             (acquired) =>
@@ -233,11 +249,21 @@ runtime cache is installed, then launch.
 flowchart TD
   NS["NanoclawAdapter.spawn(input)"]
   subgraph P1["Install pinned NanoClaw runtime"]
+    P1M{"install mode"}
+    P1P["published<br>hash bundled exact registry lock"]
+    P1WSRC["workspace<br>pack built client + protocol<br>hash exact tarball bytes"]
     P1C{"matching immutable generation exists?"}
     P1WARM["reuse immutable generation"]
-    P1COLD["preflightDocker → download pinned tarball<br>→ copy bundled channel + skill + eval provisioner<br>→ install pinned client + build<br>→ publish immutable generation"]
+    P1COLD["preflight Docker → download pinned source<br>→ copy bundled channel + skill + eval provisioner"]
+    P1CM{"workspace?"}
+    P1VENDOR["copy tarballs into vendor<br>rewrite both direct deps to file paths<br>refresh + assert package lock"]
+    P1BUILD["npm ci + build<br>build fingerprinted Docker image<br>publish immutable generation"]
+    P1M -->|published| P1P --> P1C
+    P1M -->|workspace| P1WSRC --> P1C
     P1C -->|yes| P1WARM
-    P1C -->|no| P1COLD
+    P1C -->|no| P1COLD --> P1CM
+    P1CM -->|yes| P1VENDOR --> P1BUILD
+    P1CM -->|no| P1BUILD
   end
   subgraph P2["Start isolated agent runtime"]
     P2DIR["create isolated runtime dir<br>copy container + scripts"]
@@ -248,20 +274,24 @@ flowchart TD
     P2OC --> P2DIR --> P2WS --> P2EVAL --> P2SP
   end
   NCR["waitUntilReady — server.awaitAgentReady (WS auth)<br>raced against subprocess exit,<br>bounded by the caller's readyTimeoutMs"]
-  NS --> P1 --> P2 --> NCR
+  NS --> P1M
+  P1WARM --> P2OC
+  P1BUILD --> P2OC
+  P2SP --> NCR
 ```
 
 Inbound marker: `New messages`. The immutable cache key covers the pinned
-NanoClaw source, dependency lock, bundled channel/skill/provisioner, and
-host ABI.
+NanoClaw source, dependency lock, bundled channel/skill/provisioner, host
+ABI, and workspace tarball bytes when workspace mode is selected.
 
-### [`NanoclawAdapterOptions`](./nanoclaw-adapter.ts#L22)
+### [`NanoclawAdapterOptions`](./nanoclaw-adapter.ts#L23)
 
 _Interface_
 
 ```ts
 export interface NanoclawAdapterOptions {
   readonly server: RuntimeServerHandle;
+  readonly installMode: InstallMode;
 
   /**
    * Registers conversations on first delivery so NanoClaw will process them.
@@ -272,7 +302,7 @@ export interface NanoclawAdapterOptions {
 }
 ```
 
-### [`OpenClawAdapter`](./openclaw-adapter.ts#L449)
+### [`OpenClawAdapter`](./openclaw-adapter.ts#L508)
 
 _Class_
 
@@ -350,14 +380,22 @@ readiness via the server-side WS authentication event.
 flowchart TD
   OCS["OpenClawAdapter.spawn(input)"]
   OC1["1. allocateFreePort()<br>NodeSocketServer.make({ port: 0 })"]
-  OC2["2. lease + configure state dir<br>makeTempDirectory, writeOpenClawConfig,<br>seedWorkspaceFiles, installChannelPlugin"]
+  OC2["2. lease + configure state dir<br>makeTempDirectory, writeOpenClawConfig,<br>seed workspace + model auth"]
+  OCM{"install mode"}
+  OCW["workspace<br>validate local channel build<br>copy channel dist + dependency links<br>pin plugins.allow"]
+  OCP["published<br>reuse or build pinned npm project cache<br>materialize project + OpenClaw peer link<br>omit plugins.allow"]
   OC3["3. buildOpenClawProcessPlan(openclawBin, port)<br>(handles .mjs vs binary entry)"]
   OC4["4. lease spawnOpenClawProcess<br>exact child environment<br>exitFiber + log buffer"]
   OC5["5. commit process + state-dir leases<br>to adapter state"]
   OCF["failed or interrupted handoff<br>stops child + removes state dir"]
   OCR["waitUntilReady<br>race(server.awaitAgentReady, processExitLoop)<br>inbound marker: 'inbound from agent:'"]
-  OCS --> OC1 --> OC2 --> OC3 --> OC4 --> OC5 --> OCR
+  OCS --> OC1 --> OC2 --> OCM
+  OCM -->|workspace| OCW --> OC3
+  OCM -->|published| OCP --> OC3
+  OC3 --> OC4 --> OC5 --> OCR
   OC2 -.->|failure| OCF
+  OCW -.->|failure| OCF
+  OCP -.->|failure| OCF
   OC4 -.->|failure or interruption| OCF
 ```
 
@@ -367,7 +405,7 @@ Readiness signal: server-side WS authentication event surfaces via
 (boot) or `RuntimeExitedBeforeReady` / `RuntimeReadyTimedOut`
 (post-spawn, surfaced by `processExitLoop`).
 
-### [`OpenClawAdapterDeps`](./openclaw-adapter.ts#L166)
+### [`OpenClawAdapterDeps`](./openclaw-adapter.ts#L176)
 
 _Interface_
 
@@ -376,10 +414,11 @@ export interface OpenClawAdapterDeps {
   readonly server: RuntimeServerHandle;
   readonly openclawBin: string;
   readonly channelDistDir: string;
+  readonly installMode: InstallMode;
 }
 ```
 
-### [`OpenClawAdapterOptions`](./openclaw-adapter.ts#L172)
+### [`OpenClawAdapterOptions`](./openclaw-adapter.ts#L183)
 
 _Interface_
 
@@ -388,6 +427,7 @@ export interface OpenClawAdapterOptions {
   readonly server: RuntimeServerHandle;
   readonly openclawBin?: string;
   readonly channelDistDir?: string;
+  readonly installMode: InstallMode;
 }
 ```
 
@@ -458,7 +498,7 @@ Raised by `startPendingRuntimeAgent` when `waitUntilReady` returns
 `exitCode` is `null` only if the process exited via signal.
 Caller action: inspect `stderr`; check binary auth config.
 
-### [`RuntimeKind`](./testbed.ts#L56)
+### [`RuntimeKind`](./testbed.ts#L65)
 
 _TypeAlias_
 
@@ -531,7 +571,7 @@ export interface RuntimeServerHandle {
 }
 ```
 
-### [`RuntimeStartOptions`](./testbed.ts#L58)
+### [`RuntimeStartOptions`](./testbed.ts#L67)
 
 _TypeAlias_
 
@@ -596,7 +636,7 @@ export interface SpawnInput {
 }
 ```
 
-### [`startRuntimeAgent`](./testbed.ts#L309)
+### [`startRuntimeAgent`](./testbed.ts#L339)
 
 _Function_
 
@@ -630,7 +670,7 @@ coordinated startup.
 - `RuntimeReadyTimedOut` — `waitUntilReady` exceeds `readyTimeoutMs`
 - `RuntimeExitedBeforeReady` — the process exits before signaling ready (inspect `stderr`)
 
-### [`Testbed`](./testbed.ts#L78)
+### [`Testbed`](./testbed.ts#L87)
 
 _Interface_
 
@@ -642,7 +682,7 @@ export interface Testbed {
 }
 ```
 
-### [`TestbedAgent`](./testbed.ts#L73)
+### [`TestbedAgent`](./testbed.ts#L82)
 
 _Interface_
 
@@ -653,7 +693,7 @@ export interface TestbedAgent {
 }
 ```
 
-### [`TestbedAgentSpec`](./testbed.ts#L29)
+### [`TestbedAgentSpec`](./testbed.ts#L32)
 
 _Interface_
 
@@ -668,7 +708,7 @@ export interface TestbedAgentSpec {
 }
 ```
 
-### [`TestbedLaunchOptions`](./testbed.ts#L67)
+### [`TestbedLaunchOptions`](./testbed.ts#L76)
 
 _TypeAlias_
 
@@ -680,7 +720,7 @@ export type TestbedProcessSignalOptions = TestbedLaunchOptions & {
 };
 ```
 
-### [`TestbedProcessSignalOptions`](./testbed.ts#L69)
+### [`TestbedProcessSignalOptions`](./testbed.ts#L78)
 
 _TypeAlias_
 
@@ -690,7 +730,7 @@ export type TestbedProcessSignalOptions = TestbedLaunchOptions & {
 };
 ```
 
-### [`TestbedStartupInterrupted`](./testbed.ts#L84)
+### [`TestbedStartupInterrupted`](./testbed.ts#L93)
 
 _Class_
 
@@ -718,6 +758,7 @@ export interface WorkspaceFile {
 
 - `await-agent-ready.ts`
 - `errors.ts`
+- `install-mode.ts`
 - `nanoclaw-adapter.ts`
 - `openclaw-adapter.ts`
 - `runtime.ts`

--- a/packages/testbed/src/child-process.ts
+++ b/packages/testbed/src/child-process.ts
@@ -7,6 +7,7 @@ import type { PlatformError } from "@effect/platform/Error";
 import { NodeContext } from "@effect/platform-node";
 import {
   Config,
+  Data,
   Duration,
   Effect,
   Fiber,
@@ -19,6 +20,11 @@ import {
 export interface CommandRunOptions {
   readonly cwd?: string;
   readonly timeout?: number;
+}
+
+export interface CapturedCommandOutput {
+  readonly stdout: string;
+  readonly stderr: string;
 }
 
 /**
@@ -111,11 +117,8 @@ function execEffectWith<E>(
   const { cwd, timeout } = options;
   const command =
     cwd === undefined
-      ? Command.make(commandText).pipe(Command.runInShell(true))
-      : Command.make(commandText).pipe(
-          Command.runInShell(true),
-          Command.workingDirectory(cwd),
-        );
+      ? makeShellCommand(commandText)
+      : makeShellCommandInDirectory(commandText, cwd);
   const exitCode = Command.exitCode(command).pipe(
     Effect.mapError((cause) =>
       makeError(`command failed: ${commandText}`, cause),
@@ -143,6 +146,128 @@ function execEffectWith<E>(
   );
 }
 
+function makeShellCommand(commandText: string) {
+  return Command.make(commandText).pipe(Command.runInShell(true));
+}
+
+function makeShellCommandInDirectory(commandText: string, cwd: string) {
+  return Command.workingDirectory(makeShellCommand(commandText), cwd);
+}
+
+// Callers parse this output, so capture is faithful rather than windowed
+// like BoundedLogBuffer: eliding the middle of a JSON document turns
+// "output too large" into a misleading parse error. The cap still bounds a
+// runaway child, but surfaces as its own actionable failure.
+const MAX_CAPTURED_OUTPUT_CHARS = 8 * 1024 * 1024;
+
+class CapturedOutputTooLarge extends Data.TaggedError(
+  "CapturedOutputTooLarge",
+)<{
+  readonly limit: number;
+}> {
+  override get message(): string {
+    return `command produced more than ${String(this.limit)} characters of output`;
+  }
+}
+
+function captureCommandStream(stream: Stream.Stream<Uint8Array, unknown>) {
+  const chunks: string[] = [];
+  let total = 0;
+  return stream.pipe(
+    Stream.decodeText(),
+    Stream.runForEach((chunk) => {
+      total += chunk.length;
+      if (total > MAX_CAPTURED_OUTPUT_CHARS) {
+        return Effect.fail(
+          new CapturedOutputTooLarge({ limit: MAX_CAPTURED_OUTPUT_CHARS }),
+        );
+      }
+      chunks.push(chunk);
+      return Effect.void;
+    }),
+    Effect.map(() => chunks.join("")),
+  );
+}
+
+function captureCommandOutput(command: Command.Command) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const process = yield* Command.start(command);
+      const [stdout, stderr, exitCode] = yield* Effect.all(
+        [
+          captureCommandStream(process.stdout),
+          captureCommandStream(process.stderr),
+          process.exitCode,
+        ],
+        { concurrency: 3 },
+      );
+      return { stdout, stderr, exitCode: Number(exitCode) };
+    }),
+  );
+}
+
+function commandFailureReason(
+  description: string,
+  output: CapturedCommandOutput,
+  exitCode: number,
+): string {
+  const diagnostics = (output.stderr.trim() || output.stdout.trim()).slice(
+    -LOG_TAIL_CAPACITY,
+  );
+  return (
+    `command failed with exit code ${exitCode}: ${description}` +
+    (diagnostics ? `\n${diagnostics}` : "")
+  );
+}
+
+function commandOutputEffectWith<E>(
+  makeError: ErrorFactory<E>,
+  description: string,
+  command: Command.Command,
+  timeout: number,
+): Effect.Effect<CapturedCommandOutput, E> {
+  const captured = captureCommandOutput(command).pipe(
+    Effect.mapError((cause) =>
+      makeError(`command failed: ${description}`, cause),
+    ),
+  );
+  return captured.pipe(
+    Effect.timeoutFail({
+      duration: Duration.millis(timeout),
+      onTimeout: () =>
+        makeError(`command timed out after ${timeout}ms: ${description}`),
+    }),
+    Effect.flatMap(({ exitCode, ...output }) =>
+      exitCode === 0
+        ? Effect.succeed(output)
+        : Effect.fail(
+            makeError(commandFailureReason(description, output, exitCode)),
+          ),
+    ),
+    Effect.provide(NodeContext.layer),
+  );
+}
+
+function unboundedCommandOutputEffectWith<E>(
+  makeError: ErrorFactory<E>,
+  description: string,
+  command: Command.Command,
+): Effect.Effect<CapturedCommandOutput, E> {
+  return captureCommandOutput(command).pipe(
+    Effect.mapError((cause) =>
+      makeError(`command failed: ${description}`, cause),
+    ),
+    Effect.flatMap(({ exitCode, ...output }) =>
+      exitCode === 0
+        ? Effect.succeed(output)
+        : Effect.fail(
+            makeError(commandFailureReason(description, output, exitCode)),
+          ),
+    ),
+    Effect.provide(NodeContext.layer),
+  );
+}
+
 /**
  * Shell-command and platform-error helpers shared by the runtime adapters.
  * Each module supplies its own tagged-error factory so failures stay in
@@ -152,7 +277,20 @@ export function makeCommandHelpers<E>(makeError: ErrorFactory<E>) {
   return {
     execEffect: (commandText: string, options?: CommandRunOptions) =>
       execEffectWith(makeError, commandText, options ?? {}),
-    fsEffect: <A>(reason: string, effect: Effect.Effect<A, PlatformError>) =>
+    commandOutputEffect: (
+      description: string,
+      command: Command.Command,
+      options?: Pick<CommandRunOptions, "timeout">,
+    ) => {
+      const timeout = options?.timeout;
+      return timeout === undefined
+        ? unboundedCommandOutputEffectWith(makeError, description, command)
+        : commandOutputEffectWith(makeError, description, command, timeout);
+    },
+    fsEffect: <A, R>(
+      reason: string,
+      effect: Effect.Effect<A, PlatformError, R>,
+    ): Effect.Effect<A, E, R> =>
       effect.pipe(Effect.mapError((cause) => makeError(reason, cause))),
   };
 }

--- a/packages/testbed/src/immutable-cache.ts
+++ b/packages/testbed/src/immutable-cache.ts
@@ -1,0 +1,231 @@
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { FileSystem } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
+import { Effect, Option } from "effect";
+import { makeCommandHelpers } from "./child-process.js";
+
+// Install caches and runtime dirs can become Docker bind-mount sources. Keeping
+// the shared root under home makes those paths visible to VM-backed engines.
+export const MOLTZAP_TESTBED_CACHE_ROOT = join(
+  homedir(),
+  ".cache",
+  "moltzap-testbed",
+);
+
+const BUILDING_CACHE_PREFIX = ".building-";
+const CACHE_GENERATION_PREFIX = "generation-";
+const READY_MARKER = ".ready";
+const STALE_BUILDING_CACHE_MAX_AGE_MS = 86_400_000;
+
+// Cold builds download, compile, and image-build multi-minute artifacts, so
+// every cache in this process takes turns rather than multiplying that cost
+// across concurrent agent spawns.
+export const CACHE_BUILD_PERMIT = Effect.runSync(Effect.makeSemaphore(1));
+
+type ErrorFactory<E> = (reason: string, cause?: unknown) => E;
+
+// The cache's own filesystem-error mapper: bound once per cache so each
+// operation reports failures in its owner's error channel.
+type FsEffect<E> = <A, R>(
+  reason: string,
+  effect: Effect.Effect<A, PlatformError, R>,
+) => Effect.Effect<A, E, R>;
+
+/**
+ * Hashes one cache's field list into the key naming its generations. Callers
+ * own every field, including host identity, so their tests can vary it.
+ */
+export function cacheFingerprint(
+  schemaVersion: number,
+  payload: Readonly<Record<string, unknown>>,
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify({ cacheSchema: schemaVersion, ...payload }))
+    .digest("hex");
+}
+
+/**
+ * Binds the filesystem lifecycle shared by immutable install caches to one
+ * cache root. Each owner supplies its typed error factory while cleanup and
+ * stale-cache sweeping remain best-effort operations.
+ */
+export function makeImmutableCache<E>(
+  cacheRoot: string,
+  makeError: ErrorFactory<E>,
+) {
+  const { fsEffect } = makeCommandHelpers(makeError);
+  return {
+    createBuildingCache: () => createBuildingCache(cacheRoot, fsEffect),
+    findCacheGeneration: (fingerprint: string) =>
+      findCacheGeneration(cacheRoot, fingerprint, fsEffect),
+    publishCacheGeneration: (buildingDir: string) =>
+      publishCacheGeneration(cacheRoot, buildingDir, fsEffect),
+    removeBuildingCacheBestEffort,
+    sweepStaleBuildingCaches: (
+      maxAgeMs: number = STALE_BUILDING_CACHE_MAX_AGE_MS,
+    ) => sweepStaleBuildingCaches(cacheRoot, maxAgeMs),
+    writeReadyMarker: (cacheDir: string, fingerprint: string) =>
+      writeReadyMarker(cacheDir, fingerprint, fsEffect),
+  };
+}
+
+function readReadyFingerprint<E>(readyMarker: string, fsEffect: FsEffect<E>) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const exists = yield* fsEffect(
+      "check immutable cache ready marker " + readyMarker,
+      fileSystem.exists(readyMarker),
+    );
+    if (!exists) return null;
+    return yield* fileSystem
+      .readFileString(readyMarker, "utf8")
+      .pipe(
+        Effect.catchAll((cause) =>
+          Effect.logDebug(
+            "ignoring unreadable immutable cache ready marker",
+            cause,
+          ).pipe(Effect.as(null)),
+        ),
+      );
+  });
+}
+
+function createBuildingCache<E>(cacheRoot: string, fsEffect: FsEffect<E>) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    yield* fsEffect(
+      "create immutable cache root " + cacheRoot,
+      fileSystem.makeDirectory(cacheRoot, { recursive: true }),
+    );
+    return yield* fsEffect(
+      "create unique immutable building cache",
+      fileSystem.makeTempDirectory({
+        directory: cacheRoot,
+        prefix: BUILDING_CACHE_PREFIX,
+      }),
+    );
+  });
+}
+
+function removeBuildingCacheBestEffort(buildingDir: string) {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) =>
+      fileSystem.remove(buildingDir, { recursive: true, force: true }),
+    ),
+    Effect.catchAll((cause) =>
+      Effect.logWarning(
+        "failed to remove immutable building cache " + buildingDir,
+        cause,
+      ),
+    ),
+  );
+}
+
+// A hard-killed installer cannot run its ensuring cleanup. The age gate keeps
+// one process from deleting another process's in-progress build.
+function sweepStaleBuildingCaches(cacheRoot: string, maxAgeMs: number) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const exists = yield* fileSystem.exists(cacheRoot);
+    if (!exists) return;
+    const entries = yield* fileSystem.readDirectory(cacheRoot);
+    const cutoff = Date.now() - maxAgeMs;
+    const buildingDirs = entries
+      .filter((entry) => entry.startsWith(BUILDING_CACHE_PREFIX))
+      .map((entry) => join(cacheRoot, entry));
+    for (const buildingDir of buildingDirs) {
+      const info = yield* fileSystem.stat(buildingDir);
+      const mtime = Option.getOrNull(info.mtime);
+      if (mtime !== null && mtime.getTime() <= cutoff) {
+        yield* fileSystem.remove(buildingDir, {
+          recursive: true,
+          force: true,
+        });
+      }
+    }
+  }).pipe(
+    Effect.catchAll((cause) =>
+      Effect.logWarning(
+        "failed to sweep stale immutable building caches in " + cacheRoot,
+        cause,
+      ),
+    ),
+    Effect.withSpan("sweepStaleBuildingCaches"),
+  );
+}
+
+function writeReadyMarker<E>(
+  cacheDir: string,
+  fingerprint: string,
+  fsEffect: FsEffect<E>,
+) {
+  const readyMarker = readyMarkerPath(cacheDir);
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) =>
+      fsEffect(
+        "write immutable cache ready marker " + readyMarker,
+        fileSystem.writeFileString(readyMarker, fingerprint),
+      ),
+    ),
+  );
+}
+
+function findCacheGeneration<E>(
+  cacheRoot: string,
+  fingerprint: string,
+  fsEffect: FsEffect<E>,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const exists = yield* fsEffect(
+      "check immutable cache root " + cacheRoot,
+      fileSystem.exists(cacheRoot),
+    );
+    if (!exists) return null;
+    const entries = yield* fsEffect(
+      "list immutable cache generations " + cacheRoot,
+      fileSystem.readDirectory(cacheRoot),
+    );
+    for (const entry of entries.filter(isCacheGeneration).sort()) {
+      const generationDir = join(cacheRoot, entry);
+      const readyFingerprint = yield* readReadyFingerprint(
+        readyMarkerPath(generationDir),
+        fsEffect,
+      );
+      if (readyFingerprint === fingerprint) return generationDir;
+    }
+    return null;
+  }).pipe(Effect.withSpan("findCacheGeneration"));
+}
+
+function publishCacheGeneration<E>(
+  cacheRoot: string,
+  buildingDir: string,
+  fsEffect: FsEffect<E>,
+) {
+  const generationDir = join(
+    cacheRoot,
+    CACHE_GENERATION_PREFIX +
+      basename(buildingDir).slice(BUILDING_CACHE_PREFIX.length),
+  );
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) =>
+      fsEffect(
+        "publish immutable cache generation " + generationDir,
+        fileSystem.rename(buildingDir, generationDir),
+      ),
+    ),
+    Effect.as(generationDir),
+    Effect.withSpan("publishCacheGeneration"),
+  );
+}
+
+function readyMarkerPath(cacheDir: string): string {
+  return join(cacheDir, READY_MARKER);
+}
+
+function isCacheGeneration(entry: string): boolean {
+  return entry.startsWith(CACHE_GENERATION_PREFIX);
+}

--- a/packages/testbed/src/index.ts
+++ b/packages/testbed/src/index.ts
@@ -34,6 +34,7 @@ export {
 } from "./errors.js";
 
 export {
+  type InstallMode,
   type RuntimeKind,
   type TestbedAgentSpec,
   type Testbed,

--- a/packages/testbed/src/install-mode.test.ts
+++ b/packages/testbed/src/install-mode.test.ts
@@ -1,0 +1,62 @@
+import { join } from "node:path";
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vitest";
+import { makeInstallModeResolver, type InstallMode } from "./install-mode.js";
+
+const WORKSPACE_PACKAGES_DIR = join("/workspace", "packages");
+const WORKSPACE_CHANNEL_ROOT = join(WORKSPACE_PACKAGES_DIR, "openclaw-channel");
+const INSTALLED_CHANNEL_ROOT = join(
+  "/consumer",
+  "node_modules",
+  "@moltzap",
+  "openclaw-channel",
+);
+
+interface DecisionCase {
+  readonly expected: InstallMode;
+  readonly explicit?: InstallMode;
+  readonly packageRoot: string;
+  readonly title: string;
+}
+
+const DECISION_CASES: ReadonlyArray<DecisionCase> = [
+  {
+    title: "infers workspace from a workspace package root",
+    packageRoot: WORKSPACE_CHANNEL_ROOT,
+    expected: "workspace",
+  },
+  {
+    title: "infers published from an installed node_modules root",
+    packageRoot: INSTALLED_CHANNEL_ROOT,
+    expected: "published",
+  },
+  {
+    title: "lets a published override beat workspace inference",
+    explicit: "published",
+    packageRoot: WORKSPACE_CHANNEL_ROOT,
+    expected: "published",
+  },
+  {
+    title: "lets a workspace override beat published inference",
+    explicit: "workspace",
+    packageRoot: INSTALLED_CHANNEL_ROOT,
+    expected: "workspace",
+  },
+];
+
+describe("resolveInstallMode", () => {
+  it.each(DECISION_CASES)("$title", ({ expected, explicit, packageRoot }) => {
+    const resolveChannelPackageRoot = vi.fn(() => packageRoot);
+    const resolve = makeInstallModeResolver({
+      resolveChannelPackageRoot,
+      workspacePackagesDir: WORKSPACE_PACKAGES_DIR,
+    });
+
+    const mode = Effect.runSync(resolve(explicit));
+
+    expect(mode).toBe(expected);
+    expect(resolveChannelPackageRoot).toHaveBeenCalledTimes(
+      explicit === undefined ? 1 : 0,
+    );
+  });
+});

--- a/packages/testbed/src/install-mode.ts
+++ b/packages/testbed/src/install-mode.ts
@@ -1,0 +1,113 @@
+import { fileURLToPath } from "node:url";
+import { basename, dirname, isAbsolute, parse, relative, sep } from "node:path";
+import { Effect } from "effect";
+import { resolveInstalledPackageRoot } from "./package-resolution.js";
+
+export type InstallMode = "published" | "workspace";
+
+const CHANNEL_PACKAGE_NAME = "@moltzap/openclaw-channel";
+
+interface InstallModeResolverDeps {
+  readonly resolveChannelPackageRoot: () => string;
+  readonly workspacePackagesDir: string | null;
+}
+
+interface InstallModeDecision {
+  readonly determinedBy: "explicit override" | "package resolution";
+  readonly mode: InstallMode;
+  readonly packageRoot: string | null;
+}
+
+const defaultResolverDeps: InstallModeResolverDeps = {
+  resolveChannelPackageRoot: () =>
+    resolveInstalledPackageRoot(CHANNEL_PACKAGE_NAME, import.meta.url),
+  workspacePackagesDir: findWorkspacePackagesDir(import.meta.url),
+};
+
+/**
+ * Builds a resolver around explicit package-location seams so inference stays
+ * testable without depending on the checkout that runs the test.
+ * @internal
+ */
+export function makeInstallModeResolver(deps: InstallModeResolverDeps) {
+  return (installMode?: InstallMode) =>
+    Effect.sync(() => decideInstallMode(deps, installMode)).pipe(
+      Effect.tap(logInstallModeDecision),
+      Effect.map((decision) => decision.mode),
+    );
+}
+
+/**
+ * Resolves and logs the artifact column selected for one testbed. This is the
+ * only place the mode is inferred; adapters receive an already-decided mode so
+ * a resolution failure stays in the launching Effect's error channel.
+ */
+export function resolveInstallMode(installMode?: InstallMode) {
+  return makeInstallModeResolver(defaultResolverDeps)(installMode);
+}
+
+function decideInstallMode(
+  deps: InstallModeResolverDeps,
+  installMode?: InstallMode,
+): InstallModeDecision {
+  if (installMode !== undefined) {
+    return {
+      determinedBy: "explicit override",
+      mode: installMode,
+      packageRoot: null,
+    };
+  }
+  const packageRoot = deps.resolveChannelPackageRoot();
+  return {
+    determinedBy: "package resolution",
+    mode: isWorkspacePackageRoot(packageRoot, deps.workspacePackagesDir)
+      ? "workspace"
+      : "published",
+    packageRoot,
+  };
+}
+
+function logInstallModeDecision(decision: InstallModeDecision) {
+  return Effect.logInfo("resolved testbed install mode").pipe(
+    Effect.annotateLogs({
+      installMode: decision.mode,
+      determinedBy: decision.determinedBy,
+      ...(decision.packageRoot === null
+        ? {}
+        : { packageRoot: decision.packageRoot }),
+    }),
+  );
+}
+
+function isWorkspacePackageRoot(
+  packageRoot: string,
+  workspacePackagesDir: string | null,
+): boolean {
+  if (workspacePackagesDir === null) return false;
+  const relativeRoot = relative(workspacePackagesDir, packageRoot);
+  if (
+    relativeRoot === "" ||
+    relativeRoot === ".." ||
+    relativeRoot.startsWith(".." + sep) ||
+    isAbsolute(relativeRoot)
+  ) {
+    return false;
+  }
+  return !relativeRoot.split(sep).includes("node_modules");
+}
+
+/** @internal */
+export function findWorkspacePackagesDir(
+  moduleUrl: string | URL,
+): string | null {
+  let current = dirname(fileURLToPath(moduleUrl));
+  const root = parse(current).root;
+  while (current !== root) {
+    const parent = dirname(current);
+    if (basename(current) === "testbed" && basename(parent) === "packages") {
+      return parent;
+    }
+    current = parent;
+  }
+  return null;
+}

--- a/packages/testbed/src/json-guards.ts
+++ b/packages/testbed/src/json-guards.ts
@@ -1,0 +1,61 @@
+import { Effect } from "effect";
+
+type ErrorFactory<E> = (reason: string, cause?: unknown) => E;
+
+/**
+ * Shape guards for decoded manifests and lockfiles, bound to one module's
+ * tagged-error factory so failures stay in that module's error channel. The
+ * value guards throw because they run inside `Effect.try` decode blocks;
+ * `requireSoleEntry` fails in the error channel because directory listings are
+ * already read inside an Effect.
+ */
+export function makeJsonGuards<E>(makeError: ErrorFactory<E>) {
+  function requireRecord(
+    value: unknown,
+    label: string,
+  ): Readonly<Record<string, unknown>> {
+    if (!isRecord(value)) {
+      throw makeError(`Expected ${label} to be an object`);
+    }
+    return value;
+  }
+
+  function requireString(value: unknown, label: string): string {
+    if (typeof value !== "string") {
+      throw makeError(`Expected ${label} to be a string`);
+    }
+    return value;
+  }
+
+  function requireExactValue(
+    actual: unknown,
+    expected: string,
+    label: string,
+  ): void {
+    if (actual !== expected) {
+      throw makeError(`Expected ${label} to equal ${expected}`);
+    }
+  }
+
+  function requireSoleEntry(
+    entries: ReadonlyArray<string>,
+    label: string,
+  ): Effect.Effect<string, E> {
+    const [entry] = entries;
+    return entry === undefined || entries.length !== 1
+      ? Effect.fail(makeError(`Expected one ${label}; found ${entries.length}`))
+      : Effect.succeed(entry);
+  }
+
+  return {
+    isRecord,
+    requireExactValue,
+    requireRecord,
+    requireSoleEntry,
+    requireString,
+  };
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/testbed/src/nanoclaw-adapter.ts
+++ b/packages/testbed/src/nanoclaw-adapter.ts
@@ -18,9 +18,11 @@ import {
   type NanoclawRuntimeHandle,
 } from "./nanoclaw-process.js";
 import { ensureNanoclawRuntimeInstalledEffect } from "./nanoclaw-install.js";
+import { type InstallMode } from "./install-mode.js";
 
 export interface NanoclawAdapterOptions {
   readonly server: RuntimeServerHandle;
+  readonly installMode: InstallMode;
 
   /**
    * Registers conversations on first delivery so NanoClaw will process them.
@@ -49,8 +51,9 @@ function stopNanoclawRuntimeSafely(
 const acquireNanoclawRuntime = Effect.fn("NanoclawAdapter.acquire")(function* (
   input: SpawnInput,
   autoRegisterConversations: boolean,
+  installMode: InstallMode,
 ) {
-  const install = yield* ensureNanoclawRuntimeInstalledEffect();
+  const install = yield* ensureNanoclawRuntimeInstalledEffect(installMode);
   return yield* startNanoclawRuntimeEffect(
     {
       agentName: input.agentName,
@@ -73,11 +76,21 @@ const acquireNanoclawRuntime = Effect.fn("NanoclawAdapter.acquire")(function* (
  * flowchart TD
  *   NS["NanoclawAdapter.spawn(input)"]
  *   subgraph P1["Install pinned NanoClaw runtime"]
+ *     P1M{"install mode"}
+ *     P1P["published<br>hash bundled exact registry lock"]
+ *     P1WSRC["workspace<br>pack built client + protocol<br>hash exact tarball bytes"]
  *     P1C{"matching immutable generation exists?"}
  *     P1WARM["reuse immutable generation"]
- *     P1COLD["preflightDocker → download pinned tarball<br>→ copy bundled channel + skill + eval provisioner<br>→ install pinned client + build<br>→ publish immutable generation"]
+ *     P1COLD["preflight Docker → download pinned source<br>→ copy bundled channel + skill + eval provisioner"]
+ *     P1CM{"workspace?"}
+ *     P1VENDOR["copy tarballs into vendor<br>rewrite both direct deps to file paths<br>refresh + assert package lock"]
+ *     P1BUILD["npm ci + build<br>build fingerprinted Docker image<br>publish immutable generation"]
+ *     P1M -->|published| P1P --> P1C
+ *     P1M -->|workspace| P1WSRC --> P1C
  *     P1C -->|yes| P1WARM
- *     P1C -->|no| P1COLD
+ *     P1C -->|no| P1COLD --> P1CM
+ *     P1CM -->|yes| P1VENDOR --> P1BUILD
+ *     P1CM -->|no| P1BUILD
  *   end
  *   subgraph P2["Start isolated agent runtime"]
  *     P2DIR["create isolated runtime dir<br>copy container + scripts"]
@@ -88,12 +101,15 @@ const acquireNanoclawRuntime = Effect.fn("NanoclawAdapter.acquire")(function* (
  *     P2OC --> P2DIR --> P2WS --> P2EVAL --> P2SP
  *   end
  *   NCR["waitUntilReady — server.awaitAgentReady (WS auth)<br>raced against subprocess exit,<br>bounded by the caller's readyTimeoutMs"]
- *   NS --> P1 --> P2 --> NCR
+ *   NS --> P1M
+ *   P1WARM --> P2OC
+ *   P1BUILD --> P2OC
+ *   P2SP --> NCR
  * ```
  *
  * Inbound marker: `New messages`. The immutable cache key covers the pinned
- * NanoClaw source, dependency lock, bundled channel/skill/provisioner, and
- * host ABI.
+ * NanoClaw source, dependency lock, bundled channel/skill/provisioner, host
+ * ABI, and workspace tarball bytes when workspace mode is selected.
  */
 export class NanoclawAdapter implements Runtime {
   private state: AdapterState | null = null;
@@ -149,6 +165,7 @@ export class NanoclawAdapter implements Runtime {
               acquireNanoclawRuntime(
                 input,
                 this.options.autoRegisterConversations ?? false,
+                this.options.installMode,
               ),
             ),
             (acquired) =>

--- a/packages/testbed/src/nanoclaw-install.integration.test.ts
+++ b/packages/testbed/src/nanoclaw-install.integration.test.ts
@@ -9,6 +9,7 @@ import {
   findWarmNanoclawRuntimeInstallEffect,
 } from "./nanoclaw-install.js";
 
+const PUBLISHED_INSTALL_MODE = "published";
 const CACHE_GENERATION_PREFIX = "generation-";
 const READY_MARKER = ".ready";
 const DOCKER_COMMAND = "docker";
@@ -38,7 +39,9 @@ describe.skipIf(!NANOCLAW_INSTALL_INTEGRATION_ENABLED)(
 function reusesWarmInstall() {
   return Effect.runPromise(
     Effect.gen(function* () {
-      const warmCandidate = yield* findWarmNanoclawRuntimeInstallEffect();
+      const warmCandidate = yield* findWarmNanoclawRuntimeInstallEffect(
+        PUBLISHED_INSTALL_MODE,
+      );
       expect(warmCandidate).not.toBeNull();
       if (warmCandidate === null) return;
 
@@ -62,9 +65,13 @@ function reusesWarmInstall() {
       );
       expect(Number(imageExitCode)).toBe(SUCCESS_EXIT_CODE);
 
-      const firstInstall = yield* ensureNanoclawRuntimeInstalledEffect();
+      const firstInstall = yield* ensureNanoclawRuntimeInstalledEffect(
+        PUBLISHED_INSTALL_MODE,
+      );
       expect(firstInstall).toEqual(warmCandidate);
-      const secondInstall = yield* ensureNanoclawRuntimeInstalledEffect();
+      const secondInstall = yield* ensureNanoclawRuntimeInstalledEffect(
+        PUBLISHED_INSTALL_MODE,
+      );
       expect(secondInstall).toBe(firstInstall);
     }).pipe(Effect.provide(NodeContext.layer)),
   );

--- a/packages/testbed/src/nanoclaw-install.test.ts
+++ b/packages/testbed/src/nanoclaw-install.test.ts
@@ -4,11 +4,7 @@ import { NodeContext } from "@effect/platform-node";
 import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
-import {
-  findNanoclawCacheGeneration,
-  publishNanoclawCacheGeneration,
-  sweepStaleBuildingCaches,
-} from "./nanoclaw-install.js";
+import { nanoclawInstallCache } from "./nanoclaw-install.js";
 
 const CACHE_FINGERPRINT = "a".repeat(64);
 const OTHER_FINGERPRINT = "b".repeat(64);
@@ -48,7 +44,9 @@ function sweepsOnlyStaleBuildingCaches() {
       const staleDate = new Date(Date.now() - SWEEP_MAX_AGE_MS * 2);
       yield* fileSystem.utimes(stale, staleDate, staleDate);
 
-      yield* sweepStaleBuildingCaches(cacheRoot, SWEEP_MAX_AGE_MS);
+      yield* nanoclawInstallCache(cacheRoot).sweepStaleBuildingCaches(
+        SWEEP_MAX_AGE_MS,
+      );
 
       expect(yield* fileSystem.exists(stale)).toBe(false);
       expect(yield* fileSystem.exists(fresh)).toBe(true);
@@ -75,10 +73,10 @@ function ignoresInvalidGenerations() {
       );
       yield* makeGeneration(join(cacheRoot, ".building-complete"));
 
-      const found = yield* findNanoclawCacheGeneration(
-        cacheRoot,
-        CACHE_FINGERPRINT,
-      );
+      const found =
+        yield* nanoclawInstallCache(cacheRoot).findCacheGeneration(
+          CACHE_FINGERPRINT,
+        );
 
       expect(found).toBe(null);
     }),
@@ -91,10 +89,10 @@ function selectsExactGeneration() {
       const expected = join(cacheRoot, GENERATION_PREFIX + "valid");
       yield* makeGeneration(expected);
 
-      const found = yield* findNanoclawCacheGeneration(
-        cacheRoot,
-        CACHE_FINGERPRINT,
-      );
+      const found =
+        yield* nanoclawInstallCache(cacheRoot).findCacheGeneration(
+          CACHE_FINGERPRINT,
+        );
 
       expect(found).toBe(expected);
     }),
@@ -110,10 +108,11 @@ function publishesConcurrently() {
       yield* makeGeneration(firstBuilding, CACHE_FINGERPRINT, FIRST_PAYLOAD);
       yield* makeGeneration(secondBuilding, CACHE_FINGERPRINT, SECOND_PAYLOAD);
 
+      const cache = nanoclawInstallCache(cacheRoot);
       const published = yield* Effect.all(
         [
-          publishNanoclawCacheGeneration(firstBuilding, cacheRoot),
-          publishNanoclawCacheGeneration(secondBuilding, cacheRoot),
+          cache.publishCacheGeneration(firstBuilding),
+          cache.publishCacheGeneration(secondBuilding),
         ],
         { concurrency: PUBLISHED_GENERATION_COUNT },
       );
@@ -136,9 +135,9 @@ function publishesConcurrently() {
       expect(new Set(payloads)).toEqual(
         new Set([FIRST_PAYLOAD, SECOND_PAYLOAD]),
       );
-      expect(
-        yield* findNanoclawCacheGeneration(cacheRoot, CACHE_FINGERPRINT),
-      ).not.toBe(null);
+      expect(yield* cache.findCacheGeneration(CACHE_FINGERPRINT)).not.toBe(
+        null,
+      );
     }),
   );
 }

--- a/packages/testbed/src/nanoclaw-install.ts
+++ b/packages/testbed/src/nanoclaw-install.ts
@@ -1,20 +1,18 @@
 import { createHash } from "node:crypto";
-import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, posix } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command, FileSystem } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { Data, Duration, Effect, Option, Ref } from "effect";
+import { Data, Duration, Effect, Ref } from "effect";
 import { makeCommandHelpers } from "./child-process.js";
-
-// Shared root for the install cache and per-agent runtime dirs. Must stay
-// under the user home: both hold docker bind-mount sources, and macOS
-// VM-backed engines only share home paths by default.
-export const MOLTZAP_TESTBED_CACHE_ROOT = join(
-  homedir(),
-  ".cache",
-  "moltzap-testbed",
-);
+import {
+  cacheFingerprint,
+  CACHE_BUILD_PERMIT,
+  makeImmutableCache,
+  MOLTZAP_TESTBED_CACHE_ROOT,
+} from "./immutable-cache.js";
+import { findWorkspacePackagesDir, type InstallMode } from "./install-mode.js";
+import { makeJsonGuards } from "./json-guards.js";
 
 const NANOCLAW_SHA = "641963c1e4b7ba4f000a18dfc5e2fea29069feec";
 const NANOCLAW_URL =
@@ -22,16 +20,21 @@ const NANOCLAW_URL =
 const NANOCLAW_CACHE_SCHEMA_VERSION = 5;
 const NANOCLAW_IMAGE_REPOSITORY = "nanoclaw-agent";
 const NANOCLAW_IMAGE_TAG_PREFIX = "moltzap";
-const BUILDING_CACHE_PREFIX = ".building-";
-const CACHE_GENERATION_PREFIX = "generation-";
-const INSTALL_PERMIT = Effect.runSync(Effect.makeSemaphore(1));
+const CLIENT_PACKAGE_NAME = "@moltzap/client";
+const PROTOCOL_PACKAGE_NAME = "@moltzap/protocol";
+const WORKSPACE_VENDOR_DIRECTORY = "vendor";
+const WORKSPACE_DIST_ENTRY = join("dist", "index.js");
+const WORKSPACE_PACK_TIMEOUT_MS = 120_000;
+const WORKSPACE_LOCK_TIMEOUT_MS = 120_000;
+const TARBALL_EXTENSION = ".tgz";
+const SHA512_INTEGRITY_PREFIX = "sha512-";
+const JSON_INDENT_SPACES = 2;
+const REGISTRY_MOLTZAP_PATTERN = /registry\.npmjs\.org\/@moltzap(?:\/|%2f)/i;
 
-// A verified install is process-invariant (the fingerprint covers assets and
-// host ABI), so spawns after the first skip the docker/filesystem
-// re-verification. Only success is cached — a failed attempt retries fresh.
-const WARM_INSTALL = Effect.runSync(
-  Ref.make<NanoclawRuntimeInstall | null>(null),
-);
+// A verified install is process-invariant for one mode and fingerprint, so
+// matching spawns skip docker/filesystem re-verification.
+// Only success is cached — a failed attempt retries fresh.
+const WARM_INSTALL = Effect.runSync(Ref.make<WarmNanoclawInstall | null>(null));
 
 export interface NanoclawRuntimeInstall {
   readonly cacheDir: string;
@@ -39,9 +42,63 @@ export interface NanoclawRuntimeInstall {
   readonly containerImage: string;
 }
 
-interface NanoclawCacheTarget {
+interface BaseNanoclawCacheTarget {
   readonly cacheRoot: string;
   readonly cacheFingerprint: string;
+}
+
+interface PublishedNanoclawCacheTarget extends BaseNanoclawCacheTarget {
+  readonly installMode: "published";
+}
+
+interface WorkspaceNanoclawCacheTarget extends BaseNanoclawCacheTarget {
+  readonly installMode: "workspace";
+  readonly workspaceDependencies: NanoclawWorkspaceDependencies;
+}
+
+type NanoclawCacheTarget =
+  | PublishedNanoclawCacheTarget
+  | WorkspaceNanoclawCacheTarget;
+
+interface WarmNanoclawInstall {
+  readonly installMode: InstallMode;
+  readonly install: NanoclawRuntimeInstall;
+}
+
+interface NanoclawFingerprintInput {
+  readonly channelHash: string;
+  readonly evalProvisionHash: string;
+  readonly skillHash: string;
+  readonly packageJsonHash: string;
+  readonly packageLockHash: string;
+  readonly platform: string;
+  readonly architecture: string;
+  readonly nodeAbi: string;
+}
+
+export interface NanoclawWorkspaceTarball {
+  readonly packageName: string;
+  readonly version: string;
+  readonly tarballPath: string;
+  readonly tarballFileName: string;
+  readonly sha256: string;
+  readonly integrity: string;
+}
+
+export interface NanoclawWorkspaceDependencies {
+  readonly client: NanoclawWorkspaceTarball;
+  readonly protocol: NanoclawWorkspaceTarball;
+}
+
+interface WorkspacePackageManifest {
+  readonly name: string;
+  readonly version: string;
+  readonly dependencies: Readonly<Record<string, unknown>>;
+}
+
+interface PreparedWorkspaceTarball {
+  readonly manifest: WorkspacePackageManifest;
+  readonly tarball: NanoclawWorkspaceTarball;
 }
 
 class NanoclawInstallError extends Data.TaggedError("NanoclawInstallError")<{
@@ -60,10 +117,19 @@ function installError(reason: string, cause?: unknown) {
   });
 }
 
-const { execEffect, fsEffect } = makeCommandHelpers(installError);
+const { commandOutputEffect, execEffect, fsEffect } =
+  makeCommandHelpers(installError);
+const { requireExactValue, requireRecord, requireSoleEntry, requireString } =
+  makeJsonGuards(installError);
 
 function sha256Hex(data: string | Uint8Array): string {
   return createHash("sha256").update(data).digest("hex");
+}
+
+function sha512Integrity(data: Uint8Array): string {
+  return (
+    SHA512_INTEGRITY_PREFIX + createHash("sha512").update(data).digest("base64")
+  );
 }
 
 function sha256OfFile(filePath: string) {
@@ -86,9 +152,10 @@ function bundledAssetPath(assetName: string): string {
   );
 }
 
-// Bundled assets and host ABI are process-constant, so the fingerprint is
-// computed once and reused by every spawn.
-const cachedCacheTarget = Effect.runSync(
+// Bundled assets and host ABI are process-constant, while workspace package
+// tarballs are rebuilt before lookup so their exact bytes can extend this
+// stable fingerprint input.
+const cachedFingerprintInput = Effect.runSync(
   Effect.cached(
     Effect.gen(function* () {
       const [
@@ -107,34 +174,338 @@ const cachedCacheTarget = Effect.runSync(
         ],
         { concurrency: 5 },
       );
-      const cacheFingerprint = sha256Hex(
-        JSON.stringify({
-          cacheSchema: NANOCLAW_CACHE_SCHEMA_VERSION,
-          nanoclawSha: NANOCLAW_SHA,
-          channelHash,
-          evalProvisionHash,
-          skillHash,
-          packageJsonHash,
-          packageLockHash,
-          platform: process.platform,
-          architecture: process.arch,
-          nodeAbi: process.versions.modules,
-        }),
-      );
       return {
-        cacheRoot: join(
-          MOLTZAP_TESTBED_CACHE_ROOT,
-          "nanoclaw",
-          cacheFingerprint,
-        ),
-        cacheFingerprint,
-      };
+        channelHash,
+        evalProvisionHash,
+        skillHash,
+        packageJsonHash,
+        packageLockHash,
+        platform: process.platform,
+        architecture: process.arch,
+        nodeAbi: process.versions.modules,
+      } satisfies NanoclawFingerprintInput;
     }),
   ),
 );
 
-function resolveCacheTarget() {
-  return cachedCacheTarget;
+/** @internal */
+export function nanoclawCacheFingerprint(
+  input: NanoclawFingerprintInput,
+  workspaceHashes?: {
+    readonly clientTarballHash: string;
+    readonly protocolTarballHash: string;
+  },
+): string {
+  return cacheFingerprint(NANOCLAW_CACHE_SCHEMA_VERSION, {
+    nanoclawSha: NANOCLAW_SHA,
+    channelHash: input.channelHash,
+    evalProvisionHash: input.evalProvisionHash,
+    skillHash: input.skillHash,
+    packageJsonHash: input.packageJsonHash,
+    packageLockHash: input.packageLockHash,
+    platform: input.platform,
+    architecture: input.architecture,
+    nodeAbi: input.nodeAbi,
+    ...(workspaceHashes === undefined ? {} : workspaceHashes),
+  });
+}
+
+function nanoclawCacheRoot(cacheFingerprint: string): string {
+  return join(MOLTZAP_TESTBED_CACHE_ROOT, "nanoclaw", cacheFingerprint);
+}
+
+function resolvePublishedCacheTarget() {
+  return cachedFingerprintInput.pipe(
+    Effect.map((input) => {
+      const fingerprint = nanoclawCacheFingerprint(input);
+      return {
+        installMode: "published",
+        cacheRoot: nanoclawCacheRoot(fingerprint),
+        cacheFingerprint: fingerprint,
+      } satisfies PublishedNanoclawCacheTarget;
+    }),
+  );
+}
+
+function resolveWorkspaceCacheTarget() {
+  return Effect.gen(function* () {
+    const input = yield* cachedFingerprintInput;
+    const workspaceDependencies = yield* cachedWorkspaceDependencies;
+    const fingerprint = nanoclawCacheFingerprint(input, {
+      clientTarballHash: workspaceDependencies.client.sha256,
+      protocolTarballHash: workspaceDependencies.protocol.sha256,
+    });
+    return {
+      installMode: "workspace",
+      cacheRoot: nanoclawCacheRoot(fingerprint),
+      cacheFingerprint: fingerprint,
+      workspaceDependencies,
+    } satisfies WorkspaceNanoclawCacheTarget;
+  });
+}
+
+function resolveCacheTarget(installMode: InstallMode) {
+  return installMode === "published"
+    ? resolvePublishedCacheTarget()
+    : resolveWorkspaceCacheTarget();
+}
+
+function prepareNanoclawWorkspaceDependencies() {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const packagesDir = findWorkspacePackagesDir(import.meta.url);
+    if (packagesDir === null) {
+      return yield* Effect.fail(
+        installError(
+          "Workspace install mode requires a MoltZap source checkout with packages/client and packages/protocol",
+        ),
+      );
+    }
+    // The pack directory outlives the request that creates it: its tarballs
+    // back the fingerprint every later spawn compares against, and a cold
+    // build vendors those exact bytes in.
+    const packRoot = yield* fsEffect(
+      "create temporary NanoClaw workspace pack directory",
+      fileSystem.makeTempDirectory({
+        prefix: "moltzap-nanoclaw-workspace-",
+      }),
+    );
+    const [client, protocol] = yield* Effect.all(
+      [
+        packWorkspacePackage(
+          join(packagesDir, "client"),
+          CLIENT_PACKAGE_NAME,
+          packRoot,
+        ),
+        packWorkspacePackage(
+          join(packagesDir, "protocol"),
+          PROTOCOL_PACKAGE_NAME,
+          packRoot,
+        ),
+      ],
+      { concurrency: 2 },
+    );
+    yield* assertPackedWorkspaceVersions({
+      clientManifest: client.manifest,
+      protocolManifest: protocol.manifest,
+      clientVersion: client.tarball.version,
+      protocolVersion: protocol.tarball.version,
+    });
+    return {
+      client: client.tarball,
+      protocol: protocol.tarball,
+    } satisfies NanoclawWorkspaceDependencies;
+  });
+}
+
+// Packing runs `pnpm pack` twice and hashes both tarballs before any warm
+// install can be recognized. The workspace build backing it cannot change
+// under a running testbed, so one preparation answers for every spawn.
+const cachedWorkspaceDependencies = Effect.runSync(
+  Effect.cached(prepareNanoclawWorkspaceDependencies()),
+);
+
+function packWorkspacePackage(
+  packageDir: string,
+  packageName: string,
+  packRoot: string,
+) {
+  return Effect.gen(function* () {
+    const sourceManifest = yield* readWorkspacePackageManifest(
+      join(packageDir, "package.json"),
+      packageName,
+    );
+    yield* requireBuiltWorkspacePackage(packageDir, packageName);
+    const tarballPath = yield* createWorkspaceTarball(
+      packageDir,
+      packageName,
+      packRoot,
+    );
+    const manifest = yield* readPackedWorkspaceManifest(
+      tarballPath,
+      packageName,
+    );
+    if (manifest.version !== sourceManifest.version) {
+      return yield* Effect.fail(
+        installError(
+          `Packed ${packageName} version ${manifest.version} does not match workspace version ${sourceManifest.version}`,
+        ),
+      );
+    }
+    const fileSystem = yield* FileSystem.FileSystem;
+    const bytes = yield* fsEffect(
+      `read packed workspace dependency ${tarballPath}`,
+      fileSystem.readFile(tarballPath),
+    );
+    return {
+      manifest,
+      tarball: {
+        packageName,
+        version: manifest.version,
+        tarballPath,
+        tarballFileName: basename(tarballPath),
+        sha256: sha256Hex(bytes),
+        integrity: sha512Integrity(bytes),
+      },
+    } satisfies PreparedWorkspaceTarball;
+  });
+}
+
+function requireBuiltWorkspacePackage(packageDir: string, packageName: string) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const distEntry = join(packageDir, WORKSPACE_DIST_ENTRY);
+    const exists = yield* fsEffect(
+      `check built workspace dependency ${distEntry}`,
+      fileSystem.exists(distEntry),
+    );
+    if (!exists) {
+      return yield* Effect.fail(
+        installError(
+          `Build ${packageName} before using NanoClaw workspace install mode; expected ${distEntry}`,
+        ),
+      );
+    }
+  });
+}
+
+function createWorkspaceTarball(
+  packageDir: string,
+  packageName: string,
+  packRoot: string,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const outputDir = join(packRoot, basename(packageDir));
+    yield* fsEffect(
+      `create ${packageName} pack output directory`,
+      fileSystem.makeDirectory(outputDir, { recursive: true }),
+    );
+    const command = Command.make(
+      "pnpm",
+      "pack",
+      "--pack-destination",
+      outputDir,
+    ).pipe(Command.workingDirectory(packageDir));
+    yield* commandOutputEffect(
+      `pack workspace package ${packageName}`,
+      command,
+      {
+        timeout: WORKSPACE_PACK_TIMEOUT_MS,
+      },
+    );
+    const entries = (yield* fsEffect(
+      `list packed workspace package ${packageName}`,
+      fileSystem.readDirectory(outputDir),
+    )).filter((entry) => entry.endsWith(TARBALL_EXTENSION));
+    const entry = yield* requireSoleEntry(
+      entries,
+      `packed tarball for ${packageName}`,
+    );
+    return join(outputDir, entry);
+  });
+}
+
+function readPackedWorkspaceManifest(tarballPath: string, packageName: string) {
+  return commandOutputEffect(
+    `read packed ${packageName} manifest`,
+    Command.make("tar", "-xOf", tarballPath, "package/package.json"),
+    { timeout: WORKSPACE_PACK_TIMEOUT_MS },
+  ).pipe(
+    Effect.flatMap((output) =>
+      decodeWorkspacePackageManifest(output.stdout, packageName),
+    ),
+  );
+}
+
+function readWorkspacePackageManifest(
+  manifestPath: string,
+  packageName: string,
+) {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) =>
+      fsEffect(
+        `read workspace package manifest ${manifestPath}`,
+        fileSystem.readFileString(manifestPath, "utf8"),
+      ),
+    ),
+    Effect.flatMap((contents) =>
+      decodeWorkspacePackageManifest(contents, packageName),
+    ),
+  );
+}
+
+function decodeWorkspacePackageManifest(contents: string, packageName: string) {
+  return Effect.try({
+    try: () => {
+      const value: unknown = JSON.parse(contents);
+      const manifest = requireRecord(value, `${packageName} package.json`);
+      const name = requireString(manifest.name, `${packageName} name`);
+      const version = requireString(manifest.version, `${packageName} version`);
+      if (name !== packageName) {
+        throw installError(
+          `Expected packed workspace package ${packageName}; found ${name}`,
+        );
+      }
+      return {
+        name,
+        version,
+        dependencies: optionalRecord(
+          manifest.dependencies,
+          `${packageName} dependencies`,
+        ),
+      } satisfies WorkspacePackageManifest;
+    },
+    catch: (cause) =>
+      cause instanceof NanoclawInstallError
+        ? cause
+        : installError(`Unable to decode ${packageName} package.json`, cause),
+  });
+}
+
+/** @internal */
+export function assertPackedWorkspaceVersions(input: {
+  readonly clientManifest: WorkspacePackageManifest;
+  readonly protocolManifest: WorkspacePackageManifest;
+  readonly clientVersion: string;
+  readonly protocolVersion: string;
+}) {
+  return Effect.try({
+    try: () => {
+      requireExactValue(
+        input.clientManifest.name,
+        CLIENT_PACKAGE_NAME,
+        "packed client name",
+      );
+      requireExactValue(
+        input.protocolManifest.name,
+        PROTOCOL_PACKAGE_NAME,
+        "packed protocol name",
+      );
+      requireExactValue(
+        input.clientManifest.version,
+        input.clientVersion,
+        "packed client version",
+      );
+      requireExactValue(
+        input.protocolManifest.version,
+        input.protocolVersion,
+        "packed protocol version",
+      );
+      requireExactValue(
+        input.clientManifest.dependencies[PROTOCOL_PACKAGE_NAME],
+        input.protocolManifest.version,
+        "packed client protocol dependency",
+      );
+    },
+    catch: (cause) =>
+      cause instanceof NanoclawInstallError
+        ? cause
+        : installError(
+            "Unable to validate packed NanoClaw workspace versions",
+            cause,
+          ),
+  });
 }
 
 /**
@@ -142,17 +513,18 @@ function resolveCacheTarget() {
  * guarantee they exercise the warm install path.
  * @internal
  */
-export function findWarmNanoclawRuntimeInstallEffect() {
-  return Effect.gen(function* () {
-    const target = yield* resolveCacheTarget();
-    const generationDir = yield* findNanoclawCacheGeneration(
-      target.cacheRoot,
-      target.cacheFingerprint,
-    );
-    return generationDir === null
-      ? null
-      : runtimeInstall(generationDir, target.cacheFingerprint);
-  }).pipe(Effect.withSpan("findWarmNanoclawRuntimeInstallEffect"));
+export function findWarmNanoclawRuntimeInstallEffect(installMode: InstallMode) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* resolveCacheTarget(installMode);
+      const generationDir = yield* nanoclawInstallCache(
+        target.cacheRoot,
+      ).findCacheGeneration(target.cacheFingerprint);
+      return generationDir === null
+        ? null
+        : runtimeInstall(generationDir, target.cacheFingerprint);
+    }),
+  ).pipe(Effect.withSpan("findWarmNanoclawRuntimeInstallEffect"));
 }
 
 function runtimeInstall(
@@ -171,94 +543,13 @@ function containerImageTag(cacheFingerprint: string): string {
   return NANOCLAW_IMAGE_TAG_PREFIX + "-" + cacheFingerprint;
 }
 
-function readyMarkerPath(cacheDir: string): string {
-  return join(cacheDir, ".ready");
-}
-
-function readReadyFingerprint(readyMarker: string) {
-  return Effect.gen(function* () {
-    const fileSystem = yield* FileSystem.FileSystem;
-    const exists = yield* fsEffect(
-      "check nanoclaw ready marker " + readyMarker,
-      fileSystem.exists(readyMarker),
-    );
-    if (!exists) return null;
-    return yield* fileSystem
-      .readFileString(readyMarker, "utf8")
-      .pipe(
-        Effect.catchAll((cause) =>
-          Effect.logDebug(
-            "ignoring unreadable NanoClaw ready marker",
-            cause,
-          ).pipe(Effect.as(null)),
-        ),
-      );
-  });
-}
-
-function createBuildingCache(cacheRoot: string) {
-  return Effect.gen(function* () {
-    const fileSystem = yield* FileSystem.FileSystem;
-    yield* fsEffect(
-      "create nanoclaw cache root " + cacheRoot,
-      fileSystem.makeDirectory(cacheRoot, { recursive: true }),
-    );
-    return yield* fsEffect(
-      "create unique nanoclaw building cache",
-      fileSystem.makeTempDirectory({
-        directory: cacheRoot,
-        prefix: BUILDING_CACHE_PREFIX,
-      }),
-    );
-  });
-}
-
-function removeBuildingCacheBestEffort(buildingDir: string) {
-  return FileSystem.FileSystem.pipe(
-    Effect.flatMap((fileSystem) =>
-      fileSystem.remove(buildingDir, { recursive: true, force: true }),
-    ),
-    Effect.catchAll((cause) =>
-      Effect.logWarning("failed to remove NanoClaw building cache", cause),
-    ),
-  );
-}
-
-// Building dirs from hard-killed installers (SIGKILL skips the ensuring
-// cleanup) would otherwise accumulate full checkouts forever. The age gate
-// keeps the sweep from deleting a concurrent process's in-progress build.
-const STALE_BUILDING_CACHE_MAX_AGE_MS = 86_400_000;
-
-/** @internal */
-export function sweepStaleBuildingCaches(
-  cacheRoot: string,
-  maxAgeMs: number = STALE_BUILDING_CACHE_MAX_AGE_MS,
-) {
-  return Effect.gen(function* () {
-    const fileSystem = yield* FileSystem.FileSystem;
-    const exists = yield* fileSystem.exists(cacheRoot);
-    if (!exists) return;
-    const entries = yield* fileSystem.readDirectory(cacheRoot);
-    const cutoff = Date.now() - maxAgeMs;
-    const buildingDirs = entries
-      .filter((entry) => entry.startsWith(BUILDING_CACHE_PREFIX))
-      .map((entry) => join(cacheRoot, entry));
-    for (const buildingDir of buildingDirs) {
-      const info = yield* fileSystem.stat(buildingDir);
-      const mtime = Option.getOrNull(info.mtime);
-      if (mtime !== null && mtime.getTime() <= cutoff) {
-        yield* fileSystem.remove(buildingDir, { recursive: true, force: true });
-      }
-    }
-  }).pipe(
-    Effect.catchAll((cause) =>
-      Effect.logWarning(
-        "failed to sweep stale NanoClaw building caches",
-        cause,
-      ),
-    ),
-    Effect.withSpan("sweepStaleBuildingCaches"),
-  );
+/**
+ * Binds the immutable cache lifecycle to this installer's error channel for
+ * one cache root.
+ * @internal
+ */
+export function nanoclawInstallCache(cacheRoot: string) {
+  return makeImmutableCache(cacheRoot, installError);
 }
 
 function ensureBundledAssetExists(assetPath: string) {
@@ -336,6 +627,235 @@ function injectBundledAssets(tmpDir: string) {
       join(tmpDir, "package-lock.json"),
     );
   });
+}
+
+function workspaceTarballSpec(tarball: NanoclawWorkspaceTarball): string {
+  return (
+    "file:" + posix.join(WORKSPACE_VENDOR_DIRECTORY, tarball.tarballFileName)
+  );
+}
+
+function copyWorkspaceDependencyTarballs(
+  stagingDir: string,
+  dependencies: NanoclawWorkspaceDependencies,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const vendorDir = join(stagingDir, WORKSPACE_VENDOR_DIRECTORY);
+    yield* fsEffect(
+      "create NanoClaw workspace vendor directory",
+      fileSystem.makeDirectory(vendorDir, { recursive: true }),
+    );
+    yield* Effect.forEach(
+      [dependencies.client, dependencies.protocol],
+      (tarball) =>
+        fsEffect(
+          `copy ${tarball.packageName} workspace tarball`,
+          fileSystem.copyFile(
+            tarball.tarballPath,
+            join(vendorDir, tarball.tarballFileName),
+          ),
+        ),
+      { concurrency: 2, discard: true },
+    );
+  });
+}
+
+/** @internal */
+export function rewriteNanoclawWorkspaceManifest(
+  stagingDir: string,
+  dependencies: NanoclawWorkspaceDependencies,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const manifestPath = join(stagingDir, "package.json");
+    const manifestText = yield* fsEffect(
+      "read staged NanoClaw package.json",
+      fileSystem.readFileString(manifestPath, "utf8"),
+    );
+    const rewrittenText = yield* Effect.try({
+      try: () => rewriteWorkspaceManifestText(manifestText, dependencies),
+      catch: (cause) =>
+        cause instanceof NanoclawInstallError
+          ? cause
+          : installError(
+              "Unable to rewrite staged NanoClaw package.json",
+              cause,
+            ),
+    });
+    yield* fsEffect(
+      "write staged NanoClaw workspace package.json",
+      fileSystem.writeFileString(manifestPath, rewrittenText),
+    );
+  }).pipe(Effect.withSpan("rewriteNanoclawWorkspaceManifest"));
+}
+
+function rewriteWorkspaceManifestText(
+  manifestText: string,
+  dependencies: NanoclawWorkspaceDependencies,
+): string {
+  const parsed: unknown = JSON.parse(manifestText);
+  const manifest = requireRecord(parsed, "staged NanoClaw package.json");
+  const manifestDependencies = requireRecord(
+    manifest.dependencies,
+    "staged NanoClaw dependencies",
+  );
+  const rewritten = {
+    ...manifest,
+    dependencies: {
+      ...manifestDependencies,
+      [CLIENT_PACKAGE_NAME]: workspaceTarballSpec(dependencies.client),
+      [PROTOCOL_PACKAGE_NAME]: workspaceTarballSpec(dependencies.protocol),
+    },
+  };
+  return JSON.stringify(rewritten, null, JSON_INDENT_SPACES) + "\n";
+}
+
+/** @internal */
+export function materializeNanoclawWorkspaceDependencies(
+  stagingDir: string,
+  dependencies: NanoclawWorkspaceDependencies,
+) {
+  return Effect.gen(function* () {
+    yield* copyWorkspaceDependencyTarballs(stagingDir, dependencies);
+    yield* rewriteNanoclawWorkspaceManifest(stagingDir, dependencies);
+    yield* execEffect(
+      "HUSKY=0 npm install --package-lock-only --ignore-scripts",
+      {
+        cwd: stagingDir,
+        timeout: WORKSPACE_LOCK_TIMEOUT_MS,
+      },
+    );
+    yield* assertNanoclawWorkspaceLock(stagingDir, dependencies);
+  }).pipe(Effect.withSpan("materializeNanoclawWorkspaceDependencies"));
+}
+
+/** @internal */
+export function assertNanoclawWorkspaceLock(
+  stagingDir: string,
+  dependencies: NanoclawWorkspaceDependencies,
+) {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) =>
+      fsEffect(
+        "read staged NanoClaw workspace package-lock.json",
+        fileSystem.readFileString(
+          join(stagingDir, "package-lock.json"),
+          "utf8",
+        ),
+      ),
+    ),
+    Effect.flatMap((lockText) =>
+      Effect.try({
+        try: () => validateNanoclawWorkspaceLock(lockText, dependencies),
+        catch: (cause) =>
+          cause instanceof NanoclawInstallError
+            ? cause
+            : installError(
+                "Unable to validate staged NanoClaw workspace package-lock.json",
+                cause,
+              ),
+      }),
+    ),
+    Effect.withSpan("assertNanoclawWorkspaceLock"),
+  );
+}
+
+function validateNanoclawWorkspaceLock(
+  lockText: string,
+  dependencies: NanoclawWorkspaceDependencies,
+): void {
+  if (REGISTRY_MOLTZAP_PATTERN.test(lockText)) {
+    throw installError(
+      "NanoClaw workspace lock contains a MoltZap registry artifact",
+    );
+  }
+  const parsed: unknown = JSON.parse(lockText);
+  const lock = requireRecord(parsed, "NanoClaw workspace package lock");
+  const packages = requireRecord(
+    lock.packages,
+    "NanoClaw workspace lock packages",
+  );
+  const root = requireRecord(packages[""], "NanoClaw workspace lock root");
+  const rootDependencies = requireRecord(
+    root.dependencies,
+    "NanoClaw workspace lock root dependencies",
+  );
+  requireExactValue(
+    rootDependencies[CLIENT_PACKAGE_NAME],
+    workspaceTarballSpec(dependencies.client),
+    "NanoClaw lock client dependency",
+  );
+  requireExactValue(
+    rootDependencies[PROTOCOL_PACKAGE_NAME],
+    workspaceTarballSpec(dependencies.protocol),
+    "NanoClaw lock protocol dependency",
+  );
+  requireExactMoltzapPackageKeys(packages);
+  validateWorkspaceLockEntry(packages, dependencies.client);
+  validateWorkspaceLockEntry(packages, dependencies.protocol);
+  const clientEntry = requireRecord(
+    packages[`node_modules/${CLIENT_PACKAGE_NAME}`],
+    "NanoClaw lock client entry",
+  );
+  const clientDependencies = requireRecord(
+    clientEntry.dependencies,
+    "NanoClaw lock client dependencies",
+  );
+  requireExactValue(
+    clientDependencies[PROTOCOL_PACKAGE_NAME],
+    dependencies.protocol.version,
+    "NanoClaw lock client protocol dependency",
+  );
+}
+
+function requireExactMoltzapPackageKeys(
+  packages: Readonly<Record<string, unknown>>,
+): void {
+  const actual = Object.keys(packages)
+    .filter((location) => location.includes("node_modules/@moltzap/"))
+    .sort();
+  const expected = [
+    `node_modules/${CLIENT_PACKAGE_NAME}`,
+    `node_modules/${PROTOCOL_PACKAGE_NAME}`,
+  ].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((location, index) => location !== expected[index])
+  ) {
+    throw installError(
+      `Expected only direct MoltZap workspace lock entries; found ${actual.join(", ") || "none"}`,
+    );
+  }
+}
+
+function validateWorkspaceLockEntry(
+  packages: Readonly<Record<string, unknown>>,
+  tarball: NanoclawWorkspaceTarball,
+): void {
+  const location = `node_modules/${tarball.packageName}`;
+  const entry = requireRecord(
+    packages[location],
+    `NanoClaw lock entry ${location}`,
+  );
+  requireExactValue(entry.version, tarball.version, `${location} version`);
+  requireExactValue(
+    entry.resolved,
+    workspaceTarballSpec(tarball),
+    `${location} resolved`,
+  );
+  requireExactValue(
+    entry.integrity,
+    tarball.integrity,
+    `${location} integrity`,
+  );
+}
+
+function optionalRecord(
+  value: unknown,
+  label: string,
+): Readonly<Record<string, unknown>> {
+  return value === undefined ? {} : requireRecord(value, label);
 }
 
 function downloadPinnedSource(destDir: string) {
@@ -471,81 +991,10 @@ function stampUpgradeMarker(sourceDir: string) {
   );
 }
 
-function writeReadyMarker(tmpDir: string, cacheFingerprint: string) {
-  const readyMarker = readyMarkerPath(tmpDir);
-  return FileSystem.FileSystem.pipe(
-    Effect.flatMap((fileSystem) =>
-      fsEffect(
-        "write nanoclaw ready marker " + readyMarker,
-        fileSystem.writeFileString(readyMarker, cacheFingerprint),
-      ),
-    ),
-  );
-}
-
-/**
- * Finds an immutable generation whose ready marker matches the full cache
- * fingerprint. Partial builds and corrupt generations are never selected.
- * @internal
- */
-export function findNanoclawCacheGeneration(
-  cacheRoot: string,
-  cacheFingerprint: string,
-) {
-  return Effect.gen(function* () {
-    const fileSystem = yield* FileSystem.FileSystem;
-    const exists = yield* fsEffect(
-      "check nanoclaw cache root " + cacheRoot,
-      fileSystem.exists(cacheRoot),
-    );
-    if (!exists) return null;
-    const entries = yield* fsEffect(
-      "list nanoclaw cache generations " + cacheRoot,
-      fileSystem.readDirectory(cacheRoot),
-    );
-    for (const entry of entries.filter(isCacheGeneration).sort()) {
-      const generationDir = join(cacheRoot, entry);
-      const readyFingerprint = yield* readReadyFingerprint(
-        readyMarkerPath(generationDir),
-      );
-      if (readyFingerprint === cacheFingerprint) return generationDir;
-    }
-    return null;
-  }).pipe(Effect.withSpan("findNanoclawCacheGeneration"));
-}
-
-function isCacheGeneration(entry: string): boolean {
-  return entry.startsWith(CACHE_GENERATION_PREFIX);
-}
-
-/**
- * Publishes a completed build under a unique immutable generation name.
- * @internal
- */
-export function publishNanoclawCacheGeneration(
-  buildingDir: string,
-  cacheRoot: string,
-) {
-  const generationDir = join(
-    cacheRoot,
-    CACHE_GENERATION_PREFIX +
-      basename(buildingDir).slice(BUILDING_CACHE_PREFIX.length),
-  );
-  return FileSystem.FileSystem.pipe(
-    Effect.flatMap((fileSystem) =>
-      fsEffect(
-        "publish nanoclaw cache generation " + generationDir,
-        fileSystem.rename(buildingDir, generationDir),
-      ),
-    ),
-    Effect.as(generationDir),
-    Effect.withSpan("publishNanoclawCacheGeneration"),
-  );
-}
-
 function buildAndPublish(target: NanoclawCacheTarget) {
+  const cache = nanoclawInstallCache(target.cacheRoot);
   return Effect.gen(function* () {
-    const buildingDir = yield* createBuildingCache(target.cacheRoot);
+    const buildingDir = yield* cache.createBuildingCache();
     return yield* Effect.gen(function* () {
       const buildingInstall = runtimeInstall(
         buildingDir,
@@ -553,36 +1002,47 @@ function buildAndPublish(target: NanoclawCacheTarget) {
       );
       yield* downloadPinnedSource(buildingDir);
       yield* injectBundledAssets(buildingDir);
+      if (target.installMode === "workspace") {
+        yield* materializeNanoclawWorkspaceDependencies(
+          buildingDir,
+          target.workspaceDependencies,
+        );
+      }
       yield* buildRuntime(buildingInstall);
-      yield* writeReadyMarker(buildingDir, target.cacheFingerprint);
-      const generationDir = yield* publishNanoclawCacheGeneration(
-        buildingDir,
-        target.cacheRoot,
-      );
+      yield* cache.writeReadyMarker(buildingDir, target.cacheFingerprint);
+      const generationDir = yield* cache.publishCacheGeneration(buildingDir);
       return runtimeInstall(generationDir, target.cacheFingerprint);
-    }).pipe(Effect.ensuring(removeBuildingCacheBestEffort(buildingDir)));
+    }).pipe(Effect.ensuring(cache.removeBuildingCacheBestEffort(buildingDir)));
   });
 }
 
-export function ensureNanoclawRuntimeInstalledEffect() {
-  return Effect.gen(function* () {
-    const warm = yield* Ref.get(WARM_INSTALL);
-    if (warm !== null) return warm;
-    const install = yield* INSTALL_PERMIT.withPermits(1)(
-      verifyOrBuildInstall(),
-    );
-    yield* Ref.set(WARM_INSTALL, install);
-    return install;
-  }).pipe(Effect.withSpan("ensureNanoclawRuntimeInstalledEffect"));
+export function ensureNanoclawRuntimeInstalledEffect(installMode: InstallMode) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* resolveCacheTarget(installMode);
+      const warm = yield* Ref.get(WARM_INSTALL);
+      if (
+        warm !== null &&
+        warm.installMode === installMode &&
+        warm.install.cacheFingerprint === target.cacheFingerprint
+      ) {
+        return warm.install;
+      }
+      const install = yield* CACHE_BUILD_PERMIT.withPermits(1)(
+        verifyOrBuildInstall(target),
+      );
+      yield* Ref.set(WARM_INSTALL, { installMode, install });
+      return install;
+    }),
+  ).pipe(Effect.withSpan("ensureNanoclawRuntimeInstalledEffect"));
 }
 
-function verifyOrBuildInstall() {
+function verifyOrBuildInstall(target: NanoclawCacheTarget) {
+  const cache = nanoclawInstallCache(target.cacheRoot);
   return Effect.gen(function* () {
-    const target = yield* resolveCacheTarget();
-    yield* sweepStaleBuildingCaches(target.cacheRoot);
+    yield* cache.sweepStaleBuildingCaches();
     yield* preflightDocker();
-    const generationDir = yield* findNanoclawCacheGeneration(
-      target.cacheRoot,
+    const generationDir = yield* cache.findCacheGeneration(
       target.cacheFingerprint,
     );
     if (generationDir === null) return yield* buildAndPublish(target);

--- a/packages/testbed/src/nanoclaw-process.ts
+++ b/packages/testbed/src/nanoclaw-process.ts
@@ -33,10 +33,8 @@ import {
   TESTBED_PROFILE_NAME,
   writeMoltZapProfileConfig,
 } from "./channel-plugin-install.js";
-import {
-  MOLTZAP_TESTBED_CACHE_ROOT,
-  type NanoclawRuntimeInstall,
-} from "./nanoclaw-install.js";
+import { type NanoclawRuntimeInstall } from "./nanoclaw-install.js";
+import { MOLTZAP_TESTBED_CACHE_ROOT } from "./immutable-cache.js";
 import {
   type BaseChildEnvironment,
   BaseChildEnvironmentConfig,

--- a/packages/testbed/src/nanoclaw-workspace-install.integration.test.ts
+++ b/packages/testbed/src/nanoclaw-workspace-install.integration.test.ts
@@ -1,0 +1,78 @@
+import { join } from "node:path";
+import { FileSystem } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Config, Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { ensureNanoclawRuntimeInstalledEffect } from "./nanoclaw-install.js";
+
+const CLIENT_PACKAGE_NAME = "@moltzap/client";
+const PROTOCOL_PACKAGE_NAME = "@moltzap/protocol";
+const FILE_VENDOR_PREFIX = "file:vendor/";
+const WORKSPACE_INSTALL_TEST_TIMEOUT_MS = 1_500_000;
+const REGISTRY_MOLTZAP_PATTERN = /registry\.npmjs\.org\/@moltzap(?:\/|%2f)/i;
+const EXPECTED_MOLTZAP_LOCK_KEYS = [
+  `node_modules/${CLIENT_PACKAGE_NAME}`,
+  `node_modules/${PROTOCOL_PACKAGE_NAME}`,
+].sort();
+
+const NANOCLAW_INSTALL_INTEGRATION_ENABLED = Effect.runSync(
+  Config.string("MOLTZAP_NANOCLAW_ITEST").pipe(
+    Config.withDefault("0"),
+    Config.map((value) => value === "1"),
+  ),
+);
+
+describe.skipIf(!NANOCLAW_INSTALL_INTEGRATION_ENABLED)(
+  "NanoClaw real workspace install",
+  () => {
+    it(
+      "uses only the two workspace MoltZap tarballs",
+      verifiesWorkspaceInstallLock,
+      WORKSPACE_INSTALL_TEST_TIMEOUT_MS,
+    );
+  },
+);
+
+function verifiesWorkspaceInstallLock() {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const install = yield* ensureNanoclawRuntimeInstalledEffect("workspace");
+      const fileSystem = yield* FileSystem.FileSystem;
+      const lockText = yield* fileSystem.readFileString(
+        join(install.cacheDir, "package-lock.json"),
+        "utf8",
+      );
+      expect(lockText).not.toMatch(REGISTRY_MOLTZAP_PATTERN);
+
+      const parsed: unknown = JSON.parse(lockText);
+      const lock = requireRecord(parsed);
+      const packages = requireRecord(lock.packages);
+      const root = requireRecord(packages[""]);
+      const rootDependencies = requireRecord(root.dependencies);
+      expect(rootDependencies[CLIENT_PACKAGE_NAME]).toMatch(FILE_VENDOR_PREFIX);
+      expect(rootDependencies[PROTOCOL_PACKAGE_NAME]).toMatch(
+        FILE_VENDOR_PREFIX,
+      );
+      const moltzapKeys = Object.keys(packages)
+        .filter((location) => location.includes("node_modules/@moltzap/"))
+        .sort();
+      expect(moltzapKeys).toEqual(EXPECTED_MOLTZAP_LOCK_KEYS);
+      for (const location of moltzapKeys) {
+        const entry = requireRecord(packages[location]);
+        expect(entry.resolved).toMatch(FILE_VENDOR_PREFIX);
+      }
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
+}
+
+function requireRecord(value: unknown): Readonly<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    throw new Error("Expected NanoClaw package lock object");
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/testbed/src/nanoclaw-workspace-install.test.ts
+++ b/packages/testbed/src/nanoclaw-workspace-install.test.ts
@@ -1,0 +1,562 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { Command, FileSystem } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { makeCommandHelpers } from "./child-process.js";
+import {
+  assertNanoclawWorkspaceLock,
+  assertPackedWorkspaceVersions,
+  materializeNanoclawWorkspaceDependencies,
+  nanoclawCacheFingerprint,
+  rewriteNanoclawWorkspaceManifest,
+  type NanoclawWorkspaceDependencies,
+  type NanoclawWorkspaceTarball,
+} from "./nanoclaw-install.js";
+
+const NANOCLAW_SHA = "641963c1e4b7ba4f000a18dfc5e2fea29069feec";
+const NANOCLAW_CACHE_SCHEMA_VERSION = 5;
+const CLIENT_PACKAGE_NAME = "@moltzap/client";
+const PROTOCOL_PACKAGE_NAME = "@moltzap/protocol";
+const PACKAGE_VERSION = "2026.724.2";
+const STALE_PACKAGE_VERSION = "2026.724.1";
+const CLIENT_TARBALL_FILE = "moltzap-client-2026.724.2.tgz";
+const PROTOCOL_TARBALL_FILE = "moltzap-protocol-2026.724.2.tgz";
+const CLIENT_TARBALL_SPEC = `file:vendor/${CLIENT_TARBALL_FILE}`;
+const PROTOCOL_TARBALL_SPEC = `file:vendor/${PROTOCOL_TARBALL_FILE}`;
+const CLIENT_INTEGRITY = "sha512-client-integrity";
+const PROTOCOL_INTEGRITY = "sha512-protocol-integrity";
+const STALE_INTEGRITY = "sha512-stale-integrity";
+const OTHER_DEPENDENCY_NAME = "effect";
+const OTHER_DEPENDENCY_VERSION = "3.22.0";
+const BUILD_SCRIPT = "tsc";
+const PROTOCOL_MISMATCH_REASON = "packed client protocol dependency";
+const HASH_HEX_LENGTH = 64;
+const CLIENT_HASH = "a".repeat(HASH_HEX_LENGTH);
+const OTHER_CLIENT_HASH = "b".repeat(HASH_HEX_LENGTH);
+const PROTOCOL_HASH = "c".repeat(HASH_HEX_LENGTH);
+const OTHER_PROTOCOL_HASH = "d".repeat(HASH_HEX_LENGTH);
+const REGISTRY_LEAK = "https://registry.npmjs.org/@moltzap/client/-/client.tgz";
+const FIXTURE_PACKAGE_NAME = "nanoclaw-workspace-staging-fixture";
+const FIXTURE_PACKAGE_VERSION = "1.0.0";
+const FIXTURE_COMMAND_TIMEOUT_MS = 30_000;
+const FIXTURE_TEST_TIMEOUT_MS = 30_000;
+const FIXTURE_NPM_CONFIG = [
+  "offline=true",
+  "audit=false",
+  "fund=false",
+  "update-notifier=false",
+].join("\n");
+
+const { commandOutputEffect } = makeCommandHelpers(
+  (reason, cause) =>
+    new Error(reason, cause === undefined ? undefined : { cause }),
+);
+
+const WORKSPACE_DEPENDENCIES = {
+  client: {
+    packageName: CLIENT_PACKAGE_NAME,
+    version: PACKAGE_VERSION,
+    tarballPath: `/fixtures/${CLIENT_TARBALL_FILE}`,
+    tarballFileName: CLIENT_TARBALL_FILE,
+    sha256: CLIENT_HASH,
+    integrity: CLIENT_INTEGRITY,
+  },
+  protocol: {
+    packageName: PROTOCOL_PACKAGE_NAME,
+    version: PACKAGE_VERSION,
+    tarballPath: `/fixtures/${PROTOCOL_TARBALL_FILE}`,
+    tarballFileName: PROTOCOL_TARBALL_FILE,
+    sha256: PROTOCOL_HASH,
+    integrity: PROTOCOL_INTEGRITY,
+  },
+} as const satisfies NanoclawWorkspaceDependencies;
+
+const FINGERPRINT_INPUT = {
+  channelHash: "channel-hash",
+  evalProvisionHash: "eval-provision-hash",
+  skillHash: "skill-hash",
+  packageJsonHash: "package-json-hash",
+  packageLockHash: "package-lock-hash",
+  platform: "test-platform",
+  architecture: "test-architecture",
+  nodeAbi: "test-node-abi",
+} as const;
+
+// @agent-code-guard/regression-only: these cases pin cache compatibility and workspace rebuild invalidation
+describe("NanoClaw workspace cache fingerprint", () => {
+  it("preserves the published fingerprint payload", preservesPublishedHash);
+  it(
+    "keys both workspace tarballs and remains stable",
+    includesWorkspaceHashes,
+  );
+});
+
+// @agent-code-guard/regression-only: fixture manifests and locks pin every local-artifact provenance check
+describe("NanoClaw workspace dependency staging", () => {
+  it(
+    "copies tarballs and refreshes an offline npm lock",
+    materializesWorkspaceDependencies,
+    FIXTURE_TEST_TIMEOUT_MS,
+  );
+  it(
+    "rewrites both direct dependencies and preserves other fields",
+    rewritesManifest,
+  );
+  it("accepts an exact two-package file lock", acceptsWorkspaceLock);
+  it(
+    "rejects a packed client built against another protocol",
+    rejectsMismatchedBuilds,
+  );
+  it("rejects MoltZap registry leakage", rejectsRegistryLeakage);
+  it("rejects a nested protocol copy", rejectsNestedProtocol);
+  it("rejects stale tarball integrity", rejectsStaleIntegrity);
+});
+
+function preservesPublishedHash() {
+  const expected = createHash("sha256")
+    .update(
+      JSON.stringify({
+        cacheSchema: NANOCLAW_CACHE_SCHEMA_VERSION,
+        nanoclawSha: NANOCLAW_SHA,
+        ...FINGERPRINT_INPUT,
+      }),
+    )
+    .digest("hex");
+
+  expect(nanoclawCacheFingerprint(FINGERPRINT_INPUT)).toBe(expected);
+}
+
+function includesWorkspaceHashes() {
+  const baseline = nanoclawCacheFingerprint(FINGERPRINT_INPUT, {
+    clientTarballHash: CLIENT_HASH,
+    protocolTarballHash: PROTOCOL_HASH,
+  });
+  const clientRebuilt = nanoclawCacheFingerprint(FINGERPRINT_INPUT, {
+    clientTarballHash: OTHER_CLIENT_HASH,
+    protocolTarballHash: PROTOCOL_HASH,
+  });
+  const protocolRebuilt = nanoclawCacheFingerprint(FINGERPRINT_INPUT, {
+    clientTarballHash: CLIENT_HASH,
+    protocolTarballHash: OTHER_PROTOCOL_HASH,
+  });
+  const repeated = nanoclawCacheFingerprint(FINGERPRINT_INPUT, {
+    clientTarballHash: CLIENT_HASH,
+    protocolTarballHash: PROTOCOL_HASH,
+  });
+
+  expect(clientRebuilt).not.toBe(baseline);
+  expect(protocolRebuilt).not.toBe(baseline);
+  expect(repeated).toBe(baseline);
+}
+
+function materializesWorkspaceDependencies() {
+  return runWithFixture((root) =>
+    Effect.gen(function* () {
+      const prepared = yield* prepareWorkspaceStagingFixture(root);
+      yield* materializeNanoclawWorkspaceDependencies(
+        prepared.stagingDir,
+        prepared.dependencies,
+      );
+      yield* assertMaterializedWorkspaceFixture(prepared);
+    }),
+  );
+}
+
+function prepareWorkspaceStagingFixture(root: string) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const packDir = join(root, "packs");
+    const stagingDir = join(root, "staging");
+    yield* fileSystem.makeDirectory(packDir, { recursive: true });
+    const protocol = yield* packFixturePackage({
+      root,
+      packDir,
+      directoryName: "protocol",
+      packageName: PROTOCOL_PACKAGE_NAME,
+      tarballFileName: PROTOCOL_TARBALL_FILE,
+      dependencies: {},
+    });
+    const client = yield* packFixturePackage({
+      root,
+      packDir,
+      directoryName: "client",
+      packageName: CLIENT_PACKAGE_NAME,
+      tarballFileName: CLIENT_TARBALL_FILE,
+      dependencies: { [PROTOCOL_PACKAGE_NAME]: PACKAGE_VERSION },
+    });
+    yield* seedWorkspaceStagingDir(root, stagingDir);
+    return {
+      stagingDir,
+      dependencies: { client, protocol },
+    } satisfies MaterializedWorkspaceFixture;
+  });
+}
+
+interface FixturePackageInput {
+  readonly root: string;
+  readonly packDir: string;
+  readonly directoryName: string;
+  readonly packageName: string;
+  readonly tarballFileName: string;
+  readonly dependencies: Readonly<Record<string, string>>;
+}
+
+function packFixturePackage(input: FixturePackageInput) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const packageDir = join(input.root, input.directoryName);
+    yield* fileSystem.makeDirectory(packageDir, { recursive: true });
+    yield* fileSystem.writeFileString(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: input.packageName,
+        version: PACKAGE_VERSION,
+        dependencies: input.dependencies,
+      }),
+    );
+    const command = Command.make(
+      "npm",
+      "pack",
+      "--pack-destination",
+      input.packDir,
+      "--cache",
+      join(input.root, "npm-cache"),
+      "--offline",
+    ).pipe(Command.workingDirectory(packageDir));
+    yield* commandOutputEffect(`pack fixture ${input.packageName}`, command, {
+      timeout: FIXTURE_COMMAND_TIMEOUT_MS,
+    });
+    return yield* describeFixtureTarball(
+      join(input.packDir, input.tarballFileName),
+      input.packageName,
+      input.tarballFileName,
+    );
+  });
+}
+
+function describeFixtureTarball(
+  tarballPath: string,
+  packageName: string,
+  tarballFileName: string,
+) {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) => fileSystem.readFile(tarballPath)),
+    Effect.map(
+      (bytes) =>
+        ({
+          packageName,
+          version: PACKAGE_VERSION,
+          tarballPath,
+          tarballFileName,
+          sha256: createHash("sha256").update(bytes).digest("hex"),
+          integrity:
+            "sha512-" + createHash("sha512").update(bytes).digest("base64"),
+        }) satisfies NanoclawWorkspaceTarball,
+    ),
+  );
+}
+
+function seedWorkspaceStagingDir(root: string, stagingDir: string) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const dependencies = {
+      [CLIENT_PACKAGE_NAME]: STALE_PACKAGE_VERSION,
+      [PROTOCOL_PACKAGE_NAME]: STALE_PACKAGE_VERSION,
+    };
+    yield* fileSystem.makeDirectory(stagingDir, { recursive: true });
+    yield* fileSystem.writeFileString(
+      join(stagingDir, "package.json"),
+      JSON.stringify({
+        name: FIXTURE_PACKAGE_NAME,
+        version: FIXTURE_PACKAGE_VERSION,
+        private: true,
+        scripts: { build: BUILD_SCRIPT },
+        dependencies,
+      }),
+    );
+    yield* fileSystem.writeFileString(
+      join(stagingDir, "package-lock.json"),
+      JSON.stringify({
+        name: FIXTURE_PACKAGE_NAME,
+        version: FIXTURE_PACKAGE_VERSION,
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          "": {
+            name: FIXTURE_PACKAGE_NAME,
+            version: FIXTURE_PACKAGE_VERSION,
+            dependencies,
+          },
+        },
+      }),
+    );
+    yield* fileSystem.writeFileString(
+      join(stagingDir, ".npmrc"),
+      `${FIXTURE_NPM_CONFIG}\ncache=${join(root, "npm-cache")}\n`,
+    );
+  });
+}
+
+interface MaterializedWorkspaceFixture {
+  readonly stagingDir: string;
+  readonly dependencies: NanoclawWorkspaceDependencies;
+}
+
+function assertMaterializedWorkspaceFixture(
+  fixture: MaterializedWorkspaceFixture,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    for (const tarball of [
+      fixture.dependencies.client,
+      fixture.dependencies.protocol,
+    ]) {
+      const [source, vendored] = yield* Effect.all([
+        fileSystem.readFile(tarball.tarballPath),
+        fileSystem.readFile(
+          join(fixture.stagingDir, "vendor", tarball.tarballFileName),
+        ),
+      ]);
+      expect(vendored).toEqual(source);
+    }
+    const manifest = readTestRecord(
+      JSON.parse(
+        yield* fileSystem.readFileString(
+          join(fixture.stagingDir, "package.json"),
+          "utf8",
+        ),
+      ),
+    );
+    const dependencies = readTestRecord(manifest.dependencies);
+    expect(dependencies[CLIENT_PACKAGE_NAME]).toBe(CLIENT_TARBALL_SPEC);
+    expect(dependencies[PROTOCOL_PACKAGE_NAME]).toBe(PROTOCOL_TARBALL_SPEC);
+    expect(manifest.scripts).toEqual({ build: BUILD_SCRIPT });
+    const lockText = yield* fileSystem.readFileString(
+      join(fixture.stagingDir, "package-lock.json"),
+      "utf8",
+    );
+    expect(lockText).not.toMatch(REGISTRY_LEAK);
+    const lock = readTestRecord(JSON.parse(lockText));
+    const packages = readTestRecord(lock.packages);
+    expect(
+      Object.keys(packages)
+        .filter((key) => key.includes("node_modules/@moltzap/"))
+        .sort(),
+    ).toEqual([
+      `node_modules/${CLIENT_PACKAGE_NAME}`,
+      `node_modules/${PROTOCOL_PACKAGE_NAME}`,
+    ]);
+  });
+}
+
+function readTestRecord(value: unknown): Readonly<Record<string, unknown>> {
+  if (!isTestRecord(value)) {
+    throw new Error("Expected fixture JSON object");
+  }
+  return value;
+}
+
+function isTestRecord(
+  value: unknown,
+): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function rewritesManifest() {
+  return runWithFixture((root) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const manifestPath = join(root, "package.json");
+      yield* fileSystem.writeFileString(
+        manifestPath,
+        JSON.stringify({
+          name: "nanoclaw",
+          scripts: { build: BUILD_SCRIPT },
+          dependencies: {
+            [CLIENT_PACKAGE_NAME]: PACKAGE_VERSION,
+            [PROTOCOL_PACKAGE_NAME]: PACKAGE_VERSION,
+            [OTHER_DEPENDENCY_NAME]: OTHER_DEPENDENCY_VERSION,
+          },
+        }),
+      );
+
+      yield* rewriteNanoclawWorkspaceManifest(root, WORKSPACE_DEPENDENCIES);
+
+      const rewritten: unknown = JSON.parse(
+        yield* fileSystem.readFileString(manifestPath, "utf8"),
+      );
+      expect(rewritten).toMatchObject({
+        scripts: { build: BUILD_SCRIPT },
+        dependencies: {
+          [CLIENT_PACKAGE_NAME]: CLIENT_TARBALL_SPEC,
+          [PROTOCOL_PACKAGE_NAME]: PROTOCOL_TARBALL_SPEC,
+          [OTHER_DEPENDENCY_NAME]: OTHER_DEPENDENCY_VERSION,
+        },
+      });
+    }),
+  );
+}
+
+function acceptsWorkspaceLock() {
+  return runWithLock(makeWorkspaceLock(), (root) =>
+    assertNanoclawWorkspaceLock(root, WORKSPACE_DEPENDENCIES).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result).toBeUndefined();
+        }),
+      ),
+    ),
+  );
+}
+
+function rejectsMismatchedBuilds() {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const error = yield* assertPackedWorkspaceVersions({
+        clientManifest: {
+          name: CLIENT_PACKAGE_NAME,
+          version: PACKAGE_VERSION,
+          dependencies: {
+            [PROTOCOL_PACKAGE_NAME]: STALE_PACKAGE_VERSION,
+          },
+        },
+        protocolManifest: {
+          name: PROTOCOL_PACKAGE_NAME,
+          version: PACKAGE_VERSION,
+          dependencies: {},
+        },
+        clientVersion: PACKAGE_VERSION,
+        protocolVersion: PACKAGE_VERSION,
+      }).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "NanoclawInstallError",
+        reason: expect.stringContaining(PROTOCOL_MISMATCH_REASON),
+      });
+    }),
+  );
+}
+
+function rejectsRegistryLeakage() {
+  return expectInvalidLock(
+    { ...makeWorkspaceLock(), registryLeak: REGISTRY_LEAK },
+    "registry artifact",
+  );
+}
+
+function rejectsNestedProtocol() {
+  const lock = makeWorkspaceLock();
+  const packages = lock.packages;
+  return expectInvalidLock(
+    {
+      ...lock,
+      packages: {
+        ...packages,
+        [`node_modules/${CLIENT_PACKAGE_NAME}/node_modules/${PROTOCOL_PACKAGE_NAME}`]:
+          packages[`node_modules/${PROTOCOL_PACKAGE_NAME}`],
+      },
+    },
+    "only direct",
+  );
+}
+
+function rejectsStaleIntegrity() {
+  const lock = makeWorkspaceLock();
+  return expectInvalidLock(
+    {
+      ...lock,
+      packages: {
+        ...lock.packages,
+        [`node_modules/${CLIENT_PACKAGE_NAME}`]: {
+          ...lock.packages[`node_modules/${CLIENT_PACKAGE_NAME}`],
+          integrity: STALE_INTEGRITY,
+        },
+      },
+    },
+    CLIENT_INTEGRITY,
+  );
+}
+
+function expectInvalidLock(
+  lock: Readonly<Record<string, unknown>>,
+  reasonFragment: string,
+) {
+  return runWithLock(lock, (root) =>
+    Effect.gen(function* () {
+      const error = yield* assertNanoclawWorkspaceLock(
+        root,
+        WORKSPACE_DEPENDENCIES,
+      ).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "NanoclawInstallError",
+        reason: expect.stringContaining(reasonFragment),
+      });
+    }),
+  );
+}
+
+function makeWorkspaceLock() {
+  return {
+    lockfileVersion: 3,
+    packages: {
+      "": {
+        dependencies: {
+          [CLIENT_PACKAGE_NAME]: CLIENT_TARBALL_SPEC,
+          [PROTOCOL_PACKAGE_NAME]: PROTOCOL_TARBALL_SPEC,
+        },
+      },
+      [`node_modules/${CLIENT_PACKAGE_NAME}`]: {
+        version: PACKAGE_VERSION,
+        resolved: CLIENT_TARBALL_SPEC,
+        integrity: CLIENT_INTEGRITY,
+        dependencies: {
+          [PROTOCOL_PACKAGE_NAME]: PACKAGE_VERSION,
+        },
+      },
+      [`node_modules/${PROTOCOL_PACKAGE_NAME}`]: {
+        version: PACKAGE_VERSION,
+        resolved: PROTOCOL_TARBALL_SPEC,
+        integrity: PROTOCOL_INTEGRITY,
+      },
+    },
+  };
+}
+
+function runWithLock<A, E>(
+  lock: Readonly<Record<string, unknown>>,
+  use: (root: string) => Effect.Effect<A, E, FileSystem.FileSystem>,
+) {
+  return runWithFixture((root) =>
+    FileSystem.FileSystem.pipe(
+      Effect.flatMap((fileSystem) =>
+        fileSystem.writeFileString(
+          join(root, "package-lock.json"),
+          JSON.stringify(lock),
+        ),
+      ),
+      Effect.zipRight(use(root)),
+    ),
+  );
+}
+
+function runWithFixture<A, E>(
+  use: (root: string) => Effect.Effect<A, E, FileSystem.FileSystem>,
+) {
+  return Effect.runPromise(
+    Effect.scoped(
+      FileSystem.FileSystem.pipe(
+        Effect.flatMap((fileSystem) =>
+          fileSystem.makeTempDirectoryScoped({
+            prefix: "nanoclaw-workspace-install-test-",
+          }),
+        ),
+        Effect.flatMap(use),
+        Effect.provide(NodeContext.layer),
+      ),
+    ),
+  );
+}

--- a/packages/testbed/src/openclaw-adapter.ts
+++ b/packages/testbed/src/openclaw-adapter.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jsdoc/text-escaping -- mermaid sequenceDiagram blocks need literal `<br>` (HTML5) for renderer compatibility; the escape would render as literal text. */
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { Command, FileSystem, Path, SocketServer } from "@effect/platform";
 import type { Process } from "@effect/platform/CommandExecutor";
 import { Config, Data, Effect, Exit, Fiber, Option, Scope } from "effect";
@@ -36,6 +36,8 @@ import {
   resolveInstalledPackageBin,
   resolveInstalledPackageRoot,
 } from "./package-resolution.js";
+import { type InstallMode } from "./install-mode.js";
+import { materializePublishedOpenClawPlugin } from "./openclaw-plugin-cache.js";
 
 const OPENCLAW_TERM_WAIT_MS = 10_000;
 const OPENCLAW_KILL_WAIT_MS = 5_000;
@@ -48,6 +50,14 @@ const JSON_INDENT_SPACES = 2;
 class PortAllocationFailed extends Data.TaggedError("PortAllocationFailed")<{
   readonly message: string;
   readonly cause?: unknown;
+}> {}
+
+class OpenClawInstallModeError extends Data.TaggedError(
+  "OpenClawInstallModeError",
+)<{
+  readonly message: string;
+  readonly channelDistDir: string;
+  readonly resolvedChannelDistDir: string;
 }> {}
 
 function pollExitCode(
@@ -167,12 +177,14 @@ export interface OpenClawAdapterDeps {
   readonly server: RuntimeServerHandle;
   readonly openclawBin: string;
   readonly channelDistDir: string;
+  readonly installMode: InstallMode;
 }
 
 export interface OpenClawAdapterOptions {
   readonly server: RuntimeServerHandle;
   readonly openclawBin?: string;
   readonly channelDistDir?: string;
+  readonly installMode: InstallMode;
 }
 
 interface AdapterState {
@@ -299,12 +311,26 @@ function configureOpenClawStateDir(
         agentId: input.agentId,
         apiKey: input.apiKey,
         modelId: input.modelId,
+        installMode: deps.installMode,
       }),
       seedWorkspaceFiles(join(stateDir, "workspace"), input.workspaceFiles),
       seedModelAuthProfile(stateDir),
     ],
     { concurrency: 3, discard: true },
-  ).pipe(
+  ).pipe(Effect.zipRight(installConfiguredChannel(deps, stateDir)));
+}
+
+function installConfiguredChannel(
+  deps: OpenClawAdapterDeps,
+  stateDir: string,
+): Effect.Effect<void, unknown, FileSystem.FileSystem | Path.Path> {
+  if (deps.installMode === "published") {
+    return materializePublishedOpenClawPlugin({
+      stateDir,
+      openclawBin: deps.openclawBin,
+    }).pipe(Effect.asVoid);
+  }
+  return assertWorkspaceChannelDist(deps.channelDistDir).pipe(
     Effect.zipRight(
       installChannelPlugin({
         stateDir,
@@ -312,8 +338,33 @@ function configureOpenClawStateDir(
         extName: OPENCLAW_EXTENSION_NAME,
         // OpenClaw discovers channel plugins through this package-root manifest.
         extraPackageFiles: ["openclaw.plugin.json"],
-      }).pipe(Effect.asVoid),
+      }),
     ),
+    Effect.asVoid,
+  );
+}
+
+/**
+ * Workspace mode accepts local build output, including a node_modules symlink
+ * whose real target is local, but never an installed package-store copy.
+ * @internal
+ */
+export function assertWorkspaceChannelDist(channelDistDir: string) {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) => fileSystem.realPath(channelDistDir)),
+    Effect.flatMap((resolvedChannelDistDir) =>
+      resolvedChannelDistDir.split(sep).includes("node_modules")
+        ? Effect.fail(
+            new OpenClawInstallModeError({
+              message:
+                "OpenClaw workspace install mode requires local channel build output",
+              channelDistDir,
+              resolvedChannelDistDir,
+            }),
+          )
+        : Effect.void,
+    ),
+    Effect.withSpan("assertWorkspaceChannelDist"),
   );
 }
 
@@ -429,14 +480,22 @@ function startOpenClawAdapter(
  * flowchart TD
  *   OCS["OpenClawAdapter.spawn(input)"]
  *   OC1["1. allocateFreePort()<br>NodeSocketServer.make({ port: 0 })"]
- *   OC2["2. lease + configure state dir<br>makeTempDirectory, writeOpenClawConfig,<br>seedWorkspaceFiles, installChannelPlugin"]
+ *   OC2["2. lease + configure state dir<br>makeTempDirectory, writeOpenClawConfig,<br>seed workspace + model auth"]
+ *   OCM{"install mode"}
+ *   OCW["workspace<br>validate local channel build<br>copy channel dist + dependency links<br>pin plugins.allow"]
+ *   OCP["published<br>reuse or build pinned npm project cache<br>materialize project + OpenClaw peer link<br>omit plugins.allow"]
  *   OC3["3. buildOpenClawProcessPlan(openclawBin, port)<br>(handles .mjs vs binary entry)"]
  *   OC4["4. lease spawnOpenClawProcess<br>exact child environment<br>exitFiber + log buffer"]
  *   OC5["5. commit process + state-dir leases<br>to adapter state"]
  *   OCF["failed or interrupted handoff<br>stops child + removes state dir"]
  *   OCR["waitUntilReady<br>race(server.awaitAgentReady, processExitLoop)<br>inbound marker: 'inbound from agent:'"]
- *   OCS --> OC1 --> OC2 --> OC3 --> OC4 --> OC5 --> OCR
+ *   OCS --> OC1 --> OC2 --> OCM
+ *   OCM -->|workspace| OCW --> OC3
+ *   OCM -->|published| OCP --> OC3
+ *   OC3 --> OC4 --> OC5 --> OCR
  *   OC2 -.->|failure| OCF
+ *   OCW -.->|failure| OCF
+ *   OCP -.->|failure| OCF
  *   OC4 -.->|failure or interruption| OCF
  * ```
  *
@@ -520,7 +579,7 @@ export class OpenClawAdapter implements Runtime {
  *   OCWF["createOpenClawAdapter(input)"]
  *   OCBIN["openclawBin = input.openclawBin ??<br>resolveInstalledPackageBin('openclaw')"]
  *   OCCH["channelDistDir = input.channelDistDir ??<br>resolveInstalledPackageRoot('@moltzap/openclaw-channel')/dist"]
- *   OCOUT["new OpenClawAdapter({ server, openclawBin, channelDistDir })"]
+ *   OCOUT["new OpenClawAdapter({ server, openclawBin,<br>channelDistDir, installMode })"]
  *   OCWF --> OCBIN --> OCCH --> OCOUT
  * ```
  */
@@ -532,6 +591,7 @@ export function createOpenClawAdapter(
     openclawBin:
       input.openclawBin ?? resolveInstalledPackageBin("openclaw", "openclaw"),
     channelDistDir: input.channelDistDir ?? resolveOpenClawChannelDistDir(),
+    installMode: input.installMode,
   });
 }
 
@@ -573,6 +633,7 @@ function writeOpenClawConfig(opts: {
   agentId: SpawnInput["agentId"];
   apiKey: SpawnInput["apiKey"];
   modelId?: string;
+  installMode: InstallMode;
 }): Effect.Effect<void, unknown, FileSystem.FileSystem | Path.Path> {
   return Effect.gen(function* () {
     const path = yield* Path.Path;
@@ -601,9 +662,18 @@ export function buildOpenClawConfig(
   opts: {
     readonly agentName: string;
     readonly modelId?: string;
+    readonly installMode: InstallMode;
   },
   workspaceDir: string,
 ): OpenClawConfig {
+  const pluginTrust =
+    opts.installMode === "workspace"
+      ? {
+          // Workspace copies have no npm install provenance, so their
+          // extension trust is pinned explicitly.
+          plugins: { allow: [OPENCLAW_EXTENSION_NAME] },
+        }
+      : {};
   return {
     agents: {
       defaults: {
@@ -613,10 +683,7 @@ export function buildOpenClawConfig(
       },
     },
     commands: { native: "auto", nativeSkills: "auto", restart: true },
-    // The channel extension is copied into the state dir without install
-    // provenance; openclaw treats such plugins as untracked local code and
-    // will not start their channels unless trust is pinned explicitly.
-    plugins: { allow: [OPENCLAW_EXTENSION_NAME] },
+    ...pluginTrust,
     messages: {
       // openclaw's own default and the closest heir to the removed passive
       // "queue" mode: mid-turn messages steer the active turn instead of

--- a/packages/testbed/src/openclaw-plugin-cache.integration.test.ts
+++ b/packages/testbed/src/openclaw-plugin-cache.integration.test.ts
@@ -1,0 +1,187 @@
+import { join } from "node:path";
+import { FileSystem } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Config, Data, Effect, Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { makeCommandHelpers } from "./child-process.js";
+import {
+  makeOpenClawCommand,
+  materializePublishedOpenClawPlugin,
+} from "./openclaw-plugin-cache.js";
+import {
+  resolveInstalledPackageBin,
+  resolveInstalledPackageDependency,
+} from "./package-resolution.js";
+
+const OPENCLAW_PLUGIN_ID = "openclaw-channel";
+const CHANNEL_PACKAGE_NAME = "@moltzap/openclaw-channel";
+const TESTBED_PACKAGE_NAME = "@moltzap/testbed";
+const OPENCLAW_COMMAND_TIMEOUT_MS = 30_000;
+// The cold path runs a real npm install (measured ~60s) plus a full
+// per-agent materialization before its assertions.
+const OPENCLAW_INSTALL_TEST_TIMEOUT_MS = 600_000;
+const JSON_INDENT_SPACES = 2;
+const LOADED_PLUGIN_STATUS = "loaded";
+const NPM_INSTALL_SOURCE = "npm";
+const PROVENANCE_DIAGNOSTIC_PATTERN = /provenance|untracked/i;
+
+const OpenClawPluginInfoOutput = Schema.Struct({
+  plugin: Schema.Struct({
+    id: Schema.String,
+    enabled: Schema.Boolean,
+    status: Schema.String,
+  }),
+  install: Schema.Struct({
+    source: Schema.String,
+    spec: Schema.String,
+  }),
+  diagnostics: Schema.Array(
+    Schema.Struct({
+      level: Schema.Literal("warn", "error"),
+      message: Schema.String,
+    }),
+  ),
+});
+
+class OpenClawIntegrationCommandError extends Data.TaggedError(
+  "OpenClawIntegrationCommandError",
+)<{
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {}
+
+function commandError(reason: string, cause?: unknown) {
+  return new OpenClawIntegrationCommandError({
+    reason,
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+const { commandOutputEffect } = makeCommandHelpers(commandError);
+
+interface PublishedPluginFixture {
+  readonly home: string;
+  readonly environment: Readonly<Record<string, string>>;
+  readonly expectedChannelSpec: string;
+  readonly openclawBin: string;
+}
+
+// Integration gates use Config so test modules follow the same environment
+// boundary as runtime code.
+const OPENCLAW_INSTALL_INTEGRATION_ENABLED = Effect.runSync(
+  Config.string("MOLTZAP_OPENCLAW_ITEST").pipe(
+    Config.withDefault("0"),
+    Config.map((value) => value === "1"),
+  ),
+);
+
+describe.skipIf(!OPENCLAW_INSTALL_INTEGRATION_ENABLED)(
+  "OpenClaw real published plugin cache",
+  () => {
+    it(
+      "retains npm provenance after per-agent materialization",
+      verifiesPublishedPluginProvenance,
+      OPENCLAW_INSTALL_TEST_TIMEOUT_MS,
+    );
+  },
+);
+
+function verifiesPublishedPluginProvenance() {
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const root = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "openclaw-plugin-cache-integration-",
+        });
+        const fixture = yield* preparePublishedPluginFixture(root);
+        yield* assertPublishedPluginInfo(fixture);
+      }).pipe(Effect.provide(NodeContext.layer)),
+    ),
+  );
+}
+
+function preparePublishedPluginFixture(root: string) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const stateDir = join(root, "agent-state");
+    const configPath = join(stateDir, "openclaw.json");
+    const openclawBin = resolveInstalledPackageBin("openclaw", "openclaw");
+    const channel = yield* Effect.try({
+      try: () =>
+        resolveInstalledPackageDependency(
+          TESTBED_PACKAGE_NAME,
+          CHANNEL_PACKAGE_NAME,
+          import.meta.url,
+        ),
+      catch: (cause) =>
+        commandError("Unable to resolve the expected channel version", cause),
+    });
+    yield* materializePublishedOpenClawPlugin({
+      stateDir,
+      openclawBin,
+      cacheBaseDir: join(root, "cache"),
+    });
+    yield* fileSystem.writeFileString(
+      configPath,
+      JSON.stringify({}, null, JSON_INDENT_SPACES),
+    );
+    return {
+      home: root,
+      environment: {
+        OPENCLAW_HOME: root,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+      },
+      expectedChannelSpec: `${CHANNEL_PACKAGE_NAME}@${channel.version}`,
+      openclawBin,
+    } satisfies PublishedPluginFixture;
+  });
+}
+
+function assertPublishedPluginInfo(fixture: PublishedPluginFixture) {
+  return Effect.gen(function* () {
+    const infoCommand = yield* makeOpenClawCommand(
+      fixture.openclawBin,
+      ["plugins", "info", OPENCLAW_PLUGIN_ID, "--runtime", "--json"],
+      fixture.environment,
+      fixture.home,
+    );
+    const infoOutput = yield* commandOutputEffect(
+      "inspect materialized OpenClaw plugin",
+      infoCommand,
+      { timeout: OPENCLAW_COMMAND_TIMEOUT_MS },
+    );
+    const info = yield* decodePluginInfo(infoOutput.stdout);
+    expect(info.plugin).toMatchObject({
+      id: OPENCLAW_PLUGIN_ID,
+      enabled: true,
+      status: LOADED_PLUGIN_STATUS,
+    });
+    expect(info.install).toEqual({
+      source: NPM_INSTALL_SOURCE,
+      spec: fixture.expectedChannelSpec,
+    });
+    expect(
+      info.diagnostics.some((diagnostic) =>
+        PROVENANCE_DIAGNOSTIC_PATTERN.test(diagnostic.message),
+      ),
+    ).toBe(false);
+    expect(infoOutput.stderr).not.toMatch(PROVENANCE_DIAGNOSTIC_PATTERN);
+  });
+}
+
+function decodePluginInfo(output: string) {
+  return Effect.try({
+    try: (): unknown => JSON.parse(output),
+    catch: (cause) => commandError("OpenClaw returned invalid JSON", cause),
+  }).pipe(
+    Effect.flatMap(Schema.decodeUnknown(OpenClawPluginInfoOutput)),
+    Effect.mapError((cause) =>
+      cause instanceof OpenClawIntegrationCommandError
+        ? cause
+        : commandError("Unable to decode OpenClaw plugin info", cause),
+    ),
+  );
+}

--- a/packages/testbed/src/openclaw-plugin-cache.test.ts
+++ b/packages/testbed/src/openclaw-plugin-cache.test.ts
@@ -1,0 +1,260 @@
+import { join } from "node:path";
+import { FileSystem } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import {
+  materializeOpenClawPluginCacheGeneration,
+  openClawPluginCacheFingerprint,
+  validateOpenClawPluginProject,
+} from "./openclaw-plugin-cache.js";
+
+const CHANNEL_PACKAGE_NAME = "@moltzap/openclaw-channel";
+const CHANNEL_VERSION = "1.2.3";
+const OPENCLAW_VERSION = "2026.6.33";
+const TEST_PLATFORM = "test-platform";
+const TEST_ARCHITECTURE = "test-architecture";
+const OTHER_CHANNEL_VERSION = "1.2.4";
+const OTHER_OPENCLAW_VERSION = "2026.6.34";
+const OTHER_PLATFORM = "other-platform";
+const OTHER_ARCHITECTURE = "other-architecture";
+const PROJECT_SLUG = "moltzap-openclaw-channel-test";
+const CHANNEL_PAYLOAD = "registry plugin payload";
+const HASH_HEX_LENGTH = 64;
+const REGISTRY_CHANNEL_TARBALL =
+  "https://registry.npmjs.org/@moltzap/openclaw-channel/-/openclaw-channel-1.2.3.tgz";
+const LOCAL_CHANNEL_TARBALL = "file:../openclaw-channel.tgz";
+const TEST_INTEGRITY = "sha512-test-integrity";
+
+const BASE_FINGERPRINT_INPUT = {
+  channelVersion: CHANNEL_VERSION,
+  openclawVersion: OPENCLAW_VERSION,
+  platform: TEST_PLATFORM,
+  architecture: TEST_ARCHITECTURE,
+} as const;
+
+const FINGERPRINT_VARIANTS = [
+  {
+    label: "channel version",
+    input: {
+      ...BASE_FINGERPRINT_INPUT,
+      channelVersion: OTHER_CHANNEL_VERSION,
+    },
+  },
+  {
+    label: "OpenClaw version",
+    input: {
+      ...BASE_FINGERPRINT_INPUT,
+      openclawVersion: OTHER_OPENCLAW_VERSION,
+    },
+  },
+  {
+    label: "platform",
+    input: { ...BASE_FINGERPRINT_INPUT, platform: OTHER_PLATFORM },
+  },
+  {
+    label: "architecture",
+    input: {
+      ...BASE_FINGERPRINT_INPUT,
+      architecture: OTHER_ARCHITECTURE,
+    },
+  },
+] as const;
+
+describe("OpenClaw published plugin cache fingerprint", () => {
+  const baseline = openClawPluginCacheFingerprint(BASE_FINGERPRINT_INPUT);
+
+  it("is a sha256 digest", () => {
+    expect(baseline).toHaveLength(HASH_HEX_LENGTH);
+  });
+
+  it.each(FINGERPRINT_VARIANTS)("includes $label", ({ input }) => {
+    expect(openClawPluginCacheFingerprint(input)).not.toBe(baseline);
+  });
+});
+
+describe("OpenClaw npm project provenance", () => {
+  it(
+    "accepts exact registry-backed MoltZap artifacts",
+    acceptsRegistryArtifacts,
+  );
+  it("rejects a local MoltZap artifact", rejectsLocalArtifacts);
+});
+
+describe("OpenClaw plugin cache materialization", () => {
+  it(
+    "copies one project and rebuilds its OpenClaw peer link",
+    rebuildsOpenClawPeerLink,
+  );
+  it(
+    "fails clearly when the canonical OpenClaw package is absent",
+    rejectsMissingOpenClawPackage,
+  );
+});
+
+function acceptsRegistryArtifacts() {
+  return runWithFixture((root) =>
+    Effect.gen(function* () {
+      const projectDir = join(root, "valid-project");
+      yield* seedProject(projectDir, REGISTRY_CHANNEL_TARBALL);
+
+      const result = yield* validateOpenClawPluginProject(
+        projectDir,
+        CHANNEL_VERSION,
+      );
+
+      expect(result).toBeUndefined();
+    }),
+  );
+}
+
+function rejectsLocalArtifacts() {
+  return runWithFixture((root) =>
+    Effect.gen(function* () {
+      const projectDir = join(root, "local-project");
+      yield* seedProject(projectDir, LOCAL_CHANNEL_TARBALL);
+
+      const error = yield* validateOpenClawPluginProject(
+        projectDir,
+        CHANNEL_VERSION,
+      ).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "OpenClawPluginCacheError",
+        reason: expect.stringContaining("registry-backed"),
+      });
+    }),
+  );
+}
+
+function rebuildsOpenClawPeerLink() {
+  return runWithFixture((root) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const fixture = yield* seedCachedProject(root);
+
+      const projectDir = yield* materializeOpenClawPluginCacheGeneration({
+        generationDir: fixture.generationDir,
+        stateDir: fixture.stateDir,
+        openclawPackageRoot: fixture.openclawPackageRoot,
+      });
+
+      expect(
+        yield* fileSystem.readFileString(
+          join(projectDir, "payload.txt"),
+          "utf8",
+        ),
+      ).toBe(CHANNEL_PAYLOAD);
+      const [linkTarget, canonicalRoot] = yield* Effect.all([
+        fileSystem.readLink(openclawPeerLinkPath(projectDir)),
+        fileSystem.realPath(fixture.openclawPackageRoot),
+      ]);
+      expect(linkTarget).toBe(canonicalRoot);
+    }),
+  );
+}
+
+function rejectsMissingOpenClawPackage() {
+  return runWithFixture((root) =>
+    Effect.gen(function* () {
+      const fixture = yield* seedCachedProject(root);
+      const missingPackageRoot = join(root, "missing-openclaw");
+
+      const error = yield* materializeOpenClawPluginCacheGeneration({
+        generationDir: fixture.generationDir,
+        stateDir: fixture.stateDir,
+        openclawPackageRoot: missingPackageRoot,
+      }).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "OpenClawPluginCacheError",
+        reason: expect.stringContaining(missingPackageRoot),
+      });
+    }),
+  );
+}
+
+function seedProject(projectDir: string, resolved: string) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    yield* fileSystem.makeDirectory(projectDir, { recursive: true });
+    yield* fileSystem.writeFileString(
+      join(projectDir, "package.json"),
+      JSON.stringify({
+        dependencies: { [CHANNEL_PACKAGE_NAME]: CHANNEL_VERSION },
+      }),
+    );
+    yield* fileSystem.writeFileString(
+      join(projectDir, "package-lock.json"),
+      JSON.stringify({
+        packages: {
+          "": {
+            dependencies: { [CHANNEL_PACKAGE_NAME]: CHANNEL_VERSION },
+          },
+          [`node_modules/${CHANNEL_PACKAGE_NAME}`]: {
+            version: CHANNEL_VERSION,
+            resolved,
+            integrity: TEST_INTEGRITY,
+          },
+        },
+      }),
+    );
+  });
+}
+
+function seedCachedProject(root: string) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const generationDir = join(root, "generation");
+    const projectDir = join(generationDir, "npm", "projects", PROJECT_SLUG);
+    const stateDir = join(root, "state");
+    const openclawPackageRoot = join(root, "canonical-openclaw");
+    const staleOpenclawRoot = join(root, "stale-openclaw");
+    const peerLink = openclawPeerLinkPath(projectDir);
+    yield* Effect.all(
+      [projectDir, stateDir, openclawPackageRoot, staleOpenclawRoot].map(
+        (directory) => fileSystem.makeDirectory(directory, { recursive: true }),
+      ),
+      { concurrency: 4, discard: true },
+    );
+    yield* fileSystem.writeFileString(
+      join(projectDir, "payload.txt"),
+      CHANNEL_PAYLOAD,
+    );
+    yield* fileSystem.makeDirectory(join(peerLink, ".."), {
+      recursive: true,
+    });
+    yield* fileSystem.symlink(staleOpenclawRoot, peerLink);
+    return { generationDir, openclawPackageRoot, stateDir };
+  });
+}
+
+function openclawPeerLinkPath(projectDir: string): string {
+  return join(
+    projectDir,
+    "node_modules",
+    "@moltzap",
+    "openclaw-channel",
+    "node_modules",
+    "openclaw",
+  );
+}
+
+function runWithFixture<A, E>(
+  use: (root: string) => Effect.Effect<A, E, FileSystem.FileSystem>,
+) {
+  return Effect.runPromise(
+    Effect.scoped(
+      FileSystem.FileSystem.pipe(
+        Effect.flatMap((fileSystem) =>
+          fileSystem.makeTempDirectoryScoped({
+            prefix: "openclaw-plugin-cache-test-",
+          }),
+        ),
+        Effect.flatMap(use),
+        Effect.provide(NodeContext.layer),
+      ),
+    ),
+  );
+}

--- a/packages/testbed/src/openclaw-plugin-cache.ts
+++ b/packages/testbed/src/openclaw-plugin-cache.ts
@@ -1,0 +1,606 @@
+import { basename, dirname, join } from "node:path";
+import { execPath } from "node:process";
+import { FileSystem } from "@effect/platform";
+import { Data, Effect, Ref, Schema } from "effect";
+import {
+  BaseChildEnvironmentConfig,
+  makeCommandHelpers,
+  makeExactEnvironmentCommand,
+  type CapturedCommandOutput,
+} from "./child-process.js";
+import {
+  cacheFingerprint,
+  CACHE_BUILD_PERMIT,
+  makeImmutableCache,
+  MOLTZAP_TESTBED_CACHE_ROOT,
+} from "./immutable-cache.js";
+import { makeJsonGuards } from "./json-guards.js";
+import { resolveInstalledPackageDependency } from "./package-resolution.js";
+
+const CHANNEL_PACKAGE_NAME = "@moltzap/openclaw-channel";
+const OPENCLAW_PACKAGE_NAME = "openclaw";
+const OPENCLAW_PLUGIN_ID = "openclaw-channel";
+const OPENCLAW_CACHE_SCHEMA_VERSION = 1;
+const OPENCLAW_INSTALL_TIMEOUT_MS = 120_000;
+const OPENCLAW_LIST_TIMEOUT_MS = 30_000;
+const NPM_REGISTRY_PREFIX = "https://registry.npmjs.org/";
+const NPM_INTEGRITY_PREFIX = "sha512-";
+
+const OpenClawPluginListOutput = Schema.Struct({
+  plugins: Schema.Array(
+    Schema.Struct({
+      id: Schema.String,
+      enabled: Schema.Boolean,
+      status: Schema.String,
+    }),
+  ),
+});
+
+// Everything a cache generation is keyed by and built from. The pinned
+// dependency resolution is process-constant; only `cacheRoot` varies, because
+// tests redirect the cache away from the shared root.
+interface OpenClawPluginCacheTargetInput {
+  readonly cacheFingerprint: string;
+  readonly channelSpec: string;
+  readonly channelVersion: string;
+  readonly openclawPackageRoot: string;
+}
+
+interface OpenClawPluginCacheTarget extends OpenClawPluginCacheTargetInput {
+  readonly cacheRoot: string;
+}
+
+interface WarmCacheGeneration {
+  readonly cacheFingerprint: string;
+  readonly cacheRoot: string;
+  readonly generationDir: string;
+}
+
+export interface MaterializePublishedOpenClawPluginOptions {
+  readonly stateDir: string;
+  readonly openclawBin: string;
+  readonly cacheBaseDir?: string;
+}
+
+// A published generation is immutable, so the first spawn's resolution answers
+// for every later spawn instead of re-sweeping and re-scanning the cache.
+const WARM_CACHE_GENERATION = Effect.runSync(
+  Ref.make<WarmCacheGeneration | null>(null),
+);
+
+class OpenClawPluginCacheError extends Data.TaggedError(
+  "OpenClawPluginCacheError",
+)<{
+  readonly reason: string;
+  readonly cause?: unknown;
+}> {
+  override get message(): string {
+    return this.reason;
+  }
+}
+
+function cacheError(reason: string, cause?: unknown) {
+  return new OpenClawPluginCacheError({
+    reason,
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+const { commandOutputEffect, fsEffect } = makeCommandHelpers(cacheError);
+const {
+  isRecord,
+  requireExactValue,
+  requireRecord,
+  requireSoleEntry,
+  requireString,
+} = makeJsonGuards(cacheError);
+
+/**
+ * Installs or reuses the pinned npm project and copies it into one agent's
+ * state directory with a peer link to this testbed's OpenClaw package.
+ */
+export function materializePublishedOpenClawPlugin(
+  options: MaterializePublishedOpenClawPluginOptions,
+) {
+  return Effect.gen(function* () {
+    const target = yield* resolveCacheTarget(options.cacheBaseDir);
+    const generationDir = yield* resolveCacheGeneration(
+      target,
+      options.openclawBin,
+    );
+    return yield* materializeOpenClawPluginCacheGeneration({
+      generationDir,
+      stateDir: options.stateDir,
+      openclawPackageRoot: target.openclawPackageRoot,
+    });
+  }).pipe(Effect.withSpan("materializePublishedOpenClawPlugin"));
+}
+
+// The installed dependency versions and this host's identity cannot change
+// while the process runs, so the two directory-walking package resolutions and
+// the digest run once for every agent it spawns.
+const cachedCacheTargetInput = Effect.runSync(
+  Effect.cached(
+    Effect.try({
+      try: (): OpenClawPluginCacheTargetInput => {
+        const channel = resolveInstalledPackageDependency(
+          "@moltzap/testbed",
+          CHANNEL_PACKAGE_NAME,
+          import.meta.url,
+        );
+        const openclaw = resolveInstalledPackageDependency(
+          "@moltzap/testbed",
+          OPENCLAW_PACKAGE_NAME,
+          import.meta.url,
+        );
+        return {
+          cacheFingerprint: openClawPluginCacheFingerprint({
+            channelVersion: channel.version,
+            openclawVersion: openclaw.version,
+            platform: process.platform,
+            architecture: process.arch,
+          }),
+          channelSpec: `${CHANNEL_PACKAGE_NAME}@${channel.version}`,
+          channelVersion: channel.version,
+          openclawPackageRoot: openclaw.packageRoot,
+        };
+      },
+      catch: (cause) =>
+        cacheError(
+          "Unable to resolve exact testbed dependencies for the published OpenClaw plugin cache",
+          cause,
+        ),
+    }),
+  ),
+);
+
+function resolveCacheTarget(cacheBaseDir?: string) {
+  return cachedCacheTargetInput.pipe(
+    Effect.map(
+      (input) =>
+        ({
+          ...input,
+          cacheRoot: join(
+            cacheBaseDir ?? join(MOLTZAP_TESTBED_CACHE_ROOT, "openclaw-plugin"),
+            input.cacheFingerprint,
+          ),
+        }) satisfies OpenClawPluginCacheTarget,
+    ),
+  );
+}
+
+/** @internal */
+export function openClawPluginCacheFingerprint(input: {
+  readonly channelVersion: string;
+  readonly openclawVersion: string;
+  readonly platform: string;
+  readonly architecture: string;
+}): string {
+  return cacheFingerprint(OPENCLAW_CACHE_SCHEMA_VERSION, {
+    channelVersion: input.channelVersion,
+    openclawVersion: input.openclawVersion,
+    platform: input.platform,
+    architecture: input.architecture,
+  });
+}
+
+function resolveCacheGeneration(
+  target: OpenClawPluginCacheTarget,
+  openclawBin: string,
+) {
+  return Effect.gen(function* () {
+    const warm = yield* Ref.get(WARM_CACHE_GENERATION);
+    if (
+      warm !== null &&
+      warm.cacheFingerprint === target.cacheFingerprint &&
+      warm.cacheRoot === target.cacheRoot
+    ) {
+      return warm.generationDir;
+    }
+    const generationDir = yield* CACHE_BUILD_PERMIT.withPermits(1)(
+      ensureCacheGeneration(target, openclawBin),
+    );
+    yield* Ref.set(WARM_CACHE_GENERATION, {
+      cacheFingerprint: target.cacheFingerprint,
+      cacheRoot: target.cacheRoot,
+      generationDir,
+    });
+    return generationDir;
+  });
+}
+
+function ensureCacheGeneration(
+  target: OpenClawPluginCacheTarget,
+  openclawBin: string,
+) {
+  const cache = makeImmutableCache(target.cacheRoot, cacheError);
+  return Effect.gen(function* () {
+    yield* cache.sweepStaleBuildingCaches();
+    const ready = yield* cache.findCacheGeneration(target.cacheFingerprint);
+    if (ready !== null) return ready;
+    return yield* buildAndPublishCacheGeneration(target, openclawBin);
+  });
+}
+
+function buildAndPublishCacheGeneration(
+  target: OpenClawPluginCacheTarget,
+  openclawBin: string,
+) {
+  const cache = makeImmutableCache(target.cacheRoot, cacheError);
+  return Effect.gen(function* () {
+    const buildingDir = yield* cache.createBuildingCache();
+    return yield* Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const stagingHome = yield* fsEffect(
+          "create isolated OpenClaw plugin staging home",
+          fileSystem.makeTempDirectoryScoped({
+            prefix: "moltzap-openclaw-plugin-",
+          }),
+        );
+        yield* coldInstallPlugin(openclawBin, stagingHome, target);
+        const sourceProjectDir = yield* findInstalledChannelProject(
+          join(stagingHome, ".openclaw", "npm", "projects"),
+          target.channelVersion,
+        );
+        yield* validateOpenClawPluginProject(
+          sourceProjectDir,
+          target.channelVersion,
+        );
+        yield* copyProjectIntoBuildingCache(sourceProjectDir, buildingDir);
+        yield* cache.writeReadyMarker(buildingDir, target.cacheFingerprint);
+        return yield* cache.publishCacheGeneration(buildingDir);
+      }),
+    ).pipe(Effect.ensuring(cache.removeBuildingCacheBestEffort(buildingDir)));
+  });
+}
+
+function coldInstallPlugin(
+  openclawBin: string,
+  stagingHome: string,
+  target: OpenClawPluginCacheTarget,
+) {
+  const stateDir = join(stagingHome, ".openclaw");
+  const environment = {
+    OPENCLAW_HOME: stagingHome,
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_CONFIG_PATH: join(stateDir, "openclaw.json"),
+  };
+  return Effect.gen(function* () {
+    const installCommand = yield* makeOpenClawCommand(
+      openclawBin,
+      ["plugins", "install", target.channelSpec, "--pin"],
+      environment,
+      stagingHome,
+    );
+    const listCommand = yield* makeOpenClawCommand(
+      openclawBin,
+      ["plugins", "list", "--enabled", "--json"],
+      environment,
+      stagingHome,
+    );
+    yield* commandOutputEffect(
+      `install ${target.channelSpec} with OpenClaw`,
+      installCommand,
+      { timeout: OPENCLAW_INSTALL_TIMEOUT_MS },
+    );
+    const listed = yield* commandOutputEffect(
+      "list enabled OpenClaw plugins",
+      listCommand,
+      { timeout: OPENCLAW_LIST_TIMEOUT_MS },
+    );
+    yield* verifyEnabledPlugin(listed);
+  });
+}
+
+/**
+ * Builds one OpenClaw CLI invocation under an exact environment rather than
+ * the operator's: ambient variables change the CLI's behavior (a test-runner
+ * marker silences its JSON output entirely), which would make cache builds
+ * depend on who launched them.
+ * @internal
+ */
+export function makeOpenClawCommand(
+  openclawBin: string,
+  args: ReadonlyArray<string>,
+  environment: Readonly<Record<string, string>>,
+  cwd: string,
+) {
+  const isNodeScript = openclawBin.endsWith(".mjs");
+  return Effect.map(BaseChildEnvironmentConfig, (base) =>
+    makeExactEnvironmentCommand({
+      command: isNodeScript ? execPath : openclawBin,
+      args: isNodeScript ? [openclawBin, ...args] : [...args],
+      cwd,
+      env: { ...base, ...environment },
+    }),
+  );
+}
+
+function verifyEnabledPlugin(output: CapturedCommandOutput) {
+  return Effect.try({
+    try: (): unknown => JSON.parse(output.stdout),
+    catch: (cause) =>
+      cacheError("OpenClaw plugins list returned invalid JSON", cause),
+  }).pipe(
+    Effect.flatMap(Schema.decodeUnknown(OpenClawPluginListOutput)),
+    Effect.mapError((cause) =>
+      cause instanceof OpenClawPluginCacheError
+        ? cause
+        : cacheError("Unable to decode OpenClaw plugins list", cause),
+    ),
+    Effect.flatMap((decoded) => {
+      const plugin = decoded.plugins.find(
+        (candidate) => candidate.id === OPENCLAW_PLUGIN_ID,
+      );
+      return plugin?.enabled === true && plugin.status === "loaded"
+        ? Effect.void
+        : Effect.fail(
+            cacheError(
+              `OpenClaw did not report ${OPENCLAW_PLUGIN_ID} enabled and loaded after install`,
+            ),
+          );
+    }),
+  );
+}
+
+function findInstalledChannelProject(
+  projectsDir: string,
+  channelVersion: string,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const entries = yield* fsEffect(
+      "list installed OpenClaw npm projects " + projectsDir,
+      fileSystem.readDirectory(projectsDir),
+    );
+    const matches = yield* Effect.filter(entries, (entry) =>
+      projectDeclaresChannel(
+        join(projectsDir, entry, "package.json"),
+        channelVersion,
+      ),
+    );
+    const match = yield* requireSoleEntry(
+      matches,
+      `OpenClaw npm project for ${CHANNEL_PACKAGE_NAME}@${channelVersion}`,
+    );
+    return join(projectsDir, match);
+  });
+}
+
+function projectDeclaresChannel(
+  packageJsonPath: string,
+  channelVersion: string,
+) {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) =>
+      fileSystem.readFileString(packageJsonPath, "utf8"),
+    ),
+    Effect.flatMap((contents) =>
+      Effect.try({
+        try: () => {
+          const parsed: unknown = JSON.parse(contents);
+          return (
+            isRecord(parsed) &&
+            isRecord(parsed.dependencies) &&
+            parsed.dependencies[CHANNEL_PACKAGE_NAME] === channelVersion
+          );
+        },
+        catch: () => false,
+      }).pipe(Effect.merge),
+    ),
+    Effect.catchAll(() => Effect.succeed(false)),
+  );
+}
+
+/** @internal */
+export function validateOpenClawPluginProject(
+  projectDir: string,
+  channelVersion: string,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const [manifestText, lockText] = yield* Effect.all([
+      fsEffect(
+        "read OpenClaw npm project manifest",
+        fileSystem.readFileString(join(projectDir, "package.json"), "utf8"),
+      ),
+      fsEffect(
+        "read OpenClaw npm project lock",
+        fileSystem.readFileString(
+          join(projectDir, "package-lock.json"),
+          "utf8",
+        ),
+      ),
+    ]);
+    yield* Effect.try({
+      try: () =>
+        validateProjectProvenance(
+          JSON.parse(manifestText),
+          JSON.parse(lockText),
+          channelVersion,
+        ),
+      catch: (cause) =>
+        cause instanceof OpenClawPluginCacheError
+          ? cause
+          : cacheError("Unable to validate OpenClaw npm provenance", cause),
+    });
+  }).pipe(Effect.withSpan("validateOpenClawPluginProject"));
+}
+
+function validateProjectProvenance(
+  manifest: unknown,
+  lock: unknown,
+  channelVersion: string,
+): void {
+  const manifestRecord = requireRecord(manifest, "npm project package.json");
+  const manifestDependencies = requireRecord(
+    manifestRecord.dependencies,
+    "npm project dependencies",
+  );
+  requireExactValue(
+    manifestDependencies[CHANNEL_PACKAGE_NAME],
+    channelVersion,
+    "npm project channel dependency",
+  );
+  const lockRecord = requireRecord(lock, "npm project package-lock.json");
+  const lockPackages = requireRecord(
+    lockRecord.packages,
+    "npm project lock packages",
+  );
+  const rootLock = requireRecord(lockPackages[""], "npm project lock root");
+  const rootDependencies = requireRecord(
+    rootLock.dependencies,
+    "npm project lock root dependencies",
+  );
+  requireExactValue(
+    rootDependencies[CHANNEL_PACKAGE_NAME],
+    channelVersion,
+    "npm lock channel dependency",
+  );
+  validateMoltzapLockEntries(lockPackages, channelVersion);
+}
+
+function validateMoltzapLockEntries(
+  lockPackages: Readonly<Record<string, unknown>>,
+  channelVersion: string,
+): void {
+  let channelFound = false;
+  for (const [location, value] of Object.entries(lockPackages)) {
+    if (!location.includes("node_modules/@moltzap/")) continue;
+    const entry = requireRecord(value, `npm lock entry ${location}`);
+    const resolved = requireString(entry.resolved, `${location} resolved`);
+    const integrity = requireString(entry.integrity, `${location} integrity`);
+    if (
+      entry.link === true ||
+      !resolved.startsWith(NPM_REGISTRY_PREFIX) ||
+      !integrity.startsWith(NPM_INTEGRITY_PREFIX)
+    ) {
+      throw cacheError(
+        `Published OpenClaw plugin dependency ${location} is not registry-backed with sha512 integrity`,
+      );
+    }
+    if (location.endsWith(`node_modules/${CHANNEL_PACKAGE_NAME}`)) {
+      requireExactValue(
+        entry.version,
+        channelVersion,
+        "installed channel version",
+      );
+      channelFound = true;
+    }
+  }
+  if (!channelFound) {
+    throw cacheError(
+      `OpenClaw npm lock does not contain ${CHANNEL_PACKAGE_NAME}`,
+    );
+  }
+}
+
+function copyProjectIntoBuildingCache(
+  sourceProjectDir: string,
+  buildingDir: string,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const destination = join(
+      buildingDir,
+      "npm",
+      "projects",
+      basename(sourceProjectDir),
+    );
+    yield* fsEffect(
+      "copy OpenClaw npm project into immutable cache",
+      fileSystem.copy(sourceProjectDir, destination),
+    );
+    yield* fsEffect(
+      "remove cached OpenClaw peer link",
+      fileSystem.remove(openclawPeerLinkPath(destination), {
+        recursive: true,
+        force: true,
+      }),
+    );
+  });
+}
+
+/**
+ * Copies one cached npm project and rebuilds the only machine-specific link.
+ * @internal
+ */
+export function materializeOpenClawPluginCacheGeneration(options: {
+  readonly generationDir: string;
+  readonly stateDir: string;
+  readonly openclawPackageRoot: string;
+}) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const cachedProjectsDir = join(options.generationDir, "npm", "projects");
+    const entries = yield* fsEffect(
+      "list cached OpenClaw npm projects",
+      fileSystem.readDirectory(cachedProjectsDir),
+    );
+    const entry = yield* requireSoleEntry(
+      entries,
+      "cached OpenClaw npm project",
+    );
+    const projectDir = join(options.stateDir, "npm", "projects", entry);
+    yield* fsEffect(
+      "materialize cached OpenClaw npm project",
+      fileSystem.copy(join(cachedProjectsDir, entry), projectDir),
+    );
+    yield* recreateOpenClawPeerLink(projectDir, options.openclawPackageRoot);
+    return projectDir;
+  }).pipe(Effect.withSpan("materializeOpenClawPluginCacheGeneration"));
+}
+
+function recreateOpenClawPeerLink(
+  projectDir: string,
+  openclawPackageRoot: string,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const info = yield* fsEffect(
+      "inspect testbed-resolved OpenClaw package root",
+      fileSystem.stat(openclawPackageRoot),
+    );
+    if (info.type !== "Directory") {
+      return yield* Effect.fail(
+        cacheError(
+          `Unable to resolve OpenClaw peer link target at ${openclawPackageRoot}`,
+        ),
+      );
+    }
+    const peerLink = openclawPeerLinkPath(projectDir);
+    const canonicalRoot = yield* fsEffect(
+      "canonicalize testbed-resolved OpenClaw package root",
+      fileSystem.realPath(openclawPackageRoot),
+    );
+    yield* fsEffect(
+      "remove stale OpenClaw peer link",
+      fileSystem.remove(peerLink, { recursive: true, force: true }),
+    );
+    yield* fsEffect(
+      "create OpenClaw peer link",
+      fileSystem
+        .makeDirectory(dirname(peerLink), { recursive: true })
+        .pipe(Effect.zipRight(fileSystem.symlink(canonicalRoot, peerLink))),
+    );
+  }).pipe(
+    Effect.mapError((cause) =>
+      cacheError(
+        `Unable to resolve OpenClaw peer link target at ${openclawPackageRoot}`,
+        cause,
+      ),
+    ),
+  );
+}
+
+function openclawPeerLinkPath(projectDir: string): string {
+  return join(
+    projectDir,
+    "node_modules",
+    "@moltzap",
+    "openclaw-channel",
+    "node_modules",
+    "openclaw",
+  );
+}

--- a/packages/testbed/src/package-resolution.test.ts
+++ b/packages/testbed/src/package-resolution.test.ts
@@ -6,19 +6,25 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
+  resolveInstalledPackageDependency,
   resolveInstalledPackageBin,
   resolveInstalledPackageRoot,
   resolvePackageRoot,
 } from "./package-resolution.js";
 
 const SCOPED_PACKAGE_NAME = "@moltzap-test/resolved";
+const OWNER_PACKAGE_NAME = "@moltzap-test/owner";
 const DECOY_MANIFEST_NAME = "some-other-package";
 const MISSING_PACKAGE_NAME = "@moltzap-test/definitely-missing";
 const REAL_PACKAGE_NAME = "effect";
 const MISSING_BIN_NAME = "no-such-bin";
+const DECLARED_DEPENDENCY_SPEC = "^1.2.0";
+const INSTALLED_PACKAGE_VERSION = "1.2.3";
+const NON_EXACT_PACKAGE_VERSION = "^1.2.3";
+const NESTED_PACKAGE_VERSION = "9.9.9";
 
 const fixtureRoot = mkdtempSync(join(tmpdir(), "package-resolution-test-"));
 
@@ -67,6 +73,36 @@ function seedLayeredConsumer(
     JSON.stringify({ name: SCOPED_PACKAGE_NAME }),
   );
   return { anchor, packageRoot };
+}
+
+function seedOwnedDependency(
+  fixtureName: string,
+  ownerManifest: Record<string, unknown>,
+  installedManifest: Record<string, unknown>,
+): {
+  readonly anchor: string;
+  readonly ownerPackageRoot: string;
+  readonly packageRoot: string;
+} {
+  const ownerPackageRoot = join(fixtureRoot, fixtureName);
+  const anchor = join(ownerPackageRoot, "src", "nested", "anchor.js");
+  const packageRoot = join(
+    ownerPackageRoot,
+    "node_modules",
+    SCOPED_PACKAGE_NAME,
+  );
+  mkdirSync(join(ownerPackageRoot, "src", "nested"), { recursive: true });
+  mkdirSync(packageRoot, { recursive: true });
+  writeFileSync(anchor, "export {};");
+  writeFileSync(
+    join(ownerPackageRoot, "package.json"),
+    JSON.stringify(ownerManifest),
+  );
+  writeFileSync(
+    join(packageRoot, "package.json"),
+    JSON.stringify(installedManifest),
+  );
+  return { anchor, ownerPackageRoot, packageRoot };
 }
 
 // @agent-code-guard/regression-only: seeded module layouts exercise Node resolution branches whose inputs are filesystem topology rather than generated values
@@ -169,6 +205,129 @@ describe("resolveInstalledPackageRoot", () => {
     expect(resolveInstalledPackageRoot(REAL_PACKAGE_NAME)).toContain(
       REAL_PACKAGE_NAME,
     );
+  });
+});
+
+describe("resolveInstalledPackageDependency metadata", () => {
+  it("returns the owner's declared spec and installed exact version", () => {
+    const fixture = seedOwnedDependency(
+      "installed-dependency",
+      {
+        name: OWNER_PACKAGE_NAME,
+        dependencies: {
+          [SCOPED_PACKAGE_NAME]: DECLARED_DEPENDENCY_SPEC,
+        },
+      },
+      {
+        name: SCOPED_PACKAGE_NAME,
+        version: INSTALLED_PACKAGE_VERSION,
+      },
+    );
+
+    expect(
+      resolveInstalledPackageDependency(
+        OWNER_PACKAGE_NAME,
+        SCOPED_PACKAGE_NAME,
+        fixture.anchor,
+      ),
+    ).toEqual({
+      ownerPackageRoot: fixture.ownerPackageRoot,
+      declaredSpec: DECLARED_DEPENDENCY_SPEC,
+      packageRoot: realpathSync(fixture.packageRoot),
+      version: INSTALLED_PACKAGE_VERSION,
+    });
+  });
+});
+
+describe("resolveInstalledPackageDependency anchoring", () => {
+  it("resolves from the owner anchor instead of a nested dependency", () => {
+    const fixture = seedOwnedDependency(
+      "owner-anchored-dependency",
+      {
+        name: OWNER_PACKAGE_NAME,
+        dependencies: {
+          [SCOPED_PACKAGE_NAME]: DECLARED_DEPENDENCY_SPEC,
+        },
+      },
+      {
+        name: SCOPED_PACKAGE_NAME,
+        version: INSTALLED_PACKAGE_VERSION,
+      },
+    );
+    const nestedPackageRoot = join(
+      dirname(fixture.anchor),
+      "node_modules",
+      SCOPED_PACKAGE_NAME,
+    );
+    mkdirSync(nestedPackageRoot, { recursive: true });
+    writeFileSync(
+      join(nestedPackageRoot, "package.json"),
+      JSON.stringify({
+        name: SCOPED_PACKAGE_NAME,
+        version: NESTED_PACKAGE_VERSION,
+      }),
+    );
+
+    const resolved = resolveInstalledPackageDependency(
+      OWNER_PACKAGE_NAME,
+      SCOPED_PACKAGE_NAME,
+      fixture.anchor,
+    );
+
+    expect(resolved.packageRoot).toBe(realpathSync(fixture.packageRoot));
+    expect(resolved.version).toBe(INSTALLED_PACKAGE_VERSION);
+  });
+});
+
+describe("resolveInstalledPackageDependency declaration validation", () => {
+  it("requires the dependency in the owner's own dependencies", () => {
+    const fixture = seedOwnedDependency(
+      "dev-only-dependency",
+      {
+        name: OWNER_PACKAGE_NAME,
+        devDependencies: {
+          [SCOPED_PACKAGE_NAME]: DECLARED_DEPENDENCY_SPEC,
+        },
+      },
+      {
+        name: SCOPED_PACKAGE_NAME,
+        version: INSTALLED_PACKAGE_VERSION,
+      },
+    );
+
+    expect(() =>
+      resolveInstalledPackageDependency(
+        OWNER_PACKAGE_NAME,
+        SCOPED_PACKAGE_NAME,
+        fixture.anchor,
+      ),
+    ).toThrow(`must declare ${SCOPED_PACKAGE_NAME} in its own dependencies`);
+  });
+});
+
+describe("resolveInstalledPackageDependency version validation", () => {
+  it("rejects an installed manifest without an exact version", () => {
+    const fixture = seedOwnedDependency(
+      "ranged-installed-version",
+      {
+        name: OWNER_PACKAGE_NAME,
+        dependencies: {
+          [SCOPED_PACKAGE_NAME]: DECLARED_DEPENDENCY_SPEC,
+        },
+      },
+      {
+        name: SCOPED_PACKAGE_NAME,
+        version: NON_EXACT_PACKAGE_VERSION,
+      },
+    );
+
+    expect(() =>
+      resolveInstalledPackageDependency(
+        OWNER_PACKAGE_NAME,
+        SCOPED_PACKAGE_NAME,
+        fixture.anchor,
+      ),
+    ).toThrow(`does not declare an exact version`);
   });
 });
 

--- a/packages/testbed/src/package-resolution.ts
+++ b/packages/testbed/src/package-resolution.ts
@@ -1,9 +1,13 @@
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, join, sep } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Data } from "effect";
 
 const requireFromHere = createRequire(import.meta.url);
 const PACKAGE_RESOLUTION_ANCHOR = import.meta.url;
+const VERSION_NUMBER_PATTERN = /^(?:0|[1-9]\d*)$/;
+const VERSION_IDENTIFIER_PATTERN = /^[0-9A-Za-z-]+$/;
 
 class PackageResolutionFailed extends Data.TaggedError(
   "PackageResolutionFailed",
@@ -16,6 +20,8 @@ class PackageResolutionFailed extends Data.TaggedError(
 interface PackageJson {
   readonly name?: unknown;
   readonly bin?: unknown;
+  readonly dependencies?: unknown;
+  readonly version?: unknown;
 }
 
 interface PackageJsonResolution {
@@ -30,14 +36,92 @@ interface PackageJsonCandidateResolution {
   readonly unexpectedCause: unknown | null;
 }
 
+interface OwningPackage {
+  readonly manifest: PackageJson;
+  readonly root: string;
+}
+
+export interface InstalledPackageDependency {
+  readonly ownerPackageRoot: string;
+  readonly declaredSpec: string;
+  readonly packageRoot: string;
+  readonly version: string;
+}
+
+function isPackageJson(value: unknown): value is PackageJson {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPropertyRecord(
+  value: unknown,
+): value is Readonly<Record<PropertyKey, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function splitAtFirst(
+  value: string,
+  separator: string,
+): readonly [string, string | null] {
+  const separatorIndex = value.indexOf(separator);
+  if (separatorIndex < 0) {
+    return [value, null];
+  }
+  return [
+    value.slice(0, separatorIndex),
+    value.slice(separatorIndex + separator.length),
+  ];
+}
+
+function isValidPrerelease(value: string): boolean {
+  if (value.length === 0) {
+    return false;
+  }
+  return value.split(".").every((identifier) => {
+    if (!VERSION_IDENTIFIER_PATTERN.test(identifier)) {
+      return false;
+    }
+    return /^\d+$/.test(identifier)
+      ? VERSION_NUMBER_PATTERN.test(identifier)
+      : true;
+  });
+}
+
+function isValidBuild(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value
+      .split(".")
+      .every((identifier) => VERSION_IDENTIFIER_PATTERN.test(identifier))
+  );
+}
+
+function isExactPackageVersion(version: string): boolean {
+  const [withoutBuild, build] = splitAtFirst(version, "+");
+  if (build !== null && !isValidBuild(build)) {
+    return false;
+  }
+  const [core, prerelease] = splitAtFirst(withoutBuild, "-");
+  if (prerelease !== null && !isValidPrerelease(prerelease)) {
+    return false;
+  }
+  const coreIdentifiers = core.split(".");
+  return (
+    coreIdentifiers.length === 3 &&
+    coreIdentifiers.every((identifier) =>
+      VERSION_NUMBER_PATTERN.test(identifier),
+    )
+  );
+}
+
 function parsePackageJson(
   requireFromAnchor: NodeRequire,
   packageRoot: string,
   packageName: string,
 ): PackageJson {
   const packageJsonPath = join(packageRoot, "package.json");
+  let manifest: unknown;
   try {
-    return requireFromAnchor(packageJsonPath) as PackageJson;
+    manifest = requireFromAnchor(packageJsonPath);
   } catch (cause) {
     throw new PackageResolutionFailed({
       packageName,
@@ -45,6 +129,13 @@ function parsePackageJson(
       message: `Unable to read package.json for ${packageName} at ${packageJsonPath}`,
     });
   }
+  if (!isPackageJson(manifest)) {
+    throw new PackageResolutionFailed({
+      packageName,
+      message: `Invalid package.json for ${packageName} at ${packageJsonPath}: expected an object`,
+    });
+  }
+  return manifest;
 }
 
 function packageRootFromResolvedFile(
@@ -239,6 +330,139 @@ export function resolveInstalledPackageRoot(
     packageName,
     message: `Unable to resolve installed package ${packageName}`,
   });
+}
+
+function anchorFilePath(anchor: string | URL, packageName: string): string {
+  try {
+    const path =
+      typeof anchor === "string" && !anchor.startsWith("file:")
+        ? anchor
+        : fileURLToPath(anchor);
+    return resolve(path);
+  } catch (cause) {
+    throw new PackageResolutionFailed({
+      packageName,
+      cause,
+      message: `Unable to interpret package-resolution anchor ${String(anchor)}`,
+    });
+  }
+}
+
+function findOwningPackage(
+  ownerPackageName: string,
+  anchor: string | URL,
+): OwningPackage {
+  const anchorPath = anchorFilePath(anchor, ownerPackageName);
+  let candidateRoot = dirname(anchorPath);
+  while (true) {
+    const manifestPath = join(candidateRoot, "package.json");
+    if (existsSync(manifestPath)) {
+      const manifest = parsePackageJson(
+        createRequire(manifestPath),
+        candidateRoot,
+        ownerPackageName,
+      );
+      if (manifest.name !== ownerPackageName) {
+        throw new PackageResolutionFailed({
+          packageName: ownerPackageName,
+          message: `Package-resolution anchor ${anchorPath} belongs to ${String(manifest.name)}, not ${ownerPackageName}`,
+        });
+      }
+      return { manifest, root: candidateRoot };
+    }
+    const parent = dirname(candidateRoot);
+    if (parent === candidateRoot) {
+      throw new PackageResolutionFailed({
+        packageName: ownerPackageName,
+        message: `Unable to find owning package ${ownerPackageName} from ${anchorPath}`,
+      });
+    }
+    candidateRoot = parent;
+  }
+}
+
+function ownDependencySpec(
+  ownerPackageName: string,
+  ownerPackageRoot: string,
+  manifest: PackageJson,
+  dependencyName: string,
+): string {
+  const dependencies = manifest.dependencies;
+  if (
+    !Object.hasOwn(manifest, "dependencies") ||
+    !isPropertyRecord(dependencies)
+  ) {
+    throw new PackageResolutionFailed({
+      packageName: dependencyName,
+      message: `Package ${ownerPackageName} at ${ownerPackageRoot} must declare ${dependencyName} in its own dependencies`,
+    });
+  }
+  if (!Object.hasOwn(dependencies, dependencyName)) {
+    throw new PackageResolutionFailed({
+      packageName: dependencyName,
+      message: `Package ${ownerPackageName} at ${ownerPackageRoot} must declare ${dependencyName} in its own dependencies`,
+    });
+  }
+  const declaredSpec = dependencies[dependencyName];
+  if (typeof declaredSpec !== "string" || declaredSpec.length === 0) {
+    throw new PackageResolutionFailed({
+      packageName: dependencyName,
+      message: `Package ${ownerPackageName} at ${ownerPackageRoot} has an invalid dependencies declaration for ${dependencyName}`,
+    });
+  }
+  return declaredSpec;
+}
+
+/**
+ * Resolves one of an owning package's runtime dependencies and reports both
+ * the declared install contract and the exact installed artifact.
+ *
+ * Reading from the owner's manifest anchor prevents a nested caller path from
+ * changing which installed dependency Node selects.
+ */
+export function resolveInstalledPackageDependency(
+  ownerPackageName: string,
+  dependencyName: string,
+  anchor: string | URL = PACKAGE_RESOLUTION_ANCHOR,
+): InstalledPackageDependency {
+  const owner = findOwningPackage(ownerPackageName, anchor);
+  const declaredSpec = ownDependencySpec(
+    ownerPackageName,
+    owner.root,
+    owner.manifest,
+    dependencyName,
+  );
+  const ownerManifestPath = join(owner.root, "package.json");
+  const packageRoot = resolveInstalledPackageRoot(
+    dependencyName,
+    ownerManifestPath,
+  );
+  const installedManifest = parsePackageJson(
+    createRequire(ownerManifestPath),
+    packageRoot,
+    dependencyName,
+  );
+  if (installedManifest.name !== dependencyName) {
+    throw new PackageResolutionFailed({
+      packageName: dependencyName,
+      message: `Installed package at ${packageRoot} is named ${String(installedManifest.name)}, not ${dependencyName}`,
+    });
+  }
+  if (
+    typeof installedManifest.version !== "string" ||
+    !isExactPackageVersion(installedManifest.version)
+  ) {
+    throw new PackageResolutionFailed({
+      packageName: dependencyName,
+      message: `Installed package ${dependencyName} at ${packageRoot} does not declare an exact version`,
+    });
+  }
+  return {
+    ownerPackageRoot: owner.root,
+    declaredSpec,
+    packageRoot,
+    version: installedManifest.version,
+  };
 }
 
 export function resolveInstalledPackageBin(

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -19,6 +19,7 @@ import {
 } from "@moltzap/protocol/testing";
 
 import {
+  assertWorkspaceChannelDist,
   buildOpenClawConfig,
   createOpenClawAdapter,
   OpenClawAdapter,
@@ -54,6 +55,8 @@ const READY_LABEL = "ready";
 const MATCH_TIMEOUT_MS = 5_000;
 const TIMEOUT_MATCH_RESULT = `timeout:${MATCH_TIMEOUT_MS}`;
 const PROCESS_EXIT_MATCH_RESULT = "exit:null";
+const WORKSPACE_INSTALL_MODE = "workspace";
+const PUBLISHED_INSTALL_MODE = "published";
 const TEST_AGENT_NAME = "test-agent";
 const TEST_STATE_DIR_PREFIX = `openclaw-${TEST_AGENT_NAME}-`;
 const PROCESS_SPAWN_AGENT_NAME = "process-spawn-agent";
@@ -93,6 +96,7 @@ function stubDeps(): OpenClawAdapterDeps {
     server: stubServer(),
     openclawBin: "/bin/false",
     channelDistDir: "/nonexistent/channel",
+    installMode: WORKSPACE_INSTALL_MODE,
   };
 }
 
@@ -131,6 +135,10 @@ describe("createOpenClawAdapter", () => {
     openClawFactoryUsesExplicitPaths,
   );
   it("resolves pinned installed defaults", openClawFactoryResolvesDefaults);
+  it(
+    "rejects an installed channel artifact in workspace mode",
+    openClawWorkspaceModeRejectsInstalledChannel,
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -154,11 +162,13 @@ describe("OpenClawAdapter.spawn", () => {
 const CONFIG_WORKSPACE_DIR = "/workspaces/testbed-agent";
 const CUSTOM_MODEL_ID = "custom/model";
 const DISABLED_MDNS_MODE = "off";
+const OPENCLAW_EXTENSION_NAME = "openclaw-channel";
 
+// @agent-code-guard/regression-only: each example pins one independent OpenClaw configuration contract
 describe("buildOpenClawConfig", () => {
   it("keys the moltzap account under the testbed profile", () => {
     const config = buildOpenClawConfig(
-      { agentName: "alice" },
+      { agentName: "alice", installMode: WORKSPACE_INSTALL_MODE },
       CONFIG_WORKSPACE_DIR,
     );
 
@@ -173,11 +183,16 @@ describe("buildOpenClawConfig", () => {
         model: { primary: expect.any(String) },
       },
     });
+    expect(config.plugins?.allow).toEqual([OPENCLAW_EXTENSION_NAME]);
   });
 
   it("prefers an explicit model id over the default", () => {
     const config = buildOpenClawConfig(
-      { agentName: "alice", modelId: CUSTOM_MODEL_ID },
+      {
+        agentName: "alice",
+        modelId: CUSTOM_MODEL_ID,
+        installMode: WORKSPACE_INSTALL_MODE,
+      },
       CONFIG_WORKSPACE_DIR,
     );
     expect(config.agents).toMatchObject({
@@ -187,11 +202,20 @@ describe("buildOpenClawConfig", () => {
 
   it("disables mDNS discovery for colocated gateways", () => {
     const config = buildOpenClawConfig(
-      { agentName: "alice" },
+      { agentName: "alice", installMode: WORKSPACE_INSTALL_MODE },
       CONFIG_WORKSPACE_DIR,
     );
 
     expect(config.discovery?.mdns?.mode).toBe(DISABLED_MDNS_MODE);
+  });
+
+  it("omits local plugin trust for registry-backed installs", () => {
+    const config = buildOpenClawConfig(
+      { agentName: "alice", installMode: PUBLISHED_INSTALL_MODE },
+      CONFIG_WORKSPACE_DIR,
+    );
+
+    expect(config).not.toHaveProperty("plugins");
   });
 });
 
@@ -354,7 +378,7 @@ describe("SpawnFailed", () => {
 // ---------------------------------------------------------------------------
 
 function stubNanoclawOptions(): NanoclawAdapterOptions {
-  return { server: stubServer() };
+  return { server: stubServer(), installMode: WORKSPACE_INSTALL_MODE };
 }
 
 describe("NanoclawAdapter", () => {
@@ -412,7 +436,10 @@ function openClawFactoryResolvesDefaults() {
   return runTest(
     FileSystem.FileSystem.pipe(
       Effect.flatMap((fileSystem) => {
-        const adapter = createOpenClawAdapter({ server: stubServer() });
+        const adapter = createOpenClawAdapter({
+          server: stubServer(),
+          installMode: WORKSPACE_INSTALL_MODE,
+        });
         const deps = Reflect.get(adapter, "deps") as OpenClawAdapterDeps;
         return Effect.all([
           fileSystem.exists(deps.openclawBin),
@@ -425,6 +452,40 @@ function openClawFactoryResolvesDefaults() {
       Effect.asVoid,
       Effect.provide(NodeContext.layer),
       Effect.orDie,
+    ),
+  );
+}
+
+function openClawWorkspaceModeRejectsInstalledChannel() {
+  return runTest(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "openclaw-installed-channel-test-",
+        });
+        const channelDistDir = path.join(
+          root,
+          "node_modules",
+          "@moltzap",
+          "openclaw-channel",
+          "dist",
+        );
+        yield* fileSystem.makeDirectory(channelDistDir, { recursive: true });
+        const resolvedChannelDistDir =
+          yield* fileSystem.realPath(channelDistDir);
+
+        const error = yield* assertWorkspaceChannelDist(channelDistDir).pipe(
+          Effect.flip,
+        );
+
+        expect(error).toMatchObject({
+          _tag: "OpenClawInstallModeError",
+          channelDistDir,
+          resolvedChannelDistDir,
+        });
+      }).pipe(Effect.provide(NodeContext.layer), Effect.orDie),
     ),
   );
 }
@@ -471,6 +532,7 @@ function openClawProcessSpawnFailureCleansState() {
           server: stubServer(),
           openclawBin: path.join(fixture.root, "missing-openclaw"),
           channelDistDir: fixture.channelDist,
+          installMode: WORKSPACE_INSTALL_MODE,
         });
         // The launcher process starts even when the target binary is
         // missing, so spawn commits and the death surfaces through the

--- a/packages/testbed/src/testbed.test.ts
+++ b/packages/testbed/src/testbed.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, expectTypeOf, it, afterEach, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
 import { Deferred, Effect, Either, Exit, Fiber, Option } from "effect";
 import {
   agentId,
@@ -17,9 +25,13 @@ import {
 } from "./testbed.js";
 import type { ReadyOutcome, Runtime, RuntimeServerHandle } from "./runtime.js";
 import { RuntimeReadyTimedOut } from "./errors.js";
+import { createOpenClawAdapter } from "./openclaw-adapter.js";
 
 const testbedRuntimeFactoryState = vi.hoisted(() => ({
   nextRuntime: null as null | (() => Runtime),
+}));
+const installModeMocks = vi.hoisted(() => ({
+  resolveInstallMode: vi.fn(),
 }));
 
 const READY_TAG = "Ready";
@@ -38,6 +50,8 @@ const STARTUP_SIGNAL = "SIGUSR2";
 const READY_TIMEOUT_MS = 1_000;
 const LONG_READY_TIMEOUT_MS = 60_000;
 const SHORT_READY_TIMEOUT_MS = 250;
+const PUBLISHED_INSTALL_MODE = "published";
+const WORKSPACE_INSTALL_MODE = "workspace";
 
 type RuntimeStartOptionsBase = {
   readonly server: RuntimeServerHandle;
@@ -73,6 +87,16 @@ vi.mock("./openclaw-adapter.js", () => ({
   }),
 }));
 
+vi.mock("./install-mode.js", () => installModeMocks);
+
+beforeEach(() => {
+  installModeMocks.resolveInstallMode.mockReset();
+  installModeMocks.resolveInstallMode.mockImplementation((installMode) =>
+    Effect.succeed(installMode ?? WORKSPACE_INSTALL_MODE),
+  );
+  vi.mocked(createOpenClawAdapter).mockClear();
+});
+
 afterEach(() => {
   testbedRuntimeFactoryState.nextRuntime = null;
 });
@@ -105,6 +129,10 @@ describe("testbed lifecycle", () => {
 });
 
 describe("testbed runtime options", () => {
+  it(
+    "resolves one install mode and shares it with every adapter",
+    testbedSharesOneInstallModeAcrossAdapters,
+  );
   it("rejects adapter options from the other runtime kind", () => {
     expectTypeOf<
       RuntimeStartOptionsBase & NanoclawWithOpenClawOptions
@@ -120,6 +148,39 @@ describe("testbed runtime options", () => {
     >().not.toMatchTypeOf<TestbedLaunchOptions>();
   });
 });
+
+function testbedSharesOneInstallModeAcrossAdapters() {
+  return runTest(
+    Effect.gen(function* () {
+      const first = yield* createMockRuntime({
+        readyEffect: Effect.succeed({ _tag: READY_TAG }),
+      });
+      const second = yield* createMockRuntime({
+        readyEffect: Effect.succeed({ _tag: READY_TAG }),
+      });
+      setMockTestbedRuntimes(first.runtime, second.runtime);
+
+      const testbed = yield* launchTestbed({
+        kind: OPENCLAW_KIND,
+        openclaw: { installMode: PUBLISHED_INSTALL_MODE },
+        server: stubServer(),
+        agents: alphaBetaAgentSpecs(),
+        readyTimeoutMs: READY_TIMEOUT_MS,
+      }).pipe(Effect.orDie);
+
+      expect(installModeMocks.resolveInstallMode).toHaveBeenCalledTimes(1);
+      expect(installModeMocks.resolveInstallMode).toHaveBeenCalledWith(
+        PUBLISHED_INSTALL_MODE,
+      );
+      expect(createOpenClawAdapter).toHaveBeenCalledTimes(2);
+      for (const [options] of vi.mocked(createOpenClawAdapter).mock.calls) {
+        expect(options.installMode).toBe(PUBLISHED_INSTALL_MODE);
+      }
+
+      yield* testbed.stopAll();
+    }),
+  );
+}
 
 function successfulTestbedLaunchKeepsRuntimesUntilStopAll() {
   return runTest(

--- a/packages/testbed/src/testbed.ts
+++ b/packages/testbed/src/testbed.ts
@@ -1,4 +1,6 @@
 /* eslint-disable jsdoc/text-escaping -- mermaid sequenceDiagram blocks need literal `<br>` (HTML5) for renderer compatibility; the escape would render as literal text. */
+export type { InstallMode } from "./install-mode.js";
+
 import { Data, Effect, Exit, Fiber } from "effect";
 import type { Signal } from "@effect/platform/CommandExecutor";
 import type { AgentId, AgentKey } from "@moltzap/protocol/identity";
@@ -23,6 +25,7 @@ import {
   type SpawnInput,
   type WorkspaceFile,
 } from "./runtime.js";
+import { resolveInstallMode, type InstallMode } from "./install-mode.js";
 
 const LOG_START_OFFSET = 0;
 
@@ -41,15 +44,21 @@ interface RuntimeStartOptionsBase {
   readonly readyTimeoutMs: number;
 }
 
+// Adapters take a decided install mode; a launch may override the one this
+// module resolves, so the mode is optional on the caller-facing overrides.
+type RuntimeOverrides<Options> = Omit<Options, "server" | "installMode"> & {
+  readonly installMode?: InstallMode;
+};
+
 type RuntimeSelection =
   | {
       readonly kind: "openclaw";
-      readonly openclaw?: Omit<OpenClawAdapterOptions, "server">;
+      readonly openclaw?: RuntimeOverrides<OpenClawAdapterOptions>;
       readonly nanoclaw?: never;
     }
   | {
       readonly kind: "nanoclaw";
-      readonly nanoclaw?: Omit<NanoclawAdapterOptions, "server">;
+      readonly nanoclaw?: RuntimeOverrides<NanoclawAdapterOptions>;
       readonly openclaw?: never;
     };
 
@@ -113,18 +122,34 @@ class UnknownRuntimeAgent extends Data.TaggedError("UnknownRuntimeAgent")<{
   readonly message: string;
 }> {}
 
-function createRuntime(options: RuntimeStartOptions): Runtime {
+function createRuntime(
+  options: RuntimeStartOptions,
+  installMode: InstallMode,
+): Runtime {
   switch (options.kind) {
     case "openclaw":
       return createOpenClawAdapter({
         server: options.server,
         ...options.openclaw,
+        installMode,
       });
     case "nanoclaw":
       return new NanoclawAdapter({
         server: options.server,
         ...options.nanoclaw,
+        installMode,
       });
+  }
+}
+
+function installModeOverride(
+  options: RuntimeStartOptions | TestbedLaunchOptions,
+): InstallMode | undefined {
+  switch (options.kind) {
+    case "openclaw":
+      return options.openclaw?.installMode;
+    case "nanoclaw":
+      return options.nanoclaw?.installMode;
   }
 }
 
@@ -192,10 +217,12 @@ function startTestbedAgent(
   options: TestbedLaunchOptions,
   startedAgents: StartedRuntimeAgent[],
   agent: TestbedAgentSpec,
+  installMode: InstallMode,
 ) {
   return Effect.gen(function* () {
     const pending = yield* startPendingRuntimeAgent(
       runtimeStartOptionsForAgent(options, agent),
+      installMode,
     );
     const startedAgent = {
       spec: agent,
@@ -237,8 +264,11 @@ function toTestbed(started: ReadonlyArray<StartedRuntimeAgent>): Testbed {
   };
 }
 
-function startPendingRuntimeAgent(options: RuntimeStartOptions) {
-  const runtime = createRuntime(options);
+function startPendingRuntimeAgent(
+  options: RuntimeStartOptions,
+  installMode: InstallMode,
+) {
+  const runtime = createRuntime(options, installMode);
   const spawnInput = toSpawnInput(options.agent);
   return Effect.gen(function* () {
     let cleanupArmed = true;
@@ -311,7 +341,10 @@ export function startRuntimeAgent(
 ): Effect.Effect<Runtime, RuntimeLaunchFailed, never> {
   return Effect.scoped(
     Effect.gen(function* () {
-      const pending = yield* startPendingRuntimeAgent(options);
+      const installMode = yield* resolveInstallMode(
+        installModeOverride(options),
+      );
+      const pending = yield* startPendingRuntimeAgent(options, installMode);
       yield* pending.releaseStartupCleanup;
       return pending.runtime;
     }),
@@ -340,9 +373,13 @@ export function launchTestbed(
   return Effect.scoped(
     Effect.gen(function* () {
       const startedAgents: StartedRuntimeAgent[] = [];
+      const installMode = yield* resolveInstallMode(
+        installModeOverride(options),
+      );
       const started = yield* Effect.forEach(
         options.agents,
-        (agent) => startTestbedAgent(options, startedAgents, agent),
+        (agent) =>
+          startTestbedAgent(options, startedAgents, agent, installMode),
         {
           concurrency: options.concurrency ?? 1,
         },

--- a/packages/testbed/vitest.integration.config.ts
+++ b/packages/testbed/vitest.integration.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "vitest/config";
 
-const NANOCLAW_INSTALL_TEST_TIMEOUT_MS = 30_000;
+// A cold published-plugin install runs a real npm install (measured ~60s)
+// before the assertions it feeds.
+const INSTALL_TEST_TIMEOUT_MS = 600_000;
 
 export default defineConfig({
   test: {
     include: ["src/**/*.integration.test.ts"],
     fileParallelism: false,
-    testTimeout: NANOCLAW_INSTALL_TEST_TIMEOUT_MS,
+    testTimeout: INSTALL_TEST_TIMEOUT_MS,
   },
 });

--- a/scripts/gen-architecture-configs.mjs
+++ b/scripts/gen-architecture-configs.mjs
@@ -228,17 +228,22 @@ const packageDefinitions = {
   testbed: {
     beforeShared: {
       packageRuntime: "node",
-      maxPublicExports: 30,
+      maxPublicExports: 32,
       minPublicFacadeModules: 7,
       folderChildCountOverrides: [
         {
           folder: ".",
-          maxChildren: 13,
+          maxChildren: 16,
           reason:
-            "The testbed keeps runtime adapters, orchestration, readiness, process support, locking, and trace-capture modules as deliberate peers in its documented single-tier source layout",
+            "The testbed keeps runtime adapters, orchestration, readiness, process support, locking, install-mode resolution, cache lifecycle, and trace-capture modules as deliberate peers in its documented single-tier source layout",
         },
       ],
       facadeFiles: [
+        {
+          file: "nanoclaw-install.ts",
+          reason:
+            "NanoClaw install boundary composing pinned-source download, bundled-asset injection, and dual-mode dependency materialization behind one immutable cache",
+        },
         {
           file: "channel-plugin-install.ts",
           reason:


### PR DESCRIPTION
Fixes #803. Design contract recorded on the issue beforehand and implemented against it.

`InstallMode = "published" | "workspace"` is a **testbed-level** property resolved once per launch and interpreted by each adapter, so a fleet never mixes artifact provenance:

| | published (npm consumer) | workspace (dev/evals) |
|---|---|---|
| **OpenClaw** | `openclaw plugins install --pin` once per fingerprint into a content-addressed cache; per-agent materialization of the npm project subtree + peer-link recreation; config omits `plugins.allow` so recorded provenance carries trust | dist-copy + dependency links + `plugins.allow` (dev genuinely is local code) |
| **NanoClaw** | exact registry pins (today's behavior, now named) | packs client+protocol, vendors the tarballs, rewrites deps to `file:` |

The workspace leg closes a real gap: until now even workspace eval runs exercised the **published** client rather than the local build — the seam the recent BoundedMap pin regression lived in.

## Spike-driven

Two spikes settled the unknowns before implementation (verdicts on the issue): openclaw provenance is **derived** from the npm project dir, so install-once-copy-per-agent is sound (the state-dir sqlite must NOT be copied — stale absolute paths); and npm dedupes a client tarball's transitive `@moltzap/protocol` onto a local tarball when protocol is kept as a direct `file:` dep, so no overrides machinery is needed.

## Two bugs the gated test caught that unit tests structurally could not

1. **Ambient environment changed the CLI's behavior** — openclaw emits *zero* stdout when a test-runner marker is present, and the cache invoked it with a merging env. CLI calls now use the exact-environment launcher, so cache builds no longer depend on who launched them.
2. **`captureCommandOutput` reused `BoundedLogBuffer`** — a lossy log-window type — to capture output callers `JSON.parse`. Past ~576KB it silently elided the middle, turning "output too large" into a misleading parse error. Capture is now faithful with an explicit cap that fails as its own tagged error.

## Review pass

Two reviewers over the full diff; 12 findings applied — single inference site for the mode (the install layer had silently defaulted to `"published"`, a *different* rule from inference), dead surface removed, shared JSON guards / fingerprint envelope / build permit, six pass-through wrappers deleted (two fabricated a cache root the callee ignored), and measured per-spawn waste memoized (cache re-scan, fingerprint recomputation, and a ~2s double `pnpm pack` on every warm spawn).

Deliberately deferred, recorded rather than left vague: sharing one materialized tree across a fleet (reviewer measured `cp -Rc` at ~2x, and proved the tree is identical per agent — but it needs an upstream retention probe first), threading a trust value from install into config, and a publish-time symlink-escape assertion.

## Verification

Build, lint, 117 unit tests, typecheck, guards, architecture check — all green. The gated integration test does a **real** cold `plugins install --pin` of the published channel, materializes it, and asserts via `plugins info` that provenance is recorded (source npm, pinned spec, loaded/enabled, no provenance WARN): **passes in ~240s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)