### PR TITLE
[impl-junior] fix(testbed): strip the endpoint path from OpenClaw's child server url

### DIFF
--- a/docs/modules/testbed/src.mdx
+++ b/docs/modules/testbed/src.mdx
@@ -42,7 +42,7 @@ export function awaitAgentReadyByPolling(
 ): Effect.Effect<ReadyOutcome, never, never>
 ```
 
-### [`createOpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L557)
+### [`createOpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L576)
 
 _Function_
 
@@ -305,7 +305,7 @@ export interface NanoclawAdapterOptions {
 }
 ```
 
-### [`OpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L460)
+### [`OpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L479)
 
 _Class_
 
@@ -403,8 +403,8 @@ flowchart TD
   OCS["OpenClawAdapter.spawn(input)"]
   OC1["1. allocateFreePort()<br>NodeSocketServer.make({ port: 0 })"]
   OC2["2. lease + configure state dir<br>makeTempDirectory, writeOpenClawConfig,<br>seedWorkspaceFiles, installChannelPlugin"]
-  OC3["3. buildOpenClawProcessPlan(openclawBin, port)<br>(handles .mjs vs binary entry)"]
-  OC4["4. lease spawnOpenClawProcess<br>exact child environment<br>exitFiber + log buffer"]
+  OC3["3. buildOpenClawProcessPlan<br>entry (.mjs vs binary), cwd,<br>exact child environment"]
+  OC4["4. lease spawnOpenClawProcess<br>exitFiber + log buffer"]
   OC5["5. commit process + state-dir leases<br>to adapter state"]
   OCF["failed or interrupted handoff<br>stops child + removes state dir"]
   OCR["waitUntilReady<br>race(server.awaitAgentReady, processExitLoop)<br>inbound marker: 'inbound from agent:'"]
@@ -419,7 +419,7 @@ Readiness signal: server-side WS authentication event surfaces via
 (boot) or `RuntimeExitedBeforeReady` / `RuntimeReadyTimedOut`
 (post-spawn, surfaced by `processExitLoop`).
 
-### [`OpenClawAdapterDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L174)
+### [`OpenClawAdapterDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L176)
 
 _Interface_
 
@@ -432,7 +432,7 @@ export interface OpenClawAdapterDeps {
 }
 ```
 
-### [`OpenClawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L181)
+### [`OpenClawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L183)
 
 _Interface_
 

--- a/packages/testbed/src/MODULE.md
+++ b/packages/testbed/src/MODULE.md
@@ -37,7 +37,7 @@ export function awaitAgentReadyByPolling(
 ): Effect.Effect<ReadyOutcome, never, never>
 ```
 
-### [`createOpenClawAdapter`](./openclaw-adapter.ts#L557)
+### [`createOpenClawAdapter`](./openclaw-adapter.ts#L576)
 
 _Function_
 
@@ -300,7 +300,7 @@ export interface NanoclawAdapterOptions {
 }
 ```
 
-### [`OpenClawAdapter`](./openclaw-adapter.ts#L460)
+### [`OpenClawAdapter`](./openclaw-adapter.ts#L479)
 
 _Class_
 
@@ -398,8 +398,8 @@ flowchart TD
   OCS["OpenClawAdapter.spawn(input)"]
   OC1["1. allocateFreePort()<br>NodeSocketServer.make({ port: 0 })"]
   OC2["2. lease + configure state dir<br>makeTempDirectory, writeOpenClawConfig,<br>seedWorkspaceFiles, installChannelPlugin"]
-  OC3["3. buildOpenClawProcessPlan(openclawBin, port)<br>(handles .mjs vs binary entry)"]
-  OC4["4. lease spawnOpenClawProcess<br>exact child environment<br>exitFiber + log buffer"]
+  OC3["3. buildOpenClawProcessPlan<br>entry (.mjs vs binary), cwd,<br>exact child environment"]
+  OC4["4. lease spawnOpenClawProcess<br>exitFiber + log buffer"]
   OC5["5. commit process + state-dir leases<br>to adapter state"]
   OCF["failed or interrupted handoff<br>stops child + removes state dir"]
   OCR["waitUntilReady<br>race(server.awaitAgentReady, processExitLoop)<br>inbound marker: 'inbound from agent:'"]
@@ -414,7 +414,7 @@ Readiness signal: server-side WS authentication event surfaces via
 (boot) or `RuntimeExitedBeforeReady` / `RuntimeReadyTimedOut`
 (post-spawn, surfaced by `processExitLoop`).
 
-### [`OpenClawAdapterDeps`](./openclaw-adapter.ts#L174)
+### [`OpenClawAdapterDeps`](./openclaw-adapter.ts#L176)
 
 _Interface_
 
@@ -427,7 +427,7 @@ export interface OpenClawAdapterDeps {
 }
 ```
 
-### [`OpenClawAdapterOptions`](./openclaw-adapter.ts#L181)
+### [`OpenClawAdapterOptions`](./openclaw-adapter.ts#L183)
 
 _Interface_
 

--- a/packages/testbed/src/openclaw-adapter.ts
+++ b/packages/testbed/src/openclaw-adapter.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type {
   Runtime,
   RuntimeServerHandle,
+  ServerUrl,
   SpawnInput,
   LogSlice,
   ReadyOutcome,
@@ -18,6 +19,7 @@ import type {
 import { SpawnFailed, spawnFailed } from "./errors.js";
 import { raceReadiness } from "./adapter-readiness.js";
 import {
+  type BaseChildEnvironment,
   BaseChildEnvironmentConfig,
   BoundedLogBuffer,
   escalatingKill,
@@ -208,22 +210,49 @@ interface OpenClawSpawnLease {
 interface OpenClawProcessPlan {
   readonly command: string;
   readonly args: ReadonlyArray<string>;
+  readonly cwd: string;
+  readonly env: Readonly<Record<string, string>>;
 }
 
-function buildOpenClawProcessPlan(
-  openclawBin: string,
-  port: number,
-): OpenClawProcessPlan {
+// A `ServerUrl` carries the server's `/ws` endpoint path, while the moltzap
+// client appends `/ws` to whatever base it reads from the environment, so a
+// child handed the path verbatim dials `/ws/ws` and its upgrade answers 404.
+function normalizeOpenClawServerUrl(serverUrl: ServerUrl): string {
+  return serverUrl
+    .replace(/\/ws$/, "")
+    .replace(/^ws:/, "http:")
+    .replace(/^wss:/, "https:");
+}
+
+/** @internal */
+export function buildOpenClawProcessPlan(opts: {
+  readonly openclawBin: string;
+  readonly port: number;
+  readonly stateDir: string;
+  readonly input: SpawnInput;
+  readonly baseEnvironment: BaseChildEnvironment;
+}): OpenClawProcessPlan {
   const openclawArgs = [
     "gateway",
     "run",
     "--allow-unconfigured",
     "--port",
-    String(port),
+    String(opts.port),
   ];
-  return openclawBin.endsWith(".mjs")
-    ? { command: "node", args: [openclawBin, ...openclawArgs] }
-    : { command: openclawBin, args: openclawArgs };
+  const entrypoint = opts.openclawBin.endsWith(".mjs")
+    ? { command: "node", args: [opts.openclawBin, ...openclawArgs] }
+    : { command: opts.openclawBin, args: openclawArgs };
+  return {
+    ...entrypoint,
+    cwd: opts.stateDir,
+    env: {
+      ...opts.baseEnvironment,
+      OPENCLAW_STATE_DIR: opts.stateDir,
+      OPENCLAW_CONFIG_PATH: join(opts.stateDir, "openclaw.json"),
+      MOLTZAP_CONFIG_HOME: join(opts.stateDir, ".moltzap"),
+      MOLTZAP_SERVER_URL: normalizeOpenClawServerUrl(opts.input.serverUrl),
+    },
+  };
 }
 
 function allocateOpenClawStateDir(
@@ -350,27 +379,17 @@ function spawnConfiguredOpenClaw(options: {
   readonly onStarted: (
     process: SpawnedProcess,
   ) => Effect.Effect<void, never, never>;
-}): Effect.Effect<SpawnedProcess, Error, Path.Path> {
+}): Effect.Effect<SpawnedProcess, Error, never> {
   return Effect.gen(function* () {
-    const platformPath = yield* Path.Path;
     const baseEnvironment = yield* BaseChildEnvironmentConfig;
-    const plan = buildOpenClawProcessPlan(
-      options.deps.openclawBin,
-      options.port,
-    );
     return yield* spawnOpenClawProcess({
-      ...plan,
-      cwd: options.stateDir,
-      env: {
-        ...baseEnvironment,
-        OPENCLAW_STATE_DIR: options.stateDir,
-        OPENCLAW_CONFIG_PATH: platformPath.join(
-          options.stateDir,
-          "openclaw.json",
-        ),
-        MOLTZAP_CONFIG_HOME: platformPath.join(options.stateDir, ".moltzap"),
-        MOLTZAP_SERVER_URL: options.input.serverUrl,
-      },
+      ...buildOpenClawProcessPlan({
+        openclawBin: options.deps.openclawBin,
+        port: options.port,
+        stateDir: options.stateDir,
+        input: options.input,
+        baseEnvironment,
+      }),
       logBuffer: options.logBuffer,
       onStarted: options.onStarted,
     });
@@ -441,8 +460,8 @@ function startOpenClawAdapter(
  *   OCS["OpenClawAdapter.spawn(input)"]
  *   OC1["1. allocateFreePort()<br>NodeSocketServer.make({ port: 0 })"]
  *   OC2["2. lease + configure state dir<br>makeTempDirectory, writeOpenClawConfig,<br>seedWorkspaceFiles, installChannelPlugin"]
- *   OC3["3. buildOpenClawProcessPlan(openclawBin, port)<br>(handles .mjs vs binary entry)"]
- *   OC4["4. lease spawnOpenClawProcess<br>exact child environment<br>exitFiber + log buffer"]
+ *   OC3["3. buildOpenClawProcessPlan<br>entry (.mjs vs binary), cwd,<br>exact child environment"]
+ *   OC4["4. lease spawnOpenClawProcess<br>exitFiber + log buffer"]
  *   OC5["5. commit process + state-dir leases<br>to adapter state"]
  *   OCF["failed or interrupted handoff<br>stops child + removes state dir"]
  *   OCR["waitUntilReady<br>race(server.awaitAgentReady, processExitLoop)<br>inbound marker: 'inbound from agent:'"]

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   buildOpenClawConfig,
+  buildOpenClawProcessPlan,
   createOpenClawAdapter,
   OpenClawAdapter,
   type OpenClawAdapterDeps,
@@ -194,6 +195,42 @@ describe("buildOpenClawConfig", () => {
     expect(config.discovery?.mdns?.mode).toBe(DISABLED_MDNS_MODE);
   });
 });
+
+// The gateway child reads MOLTZAP_SERVER_URL through the moltzap client,
+// which appends the `/ws` endpoint path itself.
+const OPENCLAW_STATE_DIR = "/state/openclaw-agent";
+const OPENCLAW_PORT = 41_234;
+const OPENCLAW_BASE_CHILD_ENVIRONMENT = {
+  PATH: "/test/bin:/usr/bin:/bin",
+  HOME: "/test/home",
+};
+const SECURE_SERVER_URL = "wss://example.test:8443/ws";
+const NORMALIZED_SERVER_URL = "http://localhost:9999";
+const NORMALIZED_SECURE_SERVER_URL = "https://example.test:8443";
+
+describe("buildOpenClawProcessPlan", () => {
+  it("strips the endpoint path from the child server url", () => {
+    const plan = openClawProcessPlan(stubSpawnInput());
+    expect(plan.env.MOLTZAP_SERVER_URL).toBe(NORMALIZED_SERVER_URL);
+  });
+
+  it("maps a secure endpoint url onto https", () => {
+    const plan = openClawProcessPlan(
+      stubSpawnInput({ serverUrl: ServerUrl(SECURE_SERVER_URL) }),
+    );
+    expect(plan.env.MOLTZAP_SERVER_URL).toBe(NORMALIZED_SECURE_SERVER_URL);
+  });
+});
+
+function openClawProcessPlan(input: SpawnInput) {
+  return buildOpenClawProcessPlan({
+    openclawBin: stubDeps().openclawBin,
+    port: OPENCLAW_PORT,
+    stateDir: OPENCLAW_STATE_DIR,
+    input,
+    baseEnvironment: OPENCLAW_BASE_CHILD_ENVIRONMENT,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // OpenClawAdapter — getLogs / getInboundMarker (no spawn)


### PR DESCRIPTION
Fixes https://github.com/chughtapan/moltzap/issues/851

## What changed

`openclaw-adapter.ts` handed `MOLTZAP_SERVER_URL` the run's `ServerUrl` verbatim. A `ServerUrl` carries the server's `/ws` endpoint path (`launcher-live.ts → startServerContainer` mints it, `world.ts → allocateEndpoint` preserves the pathname), and the moltzap client appends `/ws` to whatever base it reads (`protocol/src/socket/lifecycle.ts → webSocketUrl`), so the gateway child dialed `/ws/ws`, the server 404'd the upgrade, presence never came online, and `waitUntilReady` returned `Timeout` — which `launcher-live.ts → readyOrFail` turns into `AgentLaunchFailed (ready-timeout)`.

`spawnConfiguredOpenClaw` now normalizes through `normalizeOpenClawServerUrl`, the same treatment `nanoclaw-process.ts → normalizeNanoclawServerUrl` and `simulator/provisioning.ts → httpBaseFromServerUrl` already apply. openclaw is the adapter that never received it.

Observing the child environment is what the regression test needs, so `buildOpenClawProcessPlan` returns the whole plan (entry, cwd, env) as a pure function, mirroring `nanoclaw-process.ts → buildNanoclawProcessPlan`, which is tested the same way. `spawnConfiguredOpenClaw` spreads it. Nothing else changes behavior: the two path joins move from the `Path.Path` service to `node:path`, which drops that requirement from `spawnConfiguredOpenClaw`'s context.

## Scope

- Module: `packages/testbed/src/openclaw-adapter.ts` (+ its test file `runtimes.test.ts`, + regenerated `MODULE.md` / `docs/modules/testbed/src.mdx`)
- New exported signatures on the package surface (`src/index.ts`): none. `buildOpenClawProcessPlan` is `@internal`, exported for its own test file the way `buildOpenClawConfig` already is; `package-exports.test.ts` is unchanged and passing.
- New deps: none

`safer-diff-scope` reads this diff as `senior`, and both of its counters misfire here. Reported verbatim so the reviewer can judge rather than take my word:

```
$ safer-diff-scope --head HEAD --base 364af342
{"tier":"senior","files":4,"modules":2,"exports":1,"new_deps":0,"rationale":"changes 1 exported signature(s)"}

$ safer-diff-scope --diff <just the two regenerated doc files>
{"tier":"senior","files":2,"modules":2,"exports":0,"new_deps":0,"rationale":"spans 2 modules"}
```

The second run is the load-bearing one: the regenerated docs *alone* classify `senior`, because the tool derives a module from the first two path segments and `docs/modules/…` is not `packages/testbed/…`. The pre-commit hook regenerates `docs/modules/testbed/src.mdx` for any source edit that shifts a documented symbol's line, so no shape of this fix can return `junior` — the verdict carries no signal about this diff. The `exports: 1` counter is a separate misfire: it greps added lines for `+export`, and cannot distinguish a new `@internal` export consumed by the module's own test file from a change to the package's public surface. Nothing changed on the public surface.

## Tests

- `buildOpenClawProcessPlan > strips the endpoint path from the child server url` — `ws://localhost:9999/ws` → `http://localhost:9999`
- `buildOpenClawProcessPlan > maps a secure endpoint url onto https` — `wss://example.test:8443/ws` → `https://example.test:8443`

Both fail on the unfixed code. Confirmed by reverting only the normalization call to the pre-fix expression (`MOLTZAP_SERVER_URL: opts.input.serverUrl`) and running the file: `2 failed`, received `ws://localhost:9999/ws` and `wss://example.test:8443/ws`. With the call restored: `34 passed`.

Gates on this branch: `nx run testbed:test --skip-nx-cache` 252/252; root `pnpm lint` (architecture boundaries, arch:config:check, arch:check, knip, eslint, oxlint) exit 0; `pnpm format:check` clean; `pnpm docs:check:mermaid` PASS; `tsc -p tsconfig.test.json` clean; plus the pre-commit chain (docs:generate idempotency, `pnpm check`, `pnpm build`, `typecheck:tests`, sloppy-code-guard). CI on this PR: `ci` SUCCESS, `test` SUCCESS.

## Cross-model review

`approve-with-findings`. Verdict verbatim, plus the disposition of both findings, in https://github.com/chughtapan/moltzap/pull/853#issuecomment-5085012999. It confirms the launcher path is fixed end to end (`ws://127.0.0.1:<port>/ws` → child gets `http://127.0.0.1:<proxy>` → client rebuilds `ws://127.0.0.1:<proxy>/ws`), confirms the test cannot go green while production stays verbatim, and finds no other live handoff with the same defect. The one substantive finding is that `ws://host/ws/` (trailing slash) is still not normalized — unreachable from this path, unchanged by this diff, and #846's to close.

## Branding (#846) stays separate

https://github.com/chughtapan/moltzap/issues/846 recommends branding `webSocketUrl`'s parameter so a path-free base is the only thing that compiles. That is the right fix for the class and it is not junior work: it changes `@moltzap/protocol` public surface, adds a new exported branded type with a smart constructor, and updates every call site that constructs a client across packages. Three of this modality's stop rules fire on it, so it stays #846.

Evidence the class is real: this repo hand-rolls the same normalization four times — `simulator/provisioning.ts → httpBaseFromServerUrl`, `nanoclaw-process.ts → normalizeNanoclawServerUrl`, `openclaw-channel/src/test-utils/container-core.ts → normalizeContainerServerUrl`, and now `openclaw-adapter.ts → normalizeOpenClawServerUrl`. Four copies is the shape of a missing type.

## Confidence

HIGH — the root cause is reproduced and cross-model confirmed on the #851 diagnosis (product-path symptom, real `waitUntilReady`, behavioral `Timeout`/`Ready` A/B one input apart), and the regression test is confirmed red on the unfixed expression and green on the fixed one.
