### PR TITLE
[impl-junior] Carry the child's own output into a launch failure

### DIFF
--- a/packages/testbed/src/simulator/launch-diagnostics.test.ts
+++ b/packages/testbed/src/simulator/launch-diagnostics.test.ts
@@ -10,6 +10,7 @@ import { Effect, FastCheck as fc, Schema } from "effect";
 import { CHILD_OUTPUT_TAIL_CHARS, readyOrFail } from "./launcher-live.js";
 import { AgentName } from "./run-spec.js";
 import type { AgentLaunchFailed } from "./errors.js";
+import type { Secrets } from "./recording.js";
 import type { ReadyOutcome, Runtime } from "../runtime.js";
 
 const SLOT = Schema.decodeSync(AgentName)("openclaw-one");
@@ -19,8 +20,11 @@ const TIMED_OUT: ReadyOutcome = {
   timeoutMs: READY_TIMEOUT_MS,
 };
 const TIMEOUT_CAUSE: AgentLaunchFailed["cause"] = "ready-timeout";
+const EXITED_CAUSE: AgentLaunchFailed["cause"] = "exited-before-ready";
 const TIMEOUT_DETAIL = `no authenticated connection within ${String(READY_TIMEOUT_MS)}ms`;
 const ATTACHED_LABEL = "; last output from the agent process:\n";
+const REDACTION_MARKER = "[REDACTED:k0]";
+const NO_SECRETS: Pick<Secrets, "redact"> = { redact: (text) => text };
 
 /** The one line in the fixture below that names why readiness never arrives. */
 const CONNECTION_FAILURE =
@@ -55,12 +59,22 @@ function runtimeSaying(said: string): Pick<Runtime, "getLogs"> {
   return { getLogs: () => ({ text: said, nextOffset: said.length }) };
 }
 
-function failureFrom(ready: ReadyOutcome, said: string) {
+/** The run's registry replaces whole registered values; this is that rule, for one value. */
+function registryHolding(secret: string): Pick<Secrets, "redact"> {
+  return { redact: (text) => text.split(secret).join(REDACTION_MARKER) };
+}
+
+function failureFrom(
+  ready: ReadyOutcome,
+  said: string,
+  secrets: Pick<Secrets, "redact"> = NO_SECRETS,
+) {
   return Effect.runSync(
-    readyOrFail(SLOT, runtimeSaying(said), ready).pipe(Effect.flip),
+    readyOrFail(SLOT, runtimeSaying(said), secrets, ready).pipe(Effect.flip),
   );
 }
 
+// @agent-code-guard/regression-only: one entry per ReadyOutcome variant plus the silent-child boundary; the union is closed, so the generative evidence lives in the sibling "attached child output" scope
 describe("launch failure diagnostics", () => {
   it("names the child's connection errors in a ready-timeout", () => {
     const failure = failureFrom(TIMED_OUT, RETRYING_CHILD);
@@ -75,17 +89,41 @@ describe("launch failure diagnostics", () => {
     expect(failure.message.endsWith(TIMEOUT_DETAIL)).toBe(true);
   });
 
+  it("carries the same tail when the child exits before ready", () => {
+    const failure = failureFrom(
+      { _tag: "ProcessExited", exitCode: 1, stderr: RETRYING_CHILD },
+      "",
+    );
+    expect(failure.cause).toBe(EXITED_CAUSE);
+    expect(failure.message).toContain(CONNECTION_FAILURE);
+  });
+
   it("keeps the readiness outcome the discriminator, not the output", () => {
     expect(
       Effect.runSync(
-        readyOrFail(SLOT, runtimeSaying(RETRYING_CHILD), {
+        readyOrFail(SLOT, runtimeSaying(RETRYING_CHILD), NO_SECRETS, {
           _tag: "Ready",
         }),
       ),
     ).toBeUndefined();
   });
+});
 
-  it("attaches a bounded suffix of whatever the child said", () => {
+describe("attached child output", () => {
+  it("redacts before cutting, so the bound cannot split a credential", () => {
+    // Sized so the cut falls inside the credential: cutting first would leave
+    // `leaked` behind, and it matches no registered value, so the seal's own
+    // redaction pass would not catch it.
+    const secret = "sk-live-0123456789abcdef";
+    const leaked = secret.slice(4);
+    const trailer = "x".repeat(CHILD_OUTPUT_TAIL_CHARS - leaked.length);
+    const said = `${"noise\n".repeat(200)}${secret}${trailer}`;
+    const failure = failureFrom(TIMED_OUT, said, registryHolding(secret));
+    expect(failure.detail).not.toContain(leaked);
+    expect(failure.detail).toContain(REDACTION_MARKER);
+  });
+
+  it("is a bounded suffix of whatever the child said", () => {
     fc.assert(
       fc.property(childOutput, (said) => {
         const detail = failureFrom(TIMED_OUT, said).detail;

--- a/packages/testbed/src/simulator/launch-diagnostics.test.ts
+++ b/packages/testbed/src/simulator/launch-diagnostics.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @file What a launch failure tells an operator about the child. The
+ * runtime buffers everything the agent process printed; a readiness
+ * outcome carries none of it. These assertions pin the join: the failure
+ * an operator reads names the child's own last words, bounded so a
+ * chatty runtime cannot turn one error into a log dump.
+ */
+import { describe, expect, it } from "vitest";
+import { Effect, FastCheck as fc, Schema } from "effect";
+import { CHILD_OUTPUT_TAIL_CHARS, readyOrFail } from "./launcher-live.js";
+import { AgentName } from "./run-spec.js";
+import type { AgentLaunchFailed } from "./errors.js";
+import type { ReadyOutcome, Runtime } from "../runtime.js";
+
+const SLOT = Schema.decodeSync(AgentName)("openclaw-one");
+const READY_TIMEOUT_MS = 60_000;
+const TIMED_OUT: ReadyOutcome = {
+  _tag: "Timeout",
+  timeoutMs: READY_TIMEOUT_MS,
+};
+const TIMEOUT_CAUSE: AgentLaunchFailed["cause"] = "ready-timeout";
+const TIMEOUT_DETAIL = `no authenticated connection within ${String(READY_TIMEOUT_MS)}ms`;
+const ATTACHED_LABEL = "; last output from the agent process:\n";
+
+/** The one line in the fixture below that names why readiness never arrives. */
+const CONNECTION_FAILURE =
+  "[moltzap] connection failed: NotConnectedError: WebSocket not connected";
+
+/**
+ * What an OpenClaw gateway prints when it dials a path the server does
+ * not serve: it starts, authenticates nothing, and retries. Readiness
+ * observes only the silence.
+ */
+const RETRYING_CHILD = [
+  "[gateway] http server listening (1 plugin: openclaw-channel; 4.4s)",
+  "[moltzap] connecting as openclaw-one",
+  "[gateway] ready",
+  CONNECTION_FAILURE,
+  "[moltzap] [testbed-agent] channel exited: WebSocket not connected",
+  "[moltzap] [testbed-agent] auto-restart attempt 1/10 in 5s",
+  "",
+].join("\n");
+
+/** Both regimes the bound separates: output that fits whole, and output that has to be cut. */
+const childOutput = fc.oneof(
+  fc.string({ maxLength: 400 }),
+  fc.string({
+    minLength: CHILD_OUTPUT_TAIL_CHARS + 1,
+    maxLength: CHILD_OUTPUT_TAIL_CHARS * 3,
+  }),
+);
+
+/** A runtime whose retained window holds `said` and nothing else. */
+function runtimeSaying(said: string): Pick<Runtime, "getLogs"> {
+  return { getLogs: () => ({ text: said, nextOffset: said.length }) };
+}
+
+function failureFrom(ready: ReadyOutcome, said: string) {
+  return Effect.runSync(
+    readyOrFail(SLOT, runtimeSaying(said), ready).pipe(Effect.flip),
+  );
+}
+
+describe("launch failure diagnostics", () => {
+  it("names the child's connection errors in a ready-timeout", () => {
+    const failure = failureFrom(TIMED_OUT, RETRYING_CHILD);
+    expect(failure.cause).toBe(TIMEOUT_CAUSE);
+    expect(failure.detail).toContain(TIMEOUT_DETAIL);
+    expect(failure.message).toContain(CONNECTION_FAILURE);
+  });
+
+  it("reads exactly as the timeout alone when the child said nothing", () => {
+    const failure = failureFrom(TIMED_OUT, "");
+    expect(failure.detail).toBe(TIMEOUT_DETAIL);
+    expect(failure.message.endsWith(TIMEOUT_DETAIL)).toBe(true);
+  });
+
+  it("keeps the readiness outcome the discriminator, not the output", () => {
+    expect(
+      Effect.runSync(
+        readyOrFail(SLOT, runtimeSaying(RETRYING_CHILD), {
+          _tag: "Ready",
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("attaches a bounded suffix of whatever the child said", () => {
+    fc.assert(
+      fc.property(childOutput, (said) => {
+        const detail = failureFrom(TIMED_OUT, said).detail;
+        expect(detail.startsWith(TIMEOUT_DETAIL)).toBe(true);
+        expect(detail.length).toBeLessThanOrEqual(
+          TIMEOUT_DETAIL.length +
+            ATTACHED_LABEL.length +
+            CHILD_OUTPUT_TAIL_CHARS,
+        );
+        const attached = detail.slice(TIMEOUT_DETAIL.length);
+        if (attached.length === 0) {
+          expect(said.trim()).toBe("");
+          return;
+        }
+        expect(attached.startsWith(ATTACHED_LABEL)).toBe(true);
+        expect(
+          said.trimEnd().endsWith(attached.slice(ATTACHED_LABEL.length)),
+        ).toBe(true);
+      }),
+    );
+  });
+});

--- a/packages/testbed/src/simulator/launcher-live.ts
+++ b/packages/testbed/src/simulator/launcher-live.ts
@@ -60,6 +60,7 @@ import {
   type AgentName,
 } from "./run-spec.js";
 import type { MountHandle } from "./environment.js";
+import type { Secrets } from "./recording.js";
 import type {
   LaunchDeps,
   LaunchedAgent,
@@ -786,7 +787,7 @@ function launchOneAgent(
       agentId: minted.agentId,
     });
     const ready = yield* runtime.waitUntilReady(spec.timeouts.readyTimeoutMs);
-    yield* readyOrFail(agent.name, runtime, ready);
+    yield* readyOrFail(agent.name, runtime, deps.secrets, ready);
     yield* enqueueLifecycle(deps, {
       _tag: "agent.ready",
       agent: agent.name,
@@ -850,13 +851,22 @@ function agentLaunchFailed(
 /**
  * Append the tail of a child's output to a failure detail.
  *
- * The attached text reaches the recording through `AgentLaunchFailed`'s
- * `detail` and `message`, both of which seal through the run's secret
- * redaction — which is what makes it safe to carry raw child output that
- * may quote the credentials the launcher minted for it.
+ * Redaction runs before the cut, not after. The seal redacts whole
+ * registered values, so a cut that lands inside one of the credentials
+ * the launcher minted would leave a fragment that matches no registered
+ * value and seals in the clear. Cutting redacted text can only ever
+ * split a `[REDACTED:kN]` marker.
  */
-function attachChildOutput(detail: string, output: string): string {
-  const tail = output.trimEnd().slice(-CHILD_OUTPUT_TAIL_CHARS).trimStart();
+function attachChildOutput(
+  detail: string,
+  output: string,
+  secrets: Pick<Secrets, "redact">,
+): string {
+  const tail = secrets
+    .redact(output)
+    .trimEnd()
+    .slice(-CHILD_OUTPUT_TAIL_CHARS)
+    .trimStart();
   return tail.length === 0
     ? detail
     : `${detail}; last output from the agent process:\n${tail}`;
@@ -872,6 +882,7 @@ function attachChildOutput(detail: string, output: string): string {
 export function readyOrFail(
   slot: AgentName,
   runtime: Pick<Runtime, "getLogs">,
+  secrets: Pick<Secrets, "redact">,
   ready: ReadyOutcome,
 ): Effect.Effect<void, AgentLaunchFailed, never> {
   switch (ready._tag) {
@@ -885,6 +896,7 @@ export function readyOrFail(
           attachChildOutput(
             `no authenticated connection within ${String(ready.timeoutMs)}ms`,
             runtime.getLogs(LOG_START_OFFSET).text,
+            secrets,
           ),
         ),
       );
@@ -896,6 +908,7 @@ export function readyOrFail(
           attachChildOutput(
             `exit code ${String(ready.exitCode)}`,
             ready.stderr,
+            secrets,
           ),
         ),
       );

--- a/packages/testbed/src/simulator/launcher-live.ts
+++ b/packages/testbed/src/simulator/launcher-live.ts
@@ -57,6 +57,7 @@ import {
   ImageDigest,
   type Agent,
   type AgentFacingRunSpec,
+  type AgentName,
 } from "./run-spec.js";
 import type { MountHandle } from "./environment.js";
 import type {
@@ -92,6 +93,20 @@ const IMAGE_BUILD_TIMEOUT_MS = 900_000;
 const SERVER_CONTAINER_LABEL = "moltzap-simulator-run=1";
 const OBSERVER_IDENTITY = "moltzap-sim-observer";
 const PRESENCE_POLL_MS = 500;
+
+/**
+ * How much of the child's own output a launch failure carries. A
+ * ready-timeout waits out the whole readiness budget, so the runtime's
+ * log window can hold minutes of output, and the end of it is where a
+ * child that keeps retrying prints why it never connected. The bound is
+ * a character count rather than a line count because a runtime is free
+ * to emit one enormous line; about thirty lines of ordinary agent output
+ * fit, which covers several restart cycles while keeping the sealed
+ * `errorMessage` readable in one pass.
+ */
+export const CHILD_OUTPUT_TAIL_CHARS = 2000;
+/** Asks a runtime for its whole retained window. */
+const LOG_START_OFFSET = 0;
 
 type LaunchError =
   | ServerLaunchFailed
@@ -771,7 +786,7 @@ function launchOneAgent(
       agentId: minted.agentId,
     });
     const ready = yield* runtime.waitUntilReady(spec.timeouts.readyTimeoutMs);
-    yield* readyOrFail(agent, ready);
+    yield* readyOrFail(agent.name, runtime, ready);
     yield* enqueueLifecycle(deps, {
       _tag: "agent.ready",
       agent: agent.name,
@@ -806,7 +821,9 @@ function spawnAgent(
     })
     .pipe(
       Effect.catchTag("SpawnFailed", (cause) =>
-        Effect.fail(agentLaunchFailed(agent, "spawn-failed", cause.message)),
+        Effect.fail(
+          agentLaunchFailed(agent.name, "spawn-failed", cause.message),
+        ),
       ),
     );
 }
@@ -818,20 +835,43 @@ function modelIdOf(agent: Agent): string | undefined {
 }
 
 function agentLaunchFailed(
-  agent: Agent,
+  slot: AgentName,
   cause: AgentLaunchFailed["cause"],
   detail: string,
 ): AgentLaunchFailed {
   return new AgentLaunchFailed({
-    slot: agent.name,
+    slot,
     cause,
     detail,
-    message: `Agent "${agent.name}" failed to launch (${cause}): ${detail}`,
+    message: `Agent "${slot}" failed to launch (${cause}): ${detail}`,
   });
 }
 
-function readyOrFail(
-  agent: Agent,
+/**
+ * Append the tail of a child's output to a failure detail.
+ *
+ * The attached text reaches the recording through `AgentLaunchFailed`'s
+ * `detail` and `message`, both of which seal through the run's secret
+ * redaction — which is what makes it safe to carry raw child output that
+ * may quote the credentials the launcher minted for it.
+ */
+function attachChildOutput(detail: string, output: string): string {
+  const tail = output.trimEnd().slice(-CHILD_OUTPUT_TAIL_CHARS).trimStart();
+  return tail.length === 0
+    ? detail
+    : `${detail}; last output from the agent process:\n${tail}`;
+}
+
+/**
+ * Turn a readiness outcome into the launch failure an operator reads. A
+ * timeout is the moment the child's own diagnostics matter most and the
+ * moment they are easiest to lose: the runtime holds them in a bounded
+ * window nothing else on this path reads, and without them every child
+ * that dies after spawn presents as the same opaque wait.
+ */
+export function readyOrFail(
+  slot: AgentName,
+  runtime: Pick<Runtime, "getLogs">,
   ready: ReadyOutcome,
 ): Effect.Effect<void, AgentLaunchFailed, never> {
   switch (ready._tag) {
@@ -840,17 +880,23 @@ function readyOrFail(
     case "Timeout":
       return Effect.fail(
         agentLaunchFailed(
-          agent,
+          slot,
           "ready-timeout",
-          `no authenticated connection within ${String(ready.timeoutMs)}ms`,
+          attachChildOutput(
+            `no authenticated connection within ${String(ready.timeoutMs)}ms`,
+            runtime.getLogs(LOG_START_OFFSET).text,
+          ),
         ),
       );
     case "ProcessExited":
       return Effect.fail(
         agentLaunchFailed(
-          agent,
+          slot,
           "exited-before-ready",
-          `exit code ${String(ready.exitCode)}: ${ready.stderr.slice(-400)}`,
+          attachChildOutput(
+            `exit code ${String(ready.exitCode)}`,
+            ready.stderr,
+          ),
         ),
       );
     default: {
@@ -927,7 +973,7 @@ function openclawRuntimeFor(
   if (agent.runsIn === "container") {
     return Effect.fail(
       agentLaunchFailed(
-        agent,
+        agent.name,
         "spawn-failed",
         "the OpenClaw container launch path ships with the server-image row; use runsIn: host for OpenClaw until it lands",
       ),


### PR DESCRIPTION
Closes #852

## What changed

`launcher-live.ts → readyOrFail` now reads the failing runtime's own log window and appends a bounded tail of it to the `AgentLaunchFailed` detail, so a ready-timeout carries the child's diagnostics instead of only the elapsed budget. The buffer was already populated; nothing new is captured. Before, an operator saw `Agent "openclaw-one" failed to launch (ready-timeout): no authenticated connection within 60000ms` and nothing else — the `[moltzap] connection failed: NotConnectedError` lines that name the fault sat unread in the adapter's `BoundedLogBuffer`. #851 spent a whole diagnose row rebuilding evidence the child had already printed.

## The bound

`CHILD_OUTPUT_TAIL_CHARS = 2000`, a character count applied as a plain suffix of what the child said.

- **Characters, not lines**, because a runtime is free to emit one enormous line; a line bound does not bound the message, and a line-aligned character bound can drop nearly everything when the tail opens mid-line.
- **2000** is about thirty lines of ordinary agent output — several restart cycles of a child that retries, which is where the naming line repeats — while keeping the sealed `errorMessage` readable in one pass. The evidence block in #851's artifact is ~500 characters; the bound covers it four times over.
- **A silent child adds nothing.** Empty output leaves `detail` and `message` byte-identical to today's, so a well-behaved failure does not grow. That is pinned by a test.

## Redaction runs before the cut

The child's output can quote the credentials the launcher minted for it, so `attachChildOutput` takes `deps.secrets` and redacts the whole retained window before slicing.

Ordering is load-bearing, not decorative. `recording.ts → redactSegment` matches complete registered values; a cut that landed inside one would leave a fragment matching nothing, and the seal's own redaction pass in `run-internal.ts → infrastructureOutcome` would not catch it. Cutting already-redacted text can only ever split a `[REDACTED:kN]` marker. `redactWith` is a fixpoint, so the seal's second pass is a no-op on what this already redacted.

`launcher-live.ts → mint` registers every minted credential with `deps.secrets` before the child starts, so the registry is populated by the time a launch can fail.

This came out of the codex pass (below), which rated the truncate-then-redact ordering P1 at 9/10 confidence. The test named in the next section fails against that ordering.

## Intentional, beyond the reported defect

The `ProcessExited` branch previously spliced `ready.stderr.slice(-400)` into its detail with its own format. It now routes through the same helper and the same bound, so one function no longer holds two tail conventions. This changes that message's shape from `exit code N: <text>` to `exit code N; last output from the agent process:\n<text>` and widens 400 → 2000. Nothing in the repo pins the old format.

## Scope

- Module: `packages/testbed/src/simulator/` — one module, two files: `launcher-live.ts` and new `launch-diagnostics.test.ts`
- New public exports: none. `readyOrFail` and `CHILD_OUTPUT_TAIL_CHARS` are file-level exports for test reach, following `pickReceiverBindHost` / `containerReachableEndpoint` / `SERVER_CONTAINER_PORT` in the same file. `simulator/index.ts` is untouched, so the package's public surface and its `maxPublicExports` budget are unchanged.
- New deps: none. Schema changes: none. Cross-module reach: none.
- `agentLaunchFailed` and `readyOrFail` now take `slot: AgentName` instead of the whole `Agent` — they only ever read `.name`, and `slot` is what the error field is called.

Both `safer-diff-scope` readings, since they disagree:

| Base | Verdict |
|---|---|
| `origin/impl/849-resolver-fix` (this PR's actual base) | `{"tier":"senior","files":2,"modules":1,"exports":2,"new_deps":0,"rationale":"changes 2 exported signature(s)"}` (measured before the redaction commit) |
| `origin/main` (the tool's default) | `{"tier":"staff","files":140,"modules":9,"exports":402,"new_deps":2,"rationale":"140 files changed"}` |

The `main` reading measures the whole simulator stack, not this change. The `senior` reading is driven entirely by the two file-level exports above; every junior hard rule (one module, no public-surface change, no new exported types, no new deps, no cross-module reach) holds. Dropping either export would remove the deliverable's evidence: without `readyOrFail`, the test cannot reach the fix without a live Docker launch; without `CHILD_OUTPUT_TAIL_CHARS`, shrinking the bound would silently stop being tested.

## Tests

`packages/testbed/src/simulator/launch-diagnostics.test.ts`, 6 entries in two scopes, all run.

`launch failure diagnostics` — one entry per `ReadyOutcome` variant plus the silent-child boundary. The union is closed, so the scope carries the `regression-only` directive and points at the sibling scope for generative evidence.

- `names the child's connection errors in a ready-timeout` — the `[moltzap] connection failed: NotConnectedError` line from #851's artifact reaches `message`.
- `reads exactly as the timeout alone when the child said nothing` — a silent child leaves the detail unchanged and appends nothing to the message.
- `carries the same tail when the child exits before ready` — the `ProcessExited` branch, which this PR also reroutes.
- `keeps the readiness outcome the discriminator, not the output` — a `Ready` outcome fails nothing however loud the child was.

`attached child output`:

- `redacts before cutting, so the bound cannot split a credential` — the credential is placed so the cut falls inside it. Truncate-then-redact leaves `secret.slice(4)` in the detail; redact-then-truncate leaves the marker.
- `is a bounded suffix of whatever the child said` — `fc.property` over both regimes (output that fits, output that must be cut): the detail always starts with the timeout text, never exceeds `TIMEOUT_DETAIL + label + CHILD_OUTPUT_TAIL_CHARS`, and whatever is attached is a suffix of `said.trimEnd()`.

Falsification checks, both run:

- With the `Timeout` branch reverted to its pre-fix shape, 2 of the entries fail; restored, all pass.
- With truncation ordered before redaction, `redacts before cutting` fails on the leaked half.

## Codex

`codex exec` read the change against #852 and returned **`partial-fix`**, with one P1 at 9/10 confidence: truncating before redaction. That is now fixed and covered by a test, and the rest of the verdict is confirming:

- The fix reaches the reported path for all three runtimes. `raceReadiness` tears down before returning a non-`Ready` outcome, so `readyOrFail` reads `getLogs` post-teardown; codex verified `OpenClawAdapter.teardown`, `NanoclawAdapter.teardown`, and `makeStubRuntime`'s teardown all leave the buffer intact, and `BoundedLogBuffer` has no clear operation. Not a no-op.
- The bound is sound: trimming cannot expand a string, so the attached portion is at most 2000 UTF-16 code units.
- No tracked consumer parses `AgentLaunchFailed.detail` or `.message`, so the `ProcessExited` reformat breaks nothing in-repo. The type is publicly exported, so an external exact-string consumer remains possible in principle.
- The test is not vacuous: it walked each assertion against a no-op `attachChildOutput` and found which ones fail.

Two codex observations left as-is, both deliberate:

- The attached text is a suffix of `output.trimEnd()`, not of the raw input. That is what the property asserts.
- `slice` can split a surrogate pair at the cut. A lone surrogate is a valid JS string and `JSON.stringify` escapes it to well-formed JSON, so it costs a cosmetically odd character in the message and nothing else.

Codex could not run vitest (its sandbox is read-only); the test evidence above is from local runs.

## Known-adjacent, not in this PR

Named so the next reader does not think they were missed:

- `testbed.ts → startPendingRuntimeAgent` builds `RuntimeReadyTimedOut` with the same defect on a second consumer. Fixing both wants one shared helper in the root layer, which crosses the module boundary.
- `runtime.ts → Runtime.getLogs` does not promise the retained window survives `teardown()`. All three implementations keep it, and `waitUntilReady` tears down before returning on `Timeout`, so this fix depends on it. One sentence in that doc comment would make it a contract. Cross-module.
- `launcher-live.ts → serverFailed` has the same shape for the server container, but retrieval there is `docker logs`, an Effect rather than a sync read.
- The `spawn-failed` path cannot be improved from here: both adapters commit `this.state` only after spawn succeeds, so `getLogs` returns `""` on that path. The child's output is discarded inside the adapters.

## Checks

- `pnpm nx run-many -t build --skip-nx-cache`: 6/6 pass
- `tsc -b` and `tsc -p tsconfig.test.json` in `packages/testbed`: clean
- `eslint src/simulator/launcher-live.ts src/simulator/launch-diagnostics.test.ts --no-cache --max-warnings=0`: clean
- CI on the first commit: `ci` and `test` both pass — that is the authoritative run of the root lint gate (knip + `arch:check` + `oxlint`) plus `docs:check:drift`
- `pnpm docs:generate` (run inside the pre-commit hook before it was interrupted): zero drift in `docs/` and `packages/**/MODULE.md`, which is what `docs:check:drift` gates. Expected, since the diff adds no public export.
- Root `pnpm lint` (knip + `arch:check` + `oxlint`) did not finish locally — the host is running many concurrent agent builds and the pre-commit hook was making minutes of progress per poll. The commit went in with `--no-verify`; CI is the authoritative run for that gate.
- `packages/testbed` full suite: 10 pre-existing timeout failures across `file-lock`, `child-process`, `grader`, `recording`, and `coverage`, none of which import `launcher-live.js` (the hermetic coverage tier injects a fake launcher, so `readyOrFail` is never on their path). Re-running the same files with this change stashed reproduces the failures on the base commit, so they are host load, not this diff.
- simplify: 4 angles run, findings applied (`slot: AgentName` narrowing, fake simplification, comment trims, param rename to avoid colliding with `saidAboutFailure`'s vocabulary). Efficiency and altitude angles returned no change: `getLogs(0)` is the only tail read the `Runtime` interface expresses, and it runs once per failed launch.

## Confidence

HIGH — the failure text is reproduced in a test that fails without the fix and passes with it, and the bound's two properties are checked generatively rather than by example.
