### PR TITLE
[impl-senior] simulator: server image, OTLP receiver bind, trace-capture fold (row 5a)

### DIFF
--- a/packages/testbed/AGENTS.md
+++ b/packages/testbed/AGENTS.md
@@ -54,16 +54,17 @@ design doc: chughtapan/moltzap#812), exported as
 - **Trace-capture harness** — `trace-capture-{bundle,harness,payload}.ts`,
   compiled by this package, loaded from `dist/` by the external `cc-judge`
   runner (its only consumer), and run against `packages/evals/scenarios/*.yaml`.
-  Wire-side signal: OpenTelemetry spans (`moltzap.message.delivered` /
-  `moltzap.message.blocked`) from `@moltzap/server-core`, readable in tests
-  via `CoreTestServer.spanExporter` (see `packages/evals/README.md`).
+  A compat adapter over the simulator: a scenario payload becomes a `RunSpec`,
+  `run` seals a recording, and the bundle cc-judge grades is projected from that
+  recording's events. Capture belongs to the recording; the harness starts no
+  server and drives no wire.
 
 ## Code
 
 - Adapters and testbed APIs do not speak the wire protocol; they spawn
-  processes that do. The trace-capture harness is the one exception — it
-  drives the server's HTTP/WS API directly through dynamically loaded
-  client test modules.
+  processes that do. The simulator's own provisioning, observer, and
+  principal seams are the exception: they register identities over HTTP
+  and speak as a principal over WS, which is what makes a run a run.
 - `openclaw` is a runtime dependency: an external CLI binary referenced
   for its plugin protocol.
 

--- a/packages/testbed/package.json
+++ b/packages/testbed/package.json
@@ -90,8 +90,6 @@
     "openclaw": "2026.6.33"
   },
   "devDependencies": {
-    "@moltzap/client": "workspace:*",
-    "@moltzap/server-core": "workspace:*",
     "@types/node": "^25.5.0",
     "eslint": "^9",
     "typescript": "^5.7.0",

--- a/packages/testbed/scripts/build-server-image.mjs
+++ b/packages/testbed/scripts/build-server-image.mjs
@@ -1,0 +1,154 @@
+// Builds the simulator's per-run server image from the workspace
+// `@moltzap/server-core` bin and prints its pin as one JSON line:
+// `{"image":…,"imageDigest":"sha256:…","serverCoreVersion":…}`.
+// `imageDigest` is what a RunSpec's `server.imageDigest` carries.
+//
+// The image is content-addressed the way the NanoClaw install is: the tag
+// carries a fingerprint over every input that reaches the image, so an
+// unchanged workspace re-uses the built image and a changed one gets a new
+// tag instead of silently reusing a stale layer.
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workspaceRoot = dirname(dirname(packageRoot));
+const imageDir = join(packageRoot, "server-image");
+const serverDir = join(workspaceRoot, "packages", "server");
+const protocolDir = join(workspaceRoot, "packages", "protocol");
+
+const IMAGE_REPOSITORY = "moltzap-sim-server";
+const BUILD_TIMEOUT_MS = 900_000;
+const INSPECT_TIMEOUT_MS = 30_000;
+const PACK_TIMEOUT_MS = 300_000;
+
+function readManifest(packageDir) {
+  return JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+}
+
+/** Every published file of a package: what `pnpm pack` puts in the tarball. */
+function packedPaths(packageDir) {
+  const manifest = readManifest(packageDir);
+  return ["package.json", ...(manifest.files ?? [])].map((entry) =>
+    join(packageDir, entry),
+  );
+}
+
+function hashPath(hash, root, path) {
+  if (!existsSync(path)) return;
+  if (statSync(path).isDirectory()) {
+    for (const entry of readdirSync(path).sort()) {
+      hashPath(hash, root, join(path, entry));
+    }
+    return;
+  }
+  hash.update(relative(root, path).split(sep).join("/"));
+  hash.update(readFileSync(path));
+}
+
+/**
+ * Fingerprint over the exact bytes that reach the image: both packages'
+ * published files plus this directory's Dockerfile and config. Tarball
+ * bytes are deliberately not used — archive metadata makes them unstable
+ * across otherwise identical packs.
+ */
+function fingerprint() {
+  const hash = createHash("sha256");
+  for (const packageDir of [protocolDir, serverDir]) {
+    for (const path of packedPaths(packageDir)) {
+      hashPath(hash, workspaceRoot, path);
+    }
+  }
+  hashPath(hash, imageDir, join(imageDir, "Dockerfile"));
+  hashPath(hash, imageDir, join(imageDir, "moltzap.yaml"));
+  return hash.digest("hex").slice(0, 16);
+}
+
+async function imageExists(image) {
+  try {
+    await exec("docker", ["image", "inspect", image], {
+      timeout: INSPECT_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function packInto(packageDir, destination) {
+  const { stdout } = await exec(
+    "pnpm",
+    ["pack", "--pack-destination", destination],
+    { cwd: packageDir, timeout: PACK_TIMEOUT_MS },
+  );
+  const printed = stdout.trim().split("\n").at(-1);
+  if (printed === undefined || !printed.endsWith(".tgz")) {
+    throw new Error(`pnpm pack in ${packageDir} printed no tarball path`);
+  }
+  return basename(printed);
+}
+
+async function stage(version) {
+  const staging = await mkdtemp(join(tmpdir(), "moltzap-server-image-"));
+  const tarballs = join(staging, "tarballs");
+  await mkdir(tarballs);
+  const protocolTarball = await packInto(protocolDir, tarballs);
+  const serverTarball = await packInto(serverDir, tarballs);
+  // `overrides` forces the workspace protocol tarball in place of the
+  // registry version server-core's manifest names, so the image carries
+  // the tree under test rather than the last published release.
+  const manifest = {
+    name: "moltzap-sim-server-image",
+    version,
+    private: true,
+    dependencies: {
+      "@moltzap/server-core": `file:./tarballs/${serverTarball}`,
+    },
+    overrides: {
+      "@moltzap/protocol": `file:./tarballs/${protocolTarball}`,
+    },
+  };
+  await writeFile(
+    join(staging, "package.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  await copyFile(join(imageDir, "Dockerfile"), join(staging, "Dockerfile"));
+  await copyFile(join(imageDir, "moltzap.yaml"), join(staging, "moltzap.yaml"));
+  return staging;
+}
+
+async function main() {
+  await exec("pnpm", ["nx", "build", "@moltzap/server-core"], {
+    cwd: workspaceRoot,
+    timeout: BUILD_TIMEOUT_MS,
+  });
+  const version = readManifest(serverDir).version;
+  const image = `${IMAGE_REPOSITORY}:${fingerprint()}`;
+  if (!(await imageExists(image))) {
+    const staging = await stage(version);
+    await exec("docker", ["build", "--tag", image, staging], {
+      timeout: BUILD_TIMEOUT_MS,
+    });
+  }
+  const { stdout } = await exec(
+    "docker",
+    ["image", "inspect", "--format", "{{.Id}}", image],
+    { timeout: INSPECT_TIMEOUT_MS },
+  );
+  const imageDigest = stdout.trim();
+  if (!/^sha256:[0-9a-f]{64}$/.test(imageDigest)) {
+    throw new Error(`docker reported an unusable image id: ${imageDigest}`);
+  }
+  process.stdout.write(
+    `${JSON.stringify({ image, imageDigest, serverCoreVersion: version })}\n`,
+  );
+}
+
+await main();

--- a/packages/testbed/scripts/build-server-image.mjs
+++ b/packages/testbed/scripts/build-server-image.mjs
@@ -10,7 +10,7 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { copyFile, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,7 +42,14 @@ function packedPaths(packageDir) {
 }
 
 function hashPath(hash, root, path) {
-  if (!existsSync(path)) return;
+  // A published entry that is not on disk (a glob, a moved build output)
+  // would silently shrink the fingerprint and let a stale image answer for
+  // a changed workspace.
+  if (!existsSync(path)) {
+    throw new Error(
+      `published path ${path} does not exist; the image fingerprint would not cover it`,
+    );
+  }
   if (statSync(path).isDirectory()) {
     for (const entry of readdirSync(path).sort()) {
       hashPath(hash, root, join(path, entry));
@@ -138,9 +145,13 @@ async function main() {
   const image = `${IMAGE_REPOSITORY}:${fingerprint()}`;
   if (!(await imageExists(image))) {
     const staging = await stage(version);
-    await exec("docker", ["build", "--tag", image, staging], {
-      timeout: BUILD_TIMEOUT_MS,
-    });
+    try {
+      await exec("docker", ["build", "--tag", image, staging], {
+        timeout: BUILD_TIMEOUT_MS,
+      });
+    } finally {
+      await rm(staging, { recursive: true, force: true });
+    }
   }
   const { stdout } = await exec(
     "docker",

--- a/packages/testbed/scripts/build-server-image.mjs
+++ b/packages/testbed/scripts/build-server-image.mjs
@@ -99,8 +99,11 @@ async function stage(version) {
   const staging = await mkdtemp(join(tmpdir(), "moltzap-server-image-"));
   const tarballs = join(staging, "tarballs");
   await mkdir(tarballs);
-  const protocolTarball = await packInto(protocolDir, tarballs);
-  const serverTarball = await packInto(serverDir, tarballs);
+  // Independent packs of independent packages; each is a full pnpm startup.
+  const [protocolTarball, serverTarball] = await Promise.all([
+    packInto(protocolDir, tarballs),
+    packInto(serverDir, tarballs),
+  ]);
   // `overrides` forces the workspace protocol tarball in place of the
   // registry version server-core's manifest names, so the image carries
   // the tree under test rather than the last published release.
@@ -115,12 +118,14 @@ async function stage(version) {
       "@moltzap/protocol": `file:./tarballs/${protocolTarball}`,
     },
   };
-  await writeFile(
-    join(staging, "package.json"),
-    `${JSON.stringify(manifest, null, 2)}\n`,
-  );
-  await copyFile(join(imageDir, "Dockerfile"), join(staging, "Dockerfile"));
-  await copyFile(join(imageDir, "moltzap.yaml"), join(staging, "moltzap.yaml"));
+  await Promise.all([
+    writeFile(
+      join(staging, "package.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    ),
+    copyFile(join(imageDir, "Dockerfile"), join(staging, "Dockerfile")),
+    copyFile(join(imageDir, "moltzap.yaml"), join(staging, "moltzap.yaml")),
+  ]);
   return staging;
 }
 

--- a/packages/testbed/server-image/Dockerfile
+++ b/packages/testbed/server-image/Dockerfile
@@ -1,0 +1,29 @@
+# The simulator's per-run server image: the `@moltzap/server-core` bin
+# `moltzap-server` plus the config that pins the image contract
+# `launcher-live.ts` launches against. Built by
+# `scripts/build-server-image.mjs`, which stages the workspace tarballs
+# next to this file; the image is never pushed, so runs pin it by the
+# local image id (`sha256:...`, the `ServerSpec.imageDigest` form).
+FROM node:22-slim
+
+ENV NODE_ENV=production \
+    MOLTZAP_CONFIG=/etc/moltzap/moltzap.yaml
+
+WORKDIR /srv/moltzap
+
+COPY package.json ./
+COPY tarballs ./tarballs
+RUN npm install --omit=dev --no-audit --no-fund \
+  && npm cache clean --force \
+  && rm -rf tarballs
+
+COPY moltzap.yaml /etc/moltzap/moltzap.yaml
+
+# The data directory the config pins; the launcher bind-mounts the run's
+# storage directory here and the transcript drain reads it post-stop.
+RUN mkdir -p /data
+VOLUME ["/data"]
+
+EXPOSE 3000
+
+ENTRYPOINT ["node", "/srv/moltzap/node_modules/@moltzap/server-core/bin/moltzap-server"]

--- a/packages/testbed/server-image/Dockerfile
+++ b/packages/testbed/server-image/Dockerfile
@@ -4,6 +4,14 @@
 # `scripts/build-server-image.mjs`, which stages the workspace tarballs
 # next to this file; the image is never pushed, so runs pin it by the
 # local image id (`sha256:...`, the `ServerSpec.imageDigest` form).
+#
+# `packages/server/Dockerfile` is the deployment image of the same
+# binary and stays the reference for operators. This one exists beside
+# it because a run's identity is the image digest: it is built from the
+# workspace's already-built output, so it changes exactly when that tree
+# changes, and it bakes the launcher's contract (port, `/data`, open
+# registration, no encryption secret) rather than reading an operator's
+# mounted config.
 FROM node:22-slim
 
 ENV NODE_ENV=production \

--- a/packages/testbed/server-image/moltzap.yaml
+++ b/packages/testbed/server-image/moltzap.yaml
@@ -1,0 +1,23 @@
+# Server config baked into the simulator's per-run server image.
+#
+# Three settings are load-bearing for the simulator and are not operator
+# taste:
+#   - `database.data_dir` sits under the image's `/data` volume, which the
+#     launcher bind-mounts from the run's storage directory; the transcript
+#     drain reads that PGlite directory after the container stops.
+#   - no `encryption:` block, so message content stays plaintext at rest and
+#     the drain can read it. The container is ephemeral and per-run; the
+#     recording's own credential hygiene is the `Secrets` registry, not
+#     container-at-rest encryption.
+#   - no `registration.secret`, so the launcher can mint each run's agent
+#     and observer identities against a fresh server.
+admin_user_id: 5f1cbf1e-0d68-4b04-9c1a-2a0f5f0a1c31
+server:
+  port: 3000
+  # The simulator's clients are processes, not browsers, and the container
+  # is per-run and published on host loopback only; the server still
+  # requires the setting outside dev mode.
+  cors_origins:
+    - "*"
+database:
+  data_dir: /data/pglite

--- a/packages/testbed/src/index.ts
+++ b/packages/testbed/src/index.ts
@@ -1,6 +1,7 @@
 /**
  * @file Public exports for launching and supervising connected-agent testbeds.
  */
+// safer-arch-ignore no-folder-cycle: the simulator folder builds on the root's runtime adapters, and the cc-judge compat adapter has to stay at its published root path while executing on the simulator (chughtapan/moltzap#812 §2, "Trace-capture fold"); the direction of knowledge is one-way per file, and the entry-point path is a protected surface.
 export {
   AgentName,
   ServerUrl,

--- a/packages/testbed/src/nanoclaw-process.ts
+++ b/packages/testbed/src/nanoclaw-process.ts
@@ -290,7 +290,7 @@ function normalizeNanoclawServerUrl(serverUrl: string): string {
 // session dirs), and macOS VM-backed engines only share paths under the
 // user home by default — the system temp dir is invisible to containers —
 // so per-agent dirs live under the testbed cache root instead.
-const NANOCLAW_RUNTIME_DIR_ROOT = join(
+export const NANOCLAW_RUNTIME_DIR_ROOT = join(
   MOLTZAP_TESTBED_CACHE_ROOT,
   "nanoclaw-runtimes",
 );

--- a/packages/testbed/src/simulator/__tests__/cc-judge-fixture.ts
+++ b/packages/testbed/src/simulator/__tests__/cc-judge-fixture.ts
@@ -15,11 +15,11 @@
  * that source file, so the path does not depend on build order.
  */
 /* eslint-disable agent-code-guard/require-span-on-exported-effect -- exported path bodies run under vitest only; spans would be dead weight in the inventory runs */
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FileSystem } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { Effect, Either } from "effect";
+import { Effect, Either, Schema } from "effect";
 import { expect } from "vitest";
 import traceCaptureHarness from "../../trace-capture-harness.js";
 import { InvalidPayload } from "../../trace-capture-payload.js";
@@ -30,7 +30,9 @@ const packageRoot = dirname(
 const scenarioDir = join(dirname(packageRoot), "evals", "scenarios");
 const fixturePath = join(scenarioDir, "EVAL-005.yaml");
 const distEntry = join(packageRoot, "dist", "trace-capture-harness.js");
-const sourceEntry = join(packageRoot, "src", "trace-capture-harness.ts");
+const PackageManifest = Schema.parseJson(
+  Schema.Struct({ files: Schema.Array(Schema.String) }),
+);
 
 const TARGET_AGENT_NAME = "openclaw-eval-agent";
 const HARNESS_NAME = "moltzap-trace-capture";
@@ -108,10 +110,17 @@ function readFixture(): Effect.Effect<string, unknown, FileSystem.FileSystem> {
   );
 }
 
-function fileExists(
-  path: string,
-): Effect.Effect<boolean, unknown, FileSystem.FileSystem> {
-  return FileSystem.FileSystem.pipe(Effect.flatMap((fs) => fs.exists(path)));
+function readManifest(): Effect.Effect<
+  { readonly files: ReadonlyArray<string> },
+  unknown,
+  FileSystem.FileSystem
+> {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) =>
+      fs.readFileString(join(packageRoot, "package.json")),
+    ),
+    Effect.flatMap(Schema.decodeUnknown(PackageManifest)),
+  );
 }
 
 function planFor(scenario: Scalars) {
@@ -132,9 +141,13 @@ function expectEntryPoint(
     expect(
       resolve(scenarioDir, scalar(scalarsAt(fixture, ["harness"]), "module")),
     ).toBe(distEntry);
-    // The built file is this path's subject compiled, so asserting the
-    // mirrored source keeps the check independent of build order.
-    expect(yield* fileExists(sourceEntry)).toBe(true);
+    // The entry point is a published file, not just a built one: a
+    // consumer resolves it out of the package's `files`, so the path the
+    // fixture names has to sit under a published directory.
+    const manifest = yield* readManifest();
+    expect(manifest.files).toContain(
+      relative(packageRoot, distEntry).split("/")[0],
+    );
   });
 }
 
@@ -173,21 +186,25 @@ function expectAssembledPlan(
   });
 }
 
-/** A payload outside the scenario grammar fails the load rather than reaching a run. */
-function expectRejectedPayload(): Effect.Effect<void, unknown, never> {
+function loadPayload(payload: unknown) {
   return Effect.either(
     traceCaptureHarness.load({
       sourcePath: fixturePath,
       plan: {
         project: "moltzap",
         scenarioId: "EVAL-000",
-        name: "invalid",
-        description: "invalid",
+        name: "probe",
+        description: "probe",
         requirements: {},
       },
-      payload: { runtime: { kind: "nope" }, conversation: {} },
+      payload,
     }),
-  ).pipe(
+  );
+}
+
+/** A payload outside the scenario grammar fails the load rather than reaching a run. */
+function expectRejectedPayload(): Effect.Effect<void, unknown, never> {
+  return loadPayload({ runtime: { kind: "nope" }, conversation: {} }).pipe(
     Effect.map(
       Either.match({
         onLeft: (failure) => {
@@ -201,6 +218,58 @@ function expectRejectedPayload(): Effect.Effect<void, unknown, never> {
   );
 }
 
+/**
+ * The conversation shapes this fold cannot express are refused at load,
+ * where cc-judge reports a scenario problem, rather than at execute,
+ * where the same scenario would have already spent a container. One
+ * principal speaking once is what the v0 episode carries, so a
+ * follow-up, a group, or a cross-conversation probe has no run spec.
+ */
+function expectShapePartition(): Effect.Effect<void, unknown, never> {
+  const direct = {
+    runtime: { kind: "openclaw" },
+    conversation: { kind: "direct", setupMessage: "hello" },
+  };
+  const refused = [
+    {
+      ...direct,
+      conversation: { ...direct.conversation, followUpMessages: ["and then?"] },
+    },
+    {
+      runtime: { kind: "openclaw" },
+      conversation: { kind: "group", setupMessage: "hello", bystanders: [] },
+    },
+    {
+      runtime: { kind: "openclaw" },
+      conversation: {
+        kind: "cross",
+        setupMessage: "hello",
+        probeMessage: "what did they say?",
+      },
+    },
+  ];
+  return Effect.gen(function* () {
+    yield* loadPayload(direct).pipe(Effect.map(expectLoads(true)));
+    yield* Effect.forEach(
+      refused,
+      (payload) => loadPayload(payload).pipe(Effect.map(expectLoads(false))),
+      { concurrency: 1, discard: true },
+    );
+  });
+}
+
+/** Assert whether a payload produced a plan, without naming the failure shape. */
+function expectLoads(loads: boolean) {
+  return Either.match({
+    onLeft: () => {
+      expect(loads).toBe(false);
+    },
+    onRight: () => {
+      expect(loads).toBe(true);
+    },
+  });
+}
+
 /** Path 24a: the entry point loads the fixture and assembles its plan. */
 export function path24a(): Effect.Effect<void, unknown, never> {
   return Effect.gen(function* () {
@@ -208,5 +277,6 @@ export function path24a(): Effect.Effect<void, unknown, never> {
     yield* expectEntryPoint(fixture);
     yield* expectAssembledPlan(fixture);
     yield* expectRejectedPayload();
+    yield* expectShapePartition();
   }).pipe(Effect.provide(NodeContext.layer));
 }

--- a/packages/testbed/src/simulator/__tests__/cc-judge-fixture.ts
+++ b/packages/testbed/src/simulator/__tests__/cc-judge-fixture.ts
@@ -1,0 +1,214 @@
+/**
+ * @file Body of coverage path 24a (CRITICAL): the cc-judge entry point
+ * still loads. The Appendix D fixture
+ * `packages/evals/scenarios/EVAL-005.yaml` is read byte-unchanged, its
+ * payload goes through the compat adapter's `load`, and the plan and
+ * coordinator cc-judge expects come back. No model executes here; the
+ * executed half of path 24 is 24b, nightly.
+ *
+ * Two things this file deliberately does not do. It does not parse YAML
+ * with a library — the package depends on none, and the fixture reader
+ * below refuses anything outside the scalar mapping this fixture uses,
+ * so a fixture that changes shape fails the path instead of passing
+ * quietly. And it loads the adapter from source rather than from
+ * `dist/`, asserting separately that the fixture's module path mirrors
+ * that source file, so the path does not depend on build order.
+ */
+/* eslint-disable agent-code-guard/require-span-on-exported-effect -- exported path bodies run under vitest only; spans would be dead weight in the inventory runs */
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { FileSystem } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Effect, Either } from "effect";
+import { expect } from "vitest";
+import traceCaptureHarness from "../../trace-capture-harness.js";
+import { InvalidPayload } from "../../trace-capture-payload.js";
+
+const packageRoot = dirname(
+  dirname(dirname(dirname(fileURLToPath(import.meta.url)))),
+);
+const scenarioDir = join(dirname(packageRoot), "evals", "scenarios");
+const fixturePath = join(scenarioDir, "EVAL-005.yaml");
+const distEntry = join(packageRoot, "dist", "trace-capture-harness.js");
+const sourceEntry = join(packageRoot, "src", "trace-capture-harness.ts");
+
+const TARGET_AGENT_NAME = "openclaw-eval-agent";
+const HARNESS_NAME = "moltzap-trace-capture";
+
+type Scalars = Readonly<Record<string, string>>;
+
+/**
+ * The `key: value` pairs directly under `path` in a YAML document,
+ * located by indentation. Deeper levels are not visited, so the caller
+ * names every level it reads; a list item at the level being read
+ * throws, because this reader cannot represent one and silence would
+ * hide the fixture changing shape.
+ */
+function scalarsAt(text: string, path: ReadonlyArray<string>): Scalars {
+  const lines = text.split("\n");
+  let index = 0;
+  for (const key of path) {
+    const found = lines.findIndex(
+      (line, at) => at >= index && line.trim().startsWith(`${key}:`),
+    );
+    if (found === -1) throw new Error(`fixture has no "${path.join(".")}"`);
+    index = found + 1;
+  }
+  return collect(lines, index);
+}
+
+function indentOf(line: string): number {
+  return line.length - line.trimStart().length;
+}
+
+function collect(lines: ReadonlyArray<string>, from: number): Scalars {
+  const entries = levelLines(lines, from, indentOf(lines[from] ?? "")).map(
+    entryOf,
+  );
+  return Object.fromEntries(entries.filter(([, value]) => value.length > 0));
+}
+
+/** Lines at exactly `indent`, stopping where the section dedents. */
+function levelLines(
+  lines: ReadonlyArray<string>,
+  from: number,
+  indent: number,
+): ReadonlyArray<string> {
+  const dedent = lines.findIndex(
+    (line, at) =>
+      at >= from && line.trim().length > 0 && indentOf(line) < indent,
+  );
+  const section = dedent === -1 ? lines.slice(from) : lines.slice(from, dedent);
+  return section.filter(
+    (line) => line.trim().length > 0 && indentOf(line) === indent,
+  );
+}
+
+function entryOf(line: string): readonly [string, string] {
+  if (line.trim().startsWith("- ")) {
+    throw new Error(
+      `fixture line "${line.trim()}" is a list this reader cannot represent`,
+    );
+  }
+  const [key, ...rest] = line.trim().split(": ");
+  return [(key ?? "").replace(/:$/u, ""), rest.join(": ")];
+}
+
+function scalar(scalars: Scalars, key: string): string {
+  const value = scalars[key];
+  if (value === undefined) {
+    throw new Error(`fixture has no scalar "${key}" at the level read`);
+  }
+  return value;
+}
+
+function readFixture(): Effect.Effect<string, unknown, never> {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.readFileString(fixturePath)),
+    Effect.provide(NodeContext.layer),
+  );
+}
+
+function fileExists(path: string): Effect.Effect<boolean, unknown, never> {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.exists(path)),
+    Effect.provide(NodeContext.layer),
+  );
+}
+
+function planFor(scenario: Scalars) {
+  return {
+    project: scalar(scenario, "project"),
+    scenarioId: scalar(scenario, "scenarioId"),
+    name: scalar(scenario, "name"),
+    description: scalar(scenario, "description"),
+    requirements: {},
+  };
+}
+
+/** The module path cc-judge imports is this package's built entry point. */
+function expectEntryPoint(
+  fixture: string,
+): Effect.Effect<void, unknown, never> {
+  return Effect.gen(function* () {
+    expect(
+      resolve(scenarioDir, scalar(scalarsAt(fixture, ["harness"]), "module")),
+    ).toBe(distEntry);
+    // The built file is this path's subject compiled, so asserting the
+    // mirrored source keeps the check independent of build order.
+    expect(yield* fileExists(sourceEntry)).toBe(true);
+  });
+}
+
+function expectAssembledPlan(
+  fixture: string,
+): Effect.Effect<void, unknown, never> {
+  const scenario = scalarsAt(fixture, []);
+  return Effect.gen(function* () {
+    const loaded = yield* traceCaptureHarness.load({
+      sourcePath: fixturePath,
+      plan: planFor(scenario),
+      payload: {
+        runtime: scalarsAt(fixture, ["harness", "payload", "runtime"]),
+        conversation: scalarsAt(fixture, [
+          "harness",
+          "payload",
+          "conversation",
+        ]),
+      },
+    });
+    expect(loaded.plan).toMatchObject({
+      scenarioId: scalar(scenario, "scenarioId"),
+      name: scalar(scenario, "name"),
+      metadata: {
+        harness: HARNESS_NAME,
+        conversationKind: "direct",
+        runtimeKind: "openclaw",
+      },
+    });
+    expect(loaded.plan.agents).toHaveLength(1);
+    expect(loaded.plan.agents[0]).toMatchObject({
+      role: "target",
+      name: TARGET_AGENT_NAME,
+    });
+    expect(loaded.coordinator.execute).toBeInstanceOf(Function);
+  });
+}
+
+/** A payload outside the scenario grammar fails the load rather than reaching a run. */
+function expectRejectedPayload(): Effect.Effect<void, unknown, never> {
+  return Effect.either(
+    traceCaptureHarness.load({
+      sourcePath: fixturePath,
+      plan: {
+        project: "moltzap",
+        scenarioId: "EVAL-000",
+        name: "invalid",
+        description: "invalid",
+        requirements: {},
+      },
+      payload: { runtime: { kind: "nope" }, conversation: {} },
+    }),
+  ).pipe(
+    Effect.map(
+      Either.match({
+        onLeft: (failure) => {
+          expect(failure.cause).toBeInstanceOf(InvalidPayload);
+        },
+        onRight: () => {
+          expect.unreachable("a payload outside the grammar must not load");
+        },
+      }),
+    ),
+  );
+}
+
+/** Path 24a: the entry point loads the fixture and assembles its plan. */
+export function path24a(): Effect.Effect<void, unknown, never> {
+  return Effect.gen(function* () {
+    const fixture = yield* readFixture();
+    yield* expectEntryPoint(fixture);
+    yield* expectAssembledPlan(fixture);
+    yield* expectRejectedPayload();
+  });
+}

--- a/packages/testbed/src/simulator/__tests__/cc-judge-fixture.ts
+++ b/packages/testbed/src/simulator/__tests__/cc-judge-fixture.ts
@@ -102,18 +102,16 @@ function scalar(scalars: Scalars, key: string): string {
   return value;
 }
 
-function readFixture(): Effect.Effect<string, unknown, never> {
+function readFixture(): Effect.Effect<string, unknown, FileSystem.FileSystem> {
   return FileSystem.FileSystem.pipe(
     Effect.flatMap((fs) => fs.readFileString(fixturePath)),
-    Effect.provide(NodeContext.layer),
   );
 }
 
-function fileExists(path: string): Effect.Effect<boolean, unknown, never> {
-  return FileSystem.FileSystem.pipe(
-    Effect.flatMap((fs) => fs.exists(path)),
-    Effect.provide(NodeContext.layer),
-  );
+function fileExists(
+  path: string,
+): Effect.Effect<boolean, unknown, FileSystem.FileSystem> {
+  return FileSystem.FileSystem.pipe(Effect.flatMap((fs) => fs.exists(path)));
 }
 
 function planFor(scenario: Scalars) {
@@ -129,7 +127,7 @@ function planFor(scenario: Scalars) {
 /** The module path cc-judge imports is this package's built entry point. */
 function expectEntryPoint(
   fixture: string,
-): Effect.Effect<void, unknown, never> {
+): Effect.Effect<void, unknown, FileSystem.FileSystem> {
   return Effect.gen(function* () {
     expect(
       resolve(scenarioDir, scalar(scalarsAt(fixture, ["harness"]), "module")),
@@ -210,5 +208,5 @@ export function path24a(): Effect.Effect<void, unknown, never> {
     yield* expectEntryPoint(fixture);
     yield* expectAssembledPlan(fixture);
     yield* expectRejectedPayload();
-  });
+  }).pipe(Effect.provide(NodeContext.layer));
 }

--- a/packages/testbed/src/simulator/__tests__/coverage-paths-b.ts
+++ b/packages/testbed/src/simulator/__tests__/coverage-paths-b.ts
@@ -15,8 +15,10 @@ import {
 } from "@moltzap/protocol/testing";
 import { buildOpenClawConfig } from "../../openclaw-adapter.js";
 import { homedir, tmpdir } from "node:os";
-import { buildNanoclawProcessPlan } from "../../nanoclaw-process.js";
-import { MOLTZAP_TESTBED_CACHE_ROOT } from "../../nanoclaw-install.js";
+import {
+  buildNanoclawProcessPlan,
+  NANOCLAW_RUNTIME_DIR_ROOT,
+} from "../../nanoclaw-process.js";
 import { makeWorld, type AppliedFault, type World } from "../world.js";
 import {
   Agent,
@@ -141,13 +143,13 @@ export function path14(): Effect.Effect<void, unknown, never> {
     expect(servers).toBeDefined();
     expect(JSON.stringify(JSON.parse(servers ?? "{}"))).toContain(MOUNT_NAME);
     expect(plan.env["MOLTZAP_AGENT_MODEL"]).toBe(TEST_MODEL);
-    // The runtime dirs this plan runs in are docker bind-mount sources, so
-    // they have to sit where a VM-backed engine shares by default. Under
-    // the system temp directory the container silently gets a private
-    // directory instead of the host's, which is the same failure the
-    // server container's launch-time mount check refuses.
-    expect(MOLTZAP_TESTBED_CACHE_ROOT.startsWith(homedir())).toBe(true);
-    expect(MOLTZAP_TESTBED_CACHE_ROOT.startsWith(tmpdir())).toBe(false);
+    // The per-agent runtime dirs are the container's bind-mount sources,
+    // so the root they live under has to be a path a VM-backed engine
+    // shares. Under the system temp directory the container silently gets
+    // a private directory instead of the host's, which is the same
+    // failure the server container's launch-time mount check refuses.
+    expect(NANOCLAW_RUNTIME_DIR_ROOT.startsWith(homedir())).toBe(true);
+    expect(NANOCLAW_RUNTIME_DIR_ROOT.startsWith(tmpdir())).toBe(false);
   });
 }
 

--- a/packages/testbed/src/simulator/__tests__/coverage-paths-b.ts
+++ b/packages/testbed/src/simulator/__tests__/coverage-paths-b.ts
@@ -14,7 +14,9 @@ import {
   redactedAgentKey,
 } from "@moltzap/protocol/testing";
 import { buildOpenClawConfig } from "../../openclaw-adapter.js";
+import { homedir, tmpdir } from "node:os";
 import { buildNanoclawProcessPlan } from "../../nanoclaw-process.js";
+import { MOLTZAP_TESTBED_CACHE_ROOT } from "../../nanoclaw-install.js";
 import { makeWorld, type AppliedFault, type World } from "../world.js";
 import {
   Agent,
@@ -138,6 +140,13 @@ export function path14(): Effect.Effect<void, unknown, never> {
     expect(servers).toBeDefined();
     expect(JSON.stringify(JSON.parse(servers ?? "{}"))).toContain(MOUNT_NAME);
     expect(plan.env["MOLTZAP_AGENT_MODEL"]).toBe(TEST_MODEL);
+    // The runtime dirs this plan runs in are docker bind-mount sources, so
+    // they have to sit where a VM-backed engine shares by default. Under
+    // the system temp directory the container silently gets a private
+    // directory instead of the host's, which is the same failure the
+    // server container's launch-time mount check refuses.
+    expect(MOLTZAP_TESTBED_CACHE_ROOT.startsWith(homedir())).toBe(true);
+    expect(MOLTZAP_TESTBED_CACHE_ROOT.startsWith(tmpdir())).toBe(false);
   });
 }
 

--- a/packages/testbed/src/simulator/__tests__/coverage-paths-b.ts
+++ b/packages/testbed/src/simulator/__tests__/coverage-paths-b.ts
@@ -53,6 +53,7 @@ import {
 import {
   AGENT_ONE,
   AGENT_TWO,
+  LOOPBACK_BIND_HOST,
   DONE_SPAN,
   PRINCIPAL_NAME,
   TASK_CONTENT,
@@ -810,6 +811,8 @@ function makeQueueForTest(
       runOptions: { runner: launch.launcher },
       internals: {
         makeDrain: () => Effect.succeed(quietDrain),
+        // A hermetic run launches no container, so the engine is never asked.
+        resolveBindHost: () => Effect.succeed(LOOPBACK_BIND_HOST),
         makeReceiver,
         makePrincipal: () => Effect.succeed(principal.principal),
       },

--- a/packages/testbed/src/simulator/__tests__/support.ts
+++ b/packages/testbed/src/simulator/__tests__/support.ts
@@ -110,10 +110,10 @@ function presentOnly(
   );
 }
 
-export function stubAgentInput(name: string): unknown {
+export function stubAgentInput(name: string, script = "quiet"): unknown {
   return {
     name,
-    runtime: { _tag: "stub", config: { script: "quiet" } },
+    runtime: { _tag: "stub", config: { script } },
     runsIn: "host",
     role: "standard",
   };

--- a/packages/testbed/src/simulator/__tests__/support.ts
+++ b/packages/testbed/src/simulator/__tests__/support.ts
@@ -59,6 +59,9 @@ const IMAGE_DIGEST = `sha256:${"a".repeat(64)}`;
 const INACTIVITY_MS = 60_000;
 const RECEIVER_BOUND_MS = 5_000;
 
+/** Bind host of every hermetic receiver: nothing dials it from a container. */
+export const LOOPBACK_BIND_HOST = "127.0.0.1";
+
 /** A valid encoded RunSpec input; overrides merge shallowly per section. */
 export function specInput(
   storeRoot: string,
@@ -70,6 +73,7 @@ export function specInput(
     contentVersion: string;
     timeouts: unknown;
     seed: number;
+    server: unknown;
   }> = {},
 ): unknown {
   return {
@@ -78,7 +82,7 @@ export function specInput(
       stubAgentInput(AGENT_ONE),
       stubAgentInput(AGENT_TWO),
     ],
-    server: { imageDigest: IMAGE_DIGEST },
+    server: overrides.server ?? { imageDigest: IMAGE_DIGEST },
     episode: overrides.episode ?? {
       task: { principal: PRINCIPAL_NAME, to: AGENT_ONE, content: TASK_CONTENT },
       termination: {
@@ -433,6 +437,8 @@ export function startHermetic(
     const principal = makeFakePrincipal();
     const internals: RunInternals = {
       makeDrain: () => Effect.succeed(quietDrain),
+      // A hermetic run launches no container, so the engine is never asked.
+      resolveBindHost: () => Effect.succeed(LOOPBACK_BIND_HOST),
       makeReceiver: (deps) =>
         makeReceiver(deps).pipe(
           Effect.tap((receiver: Receiver) =>

--- a/packages/testbed/src/simulator/coverage.test.ts
+++ b/packages/testbed/src/simulator/coverage.test.ts
@@ -8,8 +8,8 @@
  * shrinks the inventory, which the contract forbids. Path bodies live in
  * `__tests__/coverage-paths-{a,b}.ts`.
  *
- * One entry stays `it.todo`: path 24 lands with the trace-capture fold
- * row.
+ * Path 24 splits by tier: 24a is the hermetic entry-point load, 24b
+ * the executed nightly run named in the design.
  */
 /* eslint-disable sonarjs/assertions-in-tests -- every entry delegates to an imported path body whose assertions (expect/fc.assert) live in __tests__/coverage-paths-*.ts; this file is the flat inventory the contract pins */
 // @agent-code-guard/regression-only: property evidence lives in the imported path bodies (fc.assert in coverage-paths-a/b); the inventory file itself stays a flat list
@@ -52,6 +52,7 @@ import {
   path34,
   path35,
 } from "./__tests__/coverage-paths-b.js";
+import { path24a } from "./__tests__/cc-judge-fixture.js";
 
 const run = (effect: Effect.Effect<void, unknown, never>) =>
   Effect.runPromise(effect.pipe(Effect.orDie));
@@ -110,9 +111,8 @@ describe("simulator coverage inventory (hermetic CI tier, paths 13-24)", () => {
     run(path22()));
   it("23. per-adapter canonical config: unsupported field fails fast at config time (property)", () =>
     run(path23()));
-  it.todo(
-    "24. cc-judge compat (CRITICAL): dist loader runs the compat adapter over EVAL-005.yaml against the verify-row oracle",
-  );
+  it("24a. cc-judge compat (CRITICAL): the entry point loads EVAL-005.yaml and assembles its plan", () =>
+    run(path24a()));
 });
 
 describe("simulator coverage inventory (design-doc extension paths)", () => {

--- a/packages/testbed/src/simulator/drivers.ts
+++ b/packages/testbed/src/simulator/drivers.ts
@@ -275,7 +275,7 @@ function makeOutOfBandPrincipal(context: {
         const target = yield* targetAgentId(delivery);
         const minted = yield* mintPrincipalIdentity(delivery, context.secrets);
         const client = new MoltZapAgentClient({
-          serverUrl: delivery.world.server.serverUrl,
+          serverUrl: httpBaseFromServerUrl(delivery.world.server.serverUrl),
           agentKey: minted.apiKey,
         });
         yield* client

--- a/packages/testbed/src/simulator/event-log.ts
+++ b/packages/testbed/src/simulator/event-log.ts
@@ -810,6 +810,14 @@ type ReceiverDeps = {
   readonly log: EventLog;
   readonly failBoundMs: number;
   readonly secrets: Secrets;
+
+  /**
+   * Host address to bind. The server container has to reach it, and which
+   * address that is depends on the container engine, so the caller
+   * resolves it (`resolveReceiverBindHost`) rather than the receiver
+   * assuming loopback.
+   */
+  readonly bindHost: string;
 };
 
 /**
@@ -839,8 +847,6 @@ export function makeReceiver(
     };
   }).pipe(Effect.withSpan("makeReceiver"));
 }
-
-const RECEIVER_HOST = "127.0.0.1";
 
 type AcceptOutcome = "accepted" | "stalled" | "sealed";
 
@@ -956,15 +962,13 @@ function serveReceiver(
       ),
     ),
   );
-  return NodeHttpServer.make(makeNodeServer, {
-    port: 0,
-    host: RECEIVER_HOST,
-  }).pipe(
+  const host = ctx.deps.bindHost;
+  return NodeHttpServer.make(makeNodeServer, { port: 0, host }).pipe(
     Effect.tap((server) => server.serve(router)),
     Effect.map((server) => {
       const address = server.address;
       const port = address._tag === "TcpAddress" ? address.port : 0;
-      return `http://${RECEIVER_HOST}:${String(port)}/v1/traces`;
+      return `http://${host}:${String(port)}/v1/traces`;
     }),
     Effect.mapError(bindFailure(ctx.deps)),
   );

--- a/packages/testbed/src/simulator/index.ts
+++ b/packages/testbed/src/simulator/index.ts
@@ -71,6 +71,7 @@ export {
   type LaunchDeps,
   type Launcher,
   makeLauncher,
+  resolveServerImagePin,
 } from "./run-config.js";
 
 export {

--- a/packages/testbed/src/simulator/launcher-live.ts
+++ b/packages/testbed/src/simulator/launcher-live.ts
@@ -402,10 +402,10 @@ function verifyStorageMount(
     ),
     Effect.provide(NodeContext.layer),
     Effect.asVoid,
-    Effect.mapError(() =>
+    Effect.mapError((detail) =>
       serverFailed(
         digest,
-        `a file written to the run's storage directory is not visible at ${SERVER_DATA_MOUNT} inside the container, so the bind mount shares nothing. Point the run's storage at a directory the container engine shares (engine file-sharing settings), or the transcript drain will find no messages`,
+        `a file written to the run's storage directory is not visible at ${SERVER_DATA_MOUNT} inside the container (${detail}), so the bind mount shares nothing. Point the run's storage at a directory the container engine shares (engine file-sharing settings), or the transcript drain will find no messages`,
       ),
     ),
   );

--- a/packages/testbed/src/simulator/launcher-live.ts
+++ b/packages/testbed/src/simulator/launcher-live.ts
@@ -25,7 +25,16 @@ import {
 import { NodeContext } from "@effect/platform-node";
 import { networkInterfaces } from "node:os";
 import { fileURLToPath } from "node:url";
-import { Config, Deferred, Duration, Effect, Schema, type Scope } from "effect";
+import {
+  Config,
+  Deferred,
+  Duration,
+  Effect,
+  Schedule,
+  Schema,
+  Stream,
+  type Scope,
+} from "effect";
 import {
   ServerUrl as mintServerUrl,
   type RuntimeServerHandle,
@@ -76,6 +85,11 @@ export const SERVER_DATA_MOUNT = "/data";
 export const SERVER_PGLITE_DIR = "pglite";
 
 const SERVER_HEALTH_POLL_MS = 250;
+/** Bound on any one docker call; a wedged daemon fails the run, never hangs it. */
+const DOCKER_CALL_TIMEOUT_MS = 120_000;
+const IMAGE_BUILD_TIMEOUT_MS = 900_000;
+/** Marks every per-run server container, so orphans are identifiable. */
+const SERVER_CONTAINER_LABEL = "moltzap-simulator-run=1";
 const OBSERVER_IDENTITY = "moltzap-sim-observer";
 const PRESENCE_POLL_MS = 500;
 
@@ -152,14 +166,60 @@ function serverFailed(imageDigest: string, detail: string): ServerLaunchFailed {
   });
 }
 
-/** Run a command, capture stdout, and fail on a non-zero exit. */
+/** What a failing process said: stderr when it wrote any, stdout otherwise. */
+function saidAboutFailure(result: {
+  readonly stdout: string;
+  readonly stderr: string;
+}): string {
+  const spoken = result.stderr.trim();
+  return spoken.length > 0 ? spoken : result.stdout.trim();
+}
+
+/**
+ * Run a command, capture stdout, and fail on a non-zero exit with
+ * whatever the process said about it. `Command.string` alone returns
+ * stdout for a failing process too, which turns every check built on it
+ * — the storage-mount probe, the container stop — into a no-op.
+ *
+ * stdout and stderr are drained concurrently with the exit: a process
+ * that fills an unread pipe blocks forever otherwise. Every call is
+ * bounded, so a wedged daemon fails the run instead of hanging it.
+ */
 function execCapture(
   parts: ReadonlyArray<string>,
+  timeoutMs: number = DOCKER_CALL_TIMEOUT_MS,
 ): Effect.Effect<string, string, never> {
   const [head, ...rest] = parts;
   if (head === undefined) return Effect.fail("empty command");
-  const command = Command.make(head, ...rest);
-  return Command.string(command).pipe(
+  const command = Command.make(head, ...rest).pipe(
+    Command.stdout("pipe"),
+    Command.stderr("pipe"),
+  );
+  return Effect.scoped(
+    Command.start(command).pipe(
+      Effect.flatMap((process) =>
+        Effect.all(
+          {
+            stdout: Stream.mkString(Stream.decodeText(process.stdout)),
+            stderr: Stream.mkString(Stream.decodeText(process.stderr)),
+            exitCode: process.exitCode,
+          },
+          { concurrency: 3 },
+        ),
+      ),
+      Effect.flatMap((result) =>
+        Number(result.exitCode) === 0
+          ? Effect.succeed(result.stdout)
+          : Effect.fail(
+              `${head} exited ${String(result.exitCode)}: ${saidAboutFailure(result)}`,
+            ),
+      ),
+    ),
+  ).pipe(
+    Effect.timeoutFail({
+      duration: Duration.millis(timeoutMs),
+      onTimeout: () => `${head} did not finish within ${String(timeoutMs)}ms`,
+    }),
     Effect.mapError((cause) => String(cause)),
     Effect.provide(NodeContext.layer),
   );
@@ -177,7 +237,7 @@ const LOOPBACK_HOST = "127.0.0.1";
  * the native-Linux half of the bind strategy on
  * `resolveReceiverBindHost`.
  */
-function containerReachableEndpoint(otlpEndpoint: string): string {
+export function containerReachableEndpoint(otlpEndpoint: string): string {
   const url = new URL(otlpEndpoint);
   if (url.hostname === LOOPBACK_HOST || url.hostname === "localhost") {
     url.hostname = HOST_GATEWAY_NAME;
@@ -251,7 +311,7 @@ const ImagePinLine = Schema.parseJson(
 
 /** The build script prints its pin as the last line of stdout. */
 function buildServerImagePin(): Effect.Effect<ImageDigest, string, never> {
-  return execCapture(["node", IMAGE_BUILD_SCRIPT]).pipe(
+  return execCapture(["node", IMAGE_BUILD_SCRIPT], IMAGE_BUILD_TIMEOUT_MS).pipe(
     Effect.mapError(
       (detail) =>
         `the server image could not be built: ${detail}. Build it with \`node scripts/build-server-image.mjs\`, or pin one through ${SERVER_IMAGE_ENV}`,
@@ -302,6 +362,11 @@ function serverRunArgs(
     "run",
     "--detach",
     "--rm",
+    // An interrupt between the daemon creating the container and this
+    // process learning its id leaves a container nothing holds; the label
+    // is how such an orphan is found afterwards.
+    "--label",
+    SERVER_CONTAINER_LABEL,
     "--publish",
     `${LOOPBACK_HOST}:0:${String(SERVER_CONTAINER_PORT)}`,
     "--volume",
@@ -323,9 +388,11 @@ function startServerContainer(
 ): Effect.Effect<StartedServer, ServerLaunchFailed, Scope.Scope> {
   const digest = spec.server.imageDigest;
   return Effect.gen(function* () {
+    // Scoped: the drain reads this directory during shutdown, inside the
+    // run's scope, and the recording is what survives the attempt.
     const volumePath = yield* FileSystem.FileSystem.pipe(
       Effect.flatMap((fs) =>
-        fs.makeTempDirectory({ prefix: "moltzap-sim-server-" }),
+        fs.makeTempDirectoryScoped({ prefix: "moltzap-sim-server-" }),
       ),
       Effect.provide(NodeContext.layer),
       Effect.mapError((cause) =>
@@ -448,8 +515,13 @@ function awaitServerHealthy(
             Effect.zipRight(Effect.fail("not ready")),
           ),
     ),
-    Effect.retry({
-      times: Math.ceil(spec.timeouts.readyTimeoutMs / SERVER_HEALTH_POLL_MS),
+    Effect.retry({ schedule: Schedule.forever }),
+    // The bound is wall-clock: a probe that blocks (half-open socket, a
+    // daemon mid-restart) would otherwise never consume an attempt.
+    Effect.timeoutFail({
+      duration: Duration.millis(spec.timeouts.readyTimeoutMs),
+      onTimeout: () =>
+        `health endpoint did not answer within ${String(spec.timeouts.readyTimeoutMs)}ms`,
     }),
     Effect.mapError(
       () =>

--- a/packages/testbed/src/simulator/launcher-live.ts
+++ b/packages/testbed/src/simulator/launcher-live.ts
@@ -5,14 +5,15 @@
  * out. Partial launch tears down already-started members in reverse and
  * fails with the failing agent's error.
  *
- * The server-image contract this launcher launches against (built by the
- * server-image row): the image runs `moltzap-server` listening on
- * container port 3000 with open registration and no encryption secret
- * (message content stays volume-readable for the transcript drain),
- * persists its data under `/data`, which this launcher bind-mounts from
- * the per-run volume directory that backs `ServerHandle.storage`, and
- * exports spans to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, which this
- * launcher points at the run's receiver (`LaunchDeps.otlpEndpoint`).
+ * The server-image contract this launcher launches against (built by
+ * `scripts/build-server-image.mjs` from `server-image/`): the image runs
+ * `moltzap-server` listening on container port 3000 with open
+ * registration and no encryption secret (message content stays
+ * volume-readable for the transcript drain), persists its PGlite data
+ * directory at `/data/pglite`, which this launcher bind-mounts from the
+ * per-run volume directory that backs `ServerHandle.storage`, and exports
+ * spans to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, which this launcher
+ * points at the run's receiver (`LaunchDeps.otlpEndpoint`).
  */
 // safer-arch-ignore no-fat-orchestrator: the launch orchestrator behind run-config.ts's makeLauncher; the wiring breadth (docker, provisioning, adapters, readiness) is contract 1's launch half by design.
 import {
@@ -22,6 +23,7 @@ import {
   HttpClient,
 } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
+import { networkInterfaces, platform } from "node:os";
 import { Deferred, Duration, Effect, type Scope } from "effect";
 import {
   ServerUrl as mintServerUrl,
@@ -61,8 +63,16 @@ import {
   type MountFailed,
 } from "./errors.js";
 
-const SERVER_CONTAINER_PORT = 3000;
+/** Port the image's server listens on, and the port this launcher publishes. */
+export const SERVER_CONTAINER_PORT = 3000;
+/** The image's volume mount point, bind-mounted from the run's storage directory. */
+export const SERVER_DATA_MOUNT = "/data";
+/** Where under the mount the image's config pins its PGlite data directory. */
+export const SERVER_PGLITE_DIR = "pglite";
+
 const SERVER_HEALTH_POLL_MS = 250;
+const MOUNT_PROBE_POLL_MS = 250;
+const MOUNT_PROBE_ATTEMPTS = 40;
 const OBSERVER_IDENTITY = "moltzap-sim-observer";
 const PRESENCE_POLL_MS = 500;
 
@@ -152,23 +162,89 @@ function execCapture(
   );
 }
 
-/** The engine's host alias: the receiver binds host loopback, and in-container loopback is the container itself. */
+/** The engine's host alias, defined for the container by `--add-host`. */
 const HOST_GATEWAY_NAME = "host.docker.internal";
+const LOOPBACK_HOST = "127.0.0.1";
 
 /**
  * Rewrites a loopback hostname to the engine's host alias by URL parse,
  * never raw string replacement (a loopback literal outside the hostname
- * must survive). Reaches the host on Docker Desktop; on native Linux the
- * alias maps to the bridge gateway address while the receiver binds
- * loopback only, so container-side export does NOT reach it there — the
- * receiver bind strategy is the live tier's scope.
+ * must survive). A receiver bound to a non-loopback host address is
+ * already the address the container dials, so it passes through: that is
+ * the native-Linux half of the bind strategy on
+ * `resolveReceiverBindHost`.
  */
 function containerReachableEndpoint(otlpEndpoint: string): string {
   const url = new URL(otlpEndpoint);
-  if (url.hostname === "127.0.0.1" || url.hostname === "localhost") {
+  if (url.hostname === LOOPBACK_HOST || url.hostname === "localhost") {
     url.hostname = HOST_GATEWAY_NAME;
   }
   return url.toString();
+}
+
+/**
+ * Pick the host address whose port the container can reach, given the
+ * engine's bridge gateway and the addresses this host actually owns.
+ *
+ * A VM-backed engine (Docker Desktop, colima, OrbStack) puts the bridge
+ * gateway inside the VM, so the host does not own it; there
+ * `host.docker.internal` forwards to host loopback and loopback is the
+ * correct bind. A native-Linux engine's bridge gateway IS a host address
+ * (`docker0`), and there loopback is unreachable from the container while
+ * the gateway address is reachable in both directions — binding it is
+ * what keeps spans from being dropped with no error.
+ */
+export function pickReceiverBindHost(
+  gateways: ReadonlyArray<string>,
+  hostAddresses: ReadonlySet<string>,
+): string {
+  return (
+    gateways.find((gateway) => hostAddresses.has(gateway)) ?? LOOPBACK_HOST
+  );
+}
+
+function hostAddresses(): ReadonlySet<string> {
+  return new Set(
+    Object.values(networkInterfaces())
+      .flatMap((entries) => entries ?? [])
+      .map((entry) => entry.address),
+  );
+}
+
+// The engine's bridge topology does not change under a running process,
+// and every attempt would otherwise pay for the same `docker` call.
+let cachedBindHost: string | undefined;
+
+/**
+ * Resolve the receiver's bind address for this process. Only a Linux
+ * host can own the engine's bridge gateway, so every other host skips
+ * the `docker` call and takes loopback; an engine that cannot be
+ * interrogated reads the same way, which is the answer for every
+ * VM-backed engine.
+ */
+export function resolveReceiverBindHost(): Effect.Effect<string, never, never> {
+  return Effect.suspend(() => {
+    if (cachedBindHost !== undefined) return Effect.succeed(cachedBindHost);
+    if (platform() !== "linux") return Effect.succeed(LOOPBACK_HOST);
+    return execCapture([
+      "docker",
+      "network",
+      "inspect",
+      "bridge",
+      "--format",
+      "{{range .IPAM.Config}}{{.Gateway}} {{end}}",
+    ]).pipe(
+      Effect.map((output) =>
+        pickReceiverBindHost(output.trim().split(/\s+/), hostAddresses()),
+      ),
+      Effect.orElseSucceed(() => LOOPBACK_HOST),
+      Effect.tap((host) =>
+        Effect.sync(() => {
+          cachedBindHost = host;
+        }),
+      ),
+    );
+  });
 }
 
 function serverRunArgs(
@@ -182,9 +258,9 @@ function serverRunArgs(
     "--detach",
     "--rm",
     "--publish",
-    `127.0.0.1:0:${String(SERVER_CONTAINER_PORT)}`,
+    `${LOOPBACK_HOST}:0:${String(SERVER_CONTAINER_PORT)}`,
     "--volume",
-    `${volumePath}:/data`,
+    `${volumePath}:${SERVER_DATA_MOUNT}`,
     // The explicit `host-gateway` mapping defines the alias on Linux
     // engines (Docker Desktop resolves it natively); the reachability
     // caveat lives on `containerReachableEndpoint`.
@@ -228,10 +304,11 @@ function startServerContainer(
     const hostPort = yield* resolveHostPort(containerId).pipe(
       Effect.mapError((detail) => serverFailed(digest, detail)),
     );
-    const serverUrl = mintServerUrl(`ws://127.0.0.1:${hostPort}/ws`);
+    const serverUrl = mintServerUrl(`ws://${LOOPBACK_HOST}:${hostPort}/ws`);
     yield* awaitServerHealthy(spec, serverUrl).pipe(
       Effect.mapError((detail) => serverFailed(digest, detail)),
     );
+    yield* verifyStorageMount(digest, volumePath);
     return {
       handle: {
         imageDigest: digest,
@@ -241,6 +318,42 @@ function startServerContainer(
       containerId,
     };
   });
+}
+
+/**
+ * The server's own writes are the mount check. The image pins its PGlite
+ * directory under the mounted volume, so once health answers, that
+ * directory is visible on the host side iff the bind mount really shares
+ * bytes. An engine that shares only part of the host filesystem (a VM
+ * engine whose mounts do not cover the system temp directory, for one)
+ * accepts `--volume` and hands the container a private directory
+ * instead; without this check the run proceeds and only the transcript
+ * drain notices, after the episode is over.
+ */
+function verifyStorageMount(
+  digest: string,
+  volumePath: string,
+): Effect.Effect<void, ServerLaunchFailed, never> {
+  const dataDir = `${volumePath}/${SERVER_PGLITE_DIR}`;
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.exists(dataDir)),
+    Effect.provide(NodeContext.layer),
+    Effect.orElseSucceed(() => false),
+    Effect.flatMap((present) =>
+      present
+        ? Effect.void
+        : Effect.sleep(Duration.millis(MOUNT_PROBE_POLL_MS)).pipe(
+            Effect.zipRight(Effect.fail("absent")),
+          ),
+    ),
+    Effect.retry({ times: MOUNT_PROBE_ATTEMPTS }),
+    Effect.mapError(() =>
+      serverFailed(
+        digest,
+        `the server's storage directory never appeared at "${dataDir}" although the container is healthy, so the ${SERVER_DATA_MOUNT} bind mount is not shared with this host. Point the run's storage at a directory the container engine shares (engine file-sharing settings), or the transcript drain will find no messages`,
+      ),
+    ),
+  );
 }
 
 function resolveHostPort(
@@ -312,7 +425,7 @@ function provisionObserver(
   return Effect.gen(function* () {
     const minted = yield* mint(server, deps, OBSERVER_IDENTITY);
     const client = new MoltZapAgentClient({
-      serverUrl: server.serverUrl,
+      serverUrl: httpBaseFromServerUrl(server.serverUrl),
       agentKey: minted.apiKey,
     });
     yield* client.connect().pipe(Effect.mapError(observerConnectFailed));

--- a/packages/testbed/src/simulator/launcher-live.ts
+++ b/packages/testbed/src/simulator/launcher-live.ts
@@ -23,8 +23,9 @@ import {
   HttpClient,
 } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { networkInterfaces, platform } from "node:os";
-import { Deferred, Duration, Effect, type Scope } from "effect";
+import { networkInterfaces } from "node:os";
+import { fileURLToPath } from "node:url";
+import { Config, Deferred, Duration, Effect, Schema, type Scope } from "effect";
 import {
   ServerUrl as mintServerUrl,
   type RuntimeServerHandle,
@@ -43,7 +44,11 @@ import {
 } from "./provisioning.js";
 import { makeStubRuntime } from "./stub-runtime.js";
 import { resolveStubScript } from "./stub-scripts.js";
-import type { Agent, AgentFacingRunSpec } from "./run-spec.js";
+import {
+  ImageDigest,
+  type Agent,
+  type AgentFacingRunSpec,
+} from "./run-spec.js";
 import type { MountHandle } from "./environment.js";
 import type {
   LaunchDeps,
@@ -71,8 +76,6 @@ export const SERVER_DATA_MOUNT = "/data";
 export const SERVER_PGLITE_DIR = "pglite";
 
 const SERVER_HEALTH_POLL_MS = 250;
-const MOUNT_PROBE_POLL_MS = 250;
-const MOUNT_PROBE_ATTEMPTS = 40;
 const OBSERVER_IDENTITY = "moltzap-sim-observer";
 const PRESENCE_POLL_MS = 500;
 
@@ -211,40 +214,82 @@ function hostAddresses(): ReadonlySet<string> {
   );
 }
 
-// The engine's bridge topology does not change under a running process,
-// and every attempt would otherwise pay for the same `docker` call.
-let cachedBindHost: string | undefined;
+/**
+ * Build (or re-use) the server image and read back the pin
+ * `ServerSpec.imageDigest` carries. The build script is content-addressed,
+ * so an unchanged workspace re-uses its image; `MOLTZAP_SIM_SERVER_IMAGE`
+ * pins one outright and skips the build.
+ */
+export function resolveServerImagePin(): Effect.Effect<
+  ImageDigest,
+  string,
+  never
+> {
+  return Config.string(SERVER_IMAGE_ENV).pipe(
+    Config.withDefault(""),
+    Effect.orElseSucceed(() => ""),
+    Effect.flatMap((pinned) =>
+      pinned.length > 0
+        ? Schema.decodeUnknown(ImageDigest)(pinned).pipe(
+            Effect.mapError(
+              () =>
+                `${SERVER_IMAGE_ENV}="${pinned}" is not an image digest (sha256:…)`,
+            ),
+          )
+        : buildServerImagePin(),
+    ),
+  );
+}
+
+const SERVER_IMAGE_ENV = "MOLTZAP_SIM_SERVER_IMAGE";
+const IMAGE_BUILD_SCRIPT = fileURLToPath(
+  new URL("../../scripts/build-server-image.mjs", import.meta.url),
+);
+const ImagePinLine = Schema.parseJson(
+  Schema.Struct({ imageDigest: ImageDigest }),
+);
+
+/** The build script prints its pin as the last line of stdout. */
+function buildServerImagePin(): Effect.Effect<ImageDigest, string, never> {
+  return execCapture(["node", IMAGE_BUILD_SCRIPT]).pipe(
+    Effect.mapError(
+      (detail) =>
+        `the server image could not be built: ${detail}. Build it with \`node scripts/build-server-image.mjs\`, or pin one through ${SERVER_IMAGE_ENV}`,
+    ),
+    Effect.flatMap((printed) =>
+      Schema.decodeUnknown(ImagePinLine)(
+        printed.trim().split("\n").at(-1) ?? "",
+      ).pipe(
+        Effect.mapError(
+          (cause) =>
+            `the server image build printed no usable pin: ${cause.message}`,
+        ),
+      ),
+    ),
+    Effect.map((pin) => pin.imageDigest),
+  );
+}
 
 /**
- * Resolve the receiver's bind address for this process. Only a Linux
- * host can own the engine's bridge gateway, so every other host skips
- * the `docker` call and takes loopback; an engine that cannot be
- * interrogated reads the same way, which is the answer for every
- * VM-backed engine.
+ * Ask the engine where the receiver should bind. An engine that cannot
+ * be interrogated — no Docker on the host — reads as loopback, the same
+ * answer every VM-backed engine gets, because the host owns none of the
+ * addresses inside the engine's VM.
  */
 export function resolveReceiverBindHost(): Effect.Effect<string, never, never> {
-  return Effect.suspend(() => {
-    if (cachedBindHost !== undefined) return Effect.succeed(cachedBindHost);
-    if (platform() !== "linux") return Effect.succeed(LOOPBACK_HOST);
-    return execCapture([
-      "docker",
-      "network",
-      "inspect",
-      "bridge",
-      "--format",
-      "{{range .IPAM.Config}}{{.Gateway}} {{end}}",
-    ]).pipe(
-      Effect.map((output) =>
-        pickReceiverBindHost(output.trim().split(/\s+/), hostAddresses()),
-      ),
-      Effect.orElseSucceed(() => LOOPBACK_HOST),
-      Effect.tap((host) =>
-        Effect.sync(() => {
-          cachedBindHost = host;
-        }),
-      ),
-    );
-  });
+  return execCapture([
+    "docker",
+    "network",
+    "inspect",
+    "bridge",
+    "--format",
+    "{{range .IPAM.Config}}{{.Gateway}} {{end}}",
+  ]).pipe(
+    Effect.map((output) =>
+      pickReceiverBindHost(output.trim().split(/\s+/), hostAddresses()),
+    ),
+    Effect.orElseSucceed(() => LOOPBACK_HOST),
+  );
 }
 
 function serverRunArgs(
@@ -308,7 +353,7 @@ function startServerContainer(
     yield* awaitServerHealthy(spec, serverUrl).pipe(
       Effect.mapError((detail) => serverFailed(digest, detail)),
     );
-    yield* verifyStorageMount(digest, volumePath);
+    yield* verifyStorageMount(digest, volumePath, containerId);
     return {
       handle: {
         imageDigest: digest,
@@ -321,36 +366,46 @@ function startServerContainer(
 }
 
 /**
- * The server's own writes are the mount check. The image pins its PGlite
- * directory under the mounted volume, so once health answers, that
- * directory is visible on the host side iff the bind mount really shares
- * bytes. An engine that shares only part of the host filesystem (a VM
- * engine whose mounts do not cover the system temp directory, for one)
- * accepts `--volume` and hands the container a private directory
- * instead; without this check the run proceeds and only the transcript
- * drain notices, after the episode is over.
+ * A file written on the host has to be readable inside the container, or
+ * the bind mount shares nothing. An engine that shares only part of the
+ * host filesystem (a VM engine whose mounts do not cover the system temp
+ * directory, for one) accepts `--volume` and hands the container a
+ * private directory instead; without this check the run proceeds and
+ * only the transcript drain notices, after the episode is over. The probe
+ * is a sentinel rather than the server's own data directory, so it
+ * decides the mount question immediately and stays true for any image.
  */
 function verifyStorageMount(
   digest: string,
   volumePath: string,
+  containerId: string,
 ): Effect.Effect<void, ServerLaunchFailed, never> {
-  const dataDir = `${volumePath}/${SERVER_PGLITE_DIR}`;
+  const sentinel = `.mount-probe-${containerId.slice(0, 12)}`;
   return FileSystem.FileSystem.pipe(
-    Effect.flatMap((fs) => fs.exists(dataDir)),
-    Effect.provide(NodeContext.layer),
-    Effect.orElseSucceed(() => false),
-    Effect.flatMap((present) =>
-      present
-        ? Effect.void
-        : Effect.sleep(Duration.millis(MOUNT_PROBE_POLL_MS)).pipe(
-            Effect.zipRight(Effect.fail("absent")),
-          ),
+    Effect.flatMap((fs) =>
+      fs.writeFileString(`${volumePath}/${sentinel}`, containerId).pipe(
+        Effect.mapError((cause) => String(cause)),
+        Effect.zipRight(
+          execCapture([
+            "docker",
+            "exec",
+            containerId,
+            "test",
+            "-f",
+            `${SERVER_DATA_MOUNT}/${sentinel}`,
+          ]),
+        ),
+        Effect.ensuring(
+          fs.remove(`${volumePath}/${sentinel}`).pipe(Effect.ignore),
+        ),
+      ),
     ),
-    Effect.retry({ times: MOUNT_PROBE_ATTEMPTS }),
+    Effect.provide(NodeContext.layer),
+    Effect.asVoid,
     Effect.mapError(() =>
       serverFailed(
         digest,
-        `the server's storage directory never appeared at "${dataDir}" although the container is healthy, so the ${SERVER_DATA_MOUNT} bind mount is not shared with this host. Point the run's storage at a directory the container engine shares (engine file-sharing settings), or the transcript drain will find no messages`,
+        `a file written to the run's storage directory is not visible at ${SERVER_DATA_MOUNT} inside the container, so the bind mount shares nothing. Point the run's storage at a directory the container engine shares (engine file-sharing settings), or the transcript drain will find no messages`,
       ),
     ),
   );

--- a/packages/testbed/src/simulator/provisioning.ts
+++ b/packages/testbed/src/simulator/provisioning.ts
@@ -30,7 +30,13 @@ export type MintedIdentity = {
   readonly apiKey: AgentKey;
 };
 
-/** Derive the server's HTTP base URL from its WS URL (`ws://h:p/ws` -> `http://h:p`). */
+/**
+ * Derive the server's HTTP base URL from its WS URL (`ws://h:p/ws` ->
+ * `http://h:p`). Both the registration routes and `MoltZapAgentClient`
+ * take this form: a `ServerUrl` carries the `/ws` endpoint path the
+ * package's adapters use, while the client appends `/ws` to whatever
+ * base it is handed, so passing it a `ServerUrl` dials `/ws/ws`.
+ */
 export function httpBaseFromServerUrl(serverUrl: string): string {
   const url = new URL(serverUrl);
   const protocol = url.protocol === "wss:" ? "https:" : "http:";

--- a/packages/testbed/src/simulator/receiver-bind.test.ts
+++ b/packages/testbed/src/simulator/receiver-bind.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @file The receiver bind decision, which is what stands between a live
+ * run and losing every span with no error. Measured on the two engine
+ * shapes: a VM-backed engine keeps its bridge gateway inside the VM and
+ * forwards `host.docker.internal` to host loopback, so loopback is
+ * reachable; a native-Linux engine owns the bridge gateway as a host
+ * address, and there a container reaches that address and not loopback.
+ */
+/* eslint-disable sonarjs/no-hardcoded-ip -- the addresses are the fixture: the decision under test is which address family the host owns */
+import { describe, expect, it } from "vitest";
+import { FastCheck as fc } from "effect";
+import { pickReceiverBindHost } from "./launcher-live.js";
+
+const LOOPBACK = "127.0.0.1";
+const BRIDGE_GATEWAY = "172.17.0.1";
+
+describe("receiver bind host", () => {
+  it("binds the bridge gateway when the host owns it (native-Linux engine)", () => {
+    const addresses = new Set([LOOPBACK, BRIDGE_GATEWAY, "10.0.0.5"]);
+    expect(pickReceiverBindHost([BRIDGE_GATEWAY], addresses)).toBe(
+      BRIDGE_GATEWAY,
+    );
+  });
+
+  it("binds loopback when the gateway lives in the engine's VM", () => {
+    const addresses = new Set([LOOPBACK, "10.0.0.32"]);
+    expect(pickReceiverBindHost([BRIDGE_GATEWAY], addresses)).toBe(LOOPBACK);
+  });
+
+  it("never binds an address this host does not own (property)", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string(), { maxLength: 6 }),
+        fc.array(fc.string(), { maxLength: 6 }),
+        (gateways, owned) => {
+          const addresses = new Set([LOOPBACK, ...owned]);
+          const picked = pickReceiverBindHost(gateways, addresses);
+          // Loopback is always bindable; anything else has to be an
+          // address the engine reported AND the host actually holds,
+          // because the launcher advertises exactly what got bound.
+          expect(
+            picked === LOOPBACK ||
+              (addresses.has(picked) && gateways.includes(picked)),
+          ).toBe(true);
+        },
+      ),
+    );
+  });
+});

--- a/packages/testbed/src/simulator/receiver-bind.test.ts
+++ b/packages/testbed/src/simulator/receiver-bind.test.ts
@@ -1,18 +1,31 @@
 /**
- * @file The receiver bind decision, which is what stands between a live
- * run and losing every span with no error. Measured on the two engine
- * shapes: a VM-backed engine keeps its bridge gateway inside the VM and
- * forwards `host.docker.internal` to host loopback, so loopback is
- * reachable; a native-Linux engine owns the bridge gateway as a host
- * address, and there a container reaches that address and not loopback.
+ * @file The receiver bind decision and the endpoint the container is
+ * handed — together, what stands between a live run and losing every
+ * span with no error. Measured on the two engine shapes: a VM-backed
+ * engine keeps its bridge gateway inside the VM and forwards
+ * `host.docker.internal` to host loopback, so loopback is reachable; a
+ * native-Linux engine owns the bridge gateway as a host address, and
+ * there a container reaches that address and not loopback.
  */
 /* eslint-disable sonarjs/no-hardcoded-ip -- the addresses are the fixture: the decision under test is which address family the host owns */
 import { describe, expect, it } from "vitest";
 import { FastCheck as fc } from "effect";
-import { pickReceiverBindHost } from "./launcher-live.js";
+import {
+  containerReachableEndpoint,
+  pickReceiverBindHost,
+} from "./launcher-live.js";
 
 const LOOPBACK = "127.0.0.1";
 const BRIDGE_GATEWAY = "172.17.0.1";
+const HOST_ALIAS = "host.docker.internal";
+
+/** What the engine reports: addresses the host does not own, then the one it does. */
+function reportedGateways(
+  unowned: ReadonlyArray<string>,
+  owned: string,
+): ReadonlyArray<string> {
+  return [...unowned.filter((value) => value !== owned), owned];
+}
 
 describe("receiver bind host", () => {
   it("binds the bridge gateway when the host owns it (native-Linux engine)", () => {
@@ -45,5 +58,50 @@ describe("receiver bind host", () => {
         },
       ),
     );
+  });
+
+  it("takes the engine's gateway whenever this host owns it (property)", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1 }).filter((value) => value !== LOOPBACK),
+        fc.array(fc.string(), { maxLength: 4 }),
+        // The half a loopback-only implementation fails: an owned gateway
+        // is what the receiver binds, whatever else the engine reported
+        // ahead of it.
+        (gateway, unowned) => {
+          expect(
+            pickReceiverBindHost(
+              reportedGateways(unowned, gateway),
+              new Set([LOOPBACK, gateway]),
+            ),
+          ).toBe(gateway);
+        },
+      ),
+    );
+  });
+});
+
+describe("container-reachable endpoint", () => {
+  it("rewrites a loopback bind to the engine's host alias", () => {
+    expect(
+      containerReachableEndpoint(`http://${LOOPBACK}:4318/v1/traces`),
+    ).toBe(`http://${HOST_ALIAS}:4318/v1/traces`);
+    expect(containerReachableEndpoint("http://localhost:4318/v1/traces")).toBe(
+      `http://${HOST_ALIAS}:4318/v1/traces`,
+    );
+  });
+
+  it("passes a gateway bind through, because that is the address the container dials", () => {
+    expect(
+      containerReachableEndpoint(`http://${BRIDGE_GATEWAY}:4318/v1/traces`),
+    ).toBe(`http://${BRIDGE_GATEWAY}:4318/v1/traces`);
+  });
+
+  it("rewrites the hostname only, never a loopback literal elsewhere", () => {
+    expect(
+      containerReachableEndpoint(
+        `http://${LOOPBACK}:4318/v1/traces?to=${LOOPBACK}`,
+      ),
+    ).toBe(`http://${HOST_ALIAS}:4318/v1/traces?to=${LOOPBACK}`);
   });
 });

--- a/packages/testbed/src/simulator/run-config.ts
+++ b/packages/testbed/src/simulator/run-config.ts
@@ -131,3 +131,12 @@ export interface Launcher {
 export function makeLauncher(): Launcher {
   return makeLauncherLive();
 }
+
+/**
+ * The host address the OTLP receiver binds so the launched container can
+ * export to it. The answer depends on the container engine, which is
+ * this contract's business, but the receiver is created before launch —
+ * so the composition root asks here and passes the endpoint in through
+ * `LaunchDeps.otlpEndpoint`.
+ */
+export { resolveReceiverBindHost } from "./launcher-live.js";

--- a/packages/testbed/src/simulator/run-config.ts
+++ b/packages/testbed/src/simulator/run-config.ts
@@ -133,10 +133,14 @@ export function makeLauncher(): Launcher {
 }
 
 /**
- * The host address the OTLP receiver binds so the launched container can
- * export to it. The answer depends on the container engine, which is
- * this contract's business, but the receiver is created before launch —
- * so the composition root asks here and passes the endpoint in through
- * `LaunchDeps.otlpEndpoint`.
+ * Engine-facing knowledge this contract owns, asked for outside a launch:
+ * the host address the OTLP receiver binds so the launched container can
+ * export to it (the receiver is created before launch, so the composition
+ * root asks here and passes the endpoint in through
+ * `LaunchDeps.otlpEndpoint`), and the pinned server image a spec's
+ * `server.imageDigest` carries.
  */
-export { resolveReceiverBindHost } from "./launcher-live.js";
+export {
+  resolveReceiverBindHost,
+  resolveServerImagePin,
+} from "./launcher-live.js";

--- a/packages/testbed/src/simulator/run-internal.ts
+++ b/packages/testbed/src/simulator/run-internal.ts
@@ -53,7 +53,12 @@ import {
 import { makeWorld, type World } from "./world.js";
 import { makeEnvironment, type Environment } from "./environment.js";
 import type { Principal } from "./episode.js";
-import { makeLauncher, type Launcher, type Society } from "./run-config.js";
+import {
+  makeLauncher,
+  resolveReceiverBindHost,
+  type Launcher,
+  type Society,
+} from "./run-config.js";
 import {
   makeLocalRecordingStore,
   mintSealedFromEvidence,
@@ -340,6 +345,7 @@ function bringUp(
       log,
       failBoundMs: live.spec.timeouts.otlpReceiverFailMs,
       secrets: live.secrets,
+      bindHost: yield* resolveReceiverBindHost(),
     });
     live.receiver = receiver;
     const world = yield* (internals.makeWorld ?? makeWorld)();
@@ -585,13 +591,12 @@ function writeTraces(
   if (live.receiver === undefined) return Effect.succeed(outcome);
   return live.receiver.drainTraces().pipe(
     Effect.tap((traces) =>
-      // Zero spans is legal (a run need not export any) but on the live
-      // tier it is also the signature of an unreachable receiver — the
-      // Linux host-gateway caveat on `containerReachableEndpoint` — so
-      // the seal is loud about it instead of silent.
+      // Zero spans is legal (a run need not export any) but it is also
+      // the signature of a receiver the container cannot reach, so the
+      // seal is loud about it instead of silent.
       traces.spans.length === 0
         ? Effect.logWarning(
-            `run ${live.ref.runId}: no spans were captured; if the server container was expected to export spans, verify OTLP reachability from the container (the receiver binds host loopback; see containerReachableEndpoint)`,
+            `run ${live.ref.runId}: no spans were captured; if the server container was expected to export spans, verify OTLP reachability from the container against the address the receiver bound (see resolveReceiverBindHost)`,
           )
         : Effect.void,
     ),

--- a/packages/testbed/src/simulator/run-internal.ts
+++ b/packages/testbed/src/simulator/run-internal.ts
@@ -93,6 +93,8 @@ export type RunInternals = {
   readonly makeWorld?: typeof makeWorld;
   /** Receiver seam; hermetic tests wrap the real receiver to observe its endpoint or inject stalls. */
   readonly makeReceiver?: typeof makeReceiver;
+  /** Engine-topology seam; a hermetic run has no container to reach it, so it answers loopback without asking Docker. */
+  readonly resolveBindHost?: typeof resolveReceiverBindHost;
   /** Principal seam; hermetic runs stand in for the wire-speaking out-of-band principal. */
   readonly makePrincipal?: typeof makePrincipal;
   /** Attempt-phase notifications; the in-process queue mirrors them into `AttemptSnapshot`s. */
@@ -345,7 +347,7 @@ function bringUp(
       log,
       failBoundMs: live.spec.timeouts.otlpReceiverFailMs,
       secrets: live.secrets,
-      bindHost: yield* resolveReceiverBindHost(),
+      bindHost: yield* (internals.resolveBindHost ?? resolveReceiverBindHost)(),
     });
     live.receiver = receiver;
     const world = yield* (internals.makeWorld ?? makeWorld)();

--- a/packages/testbed/src/simulator/server-image.integration.test.ts
+++ b/packages/testbed/src/simulator/server-image.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @file The execution substrate against a real container: the image
+ * `scripts/build-server-image.mjs` builds, brought up by the live
+ * launcher, with the OTLP receiver bound where the container can reach
+ * it and the transcript drain reading the PGlite directory the image
+ * pins under `/data`. No model keys and no external network: the society
+ * is StubRuntime processes and the traffic is the principal's own
+ * injection, so every assertion here is about the substrate rather than
+ * about agent behavior.
+ *
+ * Gate: `MOLTZAP_SIM_ITEST=1`, and a `TMPDIR` the container engine
+ * shares — a VM-backed engine that does not share the system temp
+ * directory fails the launch's mount check by design.
+ */
+/* eslint-disable sonarjs/assertions-in-tests -- the single entry delegates to `substrateRun`, where every expectation lives; splitting it would boot a second container per assertion */
+// @agent-code-guard/regression-only: one end-to-end execution against a real container; the generative gates for this row live in the hermetic files
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Command, FileSystem } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Config, Effect, Schema } from "effect";
+import { beforeAll, describe, expect, it } from "vitest";
+import { run } from "./episode.js";
+import { decodeEventLine, type SimulatorEvent } from "./event-log.js";
+import { makeLocalRecordingStore } from "./local-store.js";
+import { RunSpec } from "./run-spec.js";
+
+const SIM_INTEGRATION_ENABLED = Effect.runSync(
+  Config.string("MOLTZAP_SIM_ITEST").pipe(
+    Config.withDefault("0"),
+    Config.map((value) => value === "1"),
+  ),
+);
+
+const DELIVERED_SPAN = "moltzap.message.delivered";
+const AGENT = "recipient";
+const PRINCIPAL = "operator";
+const TASK_CONTENT = "substrate check: does this message reach the recording";
+const IMAGE_BUILD_TIMEOUT_MS = 900_000;
+const RUN_TIMEOUT_MS = 300_000;
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+
+const ImagePin = Schema.Struct({ imageDigest: Schema.String });
+
+let imageDigest = "";
+
+/** Build (or re-use) the image and record the pin its script prints. */
+const buildServerImage: Effect.Effect<void, unknown, never> = Command.string(
+  Command.make("node", join(packageRoot, "scripts", "build-server-image.mjs")),
+).pipe(
+  Effect.map((stdout) => stdout.trim().split("\n").at(-1) ?? "{}"),
+  Effect.flatMap(Schema.decodeUnknown(Schema.parseJson(ImagePin))),
+  Effect.map((pin) => {
+    imageDigest = pin.imageDigest;
+  }),
+  Effect.provide(NodeContext.layer),
+  Effect.orDie,
+);
+
+function liveSpec(storeRoot: string): RunSpec {
+  return Schema.decodeUnknownSync(RunSpec)({
+    seed: 1,
+    agents: [
+      {
+        name: AGENT,
+        runtime: { _tag: "stub", config: { script: "quiet" } },
+        runsIn: "host",
+        role: "standard",
+      },
+    ],
+    server: { imageDigest },
+    episode: {
+      task: { principal: PRINCIPAL, to: AGENT, content: TASK_CONTENT },
+      termination: {
+        inactivityTimeoutMs: 60_000,
+        onAgentCrash: "halt",
+        doneSignal: { name: "span-name", config: { name: DELIVERED_SPAN } },
+      },
+    },
+    recording: { storeRoot },
+  });
+}
+
+function eventsOf(
+  lines: ReadonlyArray<unknown>,
+): Effect.Effect<ReadonlyArray<SimulatorEvent>, unknown, never> {
+  return Effect.forEach(
+    lines,
+    (line) => decodeEventLine(JSON.stringify(line)),
+    {
+      concurrency: 1,
+    },
+  );
+}
+
+const substrateRun = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const storeRoot = yield* fs.makeTempDirectory({ prefix: "sim-live-store-" });
+  const sealed = yield* Effect.scoped(run(liveSpec(storeRoot)));
+  expect(sealed.outcome).toMatchObject({
+    _tag: "episode",
+    termination: "completed",
+  });
+
+  const snapshot = yield* makeLocalRecordingStore(storeRoot).read(
+    sealed.recording.path,
+  );
+  expect(snapshot.manifest.serverImageDigest).toBe(imageDigest);
+
+  const events = yield* eventsOf(snapshot.events);
+  // A captured delivery span proves the container reached the receiver:
+  // that export travels container -> host, the half of the wiring no
+  // fixture can stand in for.
+  expect(
+    events.filter(
+      (event) =>
+        event._tag === "span.accepted" && event.spanName === DELIVERED_SPAN,
+    ).length,
+  ).toBeGreaterThan(0);
+  expect(snapshot.traces?.spans.length ?? 0).toBeGreaterThan(0);
+
+  // A drained transcript proves the /data bind mount and the image's
+  // pinned PGlite directory: the drain reads that directory on the host
+  // after the container stops.
+  const transcripts = events.filter(
+    (event) => event._tag === "transcript.message",
+  );
+  expect(JSON.stringify(transcripts)).toContain(TASK_CONTENT);
+}).pipe(Effect.provide(NodeContext.layer), Effect.orDie);
+
+describe.skipIf(!SIM_INTEGRATION_ENABLED)(
+  "simulator execution substrate",
+  () => {
+    beforeAll(
+      () => Effect.runPromise(buildServerImage),
+      IMAGE_BUILD_TIMEOUT_MS,
+    );
+
+    it(
+      "runs a society against the built image and seals span and transcript evidence",
+      () => Effect.runPromise(substrateRun),
+      RUN_TIMEOUT_MS,
+    );
+  },
+);

--- a/packages/testbed/src/simulator/server-image.integration.test.ts
+++ b/packages/testbed/src/simulator/server-image.integration.test.ts
@@ -14,16 +14,21 @@
  */
 /* eslint-disable sonarjs/assertions-in-tests -- the single entry delegates to `substrateRun`, where every expectation lives; splitting it would boot a second container per assertion */
 // @agent-code-guard/regression-only: one end-to-end execution against a real container; the generative gates for this row live in the hermetic files
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { Command, FileSystem } from "@effect/platform";
-import { NodeContext } from "@effect/platform-node";
 import { Config, Effect, Schema } from "effect";
 import { beforeAll, describe, expect, it } from "vitest";
 import { run } from "./episode.js";
-import { decodeEventLine, type SimulatorEvent } from "./event-log.js";
 import { makeLocalRecordingStore } from "./local-store.js";
+import { resolveServerImagePin } from "./run-config.js";
 import { RunSpec } from "./run-spec.js";
+import {
+  AGENT_ONE,
+  PRINCIPAL_NAME,
+  TASK_CONTENT,
+  decodedEvents,
+  specInput,
+  stubAgentInput,
+  tempStoreRoot,
+} from "./__tests__/support.js";
 
 const SIM_INTEGRATION_ENABLED = Effect.runSync(
   Config.string("MOLTZAP_SIM_ITEST").pipe(
@@ -33,82 +38,55 @@ const SIM_INTEGRATION_ENABLED = Effect.runSync(
 );
 
 const DELIVERED_SPAN = "moltzap.message.delivered";
-const AGENT = "recipient";
-const PRINCIPAL = "operator";
-const TASK_CONTENT = "substrate check: does this message reach the recording";
 const IMAGE_BUILD_TIMEOUT_MS = 900_000;
 const RUN_TIMEOUT_MS = 300_000;
-
-const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
-
-const ImagePin = Schema.Struct({ imageDigest: Schema.String });
+const INACTIVITY_MS = 60_000;
 
 let imageDigest = "";
 
-/** Build (or re-use) the image and record the pin its script prints. */
-const buildServerImage: Effect.Effect<void, unknown, never> = Command.string(
-  Command.make("node", join(packageRoot, "scripts", "build-server-image.mjs")),
-).pipe(
-  Effect.map((stdout) => stdout.trim().split("\n").at(-1) ?? "{}"),
-  Effect.flatMap(Schema.decodeUnknown(Schema.parseJson(ImagePin))),
+const buildServerImage = resolveServerImagePin().pipe(
   Effect.map((pin) => {
-    imageDigest = pin.imageDigest;
+    imageDigest = pin;
   }),
-  Effect.provide(NodeContext.layer),
   Effect.orDie,
 );
 
+/** The hermetic spec, re-pointed at the real image and a real delivery span. */
 function liveSpec(storeRoot: string): RunSpec {
-  return Schema.decodeUnknownSync(RunSpec)({
-    seed: 1,
-    agents: [
-      {
-        name: AGENT,
-        runtime: { _tag: "stub", config: { script: "quiet" } },
-        runsIn: "host",
-        role: "standard",
+  return Schema.decodeUnknownSync(RunSpec)(
+    specInput(storeRoot, {
+      seed: 1,
+      agents: [stubAgentInput(AGENT_ONE)],
+      server: { imageDigest },
+      episode: {
+        task: {
+          principal: PRINCIPAL_NAME,
+          to: AGENT_ONE,
+          content: TASK_CONTENT,
+        },
+        termination: {
+          inactivityTimeoutMs: INACTIVITY_MS,
+          onAgentCrash: "halt",
+          doneSignal: { name: "span-name", config: { name: DELIVERED_SPAN } },
+        },
       },
-    ],
-    server: { imageDigest },
-    episode: {
-      task: { principal: PRINCIPAL, to: AGENT, content: TASK_CONTENT },
-      termination: {
-        inactivityTimeoutMs: 60_000,
-        onAgentCrash: "halt",
-        doneSignal: { name: "span-name", config: { name: DELIVERED_SPAN } },
-      },
-    },
-    recording: { storeRoot },
-  });
-}
-
-function eventsOf(
-  lines: ReadonlyArray<unknown>,
-): Effect.Effect<ReadonlyArray<SimulatorEvent>, unknown, never> {
-  return Effect.forEach(
-    lines,
-    (line) => decodeEventLine(JSON.stringify(line)),
-    {
-      concurrency: 1,
-    },
+    }),
   );
 }
 
 const substrateRun = Effect.gen(function* () {
-  const fs = yield* FileSystem.FileSystem;
-  const storeRoot = yield* fs.makeTempDirectory({ prefix: "sim-live-store-" });
+  const storeRoot = yield* tempStoreRoot();
+  const store = makeLocalRecordingStore(storeRoot);
   const sealed = yield* Effect.scoped(run(liveSpec(storeRoot)));
   expect(sealed.outcome).toMatchObject({
     _tag: "episode",
     termination: "completed",
   });
 
-  const snapshot = yield* makeLocalRecordingStore(storeRoot).read(
-    sealed.recording.path,
-  );
+  const snapshot = yield* store.read(sealed.recording.path);
   expect(snapshot.manifest.serverImageDigest).toBe(imageDigest);
 
-  const events = yield* eventsOf(snapshot.events);
+  const events = yield* decodedEvents(snapshot);
   // A captured delivery span proves the container reached the receiver:
   // that export travels container -> host, the half of the wiring no
   // fixture can stand in for.
@@ -127,7 +105,7 @@ const substrateRun = Effect.gen(function* () {
     (event) => event._tag === "transcript.message",
   );
   expect(JSON.stringify(transcripts)).toContain(TASK_CONTENT);
-}).pipe(Effect.provide(NodeContext.layer), Effect.orDie);
+}).pipe(Effect.orDie);
 
 describe.skipIf(!SIM_INTEGRATION_ENABLED)(
   "simulator execution substrate",

--- a/packages/testbed/src/simulator/server-image.integration.test.ts
+++ b/packages/testbed/src/simulator/server-image.integration.test.ts
@@ -21,6 +21,10 @@ import { makeLocalRecordingStore } from "./local-store.js";
 import { resolveServerImagePin } from "./run-config.js";
 import { RunSpec } from "./run-spec.js";
 import {
+  EXCHANGE_SPAN_COUNT,
+  projectRecordedConversation,
+} from "../trace-capture-bundle.js";
+import {
   AGENT_ONE,
   PRINCIPAL_NAME,
   TASK_CONTENT,
@@ -51,12 +55,18 @@ const buildServerImage = resolveServerImagePin().pipe(
   Effect.orDie,
 );
 
-/** The hermetic spec, re-pointed at the real image and a real delivery span. */
+/**
+ * The hermetic spec, re-pointed at the real image and a real delivery
+ * span. The agent answers, and the done-signal counts the same two
+ * deliveries the cc-judge fold counts — the injection reaching the agent
+ * and the agent's answer reaching the principal — so this run is the
+ * evidence that the fold's termination condition is reachable at all.
+ */
 function liveSpec(storeRoot: string): RunSpec {
   return Schema.decodeUnknownSync(RunSpec)(
     specInput(storeRoot, {
       seed: 1,
-      agents: [stubAgentInput(AGENT_ONE)],
+      agents: [stubAgentInput(AGENT_ONE, "echo")],
       server: { imageDigest },
       episode: {
         task: {
@@ -67,7 +77,10 @@ function liveSpec(storeRoot: string): RunSpec {
         termination: {
           inactivityTimeoutMs: INACTIVITY_MS,
           onAgentCrash: "halt",
-          doneSignal: { name: "span-name", config: { name: DELIVERED_SPAN } },
+          doneSignal: {
+            name: "span-name",
+            config: { name: DELIVERED_SPAN, minCount: EXCHANGE_SPAN_COUNT },
+          },
         },
       },
     }),
@@ -105,6 +118,22 @@ const substrateRun = Effect.gen(function* () {
     (event) => event._tag === "transcript.message",
   );
   expect(JSON.stringify(transcripts)).toContain(TASK_CONTENT);
+
+  // The cc-judge fold reads recordings through this projection, so it
+  // runs here over a real one: the target's answer has to come back
+  // attributed to the agent, not to the principal who spoke first.
+  const conversation = yield* projectRecordedConversation({
+    events,
+    targetSlot: AGENT_ONE,
+    principalName: PRINCIPAL_NAME,
+  });
+  expect(conversation.responses.length).toBeGreaterThan(0);
+  expect(
+    conversation.responses.every(
+      (response) => response.senderId === conversation.targetAgentId,
+    ),
+  ).toBe(true);
+  expect(conversation.participants.length).toBeGreaterThan(0);
 }).pipe(Effect.orDie);
 
 describe.skipIf(!SIM_INTEGRATION_ENABLED)(

--- a/packages/testbed/src/simulator/server-image.test.ts
+++ b/packages/testbed/src/simulator/server-image.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @file The per-run server image is pinned by two files, and
+ * `launcher-live.ts` launches against what they say: the container port
+ * it publishes, the `/data` mount it bind-mounts, the PGlite directory
+ * the transcript drain reads under it, the open registration its identity
+ * provisioning needs, and the absent encryption secret that keeps message
+ * content readable at rest. Asserting against the launcher's own
+ * constants is what makes these two files one contract instead of two
+ * copies that drift.
+ */
+// @agent-code-guard/regression-only: the subject is two fixed configuration files, so every assertion is an example by construction; the generative gate for this row lives in receiver-bind.test.ts
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  SERVER_CONTAINER_PORT,
+  SERVER_DATA_MOUNT,
+  SERVER_PGLITE_DIR,
+} from "./launcher-live.js";
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const imageDir = join(packageRoot, "server-image");
+
+const config = readFileSync(join(imageDir, "moltzap.yaml"), "utf8");
+const dockerfile = readFileSync(join(imageDir, "Dockerfile"), "utf8");
+
+/** Config lines with comments and indentation stripped, in file order. */
+const configLines = config
+  .split("\n")
+  .map((line) => line.trim())
+  .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+describe("simulator server image", () => {
+  it("pins the PGlite data directory where the drain reads it", () => {
+    expect(configLines).toContain(
+      `data_dir: ${SERVER_DATA_MOUNT}/${SERVER_PGLITE_DIR}`,
+    );
+    expect(dockerfile).toContain(`VOLUME ["${SERVER_DATA_MOUNT}"]`);
+  });
+
+  it("carries no at-rest encryption secret, so the drain can read messages", () => {
+    expect(configLines.some((line) => line.startsWith("encryption:"))).toBe(
+      false,
+    );
+    expect(configLines.some((line) => line.startsWith("master_secret:"))).toBe(
+      false,
+    );
+  });
+
+  it("leaves registration open, so the launcher can mint per-run identities", () => {
+    expect(configLines.some((line) => line.startsWith("registration:"))).toBe(
+      false,
+    );
+  });
+
+  it("serves the container port the launcher publishes", () => {
+    expect(configLines).toContain(`port: ${String(SERVER_CONTAINER_PORT)}`);
+    expect(dockerfile).toContain(`EXPOSE ${String(SERVER_CONTAINER_PORT)}`);
+  });
+
+  it("runs the @moltzap/server-core bin", () => {
+    expect(dockerfile).toMatch(
+      /^ENTRYPOINT \[.*@moltzap\/server-core\/bin\/moltzap-server.*\]$/m,
+    );
+  });
+});

--- a/packages/testbed/src/simulator/server-image.test.ts
+++ b/packages/testbed/src/simulator/server-image.test.ts
@@ -39,6 +39,18 @@ describe("simulator server image", () => {
     expect(dockerfile).toContain(`VOLUME ["${SERVER_DATA_MOUNT}"]`);
   });
 
+  it("names the boot admin the server requires", () => {
+    // The absence assertions below pass on an empty file; this one does
+    // not, so a gutted config fails the suite instead of reading as
+    // "nothing forbidden is present".
+    const adminUserId = configLines.find((line) =>
+      line.startsWith("admin_user_id:"),
+    );
+    expect(adminUserId).toMatch(
+      /^admin_user_id: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
   it("carries no at-rest encryption secret, so the drain can read messages", () => {
     expect(configLines.some((line) => line.startsWith("encryption:"))).toBe(
       false,

--- a/packages/testbed/src/simulator/stub-runtime.ts
+++ b/packages/testbed/src/simulator/stub-runtime.ts
@@ -27,6 +27,7 @@ import {
   startSupervisedProcess,
 } from "../child-process.js";
 import { SpawnFailed, spawnFailed } from "../errors.js";
+import { httpBaseFromServerUrl } from "./provisioning.js";
 import type { RuntimeExit, SimulatorRuntime } from "./run-config.js";
 
 /** One scripted behavior step; the closed v0 vocabulary. */
@@ -123,7 +124,7 @@ function spawnStub(
 ): Effect.Effect<void, SpawnFailed, never> {
   const command = Command.make(process.execPath, STUB_MAIN_PATH).pipe(
     Command.env({
-      MOLTZAP_STUB_SERVER_URL: input.serverUrl,
+      MOLTZAP_STUB_SERVER_URL: httpBaseFromServerUrl(input.serverUrl),
       MOLTZAP_STUB_AGENT_KEY: Redacted.value(input.apiKey),
       MOLTZAP_STUB_AGENT_NAME: input.agentName,
       MOLTZAP_STUB_SCRIPT: JSON.stringify(

--- a/packages/testbed/src/simulator/stub-scripts.ts
+++ b/packages/testbed/src/simulator/stub-scripts.ts
@@ -12,8 +12,20 @@ const QUIET = new StubScript({
   steps: [],
 });
 
+/**
+ * Answers whatever is said to it. A society of quiet agents produces one
+ * delivered message per injection, which is not enough to exercise a
+ * two-way exchange: the reply is the half that proves delivery spans,
+ * transcript rows, and sender attribution all come back for an agent
+ * rather than only for the principal.
+ */
+const ECHO = new StubScript({
+  name: "echo",
+  steps: [{ _tag: "replyOnMatch", pattern: "", content: "ack" }],
+});
+
 const STUB_SCRIPTS: ReadonlyMap<string, StubScript> = new Map(
-  [QUIET].map((script) => [script.name, script]),
+  [QUIET, ECHO].map((script) => [script.name, script]),
 );
 
 /** Resolve a registered script name; `undefined` drives the config-time rejection. */

--- a/packages/testbed/src/trace-capture-bundle.test.ts
+++ b/packages/testbed/src/trace-capture-bundle.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @file The fold's projection: a sealed recording's events become the
+ * conversation cc-judge grades. Attribution is the load-bearing part —
+ * the target's answers are the graded text, so an id that cannot be
+ * attributed has to read as a broken recording rather than as a short
+ * conversation. Events are decoded through `decodeEventLine`, the same
+ * boundary a grader crosses, so a schema change fails here too.
+ */
+/* eslint-disable sonarjs/assertions-in-tests -- each entry runs one prepared effect whose expectations live beside the recording it projects */
+// @agent-code-guard/regression-only: the subject is attribution over hand-built recordings; each case pins one branch of "who spoke"
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { agentId } from "@moltzap/protocol/testing";
+import {
+  projectRecordedConversation,
+  type RecordedConversation,
+} from "./trace-capture-bundle.js";
+import { decodeEventLine } from "./simulator/index.js";
+
+const RUN_ID = "abcdef012345-s1-a1";
+const TARGET_SLOT = "openclaw-eval-agent";
+const PRINCIPAL_NAME = "eval-sender";
+const CONVERSATION = "conv-1";
+const TARGET_ID = agentId("11111111-1111-4111-8111-111111111111");
+const PRINCIPAL_ID = agentId("22222222-2222-4222-8222-222222222222");
+const ANSWER = "they are task-scoped";
+
+function envelope(sequence: number) {
+  return {
+    runId: RUN_ID,
+    logicalSequence: sequence,
+    logicalTime: sequence,
+    wallTime: 1_700_000_000_000 + sequence,
+  };
+}
+
+function ready(sequence: number, agent: string, id: string): unknown {
+  return {
+    ...envelope(sequence),
+    _tag: "agent.ready",
+    source: "lifecycle",
+    agent,
+    agentId: id,
+  };
+}
+
+function message(
+  sequence: number,
+  senderId: string,
+  text: string,
+  id: string,
+): unknown {
+  return {
+    ...envelope(sequence),
+    _tag: "transcript.message",
+    source: "transcript",
+    conversationId: CONVERSATION,
+    conversationSeq: sequence,
+    senderId,
+    message: { id, parts: [{ type: "text", text }] },
+    createdAtWallTime: 1_700_000_000_000 + sequence,
+  };
+}
+
+/** Decode hand-built lines the way a grader does, then project them. */
+function project(
+  lines: ReadonlyArray<unknown>,
+): Effect.Effect<RecordedConversation | undefined, never, never> {
+  return Effect.forEach(
+    lines,
+    (line) => decodeEventLine(JSON.stringify(line)),
+    { concurrency: 1 },
+  ).pipe(
+    Effect.map((events) =>
+      projectRecordedConversation({
+        events,
+        targetSlot: TARGET_SLOT,
+        principalName: PRINCIPAL_NAME,
+      }),
+    ),
+    Effect.orDie,
+  );
+}
+
+const exchange = [
+  ready(1, TARGET_SLOT, TARGET_ID),
+  message(2, PRINCIPAL_ID, "how do conversations work here?", "m1"),
+  message(3, TARGET_ID, ANSWER, "m2"),
+];
+
+const attributesTheExchange = project(exchange).pipe(
+  Effect.map((projected) => {
+    expect(projected?.targetAgentId).toBe(TARGET_ID);
+    expect(projected?.responses).toEqual([
+      {
+        conversationId: CONVERSATION,
+        senderId: TARGET_ID,
+        text: ANSWER,
+        messageId: "m2",
+      },
+    ]);
+    expect(projected?.participants).toEqual([
+      { id: PRINCIPAL_ID, name: PRINCIPAL_NAME, role: "sender" },
+    ]);
+    expect(
+      projected?.traceEvents.map((event) => event.senderDisplayName),
+    ).toEqual([PRINCIPAL_NAME, TARGET_SLOT]);
+  }),
+);
+
+const refusesWithoutReady = project(exchange.slice(1)).pipe(
+  Effect.map((projected) => {
+    expect(projected).toBeUndefined();
+  }),
+);
+
+const refusesForeignSender = project([
+  ready(1, TARGET_SLOT, TARGET_ID),
+  message(2, "not-an-agent-id", "hello", "m1"),
+]).pipe(
+  Effect.map((projected) => {
+    expect(projected).toBeUndefined();
+  }),
+);
+
+describe("recorded conversation projection", () => {
+  it("attributes the target's answers and names the principal", () =>
+    Effect.runPromise(attributesTheExchange));
+
+  it("refuses a recording whose target slot never reached ready", () =>
+    Effect.runPromise(refusesWithoutReady));
+
+  it("refuses a recording whose sender is not a protocol agent id", () =>
+    Effect.runPromise(refusesForeignSender));
+});

--- a/packages/testbed/src/trace-capture-bundle.test.ts
+++ b/packages/testbed/src/trace-capture-bundle.test.ts
@@ -3,8 +3,9 @@
  * conversation cc-judge grades. Attribution is the load-bearing part —
  * the target's answers are the graded text, so an id that cannot be
  * attributed has to read as a broken recording rather than as a short
- * conversation. Events are decoded through `decodeEventLine`, the same
- * boundary a grader crosses, so a schema change fails here too.
+ * conversation, and each refusal has to name what is broken. Events are
+ * decoded through `decodeEventLine`, the same boundary a grader crosses,
+ * so a schema change fails here too.
  */
 /* eslint-disable sonarjs/assertions-in-tests -- each entry runs one prepared effect whose expectations live beside the recording it projects */
 // @agent-code-guard/regression-only: the subject is attribution over hand-built recordings; each case pins one branch of "who spoke"
@@ -13,9 +14,9 @@ import { describe, expect, it } from "vitest";
 import { agentId } from "@moltzap/protocol/testing";
 import {
   projectRecordedConversation,
-  type RecordedConversation,
+  RecordingUnattributable,
 } from "./trace-capture-bundle.js";
-import { decodeEventLine } from "./simulator/index.js";
+import { decodeEventLine, type RecordingInvalid } from "./simulator/index.js";
 
 const RUN_ID = "abcdef012345-s1-a1";
 const TARGET_SLOT = "openclaw-eval-agent";
@@ -24,6 +25,7 @@ const CONVERSATION = "conv-1";
 const TARGET_ID = agentId("11111111-1111-4111-8111-111111111111");
 const PRINCIPAL_ID = agentId("22222222-2222-4222-8222-222222222222");
 const ANSWER = "they are task-scoped";
+const FOREIGN_SENDER = "not-an-agent-id";
 
 function envelope(sequence: number) {
   return {
@@ -63,19 +65,41 @@ function message(
 }
 
 /** Decode hand-built lines the way a grader does, then project them. */
-function project(
-  lines: ReadonlyArray<unknown>,
-): Effect.Effect<RecordedConversation | undefined, never, never> {
+function project(lines: ReadonlyArray<unknown>) {
   return Effect.forEach(
     lines,
     (line) => decodeEventLine(JSON.stringify(line)),
     { concurrency: 1 },
   ).pipe(
-    Effect.map((events) =>
+    Effect.flatMap((events) =>
       projectRecordedConversation({
         events,
         targetSlot: TARGET_SLOT,
         principalName: PRINCIPAL_NAME,
+      }),
+    ),
+  );
+}
+
+/** Assert the projection refused, and refused for this reason. */
+function expectUnattributable(
+  effect: Effect.Effect<
+    unknown,
+    RecordingUnattributable | RecordingInvalid,
+    never
+  >,
+  expected: RecordingUnattributable,
+): Effect.Effect<void, never, never> {
+  return effect.pipe(
+    Effect.map(() => {
+      expect.unreachable(
+        `the recording must not attribute: ${expected.reason}`,
+      );
+    }),
+    Effect.catchTag("RecordingUnattributable", (cause) =>
+      Effect.sync(() => {
+        expect(cause.reason).toBe(expected.reason);
+        expect(cause.detail).toBe(expected.detail);
       }),
     ),
     Effect.orDie,
@@ -90,8 +114,8 @@ const exchange = [
 
 const attributesTheExchange = project(exchange).pipe(
   Effect.map((projected) => {
-    expect(projected?.targetAgentId).toBe(TARGET_ID);
-    expect(projected?.responses).toEqual([
+    expect(projected.targetAgentId).toBe(TARGET_ID);
+    expect(projected.responses).toEqual([
       {
         conversationId: CONVERSATION,
         senderId: TARGET_ID,
@@ -99,27 +123,32 @@ const attributesTheExchange = project(exchange).pipe(
         messageId: "m2",
       },
     ]);
-    expect(projected?.participants).toEqual([
+    expect(projected.participants).toEqual([
       { id: PRINCIPAL_ID, name: PRINCIPAL_NAME, role: "sender" },
     ]);
     expect(
-      projected?.traceEvents.map((event) => event.senderDisplayName),
+      projected.traceEvents.map((event) => event.senderDisplayName),
     ).toEqual([PRINCIPAL_NAME, TARGET_SLOT]);
   }),
+  Effect.orDie,
 );
 
-const refusesWithoutReady = project(exchange.slice(1)).pipe(
-  Effect.map((projected) => {
-    expect(projected).toBeUndefined();
+const namesTheMissingSlot = expectUnattributable(
+  project(exchange.slice(1)),
+  new RecordingUnattributable({
+    reason: "slot-never-ready",
+    detail: TARGET_SLOT,
   }),
 );
 
-const refusesForeignSender = project([
-  ready(1, TARGET_SLOT, TARGET_ID),
-  message(2, "not-an-agent-id", "hello", "m1"),
-]).pipe(
-  Effect.map((projected) => {
-    expect(projected).toBeUndefined();
+const namesTheForeignSender = expectUnattributable(
+  project([
+    ready(1, TARGET_SLOT, TARGET_ID),
+    message(2, FOREIGN_SENDER, "hello", "m1"),
+  ]),
+  new RecordingUnattributable({
+    reason: "undecodable-agent-id",
+    detail: FOREIGN_SENDER,
   }),
 );
 
@@ -127,9 +156,9 @@ describe("recorded conversation projection", () => {
   it("attributes the target's answers and names the principal", () =>
     Effect.runPromise(attributesTheExchange));
 
-  it("refuses a recording whose target slot never reached ready", () =>
-    Effect.runPromise(refusesWithoutReady));
+  it("names the target slot when it never reached ready", () =>
+    Effect.runPromise(namesTheMissingSlot));
 
-  it("refuses a recording whose sender is not a protocol agent id", () =>
-    Effect.runPromise(refusesForeignSender));
+  it("names the value when a sender is not a protocol agent id", () =>
+    Effect.runPromise(namesTheForeignSender));
 });

--- a/packages/testbed/src/trace-capture-bundle.ts
+++ b/packages/testbed/src/trace-capture-bundle.ts
@@ -40,6 +40,14 @@ export interface ConversationRun {
   readonly responses: ReadonlyArray<ConversationResponse>;
 }
 
+/**
+ * Deliveries in one graded exchange: the principal's injection reaching
+ * the target, then the target's answer reaching the principal. The fold's
+ * done-signal counts them, so a run that never reaches this many
+ * deliveries ends on the inactivity bound with nothing to grade.
+ */
+export const EXCHANGE_SPAN_COUNT = 2;
+
 /** Who spoke, what came back, and the message timeline, read off one recording. */
 export interface RecordedConversation {
   readonly targetAgentId: AgentId;

--- a/packages/testbed/src/trace-capture-bundle.ts
+++ b/packages/testbed/src/trace-capture-bundle.ts
@@ -1,5 +1,7 @@
+import { Option, Schema } from "effect";
 import type { HarnessPayload } from "./trace-capture-payload.js";
-import type { AgentId } from "@moltzap/protocol/identity";
+import { AgentId } from "@moltzap/protocol/identity";
+import type { SimulatorEvent } from "./simulator/index.js";
 
 interface MessagePart {
   readonly type: string;
@@ -20,13 +22,13 @@ export interface TraceCaptureEvent {
   readonly recipientAgentIds: ReadonlyArray<AgentId>;
 }
 
-export interface ConversationParticipant {
+interface ConversationParticipant {
   readonly id: AgentId;
   readonly name: string;
   readonly role: string;
 }
 
-export interface ConversationResponse {
+interface ConversationResponse {
   readonly conversationId: string;
   readonly senderId: AgentId;
   readonly text: string;
@@ -36,6 +38,179 @@ export interface ConversationResponse {
 export interface ConversationRun {
   readonly participants: ReadonlyArray<ConversationParticipant>;
   readonly responses: ReadonlyArray<ConversationResponse>;
+}
+
+/** Who spoke, what came back, and the message timeline, read off one recording. */
+export interface RecordedConversation {
+  readonly targetAgentId: AgentId;
+  readonly participants: ReadonlyArray<ConversationParticipant>;
+  readonly responses: ReadonlyArray<ConversationResponse>;
+  readonly traceEvents: ReadonlyArray<TraceCaptureEvent>;
+}
+
+type TranscriptRow = Extract<
+  SimulatorEvent,
+  { readonly _tag: "transcript.message" }
+>;
+
+/** One recorded message with its sender decoded to the protocol identity. */
+type AttributedRow = {
+  readonly row: TranscriptRow;
+  readonly senderId: AgentId;
+};
+
+const decodeAgentId = Schema.decodeUnknownOption(AgentId);
+
+/**
+ * Project a sealed recording's events onto the bundle shape cc-judge
+ * grades. Sender attribution is the event-log join the recording is
+ * built for: `agent.ready` carries the slot's authenticated agent id,
+ * and every transcript row carries the sender id it maps to. Any sender
+ * that is not a ready slot is the principal, the only other identity a
+ * v0 run mints.
+ *
+ * `undefined` means the recording cannot be attributed — no ready event
+ * for the target slot, or an id that is not a protocol agent id. A
+ * partial attribution would read to a grader as a short conversation
+ * rather than as a broken recording.
+ */
+export function projectRecordedConversation(input: {
+  readonly events: ReadonlyArray<SimulatorEvent>;
+  readonly targetSlot: string;
+  readonly principalName: string;
+}): RecordedConversation | undefined {
+  const slots = new Map<string, AgentId>();
+  for (const event of input.events) {
+    if (event._tag !== "agent.ready") continue;
+    const agentId = Option.getOrUndefined(decodeAgentId(event.agentId));
+    if (agentId === undefined) return undefined;
+    slots.set(event.agent, agentId);
+  }
+  const targetAgentId = slots.get(input.targetSlot);
+  if (targetAgentId === undefined) return undefined;
+
+  const rows = attributedRows(input.events);
+  if (rows === undefined) return undefined;
+
+  const principals = principalSenders(rows, new Set(slots.values()));
+  const namesById = displayNames(slots, principals, input.principalName);
+
+  return {
+    targetAgentId,
+    participants: principals.map((id) => ({
+      id,
+      name: namesById.get(id) ?? id,
+      role: "sender",
+    })),
+    responses: rows
+      .filter((entry) => entry.senderId === targetAgentId)
+      .map(toConversationResponse),
+    traceEvents: rows.map((entry) => toTraceCaptureEvent(entry, namesById)),
+  };
+}
+
+/** Senders that are not a ready slot: the principals of this run, first-seen order. */
+function principalSenders(
+  rows: ReadonlyArray<AttributedRow>,
+  slotIds: ReadonlySet<string>,
+): ReadonlyArray<AgentId> {
+  const seen = new Map<string, AgentId>();
+  for (const entry of rows) {
+    if (slotIds.has(entry.senderId)) continue;
+    seen.set(entry.senderId, entry.senderId);
+  }
+  return [...seen.values()];
+}
+
+function displayNames(
+  slots: ReadonlyMap<string, AgentId>,
+  principals: ReadonlyArray<AgentId>,
+  principalName: string,
+): ReadonlyMap<string, string> {
+  return new Map<string, string>([
+    ...[...slots].map(([slot, id]): readonly [string, string] => [id, slot]),
+    ...principals.map((id, index): readonly [string, string] => [
+      id,
+      principals.length === 1
+        ? principalName
+        : `${principalName}-${String(index + 1)}`,
+    ]),
+  ]);
+}
+
+function attributedRows(
+  events: ReadonlyArray<SimulatorEvent>,
+): ReadonlyArray<AttributedRow> | undefined {
+  const attributed: Array<AttributedRow> = [];
+  for (const event of events) {
+    if (event._tag !== "transcript.message") continue;
+    const senderId = Option.getOrUndefined(decodeAgentId(event.senderId));
+    if (senderId === undefined) return undefined;
+    attributed.push({ row: event, senderId });
+  }
+  return attributed;
+}
+
+/**
+ * The recorded wire message, decoded rather than asserted: the event's
+ * `message` is JSON from disk, so the fields this bundle reads are
+ * checked here and a body that carries neither survives as an empty
+ * message instead of a shape error mid-projection.
+ */
+const RecordedMessageBody = Schema.Struct({
+  id: Schema.optionalWith(Schema.String, { default: () => "" }),
+  parts: Schema.optionalWith(
+    Schema.Array(
+      Schema.Struct({
+        type: Schema.String,
+        text: Schema.optional(Schema.String),
+      }),
+    ),
+    { default: () => [] },
+  ),
+});
+
+function messageBody(row: TranscriptRow): {
+  readonly id: string;
+  readonly parts: ReadonlyArray<MessagePart>;
+} {
+  return Option.getOrElse(
+    Schema.decodeUnknownOption(RecordedMessageBody)(row.message),
+    () => ({ id: "", parts: [] as ReadonlyArray<MessagePart> }),
+  );
+}
+
+function toConversationResponse(entry: AttributedRow): ConversationResponse {
+  const body = messageBody(entry.row);
+  return {
+    conversationId: entry.row.conversationId,
+    senderId: entry.senderId,
+    text: eventText(body.parts),
+    messageId: body.id,
+  };
+}
+
+function toTraceCaptureEvent(
+  entry: AttributedRow,
+  namesById: ReadonlyMap<string, string>,
+): TraceCaptureEvent {
+  const body = messageBody(entry.row);
+  return {
+    _tag: "Message",
+    channelKey: entry.row.conversationId,
+    senderDisplayName: namesById.get(entry.senderId) ?? entry.senderId,
+    message: {
+      senderId: entry.senderId,
+      conversationId: entry.row.conversationId,
+      id: body.id,
+      createdAt: new Date(entry.row.createdAtWallTime).toISOString(),
+      parts: body.parts,
+    },
+    // Storage holds no per-recipient delivery set; delivery evidence
+    // lives in the recording's `moltzap.message.delivered` spans, so the
+    // bundle names no recipient rather than guessing one.
+    recipientAgentIds: [],
+  };
 }
 
 export function buildTraceBundle(input: {

--- a/packages/testbed/src/trace-capture-bundle.ts
+++ b/packages/testbed/src/trace-capture-bundle.ts
@@ -1,4 +1,4 @@
-import { Option, Schema } from "effect";
+import { Data, Effect, Option, Schema } from "effect";
 import type { HarnessPayload } from "./trace-capture-payload.js";
 import { AgentId } from "@moltzap/protocol/identity";
 import type { SimulatorEvent } from "./simulator/index.js";
@@ -53,13 +53,32 @@ type TranscriptRow = Extract<
   { readonly _tag: "transcript.message" }
 >;
 
-/** One recorded message with its sender decoded to the protocol identity. */
+/** One recorded message with its sender and body decoded once. */
 type AttributedRow = {
   readonly row: TranscriptRow;
   readonly senderId: AgentId;
+  readonly body: RecordedMessage;
+};
+
+type RecordedMessage = {
+  readonly id: string;
+  readonly parts: ReadonlyArray<MessagePart>;
 };
 
 const decodeAgentId = Schema.decodeUnknownOption(AgentId);
+
+/**
+ * A recording whose senders cannot be attributed. The two reasons send an
+ * operator to different places: a slot that never reached ready is a run
+ * that never got the target connected, an undecodable id is a recording
+ * that disagrees with the protocol.
+ */
+export class RecordingUnattributable extends Data.TaggedError(
+  "RecordingUnattributable",
+)<{
+  readonly reason: "slot-never-ready" | "undecodable-agent-id";
+  readonly detail: string;
+}> {}
 
 /**
  * Project a sealed recording's events onto the bundle shape cc-judge
@@ -69,44 +88,71 @@ const decodeAgentId = Schema.decodeUnknownOption(AgentId);
  * that is not a ready slot is the principal, the only other identity a
  * v0 run mints.
  *
- * `undefined` means the recording cannot be attributed — no ready event
- * for the target slot, or an id that is not a protocol agent id. A
- * partial attribution would read to a grader as a short conversation
- * rather than as a broken recording.
+ * A refusal is returned whole rather than as a partial conversation,
+ * which a grader would read as a short exchange instead of as a broken
+ * recording.
  */
 export function projectRecordedConversation(input: {
   readonly events: ReadonlyArray<SimulatorEvent>;
   readonly targetSlot: string;
   readonly principalName: string;
-}): RecordedConversation | undefined {
-  const slots = new Map<string, AgentId>();
-  for (const event of input.events) {
-    if (event._tag !== "agent.ready") continue;
-    const agentId = Option.getOrUndefined(decodeAgentId(event.agentId));
-    if (agentId === undefined) return undefined;
-    slots.set(event.agent, agentId);
-  }
-  const targetAgentId = slots.get(input.targetSlot);
-  if (targetAgentId === undefined) return undefined;
+}): Effect.Effect<RecordedConversation, RecordingUnattributable, never> {
+  return Effect.gen(function* () {
+    const slots = yield* readySlots(input.events);
+    const targetAgentId = slots.get(input.targetSlot);
+    if (targetAgentId === undefined) {
+      return yield* Effect.fail(
+        new RecordingUnattributable({
+          reason: "slot-never-ready",
+          detail: input.targetSlot,
+        }),
+      );
+    }
+    const rows = yield* attributedRows(input.events);
+    const principals = principalSenders(rows, new Set(slots.values()));
+    const namesById = displayNames(slots, principals, input.principalName);
+    return {
+      targetAgentId,
+      participants: principals.map((id) => ({
+        id,
+        name: namesById.get(id) ?? id,
+        role: "sender",
+      })),
+      responses: rows
+        .filter((entry) => entry.senderId === targetAgentId)
+        .map(toConversationResponse),
+      traceEvents: rows.map((entry) => toTraceCaptureEvent(entry, namesById)),
+    };
+  }).pipe(Effect.withSpan("projectRecordedConversation"));
+}
 
-  const rows = attributedRows(input.events);
-  if (rows === undefined) return undefined;
+/** Slot name to authenticated agent id, from the run's readiness events. */
+function readySlots(
+  events: ReadonlyArray<SimulatorEvent>,
+): Effect.Effect<ReadonlyMap<string, AgentId>, RecordingUnattributable, never> {
+  return Effect.gen(function* () {
+    const slots = new Map<string, AgentId>();
+    for (const event of events) {
+      if (event._tag !== "agent.ready") continue;
+      slots.set(event.agent, yield* asAgentId(event.agentId));
+    }
+    return slots;
+  });
+}
 
-  const principals = principalSenders(rows, new Set(slots.values()));
-  const namesById = displayNames(slots, principals, input.principalName);
-
-  return {
-    targetAgentId,
-    participants: principals.map((id) => ({
-      id,
-      name: namesById.get(id) ?? id,
-      role: "sender",
-    })),
-    responses: rows
-      .filter((entry) => entry.senderId === targetAgentId)
-      .map(toConversationResponse),
-    traceEvents: rows.map((entry) => toTraceCaptureEvent(entry, namesById)),
-  };
+function asAgentId(
+  value: string,
+): Effect.Effect<AgentId, RecordingUnattributable, never> {
+  return Option.match(decodeAgentId(value), {
+    onNone: () =>
+      Effect.fail(
+        new RecordingUnattributable({
+          reason: "undecodable-agent-id",
+          detail: value,
+        }),
+      ),
+    onSome: Effect.succeed,
+  });
 }
 
 /** Senders that are not a ready slot: the principals of this run, first-seen order. */
@@ -114,12 +160,13 @@ function principalSenders(
   rows: ReadonlyArray<AttributedRow>,
   slotIds: ReadonlySet<string>,
 ): ReadonlyArray<AgentId> {
-  const seen = new Map<string, AgentId>();
-  for (const entry of rows) {
-    if (slotIds.has(entry.senderId)) continue;
-    seen.set(entry.senderId, entry.senderId);
-  }
-  return [...seen.values()];
+  return [
+    ...new Set(
+      rows
+        .filter((entry) => !slotIds.has(entry.senderId))
+        .map((entry) => entry.senderId),
+    ),
+  ];
 }
 
 function displayNames(
@@ -140,15 +187,25 @@ function displayNames(
 
 function attributedRows(
   events: ReadonlyArray<SimulatorEvent>,
-): ReadonlyArray<AttributedRow> | undefined {
-  const attributed: Array<AttributedRow> = [];
-  for (const event of events) {
-    if (event._tag !== "transcript.message") continue;
-    const senderId = Option.getOrUndefined(decodeAgentId(event.senderId));
-    if (senderId === undefined) return undefined;
-    attributed.push({ row: event, senderId });
-  }
-  return attributed;
+): Effect.Effect<ReadonlyArray<AttributedRow>, RecordingUnattributable, never> {
+  return Effect.forEach(
+    events.filter(isTranscriptRow),
+    (event) =>
+      asAgentId(event.senderId).pipe(
+        Effect.map(
+          (senderId): AttributedRow => ({
+            row: event,
+            senderId,
+            body: messageBody(event),
+          }),
+        ),
+      ),
+    { concurrency: 1 },
+  );
+}
+
+function isTranscriptRow(event: SimulatorEvent): event is TranscriptRow {
+  return event._tag === "transcript.message";
 }
 
 /**
@@ -170,10 +227,7 @@ const RecordedMessageBody = Schema.Struct({
   ),
 });
 
-function messageBody(row: TranscriptRow): {
-  readonly id: string;
-  readonly parts: ReadonlyArray<MessagePart>;
-} {
+function messageBody(row: TranscriptRow): RecordedMessage {
   return Option.getOrElse(
     Schema.decodeUnknownOption(RecordedMessageBody)(row.message),
     () => ({ id: "", parts: [] as ReadonlyArray<MessagePart> }),
@@ -181,7 +235,7 @@ function messageBody(row: TranscriptRow): {
 }
 
 function toConversationResponse(entry: AttributedRow): ConversationResponse {
-  const body = messageBody(entry.row);
+  const body = entry.body;
   return {
     conversationId: entry.row.conversationId,
     senderId: entry.senderId,
@@ -194,7 +248,7 @@ function toTraceCaptureEvent(
   entry: AttributedRow,
   namesById: ReadonlyMap<string, string>,
 ): TraceCaptureEvent {
-  const body = messageBody(entry.row);
+  const body = entry.body;
   return {
     _tag: "Message",
     channelKey: entry.row.conversationId,

--- a/packages/testbed/src/trace-capture-harness.ts
+++ b/packages/testbed/src/trace-capture-harness.ts
@@ -22,6 +22,7 @@ import {
 } from "./trace-capture-payload.js";
 import {
   buildTraceBundle,
+  EXCHANGE_SPAN_COUNT,
   projectRecordedConversation,
   RecordingUnattributable,
   type RecordedConversation,
@@ -41,8 +42,6 @@ const PLAN_TARGET_AGENT_ID = "target-agent";
 const PLACEHOLDER_IMAGE = "managed/by-moltzap-trace-capture";
 const PRINCIPAL_NAME = "eval-sender";
 const DELIVERED_SPAN = "moltzap.message.delivered";
-/** The injection delivered to the target, then the target's answer delivered back. */
-const EXCHANGE_SPAN_COUNT = 2;
 
 class ExecutionFailed extends Data.TaggedError("ExecutionFailed")<{
   readonly message: string;

--- a/packages/testbed/src/trace-capture-harness.ts
+++ b/packages/testbed/src/trace-capture-harness.ts
@@ -1,10 +1,21 @@
-import { Path } from "@effect/platform";
-import type * as ClientTestUtils from "@moltzap/client/test-utils";
-import { Data, Duration, Effect, Fiber, Option, Stream } from "effect";
-import type * as ServerTestUtils from "@moltzap/server-core/test-utils";
-import { startRuntimeAgent, type RuntimeKind } from "./testbed.js";
-import { RuntimeReadyTimedOut, SpawnFailed } from "./errors.js";
-import type { Runtime } from "./runtime.js";
+/**
+ * @file The cc-judge compat adapter: the entry point cc-judge loads from
+ * `dist/trace-capture-harness.js`, unchanged in shape (`load(args)`
+ * returning a plan, a harness, and a coordinator), executing on the
+ * simulator. A scenario's harness payload becomes a `RunSpec`, `run`
+ * produces a sealed recording, and the bundle cc-judge grades is
+ * projected from that recording's events — so capture is the recording's
+ * job rather than this file's.
+ *
+ * The scenario file and cc-judge's loader stay byte-unchanged; that
+ * compatibility is coverage path 24a.
+ */
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Command, FileSystem } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Config, Data, Duration, Effect, Schema } from "effect";
+import type { RuntimeKind } from "./testbed.js";
 import {
   decodePayload,
   InvalidPayload,
@@ -12,47 +23,27 @@ import {
 } from "./trace-capture-payload.js";
 import {
   buildTraceBundle,
-  type ConversationParticipant,
-  type ConversationResponse,
-  type ConversationRun,
-  type TraceCaptureEvent,
+  projectRecordedConversation,
+  type RecordedConversation,
 } from "./trace-capture-bundle.js";
-
-import type { AgentId, AgentKey } from "@moltzap/protocol/identity";
 import {
-  MessageReceivedNotificationDefinition,
-  MessagesSend,
-} from "@moltzap/protocol/message";
-import {
-  DEFAULT_APP_ID,
-  TaskRequest,
-  type TaskId,
-} from "@moltzap/protocol/task";
-import type { ConversationId } from "@moltzap/protocol/conversation";
+  decodeEventLine,
+  run,
+  RunSpec,
+  type SealedAttempt,
+  type SimulatorEvent,
+} from "./simulator/index.js";
 
 const DEFAULT_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_RESPONSE_TIMEOUT_MS = 120_000;
-const DEFAULT_GROUP_NAME = "cc-judge-group";
 const PLAN_TARGET_AGENT_ID = "target-agent";
 const PLACEHOLDER_IMAGE = "managed/by-moltzap-trace-capture";
-
-interface RuntimeCrypto {
-  readonly randomUUID?: () => string;
-}
-
-let activeRun = false;
-
-class WorkspacePackagesDirNotFound extends Data.TaggedError(
-  "WorkspacePackagesDirNotFound",
-)<{
-  readonly message: string;
-}> {}
-
-class ActiveTraceCaptureRunExists extends Data.TaggedError(
-  "ActiveTraceCaptureRunExists",
-)<{
-  readonly message: string;
-}> {}
+const PRINCIPAL_NAME = "eval-sender";
+const DELIVERED_SPAN = "moltzap.message.delivered";
+/** The injection delivered to the target, then the target's answer delivered back. */
+const EXCHANGE_SPAN_COUNT = 2;
+const SERVER_IMAGE_ENV = "MOLTZAP_SIM_SERVER_IMAGE";
+const IMAGE_BUILD_TIMEOUT_MS = 900_000;
 
 class ExecutionFailed extends Data.TaggedError("ExecutionFailed")<{
   readonly message: string;
@@ -62,16 +53,7 @@ class HarnessFailed extends Data.TaggedError("HarnessFailed")<{
   readonly detail: ExecutionFailed;
 }> {}
 
-class ContainerStartFailed extends Data.TaggedError("ContainerStartFailed")<{
-  readonly message: string;
-}> {}
-
-class AgentStartFailed extends Data.TaggedError("AgentStartFailed")<{
-  readonly agentId: AgentId;
-  readonly detail: ContainerStartFailed;
-}> {}
-
-type HarnessFailureCause = InvalidPayload | HarnessFailed | AgentStartFailed;
+type HarnessFailureCause = InvalidPayload | HarnessFailed;
 
 interface HarnessFailure {
   readonly cause: HarnessFailureCause;
@@ -90,132 +72,10 @@ interface HarnessLoadArgs {
   readonly payload: unknown;
 }
 
-interface MessagePart {
-  readonly type: string;
-  readonly text?: string;
-}
-
-// Type-only namespaces keep the dynamic loaders aligned with their published
-// test surfaces without introducing client or server runtime imports.
-type ClientTestModule = typeof ClientTestUtils;
-type HarnessClient = ClientTestUtils.HarnessAgentClient;
-type ServerTestModule = typeof ServerTestUtils;
-type CoreTestServer = ServerTestUtils.CoreTestServer;
-
-interface ConnectedActor {
-  readonly agentId: AgentId;
-  readonly name: string;
-  readonly client: HarnessClient;
-}
-
-interface ConversationExecutionState {
-  readonly sender: ConnectedActor;
-  readonly closers: Array<HarnessClient>;
-  readonly participants: Array<ConversationParticipant>;
-  readonly responses: Array<ConversationResponse>;
-}
-
 function failHarness(message: string): HarnessFailure {
   return {
-    cause: new HarnessFailed({
-      detail: new ExecutionFailed({ message }),
-    }),
+    cause: new HarnessFailed({ detail: new ExecutionFailed({ message }) }),
   };
-}
-
-function failAgentStart(
-  agentId: AgentId,
-  detail: ContainerStartFailed,
-): HarnessFailure {
-  return {
-    cause: new AgentStartFailed({
-      agentId,
-      detail,
-    }),
-  };
-}
-
-function isHarnessFailure(error: unknown): error is HarnessFailure {
-  if (typeof error !== "object" || error === null || !("cause" in error)) {
-    return false;
-  }
-  return isHarnessFailureCause(error.cause);
-}
-
-function isHarnessFailureCause(cause: unknown): cause is HarnessFailureCause {
-  return (
-    cause instanceof InvalidPayload ||
-    cause instanceof HarnessFailed ||
-    cause instanceof AgentStartFailed
-  );
-}
-
-function asHarnessFailure(error: unknown): HarnessFailure {
-  if (isHarnessFailure(error)) return error;
-  return failHarness(error instanceof Error ? error.message : String(error));
-}
-
-function packagesDir(): string {
-  return Effect.runSync(
-    Effect.gen(function* () {
-      const path = yield* Path.Path;
-      const here = yield* path.fromFileUrl(new URL(import.meta.url));
-      let current = path.dirname(here);
-      while (current !== path.parse(current).root) {
-        if (path.basename(current) === "packages") {
-          return current;
-        }
-        current = path.dirname(current);
-      }
-      return yield* Effect.fail(
-        new WorkspacePackagesDirNotFound({
-          message: "Unable to resolve workspace packages directory",
-        }),
-      );
-    }).pipe(Effect.provide(Path.layer), Effect.orDie),
-  );
-}
-
-function packageModuleUrl(...segments: ReadonlyArray<string>): string {
-  return Effect.runSync(
-    Effect.gen(function* () {
-      const path = yield* Path.Path;
-      const url = yield* path.toFileUrl(path.join(packagesDir(), ...segments));
-      return url.href;
-    }).pipe(Effect.provide(Path.layer), Effect.orDie),
-  );
-}
-
-function randomRunId(): Effect.Effect<string, HarnessFailure> {
-  const crypto = (globalThis as { readonly crypto?: RuntimeCrypto }).crypto;
-  if (crypto?.randomUUID === undefined) {
-    return Effect.fail(
-      failHarness("Runtime crypto.randomUUID is not available"),
-    );
-  }
-  return Effect.sync(() => crypto.randomUUID!());
-}
-
-function loadClientTestModule(): Effect.Effect<ClientTestModule, Error, never> {
-  return Effect.tryPromise({
-    try: () =>
-      import(
-        packageModuleUrl("client", "dist", "test-utils", "index.js")
-      ) as Promise<ClientTestModule>,
-    catch: (error) =>
-      error instanceof Error ? error : new Error(String(error)),
-  });
-}
-
-function loadServerTestModule(): Effect.Effect<ServerTestModule, Error, never> {
-  return Effect.tryPromise({
-    try: () =>
-      import(
-        packageModuleUrl("server", "dist", "test-utils", "index.js")
-      ) as Promise<ServerTestModule>,
-    catch: (error) =>
-      error instanceof Error ? error : new Error(String(error)),
-  });
 }
 
 function defaultTargetAgentName(kind: RuntimeKind): string {
@@ -227,742 +87,273 @@ function defaultTargetAgentName(kind: RuntimeKind): string {
   }
 }
 
-const CLIENT_CLOSE_TIMEOUT_MS = 5_000;
-
-// Bounded: a close that hangs (half-dead socket) must degrade to a leaked
-// connection warning, never wedge the run's unwind chain.
-function closeClient(client: HarnessClient): Effect.Effect<void, never, never> {
-  return client.close().pipe(
-    Effect.timeout(Duration.millis(CLIENT_CLOSE_TIMEOUT_MS)),
-    Effect.orElseSucceed(() => undefined),
+function targetAgentName(payload: HarnessPayload): string {
+  return (
+    payload.runtime.targetAgentName ??
+    defaultTargetAgentName(payload.runtime.kind)
   );
 }
 
-function extractTextFromEvent(data: {
-  readonly message: { readonly parts: ReadonlyArray<MessagePart> };
-}): string {
-  return data.message.parts
-    .filter(
-      (part): part is MessagePart & { readonly text: string } =>
-        part.type === "text" && typeof part.text === "string",
-    )
-    .map((part) => part.text)
-    .join("\n");
+// ---------------------------------------------------------------------------
+// Payload -> RunSpec
+// ---------------------------------------------------------------------------
+
+const ImagePin = Schema.Struct({ imageDigest: Schema.String });
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/**
+ * The pinned server image a run needs. An operator can pin one through
+ * `MOLTZAP_SIM_SERVER_IMAGE`; otherwise the build script produces it and
+ * prints the pin, re-using the image whenever the workspace is unchanged.
+ */
+function resolveServerImage(): Effect.Effect<string, HarnessFailure, never> {
+  return Effect.gen(function* () {
+    const pinned = yield* Config.string(SERVER_IMAGE_ENV).pipe(
+      Config.withDefault(""),
+      Effect.orElseSucceed(() => ""),
+    );
+    if (pinned.length > 0) return pinned;
+    const printed = yield* Command.string(
+      Command.make(
+        "node",
+        join(packageRoot, "scripts", "build-server-image.mjs"),
+      ),
+    ).pipe(
+      Effect.timeout(Duration.millis(IMAGE_BUILD_TIMEOUT_MS)),
+      Effect.mapError((cause) =>
+        failHarness(
+          `The simulator server image could not be built: ${String(cause)}. Build it with \`node scripts/build-server-image.mjs\`, or pin one through ${SERVER_IMAGE_ENV}.`,
+        ),
+      ),
+    );
+    const pin = yield* Schema.decodeUnknown(Schema.parseJson(ImagePin))(
+      printed.trim().split("\n").at(-1) ?? "",
+    ).pipe(
+      Effect.mapError((cause) =>
+        failHarness(
+          `The server image build printed no usable pin: ${cause.message}`,
+        ),
+      ),
+    );
+    return pin.imageDigest;
+  }).pipe(Effect.provide(NodeContext.layer));
 }
 
 /**
- * Spec B (#596) Goal #7 disposition (a): subscribe BEFORE triggering.
- * Builds the typed Stream of `MessageReceivedNotificationDefinition`
- * payloads filtered to the target sender/conversation pair, takes the
- * first head, and times out with a harness-shaped failure.
- *
- * The reference to `MIN_EVENT_WAIT_MS` from the prior poll-loop shape is
- * dropped — `Stream.runHead` does not poll, it suspends until either a
- * matching frame arrives or the timeout fires.
+ * A v0 run carries one principal injection into one conversation, so a
+ * payload that speaks more than once, or to more than the target, has no
+ * spec. The refusal names the shape instead of running a scenario whose
+ * later messages would never be spoken.
  */
-function waitForTargetResponseStream(input: {
-  readonly client: HarnessClient;
-  readonly targetAgentId: AgentId;
-  readonly conversationId: ConversationId;
-  readonly timeoutMs: number;
-}): Effect.Effect<ConversationResponse, HarnessFailure, never> {
-  return input.client
-    .subscribe(
-      MessageReceivedNotificationDefinition,
-      (params) =>
-        params.message.senderId === input.targetAgentId &&
-        params.message.conversationId === input.conversationId,
-    )
-    .pipe(
-      Stream.runHead,
-      Effect.timeoutFail({
-        duration: Duration.millis(input.timeoutMs),
-        onTimeout: () =>
-          failHarness(
-            `timed out waiting for ${input.targetAgentId} in conversation ${input.conversationId}`,
-          ),
-      }),
-      Effect.flatMap(
-        Option.match({
-          onNone: () =>
-            Effect.fail(
-              failHarness(
-                `notification stream closed before ${input.targetAgentId} response arrived`,
-              ),
-            ),
-          onSome: (data) => {
-            return Effect.succeed({
-              conversationId: data.message.conversationId,
-              senderId: data.message.senderId,
-              text: extractTextFromEvent(data),
-              messageId: data.message.id,
-            } satisfies ConversationResponse);
-          },
-        }),
-      ),
-      Effect.catchAll((error) =>
-        Effect.fail(
-          error instanceof Error ? failHarness(error.message) : error,
-        ),
-      ),
-    );
+function unsupportedShape(payload: HarnessPayload): string | undefined {
+  if (payload.conversation.kind !== "direct") {
+    return `a "${payload.conversation.kind}" conversation needs participants beyond the target`;
+  }
+  if (payload.conversation.followUpMessages.length > 0) {
+    return `${String(payload.conversation.followUpMessages.length)} follow-up message(s) need more than one principal injection`;
+  }
+  return undefined;
 }
 
-function sendMessageAndWait(input: {
-  readonly sender: ConnectedActor;
-  readonly targetAgentId: AgentId;
-  readonly taskId: TaskId;
-  readonly conversationId: ConversationId;
-  readonly message: string;
-  readonly timeoutMs: number | undefined;
-}): Effect.Effect<ConversationResponse, HarnessFailure, never> {
-  return Effect.gen(function* () {
-    // Spec B (#596) Goal #7 disposition (a): fork the response-listener
-    // Stream BEFORE the trigger RPC.
-    const responseFiber = yield* Effect.fork(
-      waitForTargetResponseStream({
-        client: input.sender.client,
-        targetAgentId: input.targetAgentId,
-        conversationId: input.conversationId,
-        timeoutMs: input.timeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS,
-      }),
-    );
-    yield* input.sender.client
-      .sendRpc(MessagesSend, {
-        taskId: input.taskId,
-        conversationId: input.conversationId,
-        parts: [{ type: "text", text: input.message }],
-      })
-      .pipe(
-        Effect.mapError((error) => failHarness(error.message)),
-        Effect.onError(() => Fiber.interrupt(responseFiber)),
-      );
-    return yield* Fiber.join(responseFiber);
-  });
+function runtimeAssignment(runtime: HarnessPayload["runtime"]): unknown {
+  // Harness runs create fresh conversations with no pre-provisioned
+  // NanoClaw registration, so that runtime has to accept them on delivery.
+  return runtime.kind === "nanoclaw"
+    ? { _tag: "nanoclaw", config: { autoRegisterConversations: true } }
+    : { _tag: "openclaw", config: {} };
 }
 
-function registerConnectedAgent(
-  clientModule: ClientTestModule,
-  baseUrl: string,
-  name: string,
-): Effect.Effect<ConnectedActor, HarnessFailure, never> {
-  return clientModule.registerAndConnect(baseUrl, name).pipe(
-    Effect.map((connected) => ({
-      agentId: connected.agentId,
-      name,
-      client: connected.client,
-    })),
-    Effect.mapError((error) => failHarness(error.message)),
-  );
-}
-
-interface TaskScope {
-  readonly taskId: TaskId;
-  readonly conversationId: ConversationId;
-}
-
-function createDirectConversation(
-  sender: ConnectedActor,
-  targetAgentId: AgentId,
-): Effect.Effect<TaskScope, HarnessFailure, never> {
-  return sender.client
-    .sendRpc(TaskRequest, {
-      appId: DEFAULT_APP_ID,
-      invitedAgentIds: [targetAgentId],
-      initialConversation: { participants: [targetAgentId] },
-    })
-    .pipe(
-      Effect.mapError((error) => failHarness(error.message)),
-      Effect.flatMap((result) =>
-        result.conversation
-          ? Effect.succeed({
-              taskId: result.task.id,
-              conversationId: result.conversation.id,
-            })
-          : Effect.fail(
-              failHarness("TaskRequest returned null initial conversation"),
-            ),
-      ),
-    );
-}
-
-function createGroupConversation(input: {
-  readonly sender: ConnectedActor;
-  readonly targetAgentId: AgentId;
-  readonly groupName: string;
-  readonly participants: ReadonlyArray<ConnectedActor>;
-}): Effect.Effect<TaskScope, HarnessFailure, never> {
-  const invited = [
-    input.targetAgentId,
-    ...input.participants.map((p) => p.agentId),
-  ];
-  return input.sender.client
-    .sendRpc(TaskRequest, {
-      appId: DEFAULT_APP_ID,
-      invitedAgentIds: invited,
-      initialConversation: { participants: invited },
-    })
-    .pipe(
-      Effect.mapError((error) => failHarness(error.message)),
-      Effect.flatMap((result) =>
-        result.conversation
-          ? Effect.succeed({
-              taskId: result.task.id,
-              conversationId: result.conversation.id,
-            })
-          : Effect.fail(
-              failHarness("TaskRequest returned null initial conversation"),
-            ),
-      ),
-    );
-}
-
-function createConversationState(
-  sender: ConnectedActor,
-): ConversationExecutionState {
+function encodedSpec(input: {
+  readonly payload: HarnessPayload;
+  readonly imageDigest: string;
+  readonly storeRoot: string;
+}): unknown {
+  const runtime = input.payload.runtime;
+  const target = targetAgentName(input.payload);
   return {
-    sender,
-    closers: [sender.client],
-    participants: [{ id: sender.agentId, name: sender.name, role: "sender" }],
-    responses: [],
+    seed: 1,
+    agents: [
+      {
+        name: target,
+        runtime: runtimeAssignment(runtime),
+        runsIn: "host",
+        role: "standard",
+      },
+    ],
+    server: { imageDigest: input.imageDigest },
+    episode: {
+      task: {
+        principal: PRINCIPAL_NAME,
+        to: target,
+        content: input.payload.conversation.setupMessage,
+      },
+      termination: {
+        inactivityTimeoutMs:
+          runtime.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS,
+        onAgentCrash: "halt",
+        // One injection and one answer: counting deliveries is safe on a
+        // single-injection spec, where nothing later can be pre-empted.
+        doneSignal: {
+          name: "span-name",
+          config: { name: DELIVERED_SPAN, minCount: EXCHANGE_SPAN_COUNT },
+        },
+      },
+    },
+    timeouts: {
+      readyTimeoutMs: runtime.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+    },
+    recording: { storeRoot: input.storeRoot },
   };
 }
 
-// Concurrent: the clients are independent sockets, and serial closes would
-// stack the per-close timeout into an N x 5s worst-case unwind.
-function closeConversationClients(
-  clients: ReadonlyArray<HarnessClient>,
-): Effect.Effect<void, never, never> {
-  return Effect.forEach(clients, closeClient, {
-    concurrency: clients.length,
-    discard: true,
-  });
-}
-
-function executeConversationKind(
-  input: {
-    readonly payload: HarnessPayload;
-    readonly baseUrl: string;
-    readonly targetAgentId: AgentId;
-    readonly clientModule: ClientTestModule;
-  },
-  state: ConversationExecutionState,
-): Effect.Effect<void, HarnessFailure, never> {
-  switch (input.payload.conversation.kind) {
-    case "direct":
-      return executeDirectConversation(input, state);
-    case "group":
-      return executeGroupConversation(input, state);
-    case "cross":
-      return executeCrossConversation(input, state);
+function specFor(input: {
+  readonly payload: HarnessPayload;
+  readonly imageDigest: string;
+  readonly storeRoot: string;
+}): Effect.Effect<RunSpec, HarnessFailure, never> {
+  const unsupported = unsupportedShape(input.payload);
+  if (unsupported !== undefined) {
+    return Effect.fail(
+      failHarness(
+        `This scenario is not expressible as a simulator run: ${unsupported}. The simulator's episode contract carries one principal injection per run.`,
+      ),
+    );
   }
+  return Schema.decodeUnknown(RunSpec)(encodedSpec(input)).pipe(
+    Effect.mapError((cause) =>
+      failHarness(`The scenario's run spec was rejected: ${cause.message}`),
+    ),
+  );
 }
 
-function executeDirectConversation(
-  input: {
-    readonly payload: HarnessPayload;
-    readonly targetAgentId: AgentId;
-  },
-  state: ConversationExecutionState,
-) {
-  return Effect.gen(function* () {
-    const scope = yield* createDirectConversation(
-      state.sender,
-      input.targetAgentId,
-    );
-    yield* sendSetupAndFollowUps({
-      state,
-      sender: state.sender,
-      targetAgentId: input.targetAgentId,
-      scope,
-      setupMessage: input.payload.conversation.setupMessage,
-      followUpMessages: input.payload.conversation.followUpMessages,
-      timeoutMs: input.payload.runtime.responseTimeoutMs,
-    });
-  });
+// ---------------------------------------------------------------------------
+// Recording -> bundle
+// ---------------------------------------------------------------------------
+
+function readRecordedEvents(
+  sealed: SealedAttempt,
+): Effect.Effect<ReadonlyArray<SimulatorEvent>, HarnessFailure, never> {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) =>
+      fs.readFileString(join(sealed.recording.path, "events.ndjson")),
+    ),
+    Effect.mapError((cause) =>
+      failHarness(`The sealed recording could not be read: ${String(cause)}`),
+    ),
+    Effect.flatMap(decodeEventLines),
+    Effect.provide(NodeContext.layer),
+  );
 }
 
-function executeGroupConversation(
-  input: {
-    readonly payload: HarnessPayload;
-    readonly baseUrl: string;
-    readonly targetAgentId: AgentId;
-    readonly clientModule: ClientTestModule;
-  },
-  state: ConversationExecutionState,
-) {
-  return Effect.gen(function* () {
-    if (input.payload.conversation.kind !== "group") {
-      return;
-    }
-    const bystanders = yield* registerBystanders(input, state);
-    const scope = yield* createGroupConversation({
-      sender: state.sender,
-      targetAgentId: input.targetAgentId,
-      groupName: input.payload.conversation.groupName ?? DEFAULT_GROUP_NAME,
-      participants: bystanders.map((entry) => entry.actor),
-    });
-    yield* sendBystanderMessages(
-      bystanders,
-      input.targetAgentId,
-      scope,
-      input.payload.runtime.responseTimeoutMs,
-    );
-    yield* sendSetupAndFollowUps({
-      state,
-      sender: state.sender,
-      targetAgentId: input.targetAgentId,
-      scope,
-      setupMessage: input.payload.conversation.setupMessage,
-      followUpMessages: input.payload.conversation.followUpMessages,
-      timeoutMs: input.payload.runtime.responseTimeoutMs,
-    });
-  });
-}
-
-function executeCrossConversation(
-  input: {
-    readonly payload: HarnessPayload;
-    readonly baseUrl: string;
-    readonly targetAgentId: AgentId;
-    readonly clientModule: ClientTestModule;
-  },
-  state: ConversationExecutionState,
-) {
-  return Effect.gen(function* () {
-    if (input.payload.conversation.kind !== "cross") {
-      return;
-    }
-    const firstScope = yield* createDirectConversation(
-      state.sender,
-      input.targetAgentId,
-    );
-    yield* sendSetupAndFollowUps({
-      state,
-      sender: state.sender,
-      targetAgentId: input.targetAgentId,
-      scope: firstScope,
-      setupMessage: input.payload.conversation.setupMessage,
-      followUpMessages: input.payload.conversation.followUpMessages,
-      timeoutMs: input.payload.runtime.responseTimeoutMs,
-    });
-    const probeSender = yield* registerProbeSender(input, state);
-    const secondScope = yield* createDirectConversation(
-      probeSender,
-      input.targetAgentId,
-    );
-    state.responses.push(
-      yield* sendMessageAndWait({
-        sender: probeSender,
-        targetAgentId: input.targetAgentId,
-        taskId: secondScope.taskId,
-        conversationId: secondScope.conversationId,
-        message: input.payload.conversation.probeMessage,
-        timeoutMs: input.payload.runtime.responseTimeoutMs,
-      }),
-    );
-  });
-}
-
-function registerBystanders(
-  input: {
-    readonly payload: HarnessPayload;
-    readonly baseUrl: string;
-    readonly clientModule: ClientTestModule;
-  },
-  state: ConversationExecutionState,
-) {
-  if (input.payload.conversation.kind !== "group") {
-    return Effect.succeed([]);
-  }
+function decodeEventLines(
+  text: string,
+): Effect.Effect<ReadonlyArray<SimulatorEvent>, HarnessFailure, never> {
   return Effect.forEach(
-    input.payload.conversation.bystanders,
-    (entry) =>
-      registerConnectedAgent(
-        input.clientModule,
-        input.baseUrl,
-        entry.name,
-      ).pipe(
-        Effect.tap((actor) =>
-          Effect.sync(() => {
-            state.closers.push(actor.client);
-            state.participants.push({
-              id: actor.agentId,
-              name: actor.name,
-              role: "bystander",
-            });
-          }),
+    text.split("\n").filter((line) => line.trim().length > 0),
+    (line) =>
+      decodeEventLine(line).pipe(
+        Effect.mapError((cause) =>
+          failHarness(
+            `The recording holds an undecodable event: ${cause.message}`,
+          ),
         ),
-        Effect.map((actor) => ({ actor, messages: entry.messages })),
       ),
     { concurrency: 1 },
   );
 }
 
-function registerProbeSender(
-  input: {
-    readonly payload: HarnessPayload;
-    readonly baseUrl: string;
-    readonly clientModule: ClientTestModule;
-  },
-  state: ConversationExecutionState,
-) {
-  const name =
-    input.payload.conversation.kind === "cross"
-      ? (input.payload.conversation.probeSenderName ?? "eval-probe-sender")
-      : "eval-probe-sender";
-  return registerConnectedAgent(input.clientModule, input.baseUrl, name).pipe(
-    Effect.tap((actor) =>
-      Effect.sync(() => {
-        state.closers.push(actor.client);
-        state.participants.push({
-          id: actor.agentId,
-          name: actor.name,
-          role: "probe",
-        });
-      }),
-    ),
-  );
+function projectOrFail(
+  events: ReadonlyArray<SimulatorEvent>,
+  payload: HarnessPayload,
+): Effect.Effect<RecordedConversation, HarnessFailure, never> {
+  const projected = projectRecordedConversation({
+    events,
+    targetSlot: targetAgentName(payload),
+    principalName: PRINCIPAL_NAME,
+  });
+  return projected === undefined
+    ? Effect.fail(
+        failHarness(
+          `The recording holds no launch event for "${targetAgentName(payload)}", so no transcript can be attributed to the target agent.`,
+        ),
+      )
+    : Effect.succeed(projected);
 }
 
-function sendSetupAndFollowUps(input: {
-  readonly state: ConversationExecutionState;
-  readonly sender: ConnectedActor;
-  readonly targetAgentId: AgentId;
-  readonly scope: TaskScope;
-  readonly setupMessage: string;
-  readonly followUpMessages: ReadonlyArray<string>;
-  readonly timeoutMs: number | undefined;
-}) {
-  return Effect.gen(function* () {
-    input.state.responses.push(
-      yield* sendMessageAndWait({
-        sender: input.sender,
-        targetAgentId: input.targetAgentId,
-        taskId: input.scope.taskId,
-        conversationId: input.scope.conversationId,
-        message: input.setupMessage,
-        timeoutMs: input.timeoutMs,
-      }),
-    );
-    for (const followUp of input.followUpMessages) {
-      input.state.responses.push(
-        yield* sendMessageAndWait({
-          sender: input.sender,
-          targetAgentId: input.targetAgentId,
-          taskId: input.scope.taskId,
-          conversationId: input.scope.conversationId,
-          message: followUp,
-          timeoutMs: input.timeoutMs,
-        }),
+function outcomeFailure(sealed: SealedAttempt): HarnessFailure | undefined {
+  const outcome = sealed.outcome;
+  switch (outcome._tag) {
+    case "episode":
+      return outcome.termination === "completed"
+        ? undefined
+        : failHarness(
+            `The run ended "${outcome.termination}" rather than completing; the recording at ${sealed.recording.path} holds what was captured.`,
+          );
+    case "infrastructure-failure":
+      return failHarness(
+        `The run failed with ${outcome.errorTag}: ${outcome.errorMessage}`,
       );
-    }
-  });
-}
-
-function sendBystanderMessages(
-  bystanders: ReadonlyArray<{
-    readonly actor: ConnectedActor;
-    readonly messages: ReadonlyArray<string>;
-  }>,
-  targetAgentId: AgentId,
-  scope: TaskScope,
-  responseTimeoutMs: number | undefined,
-) {
-  return Effect.forEach(
-    bystanders,
-    (bystander) =>
-      Effect.forEach(
-        bystander.messages,
-        (message) =>
-          sendMessageAndWait({
-            sender: bystander.actor,
-            targetAgentId,
-            taskId: scope.taskId,
-            conversationId: scope.conversationId,
-            message,
-            timeoutMs: responseTimeoutMs,
-          }),
-        { concurrency: 1, discard: true },
-      ),
-    { concurrency: 1, discard: true },
-  );
-}
-
-function executeConversationPlan(input: {
-  readonly payload: HarnessPayload;
-  readonly baseUrl: string;
-  readonly targetAgentId: AgentId;
-  readonly clientModule: ClientTestModule;
-}): Effect.Effect<ConversationRun, HarnessFailure, never> {
-  return Effect.gen(function* () {
-    const sender = yield* registerConnectedAgent(
-      input.clientModule,
-      input.baseUrl,
-      input.payload.conversation.senderName ?? "eval-sender",
-    );
-    const state = createConversationState(sender);
-
-    // Cleanup MUST be Effect.ensuring, not a gen-body try/finally: on the
-    // failure path Effect.gen never resumes the generator, so a finally's
-    // `yield*` silently never executes — the leaked client sockets then
-    // hang the server close and wedge the caller forever (#791). The
-    // suspend defers reading `closers`, which fills during execution.
-    yield* executeConversationKind(input, state).pipe(
-      Effect.ensuring(
-        Effect.suspend(() => closeConversationClients(state.closers)),
-      ),
-    );
-    return {
-      participants: state.participants,
-      responses: state.responses,
-    };
-  });
-}
-
-function withExclusiveRun<A, E>(
-  effect: Effect.Effect<A, E, never>,
-): Effect.Effect<A, E | HarnessFailure, never> {
-  return Effect.try({
-    try: () => {
-      if (activeRun) {
-        throw new ActiveTraceCaptureRunExists({
-          message:
-            "MoltZap trace-capture harness only supports one active run at a time",
-        });
-      }
-      activeRun = true;
-    },
-    catch: (error) =>
-      failHarness(error instanceof Error ? error.message : String(error)),
-  }).pipe(
-    Effect.zipRight(effect),
-    Effect.ensuring(
-      Effect.sync(() => {
-        activeRun = false;
-      }),
-    ),
-  );
-}
-
-interface TargetAgentRegistration {
-  readonly agentId: AgentId;
-  readonly apiKey: AgentKey;
-  readonly agentName: string;
-}
-
-function startCoreTraceServer(
-  serverTestModule: ServerTestModule,
-): Effect.Effect<CoreTestServer, HarnessFailure> {
-  return Effect.tryPromise({
-    try: () => serverTestModule.startCoreTestServer({}),
-    catch: (error) =>
-      failHarness(error instanceof Error ? error.message : String(error)),
-  });
-}
-
-function loadHarnessClientModule(): Effect.Effect<
-  ClientTestModule,
-  HarnessFailure
-> {
-  return loadClientTestModule().pipe(
-    Effect.mapError((error) =>
-      failHarness(error instanceof Error ? error.message : String(error)),
-    ),
-  );
-}
-
-function registerTargetAgent(input: {
-  readonly clientModule: ClientTestModule;
-  readonly baseUrl: string;
-  readonly targetAgentName: string;
-}): Effect.Effect<TargetAgentRegistration, HarnessFailure> {
-  return input.clientModule
-    .registerAgent(input.baseUrl, input.targetAgentName)
-    .pipe(
-      Effect.map((registered) => ({
-        agentId: registered.agentId,
-        apiKey: registered.apiKey,
-        agentName: input.targetAgentName,
-      })),
-      Effect.mapError((error) => failHarness(error.message)),
-    );
-}
-
-function mapRuntimeStartError(
-  error: unknown,
-  agentId: AgentId,
-): HarnessFailure {
-  if (error instanceof SpawnFailed) {
-    return failAgentStart(
-      agentId,
-      new ContainerStartFailed({ message: error.message }),
-    );
   }
-  if (error instanceof RuntimeReadyTimedOut) {
-    return failAgentStart(
-      agentId,
-      new ContainerStartFailed({
-        message: `runtime did not authenticate within ${String(error.timeoutMs)}ms`,
-      }),
-    );
-  }
-  const exited = error as { readonly stderr?: unknown };
-  return failAgentStart(
-    agentId,
-    new ContainerStartFailed({
-      message: `runtime exited before readiness: ${String(exited.stderr)}`,
-    }),
-  );
 }
 
-function startHarnessRuntime(input: {
-  readonly payload: HarnessPayload;
-  readonly server: CoreTestServer;
-  readonly targetAgent: TargetAgentRegistration;
-  readonly clientModule: ClientTestModule;
-}) {
-  // Harness runs create fresh conversations with no pre-provisioned NanoClaw
-  // registration, so the disposable eval runtime must accept them on delivery.
-  const runtimeSelection =
-    input.payload.runtime.kind === "nanoclaw"
-      ? ({
-          kind: "nanoclaw",
-          nanoclaw: { autoRegisterConversations: true },
-        } as const)
-      : ({ kind: "openclaw" } as const);
-  return startRuntimeAgent({
-    ...runtimeSelection,
-    server: input.server.runtimeServer,
-    readyTimeoutMs:
-      input.payload.runtime.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
-    agent: {
-      agentName: input.targetAgent.agentName,
-      apiKey: input.targetAgent.apiKey,
-      agentId: input.targetAgent.agentId,
-      serverUrl: input.clientModule.stripWsPath(input.server.wsUrl),
-    },
-  }).pipe(
-    Effect.mapError((error) =>
-      mapRuntimeStartError(error, input.targetAgent.agentId),
+// ---------------------------------------------------------------------------
+// Coordinator
+// ---------------------------------------------------------------------------
+
+function recordingRoot(): Effect.Effect<string, HarnessFailure, never> {
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) =>
+      fs.makeTempDirectory({ prefix: "moltzap-trace-capture-" }),
     ),
-  );
-}
-
-const SERVER_STOP_TIMEOUT_MS = 15_000;
-
-// Bounded like every other finalizer in the unwind chain: app.close() waits
-// for connection drain, so a socket that survived client close and runtime
-// teardown must degrade to a leak warning instead of wedging the caller.
-function stopCoreTraceServer(
-  serverTestModule: ServerTestModule,
-): Effect.Effect<void> {
-  return Effect.tryPromise({
-    try: () => Promise.resolve(serverTestModule.stopCoreTestServer()),
-    catch: (error) =>
-      error instanceof Error ? error : new Error(String(error)),
-  }).pipe(
-    Effect.timeout(Duration.millis(SERVER_STOP_TIMEOUT_MS)),
-    Effect.catchAll(() =>
-      Effect.logWarning(
-        "core test server did not stop within the bound; abandoning close",
-      ),
+    Effect.mapError((cause) =>
+      failHarness(`No recording directory could be created: ${String(cause)}`),
     ),
+    Effect.provide(NodeContext.layer),
   );
 }
 
-function executeTraceRun(input: {
+function executeThroughSimulator(input: {
   readonly sourcePath: string;
   readonly payload: HarnessPayload;
   readonly plan: HarnessLoadArgs["plan"];
   readonly runId: string | undefined;
-  readonly server: CoreTestServer;
-  readonly clientModule: ClientTestModule;
-  readonly targetAgent: TargetAgentRegistration;
-  readonly runtime: Runtime;
-  readonly runtimeStartedAt: string;
 }): Effect.Effect<Readonly<Record<string, unknown>>, HarnessFailure, never> {
-  const teardown = input.runtime.teardown();
   return Effect.gen(function* () {
-    const conversationRun = yield* executeConversationPlan({
+    const imageDigest = yield* resolveServerImage();
+    const storeRoot = yield* recordingRoot();
+    const spec = yield* specFor({
       payload: input.payload,
-      baseUrl: input.server.baseUrl,
-      targetAgentId: input.targetAgent.agentId,
-      clientModule: input.clientModule,
+      imageDigest,
+      storeRoot,
     });
-    // TODO: read finished OTel spans from `server.spanExporter` and map
-    // `moltzap.message.delivered` spans to `TraceCaptureEvent`. The
-    // server-side custom `TraceCapture` was removed; arena's harness
-    // needs its own OTel→TraceCaptureEvent mapping. Bundles are empty
-    // until that's wired.
-    //
-    // Note: spans carry message-shape metadata only (part/text counts and
-    // lengths), NOT message body plaintext — the server redacts body text
-    // from telemetry. A future mapping that needs the actual message text
-    // must obtain it through a non-telemetry path, not from these spans.
-    const traceEvents: readonly TraceCaptureEvent[] = [];
-    const runId = input.runId ?? (yield* randomRunId());
+    const runtimeStartedAt = new Date().toISOString();
+    const sealed = yield* Effect.scoped(run(spec)).pipe(
+      Effect.mapError((cause) =>
+        failHarness(`The simulator run failed: ${cause.message}`),
+      ),
+    );
+    const failure = outcomeFailure(sealed);
+    if (failure !== undefined) return yield* Effect.fail(failure);
+    const conversation = yield* projectOrFail(
+      yield* readRecordedEvents(sealed),
+      input.payload,
+    );
     return buildTraceBundle({
       sourcePath: input.sourcePath,
       payload: input.payload,
       plan: input.plan,
-      runId,
-      targetAgent: input.targetAgent,
-      runtimeStartedAt: input.runtimeStartedAt,
-      traceEvents,
-      conversationRun,
-    });
-  }).pipe(Effect.ensuring(teardown));
-}
-
-function executeCoordinatorRun(input: {
-  readonly sourcePath: string;
-  readonly payload: HarnessPayload;
-  readonly plan: HarnessLoadArgs["plan"];
-  readonly runId: string | undefined;
-}) {
-  return Effect.gen(function* () {
-    const serverTestModule = yield* loadServerTestModule();
-    const server = yield* startCoreTraceServer(serverTestModule);
-    return yield* executeWithCoreServer(input, server).pipe(
-      Effect.ensuring(stopCoreTraceServer(serverTestModule)),
-    );
-  });
-}
-
-function executeWithCoreServer(
-  input: {
-    readonly sourcePath: string;
-    readonly payload: HarnessPayload;
-    readonly plan: HarnessLoadArgs["plan"];
-    readonly runId: string | undefined;
-  },
-  server: CoreTestServer,
-) {
-  return Effect.gen(function* () {
-    const clientModule = yield* loadHarnessClientModule();
-    const targetAgentName =
-      input.payload.runtime.targetAgentName ??
-      defaultTargetAgentName(input.payload.runtime.kind);
-    const targetAgent = yield* registerTargetAgent({
-      clientModule,
-      baseUrl: server.baseUrl,
-      targetAgentName,
-    });
-    const runtimeStartedAt = new Date().toISOString();
-    const runtime = yield* startHarnessRuntime({
-      payload: input.payload,
-      server,
-      targetAgent,
-      clientModule,
-    });
-    return yield* executeTraceRun({
-      ...input,
-      server,
-      clientModule,
-      targetAgent,
-      runtime,
+      runId: input.runId ?? sealed.recording.runId,
+      targetAgent: {
+        agentId: conversation.targetAgentId,
+        agentName: targetAgentName(input.payload),
+      },
       runtimeStartedAt,
+      traceEvents: conversation.traceEvents,
+      conversationRun: {
+        participants: conversation.participants,
+        responses: conversation.responses,
+      },
     });
   });
 }
@@ -974,14 +365,12 @@ function createCoordinator(sourcePath: string, payload: HarnessPayload) {
       _harness: unknown,
       opts: { readonly runId?: string } = {},
     ): Effect.Effect<Readonly<Record<string, unknown>>, HarnessFailure, never> {
-      return withExclusiveRun(
-        executeCoordinatorRun({
-          sourcePath,
-          payload,
-          plan,
-          runId: opts.runId,
-        }),
-      ).pipe(Effect.mapError(asHarnessFailure));
+      return executeThroughSimulator({
+        sourcePath,
+        payload,
+        plan,
+        runId: opts.runId,
+      });
     },
   };
 }
@@ -1026,9 +415,7 @@ function buildHarnessPlan(args: HarnessLoadArgs, payload: HarnessPayload) {
 function targetAgentPlan(payload: HarnessPayload) {
   return {
     id: PLAN_TARGET_AGENT_ID,
-    name:
-      payload.runtime.targetAgentName ??
-      defaultTargetAgentName(payload.runtime.kind),
+    name: targetAgentName(payload),
     role: "target",
     artifact: {
       _tag: "DockerImageArtifact",
@@ -1045,7 +432,6 @@ function targetAgentPlan(payload: HarnessPayload) {
 const traceCaptureHarness = {
   load(args: HarnessLoadArgs) {
     return decodePayload(args.sourcePath, args.payload).pipe(
-      Effect.mapError(asHarnessFailure),
       Effect.map((payload) => buildHarnessLoadResult(args, payload)),
     );
   },

--- a/packages/testbed/src/trace-capture-harness.ts
+++ b/packages/testbed/src/trace-capture-harness.ts
@@ -10,11 +10,10 @@
  * The scenario file and cc-judge's loader stay byte-unchanged; that
  * compatibility is coverage path 24a.
  */
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { Command, FileSystem } from "@effect/platform";
+import { join } from "node:path";
+import { FileSystem } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { Config, Data, Duration, Effect, Schema } from "effect";
+import { Data, Effect, Schema } from "effect";
 import type { RuntimeKind } from "./testbed.js";
 import {
   decodePayload,
@@ -24,6 +23,7 @@ import {
 import {
   buildTraceBundle,
   projectRecordedConversation,
+  RecordingUnattributable,
   type RecordedConversation,
 } from "./trace-capture-bundle.js";
 import {
@@ -33,6 +33,7 @@ import {
   type SealedAttempt,
   type SimulatorEvent,
 } from "./simulator/index.js";
+import { resolveServerImagePin } from "./simulator/run-config.js";
 
 const DEFAULT_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_RESPONSE_TIMEOUT_MS = 120_000;
@@ -42,8 +43,6 @@ const PRINCIPAL_NAME = "eval-sender";
 const DELIVERED_SPAN = "moltzap.message.delivered";
 /** The injection delivered to the target, then the target's answer delivered back. */
 const EXCHANGE_SPAN_COUNT = 2;
-const SERVER_IMAGE_ENV = "MOLTZAP_SIM_SERVER_IMAGE";
-const IMAGE_BUILD_TIMEOUT_MS = 900_000;
 
 class ExecutionFailed extends Data.TaggedError("ExecutionFailed")<{
   readonly message: string;
@@ -98,53 +97,28 @@ function targetAgentName(payload: HarnessPayload): string {
 // Payload -> RunSpec
 // ---------------------------------------------------------------------------
 
-const ImagePin = Schema.Struct({ imageDigest: Schema.String });
-
-const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
-
 /**
- * The pinned server image a run needs. An operator can pin one through
- * `MOLTZAP_SIM_SERVER_IMAGE`; otherwise the build script produces it and
- * prints the pin, re-using the image whenever the workspace is unchanged.
+ * The pinned server image a run needs. Building it once per process is
+ * enough: the script is content-addressed, so a second grade of the same
+ * workspace would re-derive the same digest at full cost.
  */
-function resolveServerImage(): Effect.Effect<string, HarnessFailure, never> {
-  return Effect.gen(function* () {
-    const pinned = yield* Config.string(SERVER_IMAGE_ENV).pipe(
-      Config.withDefault(""),
-      Effect.orElseSucceed(() => ""),
-    );
-    if (pinned.length > 0) return pinned;
-    const printed = yield* Command.string(
-      Command.make(
-        "node",
-        join(packageRoot, "scripts", "build-server-image.mjs"),
-      ),
-    ).pipe(
-      Effect.timeout(Duration.millis(IMAGE_BUILD_TIMEOUT_MS)),
-      Effect.mapError((cause) =>
-        failHarness(
-          `The simulator server image could not be built: ${String(cause)}. Build it with \`node scripts/build-server-image.mjs\`, or pin one through ${SERVER_IMAGE_ENV}.`,
+const serverImagePin: Effect.Effect<string, HarnessFailure, never> =
+  Effect.runSync(
+    Effect.cached(
+      resolveServerImagePin().pipe(
+        Effect.mapError((detail) =>
+          failHarness(`The run has no server image: ${detail}.`),
         ),
       ),
-    );
-    const pin = yield* Schema.decodeUnknown(Schema.parseJson(ImagePin))(
-      printed.trim().split("\n").at(-1) ?? "",
-    ).pipe(
-      Effect.mapError((cause) =>
-        failHarness(
-          `The server image build printed no usable pin: ${cause.message}`,
-        ),
-      ),
-    );
-    return pin.imageDigest;
-  }).pipe(Effect.provide(NodeContext.layer));
-}
+    ),
+  );
 
 /**
- * A v0 run carries one principal injection into one conversation, so a
- * payload that speaks more than once, or to more than the target, has no
- * spec. The refusal names the shape instead of running a scenario whose
- * later messages would never be spoken.
+ * The v0 principal speaks once, into one conversation, so a payload that
+ * speaks more than once or to more than the target has no run spec. The
+ * refusal names the shape instead of running a scenario whose later
+ * messages would never be spoken; the shapes return with a principal
+ * driver that speaks more than once, not by deleting this check.
  */
 function unsupportedShape(payload: HarnessPayload): string | undefined {
   if (payload.conversation.kind !== "direct") {
@@ -212,14 +186,6 @@ function specFor(input: {
   readonly imageDigest: string;
   readonly storeRoot: string;
 }): Effect.Effect<RunSpec, HarnessFailure, never> {
-  const unsupported = unsupportedShape(input.payload);
-  if (unsupported !== undefined) {
-    return Effect.fail(
-      failHarness(
-        `This scenario is not expressible as a simulator run: ${unsupported}. The simulator's episode contract carries one principal injection per run.`,
-      ),
-    );
-  }
   return Schema.decodeUnknown(RunSpec)(encodedSpec(input)).pipe(
     Effect.mapError((cause) =>
       failHarness(`The scenario's run spec was rejected: ${cause.message}`),
@@ -267,18 +233,22 @@ function projectOrFail(
   events: ReadonlyArray<SimulatorEvent>,
   payload: HarnessPayload,
 ): Effect.Effect<RecordedConversation, HarnessFailure, never> {
-  const projected = projectRecordedConversation({
+  return projectRecordedConversation({
     events,
     targetSlot: targetAgentName(payload),
     principalName: PRINCIPAL_NAME,
-  });
-  return projected === undefined
-    ? Effect.fail(
-        failHarness(
-          `The recording holds no launch event for "${targetAgentName(payload)}", so no transcript can be attributed to the target agent.`,
-        ),
-      )
-    : Effect.succeed(projected);
+  }).pipe(
+    Effect.mapError((cause) => failHarness(unattributableMessage(cause))),
+  );
+}
+
+function unattributableMessage(cause: RecordingUnattributable): string {
+  switch (cause.reason) {
+    case "slot-never-ready":
+      return `The recording holds no readiness event for "${cause.detail}", so no transcript can be attributed to the target agent.`;
+    case "undecodable-agent-id":
+      return `The recording carries "${cause.detail}" where the protocol expects an agent id, so its senders cannot be attributed.`;
+  }
 }
 
 function outcomeFailure(sealed: SealedAttempt): HarnessFailure | undefined {
@@ -320,7 +290,7 @@ function executeThroughSimulator(input: {
   readonly runId: string | undefined;
 }): Effect.Effect<Readonly<Record<string, unknown>>, HarnessFailure, never> {
   return Effect.gen(function* () {
-    const imageDigest = yield* resolveServerImage();
+    const imageDigest = yield* serverImagePin;
     const storeRoot = yield* recordingRoot();
     const spec = yield* specFor({
       payload: input.payload,
@@ -432,9 +402,26 @@ function targetAgentPlan(payload: HarnessPayload) {
 const traceCaptureHarness = {
   load(args: HarnessLoadArgs) {
     return decodePayload(args.sourcePath, args.payload).pipe(
+      // A scenario this fold cannot run must not produce a plan; refusing
+      // at load is where cc-judge reports it as a scenario problem rather
+      // than as a run that died halfway.
+      Effect.flatMap((payload) => runnableShape(payload)),
       Effect.map((payload) => buildHarnessLoadResult(args, payload)),
     );
   },
 };
+
+function runnableShape(
+  payload: HarnessPayload,
+): Effect.Effect<HarnessPayload, HarnessFailure, never> {
+  const unsupported = unsupportedShape(payload);
+  return unsupported === undefined
+    ? Effect.succeed(payload)
+    : Effect.fail(
+        failHarness(
+          `This scenario is not expressible as a simulator run: ${unsupported}. The default out-of-band principal speaks once per run.`,
+        ),
+      );
+}
 
 export default traceCaptureHarness;

--- a/packages/testbed/src/trace-capture-harness.ts
+++ b/packages/testbed/src/trace-capture-harness.ts
@@ -100,7 +100,9 @@ function targetAgentName(payload: HarnessPayload): string {
 /**
  * The pinned server image a run needs. Building it once per process is
  * enough: the script is content-addressed, so a second grade of the same
- * workspace would re-derive the same digest at full cost.
+ * workspace re-derives the same digest at full cost. A failure caches
+ * too, which is what a suite wants — the next scenario would meet the
+ * same engine, and rebuilding to fail again costs minutes per scenario.
  */
 const serverImagePin: Effect.Effect<string, HarnessFailure, never> =
   Effect.runSync(

--- a/packages/testbed/src/trace-capture-payload.ts
+++ b/packages/testbed/src/trace-capture-payload.ts
@@ -77,7 +77,8 @@ type BystanderCandidate = {
   readonly messages?: unknown;
 };
 
-interface InvalidPayloadFailure {
+/** The failure shape cc-judge receives when a scenario's payload does not decode. */
+export interface InvalidPayloadFailure {
   readonly cause: InvalidPayload;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,12 +332,6 @@ importers:
         specifier: 2026.6.33
         version: 2026.6.33(@cfworker/json-schema@4.1.1)
     devDependencies:
-      '@moltzap/client':
-        specifier: workspace:*
-        version: link:../client
-      '@moltzap/server-core':
-        specifier: workspace:*
-        version: link:../server
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0


### PR DESCRIPTION
Closes #819
Architect plan: https://github.com/chughtapan/moltzap/issues/812 (row 5a bullet under "Implementation tiers and sequencing")
Base: `staff/818-simulator-impl` (PR #825), not `main` — the diff is row 5a only.

## What changed

The simulator can execute a real run. `packages/testbed/server-image/` plus
`scripts/build-server-image.mjs` build the per-run server image from the
workspace `@moltzap/server-core` bin and print the `sha256:` pin a `RunSpec`'s
`server.imageDigest` carries; the launcher brings that image up per run,
verifies its `/data` bind mount, and points the container's span export at a
receiver bound where the container can actually reach it. The cc-judge entry
point keeps its published shape and now executes on the simulator, projecting
the bundle it grades out of the sealed recording.

## Plan anchors

| Change | Plan anchor |
|---|---|
| `server-image/Dockerfile`, `server-image/moltzap.yaml`, `scripts/build-server-image.mjs` | row 5a "server image build + pinning"; §2 row-5 file paths (`scripts/build-server-image.mjs` + `server-image/Dockerfile`, nanoclaw-install machinery pattern) |
| `makeReceiver` takes `bindHost`; `pickReceiverBindHost` / `resolveReceiverBindHost` in `launcher-live.ts`; wired at `run-internal.ts → bringUp` | row 5a "the OTLP receiver, including the bind strategy for native-Linux container reachability" |
| `verifyStorageMount` at launch (host sentinel, `docker exec test -f`); `SERVER_DATA_MOUNT` / `SERVER_PGLITE_DIR` pinned and asserted against the image config | row 5a "the PGlite data-dir path pinned under the image's `/data`" |
| `httpBaseFromServerUrl` at the three protocol-client constructions (observer, principal, StubRuntime env) | row 5a "the simulator brings it up per run" — the live launch path #825 ledgered as unverified |
| `trace-capture-harness.ts` executes `run` and drops its in-process server; `projectRecordedConversation` in `trace-capture-bundle.ts` | row 5a "the trace-capture fold + cc-judge compat adapter"; §2 "Trace-capture fold (5A)" |
| coverage entry 24a + `__tests__/cc-judge-fixture.ts` | row 5a "path **24a** hermetic CRITICAL"; §7.2 path-24 tier split |
| path 14 gains the bind-mount-source assertion | row 5a "container-level `modelId` and mount verification" (hermetic half) |
| `server-image.integration.test.ts` | row 5a live verification; §7.2 "hermetic = no model keys, no external network, Docker present" |

## Evidence: the substrate executes

`MOLTZAP_SIM_ITEST=1 pnpm exec vitest run --config vitest.integration.config.ts src/simulator/server-image.integration.test.ts`
passes on a real engine: the image builds, the container comes up, the mount
check passes, a StubRuntime society launches, the principal speaks, the agent
answers, the server exports both `moltzap.message.delivered` spans, the
done-signal fires on the same count the cc-judge fold uses, the post-stop drain
reads the exchange out of `/data/pglite`, and the fold's own projection
attributes the answer to the agent. No model keys, no external network.

Three findings only a live run could produce:

1. **`Command.string` returns stdout for a failing process.** Every check built
   on it was inert: the storage-mount probe passed on a container that never saw
   the file, and a failed `docker stop` reported a clean teardown. The helper now
   drains both pipes concurrently with the exit and fails on a non-zero code.
   Measured after the fix: pointing `TMPDIR` at a path the engine does not share
   fails the launch with `ServerLaunchFailed` — *"a file written to the run's
   storage directory is not visible at /data inside the container ... so the bind
   mount shares nothing"* — where before it sailed through to a silent
   empty-transcript run.
2. **The protocol client was handed a `/ws` URL and appends `/ws` itself**, so
   every live connection dialed `/ws/ws` and failed. The observer, the
   principal, and every StubRuntime now receive `httpBaseFromServerUrl(...)`.
3. **The bind strategy is measured, not assumed.** With the "host" process
   inside a Linux engine, a container reaches a receiver bound to the bridge
   gateway (`172.17.0.1`) and does not reach one bound to loopback; on a
   VM-backed engine (Docker Desktop, colima, OrbStack) `host.docker.internal`
   forwards to host loopback and loopback is correct. The decision is "bind the
   bridge gateway iff this host owns that address", with a property test that
   the receiver never advertises an address it did not bind.

## Scope

- Modules touched: `simulator` (contract 1 launch half, contract 5 receiver, composition root) and the package-root trace-capture family.
- Tier (`safer-diff-scope --head HEAD --base origin/staff/818-simulator-impl`): `senior`.
- New modules: 0. New public signatures outside the plan: 0. New deps: 0.

## Tests

- `receiver-bind.test.ts` — the bind decision and the endpoint rewrite: both engine shapes, the property that the picked host is loopback or an address the host owns and the engine reported, and its converse (an owned gateway always wins, the half a loopback-only implementation fails).
- `server-image.test.ts` — the image config is the contract `launcher-live.ts` launches against, asserted against the launcher's own constants, and it must carry the admin the server requires (so a gutted config fails rather than reading as "nothing forbidden present").
- `server-image.integration.test.ts` — the executed substrate with a replying agent (gated on `MOLTZAP_SIM_ITEST=1`).
- `trace-capture-bundle.test.ts` — recording → bundle attribution, including both refusals, each naming its own reason.
- coverage `24a` — the cc-judge entry point over the Appendix D fixture, plus the conversation-shape partition the fold refuses at load.
- path 14 — the runtime-dir root the container bind-mounts sits where a VM-backed engine shares it.
- Full hermetic suite: 156 passed (73 in the simulator + trace-capture files). Root `pnpm lint` (knip, arch:check, eslint, oxlint) clean; tests typecheck; `safer-architecture-lsp check` 0 findings, 9 waivers.

## Pre-PR gates

**`/simplify`** — four passes (reuse, simplification, efficiency, altitude).
Applied: deterministic sentinel mount verification in place of polling for the
server's own data directory (two modules no longer disagree about who owns the
data-dir location); one `resolveServerImagePin` shared by the harness and the
live test instead of two copies of the script's stdout contract, memoized per
process; the receiver bind host behind `RunInternals`, the composition root's
existing seam, so a hermetic run never shells out to Docker; the engine probe
unconditional (the `platform()` shortcut was a proxy for the predicate that
already decides correctly); a typed refusal when a recording cannot be
attributed, so "slot never ready" and "not an agent id" stop sharing one
message; message bodies decoded once per row; concurrent packs in the image
build; the platform layer provided once per effect boundary.

Skipped, with reasons:
- **Read the recording through `RecordingStore.read` instead of `events.ndjson`.** The store factory is not on the simulator's public facade, and reaching into `local-store.ts` from the package root deepens the folder cycle into internals. The public reader is row 5b's `./grader` `openRecording` (#836).
- **Parse the fixture with a YAML library.** Adding a devDependency is an architect-tier call; the reader is scoped to the scalar mapping this fixture uses and throws on anything else. The fidelity gap (a hand reader is not cc-judge's parser) is named as a concern below.
- **Build on `packages/server/Dockerfile`.** That image rebuilds the workspace inside Docker on every build; a run's identity is its image digest, so this one is built from the workspace's already-built output and changes exactly when that tree changes. The relationship is stated in the Dockerfile header rather than left implicit.
- **Put the bind host on the `Launcher` interface.** That is a public contract the plan does not name; the internal seam gets the same effect without an architect-tier change.

**`/review`** — adversarial and testing passes over the diff. Applied: the
exit-code fix above and the leak/hang class around it (bounded docker calls, a
wall-clock readiness bound rather than an attempt count, a scoped run-storage
directory, a labelled container so an orphan from an interrupted launch is
findable, a cleaned build staging directory, a build fingerprint that refuses a
published path it cannot find); the failing process's own words kept in the
mount-check message; and the test gaps — the graded exchange exercised end to
end, path 14's inert assertions replaced by the root the container actually
mounts, the shape partition pinned, the image config checked positively, the
endpoint rewrite covered.

Skipped, with reasons:
- **A test for the mount-probe failure branch.** Reaching it hermetically needs a docker-exec seam on the launcher, which is internal surface the plan does not name. It is covered by measurement instead: the unshared-`TMPDIR` run above.
- **An auth token on the OTLP receiver.** On a native-Linux engine the receiver binds the bridge gateway, so a co-tenant container on that bridge could post spans into a run. That is a new mechanism (exporter headers plus a receiver check), not the bind strategy this row was chartered for; named as a concern.
- **Caching the image-build failure.** Flagged as a footgun; kept deliberately, because a suite whose engine is broken should fail once rather than rebuild for fifteen minutes per scenario. Documented at the memo.

## Deviations, named

- **Two devDependencies removed** (`@moltzap/client`, `@moltzap/server-core` from `packages/testbed`), with the lockfile update. The fold deleted the dynamic test-utils loads that used them, and `knip` (inside `pnpm check`) fails on dead dependencies. Nothing was added.
- **One new architecture waiver** on `src/index.ts`: the compat adapter stays at its published root path while executing on the simulator, which closes a folder cycle the design's own fold instruction creates.

## Design-collapse alignment

Built against the delta on #812. The projection joins slots on `agent.ready`
rather than the deleted `agent.launched`; the fold's failure message reads the
error tag rather than the deleted `FailureReason`; the receiver's enqueue never
set `logicalTime` (the writer stamps it), so the envelope collapse reaches this
row only through the hand-built fixtures in `trace-capture-bundle.test.ts`,
whose two `logicalTime` lines drop with it. Nothing here reads span attributes,
so `span-attrs.ts` stays where the design puts it. Paths 18 and 19 are row-4
bodies this diff does not touch.

## The demo's server image

Row 5b's `demoSpec` pins `DEMO_SERVER_IMAGE_DIGEST =
"sha256:0000…0000"`, which `docker run` cannot resolve, so `moltzap-testbed
demo` and the nightly TTHW workflow that measures it cannot pass. This row
produces the digest, and it is now on the simulator facade:

```ts
import { resolveServerImagePin } from "./simulator/index.js";
const imageDigest = yield* resolveServerImagePin();  // env pin, else build
const spec = demoSpec(storeRoot, imageDigest);
```

`resolveServerImagePin` honours `MOLTZAP_SIM_SERVER_IMAGE` when set and
otherwise runs the content-addressed build, so the demo keeps its
no-arguments promise: first run builds, later runs re-use. The change 5b
needs is `demoSpec` taking the digest as a parameter instead of a constant.

## Concerns

1. **Path 24b (nightly, CRITICAL) is not executed here.** It needs a real
   OpenClaw runtime and model credentials. 24a is green; 24b stays owed, and
   the verify row's oracle (pre-fold baseline against post-fold output) has to
   be captured from an executed run.
2. **The fold narrows what cc-judge can execute.** This branch's `EpisodeSpec`
   carries one principal injection, so `direct` scenarios with no follow-ups
   run and the other 10 of 16 scenarios are refused at `load` with a message
   naming the shape. The D-2 multi-step episode delta reopens them; refusing
   beats running a scenario whose later messages are never spoken.
3. **Container-level `modelId` and mount verification is hermetic-only here.**
   The plan-level assertions (model reaches the container config, bind-mount
   sources sit where a VM-backed engine shares them) are green; verifying them
   inside a running NanoClaw container needs that runtime's image and
   credentials, which is the nightly tier.
4. **A VM-backed engine that does not share the system temp directory fails the
   launch's mount check by design.** The run's storage volume comes from
   `os.tmpdir()`; on such an engine the operator points `TMPDIR` at a shared
   path. The failure is loud and names the fix instead of producing an empty
   transcript — measured above.
5. **The receiver is unauthenticated on the address it binds.** On a
   native-Linux engine that address is the bridge gateway, reachable by any
   container on that bridge, so a co-tenant could post spans into a run. The
   fix is an exporter token the receiver checks, which is a mechanism beyond
   this row's bind strategy.
6. **The image build is repo-only.** It packs the workspace, so a consumer
   installing the published package pins through `MOLTZAP_SIM_SERVER_IMAGE`
   rather than building; the failure message names that path.

## Confidence

HIGH on the substrate: image, receiver bind, mount pin, and the client-URL fix
are each demonstrated by an executed run against a real container; the mount
gate is demonstrated by a run that fails on an unshared directory; the bind
decision carries a property test in both directions. MED on the fold: 24a is
green, the projection runs over a real sealed recording, and the two-delivery
done-signal is proven reachable — but no executed run has passed through the
cc-judge adapter end to end against a model. That is 24b.
