### PR TITLE
[impl-senior] fix(protocol): brand the server base URL so it cannot carry a path

### DIFF
--- a/docs/modules/protocol/network.mdx
+++ b/docs/modules/protocol/network.mdx
@@ -257,7 +257,7 @@ Reason discriminant carried in `ProtocolMismatchError.data.reason`:
 `maxProtocol`; the client must update. `server-below-client-min` — the
 client is newer than the server supports.
 
-### [`serverBaseUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L77)
+### [`serverBaseUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L94)
 
 _Variable_
 
@@ -270,7 +270,7 @@ such as one a locally started server just reported. Decode with
 `Schema.decodeEither(ServerBaseUrl)` wherever the value comes from
 configuration or another package.
 
-### [`ServerBaseUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L51)
+### [`ServerBaseUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L58)
 
 _TypeAlias_
 
@@ -281,7 +281,7 @@ export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">;
 A MoltZap server address carrying no path, query, or fragment, over
 `http`, `https`, `ws`, or `wss`.
 
-### [`ServerBaseUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L51)
+### [`ServerBaseUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L58)
 
 _Variable_
 
@@ -292,7 +292,7 @@ export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">
 Decodes either address a caller is likely to hold — the base URL or the
 socket endpoint — into the path-free base. Any other path fails.
 
-### [`webSocketUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L80)
+### [`webSocketUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L97)
 
 _Function_
 

--- a/docs/modules/protocol/network.mdx
+++ b/docs/modules/protocol/network.mdx
@@ -13,7 +13,7 @@ Public barrel for connect and presence protocol descriptors.
 
 ## Public surface
 
-### [`agentCallableNetworkRpcMethods`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/index.ts#L21)
+### [`agentCallableNetworkRpcMethods`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/index.ts#L23)
 
 _Variable_
 
@@ -74,7 +74,7 @@ export const AgentPresenceSubscribe = defineRpc({
 })
 ```
 
-### [`appCallableNetworkRpcMethods`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/index.ts#L27)
+### [`appCallableNetworkRpcMethods`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/index.ts#L29)
 
 _Variable_
 
@@ -176,7 +176,7 @@ export class InvalidProtocolVersionError extends Data.TaggedError(
 }
 ```
 
-### [`networkNotifications`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/index.ts#L41)
+### [`networkNotifications`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/index.ts#L43)
 
 _Variable_
 
@@ -186,7 +186,7 @@ export const networkNotifications = [] as const
 
 Network notifications emitted by the server.
 
-### [`networkRpcMethods`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/index.ts#L33)
+### [`networkRpcMethods`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/index.ts#L35)
 
 _Variable_
 
@@ -250,32 +250,6 @@ _TypeAlias_
 export type ProtocolMismatchReason =
   | "server-above-client-max"
   | "server-below-client-min";
-
-/**
- * Raised by connect methods when the client's `[minProtocol, maxProtocol]`
- * range does not bracket the server's `PROTOCOL_VERSION`. The server's connect
- * handlers raise it BEFORE auth resolution
- * so old clients are rejected at the version gate. `data` carries the
- * diagnostic `{ reason, serverVersion, clientMinProtocol, clientMaxProtocol }`,
- * concretely typed so `error.data.reason` narrows at every reader.
- */
-export class ProtocolMismatchError extends Schema.TaggedError<ProtocolMismatchError>()(
-  "ProtocolMismatchError",
-  {
-    message: Schema.optional(Schema.String),
-    data: Schema.Struct({
-      reason: Schema.Literal(
-        "server-above-client-max",
-        "server-below-client-min",
-      ),
-      serverVersion: Schema.String,
-      clientMinProtocol: Schema.String,
-      clientMaxProtocol: Schema.String,
-    }),
-  },
-) {
-  static readonly message = "Client protocol version not supported";
-}
 ```
 
 Reason discriminant carried in `ProtocolMismatchError.data.reason`:
@@ -283,8 +257,54 @@ Reason discriminant carried in `ProtocolMismatchError.data.reason`:
 `maxProtocol`; the client must update. `server-below-client-min` — the
 client is newer than the server supports.
 
+### [`serverBaseUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L77)
+
+_Variable_
+
+```ts
+export const serverBaseUrl = Schema.decodeSync(ServerBaseUrl)
+```
+
+Throwing constructor for addresses a caller already knows are well-formed,
+such as one a locally started server just reported. Decode with
+`Schema.decodeEither(ServerBaseUrl)` wherever the value comes from
+configuration or another package.
+
+### [`ServerBaseUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L51)
+
+_TypeAlias_
+
+```ts
+export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">;
+```
+
+A MoltZap server address carrying no path, query, or fragment, over
+`http`, `https`, `ws`, or `wss`.
+
+### [`ServerBaseUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L51)
+
+_Variable_
+
+```ts
+export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">
+```
+
+Decodes either address a caller is likely to hold — the base URL or the
+socket endpoint — into the path-free base. Any other path fails.
+
+### [`webSocketUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/network/server-url.ts#L80)
+
+_Function_
+
+```ts
+export const webSocketUrl = (base: ServerBaseUrl): string
+```
+
+The socket endpoint a client dials for the given server.
+
 ## Files
 
 - `connect.ts`
 - `index.ts`
 - `presence.ts`
+- `server-url.ts`

--- a/docs/modules/protocol/socket.mdx
+++ b/docs/modules/protocol/socket.mdx
@@ -79,7 +79,7 @@ export function classifyCloseCause(
 ): CloseKind
 ```
 
-### [`ClientConnectError`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L117)
+### [`ClientConnectError`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L123)
 
 _TypeAlias_
 
@@ -87,7 +87,7 @@ _TypeAlias_
 export type ClientConnectError<Rpcs extends ProtocolRpc> =
 ```
 
-### [`ClientDefinitionError`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L106)
+### [`ClientDefinitionError`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L112)
 
 _TypeAlias_
 
@@ -95,7 +95,7 @@ _TypeAlias_
 export type ClientDefinitionError<D extends ClientRpcDefinition> =
 ```
 
-### [`ClientDefinitionPayload`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L102)
+### [`ClientDefinitionPayload`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L108)
 
 _TypeAlias_
 
@@ -103,7 +103,7 @@ _TypeAlias_
 export type ClientDefinitionPayload<D extends ClientRpcDefinition> =
 ```
 
-### [`ClientDefinitionSuccess`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L104)
+### [`ClientDefinitionSuccess`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L110)
 
 _TypeAlias_
 
@@ -111,7 +111,7 @@ _TypeAlias_
 export type ClientDefinitionSuccess<D extends ClientRpcDefinition> =
 ```
 
-### [`ClientLifecycleOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L212)
+### [`ClientLifecycleOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L228)
 
 _Interface_
 
@@ -137,17 +137,15 @@ export interface ClientLifecycleOptions<
 }
 ```
 
-### [`clientRpc`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L100)
+### [`clientRpc`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L106)
 
 _Property_
 
 ```ts
   readonly clientRpc: Rpcs;
-};
-export type ClientDefinitionPayload<D extends ClientRpcDefinition> =
 ```
 
-### [`ClientRpcDefinition`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L99)
+### [`ClientRpcDefinition`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L105)
 
 _TypeAlias_
 
@@ -226,7 +224,7 @@ _Variable_
 export type ConnectionId = string & Brand.Brand<"ConnectionId">
 ```
 
-### [`ConnectResult`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L111)
+### [`ConnectResult`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L117)
 
 _TypeAlias_
 
@@ -574,7 +572,7 @@ _Function_
 export const newConnectionId = (): ConnectionId
 ```
 
-### [`openProtocolAgentClientSocket`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L561)
+### [`openProtocolAgentClientSocket`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L578)
 
 _Function_
 
@@ -588,7 +586,7 @@ export const openProtocolAgentClientSocket = (
 >
 ```
 
-### [`openProtocolAppClientSocket`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L573)
+### [`openProtocolAppClientSocket`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L590)
 
 _Function_
 
@@ -602,7 +600,7 @@ export const openProtocolAppClientSocket = (
 >
 ```
 
-### [`ProtocolClientLifecycle`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L642)
+### [`ProtocolClientLifecycle`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L659)
 
 _Class_
 
@@ -737,7 +735,7 @@ _TypeAlias_
 export type ReverseCallbackError<D extends AnyAppCallbackRpcDefinition> =
 ```
 
-### [`ReverseCallbackHandlers`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L259)
+### [`ReverseCallbackHandlers`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L275)
 
 _TypeAlias_
 
@@ -795,8 +793,6 @@ _TypeAlias_
 
 ```ts
 export type ReverseCallError = NotConnectedError | RpcTimeoutError;
-
-type ReverseRpcs = RpcGroup.Rpcs<typeof ReverseRpcGroup>;
 ```
 
 ### [`ReverseClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/server.ts#L204)
@@ -826,7 +822,7 @@ export interface ReverseClient {
 }
 ```
 
-### [`RPC_TIMEOUT_MS`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L85)
+### [`RPC_TIMEOUT_MS`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L91)
 
 _Variable_
 
@@ -834,7 +830,7 @@ _Variable_
 export const RPC_TIMEOUT_MS = 30_000
 ```
 
-### [`RpcCallOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L95)
+### [`RpcCallOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/socket/lifecycle.ts#L101)
 
 _Interface_
 

--- a/docs/modules/protocol/testing/conformance/_shared/driver.mdx
+++ b/docs/modules/protocol/testing/conformance/_shared/driver.mdx
@@ -13,7 +13,7 @@ Lifecycle-backed conformance client barrel.
 
 ## Public surface
 
-### [`AgentTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L93)
+### [`AgentTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L94)
 
 _Interface_
 
@@ -27,7 +27,7 @@ export interface AgentTestClient extends NotificationClient {
 }
 ```
 
-### [`AgentTestClientConfig`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L58)
+### [`AgentTestClientConfig`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L59)
 
 _Interface_
 
@@ -40,7 +40,7 @@ export interface AgentTestClientConfig {
 }
 ```
 
-### [`AppTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L101)
+### [`AppTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L102)
 
 _Interface_
 
@@ -68,7 +68,7 @@ export interface AppTestClient extends NotificationClient {
 }
 ```
 
-### [`AppTestClientConfig`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L65)
+### [`AppTestClientConfig`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L66)
 
 _Interface_
 
@@ -81,7 +81,7 @@ export interface AppTestClientConfig {
 }
 ```
 
-### [`CloseableAgentTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L123)
+### [`CloseableAgentTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L124)
 
 _Interface_
 
@@ -91,7 +91,7 @@ export interface CloseableAgentTestClient extends AgentTestClient {
 }
 ```
 
-### [`CloseableAppTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L127)
+### [`CloseableAppTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L128)
 
 _Interface_
 
@@ -101,7 +101,7 @@ export interface CloseableAppTestClient extends AppTestClient {
 }
 ```
 
-### [`makeAgentTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L162)
+### [`makeAgentTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L163)
 
 _Function_
 
@@ -111,7 +111,7 @@ export function makeAgentTestClient(
 ): Effect.Effect<AgentTestClient, SendRpcError, Scope.Scope>
 ```
 
-### [`makeAppTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L180)
+### [`makeAppTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L181)
 
 _Function_
 
@@ -121,7 +121,7 @@ export function makeAppTestClient(
 ): Effect.Effect<AppTestClient, SendRpcError, Scope.Scope>
 ```
 
-### [`makeCloseableAgentTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L172)
+### [`makeCloseableAgentTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L173)
 
 _Function_
 
@@ -131,7 +131,7 @@ export function makeCloseableAgentTestClient(
 ): Effect.Effect<CloseableAgentTestClient, SendRpcError>
 ```
 
-### [`makeCloseableAppTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L190)
+### [`makeCloseableAppTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L191)
 
 _Function_
 
@@ -141,7 +141,7 @@ export function makeCloseableAppTestClient(
 ): Effect.Effect<CloseableAppTestClient, SendRpcError>
 ```
 
-### [`NotificationClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L78)
+### [`NotificationClient`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L79)
 
 _Interface_
 
@@ -162,7 +162,7 @@ export interface NotificationClient {
 }
 ```
 
-### [`ServerRequestWaitError`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L131)
+### [`ServerRequestWaitError`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L132)
 
 _Class_
 
@@ -176,7 +176,7 @@ export class ServerRequestWaitError extends Data.TaggedError(
 }> {}
 ```
 
-### [`ServerRpcContext`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L143)
+### [`ServerRpcContext`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L144)
 
 _Interface_
 
@@ -187,16 +187,15 @@ export interface ServerRpcContext {
 }
 ```
 
-### [`ServerRpcDefinition`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L139)
+### [`ServerRpcDefinition`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L140)
 
 _TypeAlias_
 
 ```ts
 export type ServerRpcDefinition = AnyAppCallbackRpcDefinition;
-export type ServerRpcParams<D extends ServerRpcDefinition> = ParamsOf<D>;
 ```
 
-### [`ServerRpcParams`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L140)
+### [`ServerRpcParams`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L141)
 
 _TypeAlias_
 
@@ -204,7 +203,7 @@ _TypeAlias_
 export type ServerRpcParams<D extends ServerRpcDefinition> = ParamsOf<D>;
 ```
 
-### [`ServerRpcResult`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L141)
+### [`ServerRpcResult`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts#L142)
 
 _TypeAlias_
 

--- a/docs/modules/protocol/testing/conformance/app.mdx
+++ b/docs/modules/protocol/testing/conformance/app.mdx
@@ -219,9 +219,6 @@ _Property_
 
 ```ts
   readonly leaseId: string;
-};
-
-export function freshMessageId(): Schema.Schema.Type<typeof MessageId> {
 ```
 
 ### [`leaseId`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/app/_helpers.ts#L66)
@@ -238,7 +235,6 @@ _Property_
 
 ```ts
   readonly leaseId: string;
-  readonly verdict: { decision: string; reason?: string };
 ```
 
 ### [`LeaseIdOnlyView`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/app/_helpers.ts#L66)
@@ -263,83 +259,6 @@ export type LeaseState =
   | "EXPIRED"
   | "ABANDONED"
   | "HOLD";
-
-// ── Recipient handle ──────────────────────────────────────────────────
-
-/**
- * Recipient-side surface. Owns one `AgentTestClient` connected to the real
- * server under a recipient agent identity. All methods return Effects
- * scoped to the surrounding `Scope`; releasing the scope closes the
- * underlying agent client.
- */
-export interface RecipientHandle {
-  readonly agentId: Schema.Schema.Type<typeof AgentId>;
-
-  /**
-   * Issue `agent/dispatch/request` for the given inbound. Returns the ack
-   * payload `{leaseId, dispatchId}`. Single recipient may issue many
-   * concurrent requests; the property is responsible for ordering its
-   * own assertions.
-   */
-  readonly requestDispatch: (params: {
-    readonly conversationId: Schema.Schema.Type<typeof ConversationId>;
-    readonly messageId: Schema.Schema.Type<typeof MessageId>;
-    readonly senderAgentId: Schema.Schema.Type<typeof AgentId>;
-    readonly attempt?: number;
-  }) => Effect.Effect<
-    {
-      readonly leaseId: Schema.Schema.Type<typeof LeaseId>;
-      readonly dispatchId: Schema.Schema.Type<typeof DispatchId>;
-    },
-    PropertyFailure
-  >;
-
-  /**
-   * Park until a `agent/dispatch/released` notification arrives that matches
-   * `predicate` (default: any). Used by every property in the
-   * `DispatchRelease` group + every property that asserts a verdict
-   * delivery.
-   */
-  readonly waitForRelease: (
-    predicate?: (
-      frame: NotificationDelivery<typeof DispatchRelease>,
-    ) => boolean,
-    timeoutMs?: number,
-  ) => Effect.Effect<
-    NotificationDelivery<typeof DispatchRelease>,
-    PropertyFailure
-  >;
-
-  /**
-   * Send `agent/message/send` carrying `dispatchLeaseId`. Used to consume a
-   * GRANTED lease + assert the consumed/duplicate behavior. Returns the
-   * minted message id on success; on the lease-already-CONSUMED path,
-   * fails with a `PropertyInvariantViolation` whose `reason` carries
-   * the wire-error code + `LeaseInvalid` data tag the server returned.
-   */
-  readonly sendWithLease: (params: {
-    readonly taskId: Schema.Schema.Type<typeof TaskId>;
-    readonly conversationId: Schema.Schema.Type<typeof ConversationId>;
-    readonly leaseId: Schema.Schema.Type<typeof LeaseId>;
-    readonly text: string;
-  }) => Effect.Effect<
-    {
-      readonly messageId: Schema.Schema.Type<typeof MessageId>;
-      readonly errorTag?: string;
-      readonly errorState?: string;
-    },
-    PropertyFailure
-  >;
-
-  /**
-   * Disconnect the recipient's WS without graceful shutdown.
-   * Drives ABANDONED + EXPIRED-on-disconnect transitions for every
-   * `*-disconnect-*` property. The returned Effect resolves once the
-   * server has observed the close (registry's connection-close
-   * finalizer fired).
-   */
-  readonly hardClose: Effect.Effect<void, PropertyFailure>;
-}
 ```
 
 Closed lease-state union mirroring `LeaseStateSchema`. The driver's
@@ -371,10 +290,6 @@ _Property_
 
 ```ts
   readonly messageId: string;
-  readonly leaseId: string;
-};
-
-export function freshMessageId(): Schema.Schema.Type<typeof MessageId> {
 ```
 
 ### [`ModeratorHandle`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/app/_driver.ts#L190)

--- a/docs/modules/protocol/testing/conformance/network.mdx
+++ b/docs/modules/protocol/testing/conformance/network.mdx
@@ -98,11 +98,6 @@ _TypeAlias_
 
 ```ts
 export type PresenceStatus = "online" | "working" | "offline";
-
-export interface PresenceStatusEntry {
-  readonly agentId: AgentId;
-  readonly status: PresenceStatus;
-}
 ```
 
 ### [`PresenceStatusEntry`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/network/_helpers.ts#L24)

--- a/docs/modules/protocol/testing/conformance/task.mdx
+++ b/docs/modules/protocol/testing/conformance/task.mdx
@@ -64,36 +64,6 @@ _Property_
 
 ```ts
   readonly agent: TestAgent;
-  readonly client: AgentTestClient;
-
-  /**
-   * Per-client historical notification buffer: `subscribe`
-   * only emits frames arriving AFTER materialisation, so a sequential
-   * `send → awaitOneNotification` races the response frame. The buffer
-   * is fed by a long-lived
-   * `subscribeAll()` pump installed at `acquireClient` time;
-   * `awaitOneNotification` consumes the buffer so frames that arrived
-   * between the triggering RPC and the wait are still observable. This
-   * mirrors `@moltzap/server-core/test-utils → connectTestClient` (the
-   * `makeNotificationBuffer` JSDoc below covers the design).
-   */
-  readonly notifications: NotificationBuffer;
-};
-
-/**
- * Historical notification buffer used by `awaitOneNotification`. Holds
- * every inbound notification arriving on a single client's
- * `subscribeAll()` Stream until a consumer pulls a matching frame.
- *
- * The `snapshot` and `closed` fields are the only public surfaces;
- * the pump fiber that feeds them is interrupted by the enclosing
- * Scope finalizer installed by `makeNotificationBuffer`. `closed` is
- * set to true when the transport-side stream terminates (either via
- * `TransportClosedError` or normal exhaustion); `awaitOneNotification`
- * consumes it to surface "Connection closed" rather than masquerading
- * a missing notification as a timeout.
- */
-export interface NotificationBuffer {
 ```
 
 ### [`archiveConversation`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/task/_helpers.ts#L321)
@@ -162,35 +132,6 @@ _Property_
 
 ```ts
   readonly client: AgentTestClient;
-
-  /**
-   * Per-client historical notification buffer: `subscribe`
-   * only emits frames arriving AFTER materialisation, so a sequential
-   * `send → awaitOneNotification` races the response frame. The buffer
-   * is fed by a long-lived
-   * `subscribeAll()` pump installed at `acquireClient` time;
-   * `awaitOneNotification` consumes the buffer so frames that arrived
-   * between the triggering RPC and the wait are still observable. This
-   * mirrors `@moltzap/server-core/test-utils → connectTestClient` (the
-   * `makeNotificationBuffer` JSDoc below covers the design).
-   */
-  readonly notifications: NotificationBuffer;
-};
-
-/**
- * Historical notification buffer used by `awaitOneNotification`. Holds
- * every inbound notification arriving on a single client's
- * `subscribeAll()` Stream until a consumer pulls a matching frame.
- *
- * The `snapshot` and `closed` fields are the only public surfaces;
- * the pump fiber that feeds them is interrupted by the enclosing
- * Scope finalizer installed by `makeNotificationBuffer`. `closed` is
- * set to true when the transport-side stream terminates (either via
- * `TransportClosedError` or normal exhaustion); `awaitOneNotification`
- * consumes it to surface "Connection closed" rather than masquerading
- * a missing notification as a timeout.
- */
-export interface NotificationBuffer {
 ```
 
 ### [`CONVERSATION_FAMILY_PROPERTIES`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/task/conversation-family.ts#L453)
@@ -392,22 +333,6 @@ _Property_
 
 ```ts
   readonly notifications: NotificationBuffer;
-};
-
-/**
- * Historical notification buffer used by `awaitOneNotification`. Holds
- * every inbound notification arriving on a single client's
- * `subscribeAll()` Stream until a consumer pulls a matching frame.
- *
- * The `snapshot` and `closed` fields are the only public surfaces;
- * the pump fiber that feeds them is interrupted by the enclosing
- * Scope finalizer installed by `makeNotificationBuffer`. `closed` is
- * set to true when the transport-side stream terminates (either via
- * `TransportClosedError` or normal exhaustion); `awaitOneNotification`
- * consumes it to surface "Connection closed" rather than masquerading
- * a missing notification as a timeout.
- */
-export interface NotificationBuffer {
 ```
 
 Per-client historical notification buffer: `subscribe`

--- a/docs/modules/protocol/testing/conformance/transport.mdx
+++ b/docs/modules/protocol/testing/conformance/transport.mdx
@@ -90,7 +90,6 @@ _Property_
 
 ```ts
   readonly proxy: ToxiproxyProxy;
-  readonly unavailable: (reason: string) => PropertyUnavailable;
 ```
 
 ### [`proxyName`](https://github.com/chughtapan/moltzap/blob/main/packages/protocol/src/testing/conformance/transport/_helpers.ts#L48)

--- a/docs/modules/server-core/dispatch.mdx
+++ b/docs/modules/server-core/dispatch.mdx
@@ -569,10 +569,6 @@ export type LeaseState =
   | "EXPIRED"
   | "ABANDONED"
   | "HOLD";
-
-/** Verdict shapes accepted by `resolve` — mirrors the wire decision. */
-export type LeaseVerdict =
-  | { readonly _tag: "grant"; readonly leaseTimeoutMs?: number }
 ```
 
 Discriminated state of a lease. The registry's `Ref.modify`

--- a/docs/modules/server-core/network.mdx
+++ b/docs/modules/server-core/network.mdx
@@ -237,16 +237,6 @@ _TypeAlias_
 
 ```ts
 export type DeliveryError = RecipientNotResolved | WriteFailed;
-
-// ---------------------------------------------------------------------------
-// Service
-// ---------------------------------------------------------------------------
-
-interface BroadcastOptions {
-  readonly forConversation?: ConversationId;
-  readonly excludeConnectionId?: ConnectionId;
-  readonly messageId?: MessageId;
-}
 ```
 
 ### [`NetworkSendService`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/network/network-send.ts#L87)

--- a/docs/modules/server-core/network/presence.mdx
+++ b/docs/modules/server-core/network/presence.mdx
@@ -82,44 +82,6 @@ _TypeAlias_
 
 ```ts
 export type DerivedPresenceStatus = "online" | "working" | "offline";
-
-/**
- * Per-agent presence entry. An agent may hold multiple simultaneous
- * WebSocket connections (web tab + CLI + mobile — see
- * `AgentEndpointResolver`'s module JSDoc), so the entry tracks the
- * full set of live connections + the active leases keyed by which
- * connection holds them.
- *
- * - `liveConns` — every WS connection the
- *   agent is currently authenticated on.
- * - `leasesByConn` — per-connection breakdown of active leases
- *   (GRANTED or CLAIMED), keyed by connection.
- *   When a connection disconnects, its bucket is dropped wholesale so
- *   the leases bound to the dead conn don't keep the agent in
- *   `working` forever.
- *
- * Invariant: every key in `leasesByConn` MUST be present in
- * `liveConns`. A lease callback that arrives bound to a
- * `recipientConnId` not in `liveConns` is a fast-reconnect race ghost
- * and no-ops (audited as `LeaseCallbackFromStaleConnection`).
- *
- * Status derivation: `working` if any live connection holds at least
- * one active lease; `online` if the entry exists but holds no active
- * leases anywhere; `offline` if the entry is absent. See
- * {@link deriveEntryStatus}.
- *
- * The multi-connection shape is correctness-by-construction: a second
- * simultaneous connection ADDS to `liveConns` rather than clobbering
- * the agent's lease set, so the original conn's active leases stay
- * accounted-for.
- *
- * "offline" is represented by entry absence; presence state NEVER
- * holds an entry whose `liveConns` is empty.
- */
-export interface AgentPresenceEntry {
-  readonly liveConns: ReadonlySet<ConnectionId>;
-  readonly leasesByConn: ReadonlyMap<ConnectionId, ReadonlySet<LeaseId>>;
-}
 ```
 
 Derived presence status. Three-state set:

--- a/docs/modules/server-core/socket.mdx
+++ b/docs/modules/server-core/socket.mdx
@@ -62,16 +62,6 @@ _TypeAlias_
 
 ```ts
 export type AgentStatus = "active" | "suspended";
-
-/**
- * Principal context arms stored on authenticated socket connections. Handlers
- * receive the arm selected by each method's `requires` head.
- */
-export class AgentContext extends Data.TaggedClass("AgentContext")<{
-  readonly agentId: AgentId;
-  readonly agentStatus: AgentStatus;
-  readonly ownerUserId: UserId;
-}> {}
 ```
 
 Closed agent lifecycle states. Mirrors
@@ -110,15 +100,6 @@ export type Connection =
   | UnauthenticatedConnection
   | AgentConnection
   | AppConnection;
-
-/**
- * Outcome of `ConnectionManager.authenticate`'s atomic transition. The
- * success arms are split per minted arm so the Connect handler's
- * `Match.value(outcome).pipe(Match.when({ kind: "ok-agent" }, ...))` narrows
- * `authed` structurally — no `as AgentConnection` cast.
- */
-export type TransitionOutcome =
-  | { readonly kind: "not-connected" }
 ```
 
 The three-arm connection state — the connections map's only entry shape.
@@ -288,19 +269,6 @@ _TypeAlias_
 
 ```ts
 export type Originator = ReverseClient;
-
-/**
- * The per-connection socket handle registered with `ConnectionManager`.
- */
-export interface WebSocketRef {
-  /**
-   * Write a raw frame to this connection. Fails with SocketError on send
-   * failure or if the socket is already closed.
-   */
-  readonly write: (raw: string) => Effect.Effect<void, SocketError>;
-  /** Close this connection's scope, tearing down the underlying socket. */
-  readonly shutdown: Effect.Effect<void>;
-}
 ```
 
 The per-connection reverse `RpcClient&lt;ReverseRpcGroup>` the server fires

--- a/docs/modules/server-core/test-utils.mdx
+++ b/docs/modules/server-core/test-utils.mdx
@@ -29,7 +29,7 @@ task-callback RPC at construction time — adding a new entry to
 `appCallbackMethods` becomes a compile error at every endpoint
 construction site.
 
-### [`AwaitNotificationError`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L56)
+### [`AwaitNotificationError`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L57)
 
 _TypeAlias_
 
@@ -37,55 +37,9 @@ _TypeAlias_
 export type AwaitNotificationError =
   | AwaitNotificationTimeoutError
   | AwaitNotificationClosedError;
-
-/**
- * Stream-based one-shot waiter. Consumes `client.subscribe(def)` via
- * `Stream.runHead`, failing with `AwaitNotificationTimeoutError` on timeout
- * and `AwaitNotificationClosedError` when the transport closed before a
- * matching frame arrived. Distinguishing close from timeout keeps a dead
- * connection from masquerading as a missing notification.
- */
-export function awaitOneNotification<D extends AnyNotificationDefinition>(
-  client: Pick<TestAgentClient, "subscribe">,
-  definition: D,
-  timeoutMs: number = DEFAULT_AWAIT_NOTIFICATION_TIMEOUT_MS,
-): Effect.Effect<NotificationDelivery<D>, AwaitNotificationError> {
-  const closed = () =>
-    new AwaitNotificationClosedError({
-      definition: definition.name,
-    });
-  return client.subscribe(definition).pipe(
-    Stream.map(
-      (params): NotificationDelivery<D> => ({
-        definition,
-        method: definition.name,
-        params,
-      }),
-    ),
-    Stream.runHead,
-    Effect.either,
-    Effect.flatMap(
-      Either.match({
-        onLeft: () => Effect.fail(closed()),
-        onRight: Option.match({
-          onNone: () => Effect.fail(closed()),
-          onSome: (notification) => Effect.succeed(notification),
-        }),
-      }),
-    ),
-    Effect.timeoutFail({
-      duration: Duration.millis(timeoutMs),
-      onTimeout: () =>
-        new AwaitNotificationTimeoutError({
-          definition: definition.name,
-          durationMs: timeoutMs,
-        }),
-    }),
-  );
-}
 ```
 
-### [`awaitOneNotification`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L67)
+### [`awaitOneNotification`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L68)
 
 _Function_
 
@@ -103,7 +57,7 @@ and `AwaitNotificationClosedError` when the transport closed before a
 matching frame arrived. Distinguishing close from timeout keeps a dead
 connection from masquerading as a missing notification.
 
-### [`closeAllClients`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L170)
+### [`closeAllClients`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L171)
 
 _Function_
 
@@ -111,7 +65,7 @@ _Function_
 export function closeAllClients(): Effect.Effect<void, never>
 ```
 
-### [`connectAppClient`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L278)
+### [`connectAppClient`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L281)
 
 _Function_
 
@@ -123,7 +77,7 @@ export function connectAppClient(
 ): Effect.Effect<TestAppClient, Error>
 ```
 
-### [`ConnectedAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L106)
+### [`ConnectedAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L107)
 
 _Interface_
 
@@ -136,7 +90,7 @@ export interface ConnectedAgent {
 }
 ```
 
-### [`connectTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L219)
+### [`connectTestClient`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L220)
 
 _Function_
 
@@ -156,8 +110,6 @@ _TypeAlias_
 export type CoreSchemaSqlLoadError =
   | CoreSchemaSqlAccessError
   | CoreSchemaSqlReadError;
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 ```
 
 ### [`CoreTestDatabasePort`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/ports.ts#L22)
@@ -203,19 +155,6 @@ _TypeAlias_
 
 ```ts
 export type CoreTestServer = CoreTestServerPort;
-
-/**
- * Start a test server and expose its package-owned integration ports.
- * @param opts Test server configuration.
- * @returns A promise for the running server's integration ports.
- */
-export function startCoreTestServer(opts: StartCoreTestServerOptions = {}) {
-  return Effect.runPromise(
-    startCoreTestServerEffect(opts).pipe(
-      Effect.map((server) => server.testPort),
-    ),
-  );
-}
 ```
 
 Canonical published handle for a running core test server.
@@ -295,7 +234,7 @@ export interface CoreTestSpanExporterPort {
 
 Trace-capture operations available to test-harness consumers.
 
-### [`createTestAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L196)
+### [`createTestAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L197)
 
 _Function_
 
@@ -456,15 +395,9 @@ export type PgliteHarnessError =
   | PgliteCreateError
   | PgliteExecError
   | PgliteCloseError;
-
-const SQL_PREVIEW_MAX_CHARS = 160;
-
-function sqlPreview(sql: string): string {
-  return sql.replace(/\s+/g, " ").trim().slice(0, SQL_PREVIEW_MAX_CHARS);
-}
 ```
 
-### [`postJson`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L311)
+### [`postJson`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L314)
 
 _Function_
 
@@ -480,7 +413,7 @@ POST `body` as JSON to `${baseUrl}${path}` and resolve with
 `{status, json}`. HTTP integration tests import this helper to avoid
 repeated request/JSON boilerplate.
 
-### [`registerAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L177)
+### [`registerAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L178)
 
 _Function_
 
@@ -492,7 +425,7 @@ export function registerAgent(
 ): Effect.Effect<TestAgent, Error>
 ```
 
-### [`registerAndConnect`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L295)
+### [`registerAndConnect`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L298)
 
 _Function_
 
@@ -504,7 +437,7 @@ export function registerAndConnect(
 
 Register and connect an agent. Tracked for automatic cleanup.
 
-### [`registerApp`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L253)
+### [`registerApp`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L256)
 
 _Function_
 
@@ -527,7 +460,7 @@ _Function_
 export function resetCoreTestDb()
 ```
 
-### [`setupAgentGroup`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L411)
+### [`setupAgentGroup`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L414)
 
 _Function_
 
@@ -547,7 +480,7 @@ export function setupAgentGroup(
 
 Create N agents, all connected. Optionally create a group conversation.
 
-### [`setupAgentPair`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L399)
+### [`setupAgentPair`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L402)
 
 _Function_
 
@@ -612,7 +545,7 @@ _Function_
 export function stopCoreTestServer()
 ```
 
-### [`trackClient`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L166)
+### [`trackClient`](https://github.com/chughtapan/moltzap/blob/main/packages/server/src/test-utils/helpers.ts#L167)
 
 _Function_
 

--- a/docs/modules/testbed/src.mdx
+++ b/docs/modules/testbed/src.mdx
@@ -13,7 +13,7 @@ Public exports for launching and supervising connected-agent testbeds.
 
 ## Public surface
 
-### [`AgentName`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L7)
+### [`AgentName`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L8)
 
 _TypeAlias_
 
@@ -21,7 +21,7 @@ _TypeAlias_
 export type AgentName = string & Brand.Brand<"AgentName">;
 ```
 
-### [`AgentName`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L7)
+### [`AgentName`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L8)
 
 _Variable_
 
@@ -71,16 +71,9 @@ _TypeAlias_
 
 ```ts
 export type InstallMode = "published" | "workspace";
-
-const CHANNEL_PACKAGE_NAME = "@moltzap/openclaw-channel";
-
-interface InstallModeResolverDeps {
-  readonly resolveChannelPackageRoot: () => string;
-  readonly workspacePackagesDir: string | null;
-}
 ```
 
-### [`launchTestbed`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L370)
+### [`launchTestbed`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L393)
 
 _Function_
 
@@ -105,7 +98,7 @@ Sibling: launchTestbedWithProcessSignals adds SIGINT
 / SIGTERM handlers so Ctrl-C during startup interrupts cleanly via
 `TestbedStartupInterrupted`.
 
-### [`launchTestbedWithProcessSignals`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L476)
+### [`launchTestbedWithProcessSignals`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L511)
 
 _Function_
 
@@ -139,7 +132,7 @@ flowchart TD
 
 - `TestbedStartupInterrupted` — a signal arrives during testbed startup
 
-### [`LogSlice`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L49)
+### [`LogSlice`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L57)
 
 _Interface_
 
@@ -436,7 +429,7 @@ export interface OpenClawAdapterOptions {
 }
 ```
 
-### [`ReadyOutcome`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L63)
+### [`ReadyOutcome`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L71)
 
 _TypeAlias_
 
@@ -445,7 +438,7 @@ export type ReadyOutcome =
   | { readonly _tag: "Ready" }
 ```
 
-### [`Runtime`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L82)
+### [`Runtime`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L90)
 
 _Interface_
 
@@ -503,7 +496,7 @@ Raised by `startPendingRuntimeAgent` when `waitUntilReady` returns
 `exitCode` is `null` only if the process exited via signal.
 Caller action: inspect `stderr`; check binary auth config.
 
-### [`RuntimeKind`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L65)
+### [`RuntimeKind`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L67)
 
 _TypeAlias_
 
@@ -550,7 +543,7 @@ has been torn down before the failure reaches the caller.
 Caller action: increase `readyTimeoutMs`, or enable process-level
 diagnostics at the adapter boundary.
 
-### [`RuntimeServerHandle`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L20)
+### [`RuntimeServerHandle`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L28)
 
 _Interface_
 
@@ -576,35 +569,34 @@ export interface RuntimeServerHandle {
 }
 ```
 
-### [`RuntimeStartOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L67)
+### [`RuntimeStartOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L69)
 
 _TypeAlias_
 
 ```ts
 export type RuntimeStartOptions = RuntimeStartOptionsBase & RuntimeSelection;
-
-interface TestbedLaunchOptionsBase {
-  readonly server: RuntimeServerHandle;
-  readonly agents: ReadonlyArray<TestbedAgentSpec>;
-  readonly readyTimeoutMs: number;
-  readonly concurrency?: number | "unbounded";
-}
 ```
 
-### [`ServerUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L8)
+### [`ServerUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L20)
 
 _TypeAlias_
 
 ```ts
-export type ServerUrl = string & Brand.Brand<"ServerUrl">;
+export type ServerUrl = ServerBaseUrl;
 ```
 
-### [`ServerUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L8)
+The address an adapter hands its child process: the protocol's path-free
+base, under this package's long-standing name. The child's client appends
+the socket route itself, so a value carrying one dials `/ws/ws` and never
+authenticates. Accepts either form a caller is likely to hold — the base
+URL or the socket endpoint — and throws on any other path.
+
+### [`ServerUrl`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L20)
 
 _Variable_
 
 ```ts
-export type ServerUrl = string & Brand.Brand<"ServerUrl">
+export type ServerUrl = ServerBaseUrl
 ```
 
 ### [`SpawnFailed`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/errors.ts#L16)
@@ -626,7 +618,7 @@ failure, state-dir creation failure.
 `cause` carries the underlying Error.
 Caller action: surface to user. No retry — binary or config is wrong.
 
-### [`SpawnInput`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L40)
+### [`SpawnInput`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L48)
 
 _Interface_
 
@@ -635,13 +627,13 @@ export interface SpawnInput {
   readonly agentName: AgentName;
   readonly apiKey: AgentKey;
   readonly agentId: AgentId;
-  readonly serverUrl: ServerUrl;
+  readonly serverUrl: ServerBaseUrl;
   readonly workspaceFiles?: ReadonlyArray<WorkspaceFile>;
   readonly modelId?: string;
 }
 ```
 
-### [`startRuntimeAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L339)
+### [`startRuntimeAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L357)
 
 _Function_
 
@@ -675,7 +667,7 @@ coordinated startup.
 - `RuntimeReadyTimedOut` — `waitUntilReady` exceeds `readyTimeoutMs`
 - `RuntimeExitedBeforeReady` — the process exits before signaling ready (inspect `stderr`)
 
-### [`Testbed`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L87)
+### [`Testbed`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L89)
 
 _Interface_
 
@@ -687,7 +679,7 @@ export interface Testbed {
 }
 ```
 
-### [`TestbedAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L82)
+### [`TestbedAgent`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L84)
 
 _Interface_
 
@@ -698,7 +690,7 @@ export interface TestbedAgent {
 }
 ```
 
-### [`TestbedAgentSpec`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L32)
+### [`TestbedAgentSpec`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L34)
 
 _Interface_
 
@@ -713,19 +705,15 @@ export interface TestbedAgentSpec {
 }
 ```
 
-### [`TestbedLaunchOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L76)
+### [`TestbedLaunchOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L78)
 
 _TypeAlias_
 
 ```ts
 export type TestbedLaunchOptions = TestbedLaunchOptionsBase & RuntimeSelection;
-
-export type TestbedProcessSignalOptions = TestbedLaunchOptions & {
-  readonly signals?: ReadonlyArray<Signal>;
-};
 ```
 
-### [`TestbedProcessSignalOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L78)
+### [`TestbedProcessSignalOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L80)
 
 _TypeAlias_
 
@@ -735,7 +723,7 @@ export type TestbedProcessSignalOptions = TestbedLaunchOptions & {
 };
 ```
 
-### [`TestbedStartupInterrupted`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L93)
+### [`TestbedStartupInterrupted`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/testbed.ts#L95)
 
 _Class_
 
@@ -748,7 +736,7 @@ export class TestbedStartupInterrupted extends Data.TaggedError(
 }> {}
 ```
 
-### [`WorkspaceFile`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L15)
+### [`WorkspaceFile`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/runtime.ts#L23)
 
 _Interface_
 

--- a/packages/client/src/test-utils/index.ts
+++ b/packages/client/src/test-utils/index.ts
@@ -25,6 +25,7 @@ export { FakeMoltZapService, type RecordedCall } from "./fake-service.js";
 export { withTestServiceConfig } from "../config.test-utils.js";
 
 import type { Message } from "@moltzap/protocol/message";
+import { serverBaseUrl, type ServerBaseUrl } from "@moltzap/protocol/network";
 import { Data, Effect } from "effect";
 import { testAgentId, testConversationId, testMessageId } from "./ids.js";
 
@@ -39,12 +40,12 @@ export {
 const FLUSH_DISPATCH_TURNS = 20;
 
 /**
- * Strip the WebSocket route suffix from a test server URL.
+ * Reduce a test server's WebSocket endpoint to the base a client connects to.
  * @param wsUrl Test server WebSocket URL.
- * @returns Base URL without the `/ws` suffix.
+ * @returns Path-free base URL.
  */
-export const stripWsPath = (wsUrl: string): string =>
-  wsUrl.replace(/\/ws\/?$/, "");
+export const stripWsPath = (wsUrl: string): ServerBaseUrl =>
+  serverBaseUrl(wsUrl);
 
 class FlushDispatchChainError extends Data.TaggedError(
   "FlushDispatchChainError",

--- a/packages/openclaw-channel/src/test-utils/container-core.ts
+++ b/packages/openclaw-channel/src/test-utils/container-core.ts
@@ -15,6 +15,7 @@ import { FileSystem } from "@effect/platform";
 import { NodeFileSystem } from "@effect/platform-node";
 import { Effect, Redacted } from "effect";
 import type { AgentId, AgentKey } from "@moltzap/protocol/identity";
+import { serverBaseUrl } from "@moltzap/protocol/network";
 
 const CONTROL_UI_PORT = 18789;
 const OPENCLAW_TOKEN_RADIX = 36;
@@ -102,10 +103,10 @@ interface BuildOpenClawConfigOptions {
   agentName: string;
 }
 
+// Containers reach the host's loopback only through the Docker gateway alias.
 export function normalizeContainerServerUrl(serverUrl: string): string {
-  return serverUrl
-    .replace(/\/ws$/, "")
-    .replace(/^ws:/, "http:")
+  return serverBaseUrl(serverUrl)
+    .replace(/^ws/, "http")
     .replace("localhost", "host.docker.internal")
     .replace("127.0.0.1", "host.docker.internal");
 }

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -18,7 +18,9 @@ Package subpaths (`imports`/`exports` in `package.json`) mirror this layout:
   subscribers, pagination cursors, shared wire errors.
 - `src/identity/` — agents, apps, users, contacts, principal middleware tags,
   `ActiveAgent`, identity RPCs.
-- `src/network/` — `agent/network/connect`, `app/network/connect`, presence.
+- `src/network/` — `agent/network/connect`, `app/network/connect`, presence,
+  and the server address: path-free `ServerBaseUrl` plus the `webSocketUrl`
+  endpoint derived from it.
 - `src/task/`, `src/conversation/`, `src/message/` — task-domain RPCs,
   identifiers, notifications, requirement descriptors, dispatch
   RPCs/callbacks.

--- a/packages/protocol/scripts/docs/__tests__/signature-extract.test.ts
+++ b/packages/protocol/scripts/docs/__tests__/signature-extract.test.ts
@@ -83,6 +83,19 @@ describe("extractSignatureText", () => {
     expect(sig).toBe("export type Foo = string;");
   });
 
+  it("stops a bracket-free alias before the next declaration", () => {
+    const source = [
+      "export type Foo = Bar;",
+      "",
+      "export interface Baz {",
+      "  readonly qux: string;",
+      "}",
+      "",
+    ].join("\n");
+    const sig = extractSignatureText(source, 1, ReflectionKind.TypeAlias);
+    expect(sig).toBe("export type Foo = Bar;");
+  });
+
   it("returns null when the line is out of range", () => {
     const source = "line one\nline two\n";
     expect(

--- a/packages/protocol/scripts/docs/modules.ts
+++ b/packages/protocol/scripts/docs/modules.ts
@@ -649,9 +649,10 @@ function extractFunctionSignature(
  * (parens, brackets, angles, braces) returns to zero after at least
  * one opening token, checked at line boundaries so a single-line
  * declaration like `class X extends Y()&lt;...&gt;() {}` whose depth dips
- * through zero mid-line stays intact. For one-line declarations with
- * no brace block (e.g. `export type Foo = string;`) falls back to
- * cutting at the first top-level `;` outside strings/comments.
+ * through zero mid-line stays intact. A declaration with no opening
+ * token at all (e.g. `export type Foo = Bar;`) ends at its own top-level
+ * `;`; without that cut the scan runs on until some *later* declaration
+ * opens a bracket, swallowing everything in between.
  *
  * Tokenization (string/line-comment/block-comment skipping plus the
  * `=>`/`&lt;=`/`&gt;=`/`==`/`!=` digraph carve-out) is shared with
@@ -669,23 +670,24 @@ function extractBalancedBody(
   let depth = 0;
   let opened = false;
   let returnIx = -1;
+  let semiIx = -1;
   scanTopLevel(text, (ch, i) => {
     if (ch === "(" || ch === "[" || ch === "<" || ch === "{") {
       depth++;
       opened = true;
     } else if (ch === ")" || ch === "]" || ch === ">" || ch === "}") {
       depth--;
+    } else if (ch === ";" && !opened) {
+      semiIx = i;
+      return "stop";
     } else if (ch === "\n" && opened && depth <= 0) {
       returnIx = i;
       return "stop";
     }
     return "continue";
   });
+  if (semiIx >= 0) return text.slice(0, semiIx + 1).trimEnd();
   if (returnIx >= 0) return text.slice(0, returnIx).trimEnd();
-  if (!opened) {
-    const semi = findOutsideStrings(text, ";");
-    if (semi >= 0) return text.slice(0, semi + 1).trimEnd();
-  }
   return text.trimEnd();
 }
 
@@ -733,18 +735,6 @@ function pickFirstCut(text: string, needles: ReadonlyArray<string>): number {
     else if (ch === "}") braceDepth--;
     return "continue";
   });
-}
-
-function findOutsideStrings(text: string, needle: string): number {
-  let result = -1;
-  scanTopLevel(text, (_ch, i) => {
-    if (text.startsWith(needle, i)) {
-      result = i;
-      return "stop";
-    }
-    return "continue";
-  });
-  return result;
 }
 
 /**

--- a/packages/protocol/src/network/MODULE.md
+++ b/packages/protocol/src/network/MODULE.md
@@ -8,7 +8,7 @@ Public barrel for connect and presence protocol descriptors.
 
 ## Public surface
 
-### [`agentCallableNetworkRpcMethods`](./index.ts#L21)
+### [`agentCallableNetworkRpcMethods`](./index.ts#L23)
 
 _Variable_
 
@@ -69,7 +69,7 @@ export const AgentPresenceSubscribe = defineRpc({
 })
 ```
 
-### [`appCallableNetworkRpcMethods`](./index.ts#L27)
+### [`appCallableNetworkRpcMethods`](./index.ts#L29)
 
 _Variable_
 
@@ -171,7 +171,7 @@ export class InvalidProtocolVersionError extends Data.TaggedError(
 }
 ```
 
-### [`networkNotifications`](./index.ts#L41)
+### [`networkNotifications`](./index.ts#L43)
 
 _Variable_
 
@@ -181,7 +181,7 @@ export const networkNotifications = [] as const
 
 Network notifications emitted by the server.
 
-### [`networkRpcMethods`](./index.ts#L33)
+### [`networkRpcMethods`](./index.ts#L35)
 
 _Variable_
 
@@ -245,32 +245,6 @@ _TypeAlias_
 export type ProtocolMismatchReason =
   | "server-above-client-max"
   | "server-below-client-min";
-
-/**
- * Raised by connect methods when the client's `[minProtocol, maxProtocol]`
- * range does not bracket the server's `PROTOCOL_VERSION`. The server's connect
- * handlers raise it BEFORE auth resolution
- * so old clients are rejected at the version gate. `data` carries the
- * diagnostic `{ reason, serverVersion, clientMinProtocol, clientMaxProtocol }`,
- * concretely typed so `error.data.reason` narrows at every reader.
- */
-export class ProtocolMismatchError extends Schema.TaggedError<ProtocolMismatchError>()(
-  "ProtocolMismatchError",
-  {
-    message: Schema.optional(Schema.String),
-    data: Schema.Struct({
-      reason: Schema.Literal(
-        "server-above-client-max",
-        "server-below-client-min",
-      ),
-      serverVersion: Schema.String,
-      clientMinProtocol: Schema.String,
-      clientMaxProtocol: Schema.String,
-    }),
-  },
-) {
-  static readonly message = "Client protocol version not supported";
-}
 ```
 
 Reason discriminant carried in `ProtocolMismatchError.data.reason`:
@@ -278,8 +252,54 @@ Reason discriminant carried in `ProtocolMismatchError.data.reason`:
 `maxProtocol`; the client must update. `server-below-client-min` — the
 client is newer than the server supports.
 
+### [`serverBaseUrl`](./server-url.ts#L77)
+
+_Variable_
+
+```ts
+export const serverBaseUrl = Schema.decodeSync(ServerBaseUrl)
+```
+
+Throwing constructor for addresses a caller already knows are well-formed,
+such as one a locally started server just reported. Decode with
+`Schema.decodeEither(ServerBaseUrl)` wherever the value comes from
+configuration or another package.
+
+### [`ServerBaseUrl`](./server-url.ts#L51)
+
+_TypeAlias_
+
+```ts
+export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">;
+```
+
+A MoltZap server address carrying no path, query, or fragment, over
+`http`, `https`, `ws`, or `wss`.
+
+### [`ServerBaseUrl`](./server-url.ts#L51)
+
+_Variable_
+
+```ts
+export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">
+```
+
+Decodes either address a caller is likely to hold — the base URL or the
+socket endpoint — into the path-free base. Any other path fails.
+
+### [`webSocketUrl`](./server-url.ts#L80)
+
+_Function_
+
+```ts
+export const webSocketUrl = (base: ServerBaseUrl): string
+```
+
+The socket endpoint a client dials for the given server.
+
 ## Files
 
 - `connect.ts`
 - `index.ts`
 - `presence.ts`
+- `server-url.ts`

--- a/packages/protocol/src/network/MODULE.md
+++ b/packages/protocol/src/network/MODULE.md
@@ -252,7 +252,7 @@ Reason discriminant carried in `ProtocolMismatchError.data.reason`:
 `maxProtocol`; the client must update. `server-below-client-min` — the
 client is newer than the server supports.
 
-### [`serverBaseUrl`](./server-url.ts#L77)
+### [`serverBaseUrl`](./server-url.ts#L94)
 
 _Variable_
 
@@ -265,7 +265,7 @@ such as one a locally started server just reported. Decode with
 `Schema.decodeEither(ServerBaseUrl)` wherever the value comes from
 configuration or another package.
 
-### [`ServerBaseUrl`](./server-url.ts#L51)
+### [`ServerBaseUrl`](./server-url.ts#L58)
 
 _TypeAlias_
 
@@ -276,7 +276,7 @@ export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">;
 A MoltZap server address carrying no path, query, or fragment, over
 `http`, `https`, `ws`, or `wss`.
 
-### [`ServerBaseUrl`](./server-url.ts#L51)
+### [`ServerBaseUrl`](./server-url.ts#L58)
 
 _Variable_
 
@@ -287,7 +287,7 @@ export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">
 Decodes either address a caller is likely to hold — the base URL or the
 socket endpoint — into the path-free base. Any other path fails.
 
-### [`webSocketUrl`](./server-url.ts#L80)
+### [`webSocketUrl`](./server-url.ts#L97)
 
 _Function_
 

--- a/packages/protocol/src/network/README.md
+++ b/packages/protocol/src/network/README.md
@@ -1,0 +1,14 @@
+# Network protocol
+
+This folder owns how an endpoint reaches a MoltZap server and announces
+itself once connected.
+
+- `connect.ts` defines the agent and app connect RPCs, the protocol version,
+  and version-range checking.
+- `presence.ts` defines the presence subscriptions.
+- `server-url.ts` defines the server address: a path-free `ServerBaseUrl` and
+  the socket endpoint the client dials from it.
+- `index.ts` curates the network RPC and notification catalogs.
+
+Connection records, endpoint routing, and presence bookkeeping belong to
+`@moltzap/server-core`; socket lifecycle belongs to `socket/`.

--- a/packages/protocol/src/network/index.ts
+++ b/packages/protocol/src/network/index.ts
@@ -14,6 +14,8 @@ export type { HelloOk, ProtocolMismatchReason } from "./connect.js";
 
 export { AgentPresenceSubscribe, AppPresenceSubscribe } from "./presence.js";
 
+export { ServerBaseUrl, serverBaseUrl, webSocketUrl } from "./server-url.js";
+
 import { AgentConnect, AppConnect } from "./connect.js";
 import { AgentPresenceSubscribe, AppPresenceSubscribe } from "./presence.js";
 

--- a/packages/protocol/src/network/server-url.test.ts
+++ b/packages/protocol/src/network/server-url.test.ts
@@ -5,8 +5,19 @@ import { serverBaseUrl, webSocketUrl } from "./server-url.js";
 const PROPERTY_RUNS = 100;
 const PATH_BEARING_URL = "http://localhost:9999/elsewhere";
 const DOUBLED_ROUTE = "/ws/ws";
+const WS_SCHEME = /^wss?:$/;
 
-const arbScheme = fc.constantFrom("http", "https", "ws", "wss");
+// Schemes are case-insensitive on the wire, so a caller may hold any spelling.
+const arbScheme = fc.constantFrom(
+  "http",
+  "https",
+  "ws",
+  "wss",
+  "HTTP",
+  "HTTPS",
+  "WS",
+  "Wss",
+);
 const arbHost = fc.constantFrom(
   "localhost",
   "127.0.0.1",
@@ -22,6 +33,25 @@ const arbBase = fc
 // The forms a caller may hold for one server: the base, the base with a
 // trailing slash, and the socket endpoint in either spelling.
 const arbSuffix = fc.constantFrom("", "/", "/ws", "/ws/");
+
+// The value is rebuilt from the parsed URL, so the scheme reaches
+// `webSocketUrl` in the spelling its swap matches and the authority in the
+// spelling the socket dials.
+describe("ServerBaseUrl canonicalization", () => {
+  it.each([
+    ["HTTP://localhost:3000", "http://localhost:3000"],
+    ["HTTPS://api.moltzap.xyz", "https://api.moltzap.xyz"],
+    ["WS://localhost:3000/ws", "ws://localhost:3000"],
+    ["http://LOCALHOST:3000", "http://localhost:3000"],
+    ["http://localhost:80", "http://localhost"],
+    ["https://api.moltzap.xyz:443", "https://api.moltzap.xyz"],
+    ["http://localhost//", "http://localhost"],
+    ["http://localhost//ws", "http://localhost"],
+    ["  http://localhost:3000  ", "http://localhost:3000"],
+  ])("canonicalizes %s to %s", (input, expected) => {
+    expect(serverBaseUrl(input)).toBe(expected);
+  });
+});
 
 describe("ServerBaseUrl", () => {
   it.each([
@@ -42,6 +72,9 @@ describe("ServerBaseUrl", () => {
     "http://localhost/ws/extra",
     "http://localhost/?query=1",
     "http://localhost#fragment",
+    // The authority form cannot carry credentials, so accepting these would
+    // drop them silently.
+    "http://user:secret@localhost",
     "file:///srv/moltzap",
     "not a url",
     "",
@@ -80,6 +113,16 @@ describe("webSocketUrl", () => {
         const endpoint = webSocketUrl(serverBaseUrl(`${base}${suffix}`));
         expect(endpoint).toBe(webSocketUrl(serverBaseUrl(base)));
         expect(endpoint).not.toContain(DOUBLED_ROUTE);
+      }),
+      { numRuns: PROPERTY_RUNS },
+    );
+  });
+
+  it("always yields a URL a socket can open", () => {
+    fc.assert(
+      fc.property(arbBase, arbSuffix, (base, suffix) => {
+        const endpoint = webSocketUrl(serverBaseUrl(`${base}${suffix}`));
+        expect(new URL(endpoint).protocol).toMatch(WS_SCHEME);
       }),
       { numRuns: PROPERTY_RUNS },
     );

--- a/packages/protocol/src/network/server-url.test.ts
+++ b/packages/protocol/src/network/server-url.test.ts
@@ -1,0 +1,87 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { serverBaseUrl, webSocketUrl } from "./server-url.js";
+
+const PROPERTY_RUNS = 100;
+const PATH_BEARING_URL = "http://localhost:9999/elsewhere";
+const DOUBLED_ROUTE = "/ws/ws";
+
+const arbScheme = fc.constantFrom("http", "https", "ws", "wss");
+const arbHost = fc.constantFrom(
+  "localhost",
+  "127.0.0.1",
+  "api.moltzap.xyz",
+  "host.docker.internal",
+);
+const arbAuthority = fc
+  .tuple(arbHost, fc.option(fc.integer({ min: 1, max: 65_535 }), { nil: null }))
+  .map(([host, port]) => (port === null ? host : `${host}:${String(port)}`));
+const arbBase = fc
+  .tuple(arbScheme, arbAuthority)
+  .map(([scheme, authority]) => `${scheme}://${authority}`);
+// The forms a caller may hold for one server: the base, the base with a
+// trailing slash, and the socket endpoint in either spelling.
+const arbSuffix = fc.constantFrom("", "/", "/ws", "/ws/");
+
+describe("ServerBaseUrl", () => {
+  it.each([
+    ["ws://127.0.0.1:32821/ws", "ws://127.0.0.1:32821"],
+    ["ws://127.0.0.1:32821/ws/", "ws://127.0.0.1:32821"],
+    ["wss://api.moltzap.xyz/ws", "wss://api.moltzap.xyz"],
+    ["http://localhost:3000/ws", "http://localhost:3000"],
+    ["http://localhost:3000", "http://localhost:3000"],
+    ["http://localhost:3000/", "http://localhost:3000"],
+    ["https://api.moltzap.xyz", "https://api.moltzap.xyz"],
+  ])("decodes %s to %s", (input, expected) => {
+    expect(serverBaseUrl(input)).toBe(expected);
+  });
+
+  it.each([
+    "ws://localhost/ws/ws",
+    PATH_BEARING_URL,
+    "http://localhost/ws/extra",
+    "http://localhost/?query=1",
+    "http://localhost#fragment",
+    "file:///srv/moltzap",
+    "not a url",
+    "",
+  ])("rejects %s", (input) => {
+    expect(() => serverBaseUrl(input)).toThrow();
+  });
+
+  it("names the offending value in the failure", () => {
+    expect(() => serverBaseUrl(PATH_BEARING_URL)).toThrow(PATH_BEARING_URL);
+  });
+
+  it("is idempotent", () => {
+    fc.assert(
+      fc.property(arbBase, arbSuffix, (base, suffix) => {
+        const held = `${base}${suffix}`;
+        expect(serverBaseUrl(serverBaseUrl(held))).toBe(serverBaseUrl(held));
+      }),
+      { numRuns: PROPERTY_RUNS },
+    );
+  });
+});
+
+describe("webSocketUrl", () => {
+  it.each([
+    ["http://localhost:3000", "ws://localhost:3000/ws"],
+    ["https://api.moltzap.xyz", "wss://api.moltzap.xyz/ws"],
+    ["ws://127.0.0.1:32821/ws", "ws://127.0.0.1:32821/ws"],
+    ["ws://127.0.0.1:32821/ws/", "ws://127.0.0.1:32821/ws"],
+  ])("dials %s at %s", (input, expected) => {
+    expect(webSocketUrl(serverBaseUrl(input))).toBe(expected);
+  });
+
+  it("appends the route exactly once, whichever form the caller holds", () => {
+    fc.assert(
+      fc.property(arbBase, arbSuffix, (base, suffix) => {
+        const endpoint = webSocketUrl(serverBaseUrl(`${base}${suffix}`));
+        expect(endpoint).toBe(webSocketUrl(serverBaseUrl(base)));
+        expect(endpoint).not.toContain(DOUBLED_ROUTE);
+      }),
+      { numRuns: PROPERTY_RUNS },
+    );
+  });
+});

--- a/packages/protocol/src/network/server-url.ts
+++ b/packages/protocol/src/network/server-url.ts
@@ -6,7 +6,7 @@
  * dial `/ws/ws`, and the resulting socket never opens. `ServerBaseUrl` is the
  * type that makes such a value unconstructible.
  */
-import { Schema, type Brand } from "effect";
+import { ParseResult, Schema, type Brand } from "effect";
 
 /** Route the server serves the WebSocket upgrade on. */
 const SOCKET_ROUTE = "/ws";
@@ -23,25 +23,32 @@ const SERVER_SCHEMES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Reduce a base or socket URL to scheme and authority.
+ * Reduce an address to scheme and authority, or `null` when it is not one this
+ * client can dial.
  *
- * Discarding the socket route loses nothing a client could reach: the route
- * this appends is fixed, so a server published under a path prefix is not
- * addressable through this package at all. Every other path survives here and
- * is rejected by the refinement rather than silently dropped.
+ * Discarding the socket route loses nothing reachable: the route `webSocketUrl`
+ * appends is fixed, so a server published under a path prefix is not
+ * addressable through this package at all. Every other path is rejected rather
+ * than silently dropped, and so are credentials, which the authority form
+ * cannot carry.
+ *
+ * The result is rebuilt from the parsed URL rather than sliced out of the
+ * input, so the scheme reaches `webSocketUrl` in the lower-case spelling its
+ * swap matches. `HTTP://host` would otherwise survive validation and then dial
+ * an `HTTP://` URL that no WebSocket can open.
  */
-const toOrigin = (value: string): string =>
-  value.replace(SOCKET_ROUTE_SUFFIX, "").replace(TRAILING_SLASH, "");
-
-const isOrigin = (value: string): boolean => {
-  const url = URL.parse(value);
-  if (url === null) return false;
-  return (
-    SERVER_SCHEMES.has(url.protocol) &&
-    url.pathname === "/" &&
-    url.search === "" &&
-    url.hash === ""
-  );
+const toOrigin = (value: string): string | null => {
+  const trimmed = value
+    .replace(SOCKET_ROUTE_SUFFIX, "")
+    .replace(TRAILING_SLASH, "");
+  // `URL.canParse` rather than `URL.parse`: the package's engine floor is Node
+  // 22.0 and `parse` only exists from 22.1.
+  if (!URL.canParse(trimmed)) return null;
+  const url = new URL(trimmed);
+  if (!SERVER_SCHEMES.has(url.protocol)) return null;
+  if (url.pathname !== "/" || url.search !== "" || url.hash !== "") return null;
+  if (url.username !== "" || url.password !== "") return null;
+  return `${url.protocol}//${url.host}`;
 };
 
 /**
@@ -55,15 +62,25 @@ export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">;
  * socket endpoint — into the path-free base. Any other path fails.
  */
 export const ServerBaseUrl: Schema.Schema<ServerBaseUrl, string> =
-  Schema.transform(
-    Schema.String.pipe(
-      Schema.filter((value) => isOrigin(toOrigin(value)), {
-        message: (issue) =>
-          `Expected a MoltZap server base URL (scheme and host, no path), got ${JSON.stringify(issue.actual)}`,
-      }),
-    ),
+  Schema.transformOrFail(
+    Schema.String,
     Schema.String.pipe(Schema.brand("ServerBaseUrl")),
-    { strict: true, decode: toOrigin, encode: (base) => base },
+    {
+      strict: true,
+      decode: (value, _options, ast) => {
+        const origin = toOrigin(value);
+        return origin === null
+          ? ParseResult.fail(
+              new ParseResult.Type(
+                ast,
+                value,
+                `Expected a MoltZap server base URL (scheme and host, no path), got ${JSON.stringify(value)}`,
+              ),
+            )
+          : ParseResult.succeed(origin);
+      },
+      encode: ParseResult.succeed,
+    },
   ).pipe(
     Schema.annotations({ description: "Path-free MoltZap server base URL" }),
   );

--- a/packages/protocol/src/network/server-url.ts
+++ b/packages/protocol/src/network/server-url.ts
@@ -1,0 +1,81 @@
+/**
+ * @file The MoltZap server base URL and the socket endpoint derived from it.
+ *
+ * `webSocketUrl` appends the socket route unconditionally, so the two halves
+ * of that invariant live together: a value that already carries a path would
+ * dial `/ws/ws`, and the resulting socket never opens. `ServerBaseUrl` is the
+ * type that makes such a value unconstructible.
+ */
+import { Schema, type Brand } from "effect";
+
+/** Route the server serves the WebSocket upgrade on. */
+const SOCKET_ROUTE = "/ws";
+
+const SOCKET_ROUTE_SUFFIX = /\/ws\/?$/;
+const TRAILING_SLASH = /\/$/;
+const WS_SCHEME_PREFIX = /^http/;
+
+const SERVER_SCHEMES: ReadonlySet<string> = new Set([
+  "http:",
+  "https:",
+  "ws:",
+  "wss:",
+]);
+
+/**
+ * Reduce a base or socket URL to scheme and authority.
+ *
+ * Discarding the socket route loses nothing a client could reach: the route
+ * this appends is fixed, so a server published under a path prefix is not
+ * addressable through this package at all. Every other path survives here and
+ * is rejected by the refinement rather than silently dropped.
+ */
+const toOrigin = (value: string): string =>
+  value.replace(SOCKET_ROUTE_SUFFIX, "").replace(TRAILING_SLASH, "");
+
+const isOrigin = (value: string): boolean => {
+  const url = URL.parse(value);
+  if (url === null) return false;
+  return (
+    SERVER_SCHEMES.has(url.protocol) &&
+    url.pathname === "/" &&
+    url.search === "" &&
+    url.hash === ""
+  );
+};
+
+/**
+ * A MoltZap server address carrying no path, query, or fragment, over
+ * `http`, `https`, `ws`, or `wss`.
+ */
+export type ServerBaseUrl = string & Brand.Brand<"ServerBaseUrl">;
+
+/**
+ * Decodes either address a caller is likely to hold — the base URL or the
+ * socket endpoint — into the path-free base. Any other path fails.
+ */
+export const ServerBaseUrl: Schema.Schema<ServerBaseUrl, string> =
+  Schema.transform(
+    Schema.String.pipe(
+      Schema.filter((value) => isOrigin(toOrigin(value)), {
+        message: (issue) =>
+          `Expected a MoltZap server base URL (scheme and host, no path), got ${JSON.stringify(issue.actual)}`,
+      }),
+    ),
+    Schema.String.pipe(Schema.brand("ServerBaseUrl")),
+    { strict: true, decode: toOrigin, encode: (base) => base },
+  ).pipe(
+    Schema.annotations({ description: "Path-free MoltZap server base URL" }),
+  );
+
+/**
+ * Throwing constructor for addresses a caller already knows are well-formed,
+ * such as one a locally started server just reported. Decode with
+ * `Schema.decodeEither(ServerBaseUrl)` wherever the value comes from
+ * configuration or another package.
+ */
+export const serverBaseUrl = Schema.decodeSync(ServerBaseUrl);
+
+/** The socket endpoint a client dials for the given server. */
+export const webSocketUrl = (base: ServerBaseUrl): string =>
+  base.replace(WS_SCHEME_PREFIX, "ws") + SOCKET_ROUTE;

--- a/packages/protocol/src/network/server-url.types-check.ts
+++ b/packages/protocol/src/network/server-url.types-check.ts
@@ -1,0 +1,15 @@
+/**
+ * @file Type canary for the socket endpoint constructor (`network/server-url.ts`).
+ *
+ * The invariant: `webSocketUrl` appends its route to whatever it is handed, so
+ * only a value proven path-free may reach it. If the parameter loosens back to
+ * `string`, a caller holding a complete socket endpoint compiles again and
+ * dials `/ws/ws` — the failure this brand exists to make unrepresentable.
+ */
+import { serverBaseUrl, webSocketUrl } from "./server-url.js";
+
+// @ts-expect-error a plain string is not proven path-free
+webSocketUrl("ws://127.0.0.1:32821/ws");
+
+// Positive control: the same address routed through the constructor compiles.
+webSocketUrl(serverBaseUrl("ws://127.0.0.1:32821/ws"));

--- a/packages/protocol/src/socket/MODULE.md
+++ b/packages/protocol/src/socket/MODULE.md
@@ -74,7 +74,7 @@ export function classifyCloseCause(
 ): CloseKind
 ```
 
-### [`ClientConnectError`](./lifecycle.ts#L117)
+### [`ClientConnectError`](./lifecycle.ts#L123)
 
 _TypeAlias_
 
@@ -82,7 +82,7 @@ _TypeAlias_
 export type ClientConnectError<Rpcs extends ProtocolRpc> =
 ```
 
-### [`ClientDefinitionError`](./lifecycle.ts#L106)
+### [`ClientDefinitionError`](./lifecycle.ts#L112)
 
 _TypeAlias_
 
@@ -90,7 +90,7 @@ _TypeAlias_
 export type ClientDefinitionError<D extends ClientRpcDefinition> =
 ```
 
-### [`ClientDefinitionPayload`](./lifecycle.ts#L102)
+### [`ClientDefinitionPayload`](./lifecycle.ts#L108)
 
 _TypeAlias_
 
@@ -98,7 +98,7 @@ _TypeAlias_
 export type ClientDefinitionPayload<D extends ClientRpcDefinition> =
 ```
 
-### [`ClientDefinitionSuccess`](./lifecycle.ts#L104)
+### [`ClientDefinitionSuccess`](./lifecycle.ts#L110)
 
 _TypeAlias_
 
@@ -106,7 +106,7 @@ _TypeAlias_
 export type ClientDefinitionSuccess<D extends ClientRpcDefinition> =
 ```
 
-### [`ClientLifecycleOptions`](./lifecycle.ts#L212)
+### [`ClientLifecycleOptions`](./lifecycle.ts#L228)
 
 _Interface_
 
@@ -132,17 +132,15 @@ export interface ClientLifecycleOptions<
 }
 ```
 
-### [`clientRpc`](./lifecycle.ts#L100)
+### [`clientRpc`](./lifecycle.ts#L106)
 
 _Property_
 
 ```ts
   readonly clientRpc: Rpcs;
-};
-export type ClientDefinitionPayload<D extends ClientRpcDefinition> =
 ```
 
-### [`ClientRpcDefinition`](./lifecycle.ts#L99)
+### [`ClientRpcDefinition`](./lifecycle.ts#L105)
 
 _TypeAlias_
 
@@ -221,7 +219,7 @@ _Variable_
 export type ConnectionId = string & Brand.Brand<"ConnectionId">
 ```
 
-### [`ConnectResult`](./lifecycle.ts#L111)
+### [`ConnectResult`](./lifecycle.ts#L117)
 
 _TypeAlias_
 
@@ -569,7 +567,7 @@ _Function_
 export const newConnectionId = (): ConnectionId
 ```
 
-### [`openProtocolAgentClientSocket`](./lifecycle.ts#L561)
+### [`openProtocolAgentClientSocket`](./lifecycle.ts#L578)
 
 _Function_
 
@@ -583,7 +581,7 @@ export const openProtocolAgentClientSocket = (
 >
 ```
 
-### [`openProtocolAppClientSocket`](./lifecycle.ts#L573)
+### [`openProtocolAppClientSocket`](./lifecycle.ts#L590)
 
 _Function_
 
@@ -597,7 +595,7 @@ export const openProtocolAppClientSocket = (
 >
 ```
 
-### [`ProtocolClientLifecycle`](./lifecycle.ts#L642)
+### [`ProtocolClientLifecycle`](./lifecycle.ts#L659)
 
 _Class_
 
@@ -732,7 +730,7 @@ _TypeAlias_
 export type ReverseCallbackError<D extends AnyAppCallbackRpcDefinition> =
 ```
 
-### [`ReverseCallbackHandlers`](./lifecycle.ts#L259)
+### [`ReverseCallbackHandlers`](./lifecycle.ts#L275)
 
 _TypeAlias_
 
@@ -790,8 +788,6 @@ _TypeAlias_
 
 ```ts
 export type ReverseCallError = NotConnectedError | RpcTimeoutError;
-
-type ReverseRpcs = RpcGroup.Rpcs<typeof ReverseRpcGroup>;
 ```
 
 ### [`ReverseClient`](./server.ts#L204)
@@ -821,7 +817,7 @@ export interface ReverseClient {
 }
 ```
 
-### [`RPC_TIMEOUT_MS`](./lifecycle.ts#L85)
+### [`RPC_TIMEOUT_MS`](./lifecycle.ts#L91)
 
 _Variable_
 
@@ -829,7 +825,7 @@ _Variable_
 export const RPC_TIMEOUT_MS = 30_000
 ```
 
-### [`RpcCallOptions`](./lifecycle.ts#L95)
+### [`RpcCallOptions`](./lifecycle.ts#L101)
 
 _Interface_
 

--- a/packages/protocol/src/socket/lifecycle.ts
+++ b/packages/protocol/src/socket/lifecycle.ts
@@ -17,10 +17,16 @@ import {
   Option,
   Ref,
   Schedule,
+  Schema,
   Scope,
   Stream,
 } from "effect";
-import { AgentConnect, AppConnect } from "#network";
+import {
+  AgentConnect,
+  AppConnect,
+  ServerBaseUrl,
+  webSocketUrl,
+} from "#network";
 import {
   AgentCallableGroup,
   AppCallableGroup,
@@ -126,8 +132,18 @@ type ClientWebSocket = Effect.Effect.Success<
 const makeNotConnectedError = (): NotConnectedError =>
   new NotConnectedError({ message: MSG_NOT_CONNECTED });
 
-const webSocketUrl = (serverUrl: string): string =>
-  serverUrl.replace(/^http/, "ws") + "/ws";
+const decodeServerBaseUrl = Schema.decodeEither(ServerBaseUrl);
+
+// Callers reach the lifecycle across a package boundary with a plain string,
+// so the address is decoded here rather than trusted.
+const socketUrl = (
+  serverUrl: string,
+): Effect.Effect<string, NotConnectedError> =>
+  Either.match(decodeServerBaseUrl(serverUrl), {
+    onLeft: (error) =>
+      Effect.fail(new NotConnectedError({ message: error.message })),
+    onRight: (base) => Effect.succeed(webSocketUrl(base)),
+  });
 
 const openSocket = (
   url: string,
@@ -523,8 +539,9 @@ const openClientSocketSession = <Rpcs extends ProtocolRpc>(
   Socket.WebSocketConstructor
 > =>
   Effect.gen(function* () {
+    const url = yield* socketUrl(options.serverUrl);
     const scope = yield* Scope.make();
-    const socket = yield* openSocket(webSocketUrl(options.serverUrl), scope);
+    const socket = yield* openSocket(url, scope);
     const write = yield* Scope.extend(socket.writer, scope);
     const wireWrite: WireWrite = (chunk) => write(chunk);
 

--- a/packages/protocol/src/testing/conformance/_shared/driver/MODULE.md
+++ b/packages/protocol/src/testing/conformance/_shared/driver/MODULE.md
@@ -8,7 +8,7 @@ Lifecycle-backed conformance client barrel.
 
 ## Public surface
 
-### [`AgentTestClient`](./test-client.ts#L93)
+### [`AgentTestClient`](./test-client.ts#L94)
 
 _Interface_
 
@@ -22,7 +22,7 @@ export interface AgentTestClient extends NotificationClient {
 }
 ```
 
-### [`AgentTestClientConfig`](./test-client.ts#L58)
+### [`AgentTestClientConfig`](./test-client.ts#L59)
 
 _Interface_
 
@@ -35,7 +35,7 @@ export interface AgentTestClientConfig {
 }
 ```
 
-### [`AppTestClient`](./test-client.ts#L101)
+### [`AppTestClient`](./test-client.ts#L102)
 
 _Interface_
 
@@ -63,7 +63,7 @@ export interface AppTestClient extends NotificationClient {
 }
 ```
 
-### [`AppTestClientConfig`](./test-client.ts#L65)
+### [`AppTestClientConfig`](./test-client.ts#L66)
 
 _Interface_
 
@@ -76,7 +76,7 @@ export interface AppTestClientConfig {
 }
 ```
 
-### [`CloseableAgentTestClient`](./test-client.ts#L123)
+### [`CloseableAgentTestClient`](./test-client.ts#L124)
 
 _Interface_
 
@@ -86,7 +86,7 @@ export interface CloseableAgentTestClient extends AgentTestClient {
 }
 ```
 
-### [`CloseableAppTestClient`](./test-client.ts#L127)
+### [`CloseableAppTestClient`](./test-client.ts#L128)
 
 _Interface_
 
@@ -96,7 +96,7 @@ export interface CloseableAppTestClient extends AppTestClient {
 }
 ```
 
-### [`makeAgentTestClient`](./test-client.ts#L162)
+### [`makeAgentTestClient`](./test-client.ts#L163)
 
 _Function_
 
@@ -106,7 +106,7 @@ export function makeAgentTestClient(
 ): Effect.Effect<AgentTestClient, SendRpcError, Scope.Scope>
 ```
 
-### [`makeAppTestClient`](./test-client.ts#L180)
+### [`makeAppTestClient`](./test-client.ts#L181)
 
 _Function_
 
@@ -116,7 +116,7 @@ export function makeAppTestClient(
 ): Effect.Effect<AppTestClient, SendRpcError, Scope.Scope>
 ```
 
-### [`makeCloseableAgentTestClient`](./test-client.ts#L172)
+### [`makeCloseableAgentTestClient`](./test-client.ts#L173)
 
 _Function_
 
@@ -126,7 +126,7 @@ export function makeCloseableAgentTestClient(
 ): Effect.Effect<CloseableAgentTestClient, SendRpcError>
 ```
 
-### [`makeCloseableAppTestClient`](./test-client.ts#L190)
+### [`makeCloseableAppTestClient`](./test-client.ts#L191)
 
 _Function_
 
@@ -136,7 +136,7 @@ export function makeCloseableAppTestClient(
 ): Effect.Effect<CloseableAppTestClient, SendRpcError>
 ```
 
-### [`NotificationClient`](./test-client.ts#L78)
+### [`NotificationClient`](./test-client.ts#L79)
 
 _Interface_
 
@@ -157,7 +157,7 @@ export interface NotificationClient {
 }
 ```
 
-### [`ServerRequestWaitError`](./test-client.ts#L131)
+### [`ServerRequestWaitError`](./test-client.ts#L132)
 
 _Class_
 
@@ -171,7 +171,7 @@ export class ServerRequestWaitError extends Data.TaggedError(
 }> {}
 ```
 
-### [`ServerRpcContext`](./test-client.ts#L143)
+### [`ServerRpcContext`](./test-client.ts#L144)
 
 _Interface_
 
@@ -182,16 +182,15 @@ export interface ServerRpcContext {
 }
 ```
 
-### [`ServerRpcDefinition`](./test-client.ts#L139)
+### [`ServerRpcDefinition`](./test-client.ts#L140)
 
 _TypeAlias_
 
 ```ts
 export type ServerRpcDefinition = AnyAppCallbackRpcDefinition;
-export type ServerRpcParams<D extends ServerRpcDefinition> = ParamsOf<D>;
 ```
 
-### [`ServerRpcParams`](./test-client.ts#L140)
+### [`ServerRpcParams`](./test-client.ts#L141)
 
 _TypeAlias_
 
@@ -199,7 +198,7 @@ _TypeAlias_
 export type ServerRpcParams<D extends ServerRpcDefinition> = ParamsOf<D>;
 ```
 
-### [`ServerRpcResult`](./test-client.ts#L141)
+### [`ServerRpcResult`](./test-client.ts#L142)
 
 _TypeAlias_
 

--- a/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts
+++ b/packages/protocol/src/testing/conformance/_shared/driver/test-client.ts
@@ -35,6 +35,7 @@ import {
   type ClientDefinitionSuccess,
   type CloseInfo,
 } from "#socket";
+import { serverBaseUrl } from "#network";
 import {
   NotConnectedError,
   RpcTimeoutError as ProtocolRpcTimeoutError,
@@ -311,8 +312,10 @@ function rpcCallOptions(
   return { timeoutMs: opts?.timeoutMs ?? defaultTimeoutMs };
 }
 
+// Conformance fixtures hand out the server's socket endpoint; the client
+// takes the base and dials the route itself.
 function clientBaseUrl(url: string): string {
-  return url.replace(/^ws/, "http").replace(/\/ws\/?$/, "");
+  return serverBaseUrl(url).replace(/^ws/, "http");
 }
 
 function makeDynamicAppHandlers(

--- a/packages/protocol/src/testing/conformance/app/MODULE.md
+++ b/packages/protocol/src/testing/conformance/app/MODULE.md
@@ -214,9 +214,6 @@ _Property_
 
 ```ts
   readonly leaseId: string;
-};
-
-export function freshMessageId(): Schema.Schema.Type<typeof MessageId> {
 ```
 
 ### [`leaseId`](./_helpers.ts#L66)
@@ -233,7 +230,6 @@ _Property_
 
 ```ts
   readonly leaseId: string;
-  readonly verdict: { decision: string; reason?: string };
 ```
 
 ### [`LeaseIdOnlyView`](./_helpers.ts#L66)
@@ -258,83 +254,6 @@ export type LeaseState =
   | "EXPIRED"
   | "ABANDONED"
   | "HOLD";
-
-// ── Recipient handle ──────────────────────────────────────────────────
-
-/**
- * Recipient-side surface. Owns one `AgentTestClient` connected to the real
- * server under a recipient agent identity. All methods return Effects
- * scoped to the surrounding `Scope`; releasing the scope closes the
- * underlying agent client.
- */
-export interface RecipientHandle {
-  readonly agentId: Schema.Schema.Type<typeof AgentId>;
-
-  /**
-   * Issue `agent/dispatch/request` for the given inbound. Returns the ack
-   * payload `{leaseId, dispatchId}`. Single recipient may issue many
-   * concurrent requests; the property is responsible for ordering its
-   * own assertions.
-   */
-  readonly requestDispatch: (params: {
-    readonly conversationId: Schema.Schema.Type<typeof ConversationId>;
-    readonly messageId: Schema.Schema.Type<typeof MessageId>;
-    readonly senderAgentId: Schema.Schema.Type<typeof AgentId>;
-    readonly attempt?: number;
-  }) => Effect.Effect<
-    {
-      readonly leaseId: Schema.Schema.Type<typeof LeaseId>;
-      readonly dispatchId: Schema.Schema.Type<typeof DispatchId>;
-    },
-    PropertyFailure
-  >;
-
-  /**
-   * Park until a `agent/dispatch/released` notification arrives that matches
-   * `predicate` (default: any). Used by every property in the
-   * `DispatchRelease` group + every property that asserts a verdict
-   * delivery.
-   */
-  readonly waitForRelease: (
-    predicate?: (
-      frame: NotificationDelivery<typeof DispatchRelease>,
-    ) => boolean,
-    timeoutMs?: number,
-  ) => Effect.Effect<
-    NotificationDelivery<typeof DispatchRelease>,
-    PropertyFailure
-  >;
-
-  /**
-   * Send `agent/message/send` carrying `dispatchLeaseId`. Used to consume a
-   * GRANTED lease + assert the consumed/duplicate behavior. Returns the
-   * minted message id on success; on the lease-already-CONSUMED path,
-   * fails with a `PropertyInvariantViolation` whose `reason` carries
-   * the wire-error code + `LeaseInvalid` data tag the server returned.
-   */
-  readonly sendWithLease: (params: {
-    readonly taskId: Schema.Schema.Type<typeof TaskId>;
-    readonly conversationId: Schema.Schema.Type<typeof ConversationId>;
-    readonly leaseId: Schema.Schema.Type<typeof LeaseId>;
-    readonly text: string;
-  }) => Effect.Effect<
-    {
-      readonly messageId: Schema.Schema.Type<typeof MessageId>;
-      readonly errorTag?: string;
-      readonly errorState?: string;
-    },
-    PropertyFailure
-  >;
-
-  /**
-   * Disconnect the recipient's WS without graceful shutdown.
-   * Drives ABANDONED + EXPIRED-on-disconnect transitions for every
-   * `*-disconnect-*` property. The returned Effect resolves once the
-   * server has observed the close (registry's connection-close
-   * finalizer fired).
-   */
-  readonly hardClose: Effect.Effect<void, PropertyFailure>;
-}
 ```
 
 Closed lease-state union mirroring `LeaseStateSchema`. The driver's
@@ -366,10 +285,6 @@ _Property_
 
 ```ts
   readonly messageId: string;
-  readonly leaseId: string;
-};
-
-export function freshMessageId(): Schema.Schema.Type<typeof MessageId> {
 ```
 
 ### [`ModeratorHandle`](./_driver.ts#L190)

--- a/packages/protocol/src/testing/conformance/network/MODULE.md
+++ b/packages/protocol/src/testing/conformance/network/MODULE.md
@@ -93,11 +93,6 @@ _TypeAlias_
 
 ```ts
 export type PresenceStatus = "online" | "working" | "offline";
-
-export interface PresenceStatusEntry {
-  readonly agentId: AgentId;
-  readonly status: PresenceStatus;
-}
 ```
 
 ### [`PresenceStatusEntry`](./_helpers.ts#L24)

--- a/packages/protocol/src/testing/conformance/task/MODULE.md
+++ b/packages/protocol/src/testing/conformance/task/MODULE.md
@@ -59,36 +59,6 @@ _Property_
 
 ```ts
   readonly agent: TestAgent;
-  readonly client: AgentTestClient;
-
-  /**
-   * Per-client historical notification buffer: `subscribe`
-   * only emits frames arriving AFTER materialisation, so a sequential
-   * `send → awaitOneNotification` races the response frame. The buffer
-   * is fed by a long-lived
-   * `subscribeAll()` pump installed at `acquireClient` time;
-   * `awaitOneNotification` consumes the buffer so frames that arrived
-   * between the triggering RPC and the wait are still observable. This
-   * mirrors `@moltzap/server-core/test-utils → connectTestClient` (the
-   * `makeNotificationBuffer` JSDoc below covers the design).
-   */
-  readonly notifications: NotificationBuffer;
-};
-
-/**
- * Historical notification buffer used by `awaitOneNotification`. Holds
- * every inbound notification arriving on a single client's
- * `subscribeAll()` Stream until a consumer pulls a matching frame.
- *
- * The `snapshot` and `closed` fields are the only public surfaces;
- * the pump fiber that feeds them is interrupted by the enclosing
- * Scope finalizer installed by `makeNotificationBuffer`. `closed` is
- * set to true when the transport-side stream terminates (either via
- * `TransportClosedError` or normal exhaustion); `awaitOneNotification`
- * consumes it to surface "Connection closed" rather than masquerading
- * a missing notification as a timeout.
- */
-export interface NotificationBuffer {
 ```
 
 ### [`archiveConversation`](./_helpers.ts#L321)
@@ -157,35 +127,6 @@ _Property_
 
 ```ts
   readonly client: AgentTestClient;
-
-  /**
-   * Per-client historical notification buffer: `subscribe`
-   * only emits frames arriving AFTER materialisation, so a sequential
-   * `send → awaitOneNotification` races the response frame. The buffer
-   * is fed by a long-lived
-   * `subscribeAll()` pump installed at `acquireClient` time;
-   * `awaitOneNotification` consumes the buffer so frames that arrived
-   * between the triggering RPC and the wait are still observable. This
-   * mirrors `@moltzap/server-core/test-utils → connectTestClient` (the
-   * `makeNotificationBuffer` JSDoc below covers the design).
-   */
-  readonly notifications: NotificationBuffer;
-};
-
-/**
- * Historical notification buffer used by `awaitOneNotification`. Holds
- * every inbound notification arriving on a single client's
- * `subscribeAll()` Stream until a consumer pulls a matching frame.
- *
- * The `snapshot` and `closed` fields are the only public surfaces;
- * the pump fiber that feeds them is interrupted by the enclosing
- * Scope finalizer installed by `makeNotificationBuffer`. `closed` is
- * set to true when the transport-side stream terminates (either via
- * `TransportClosedError` or normal exhaustion); `awaitOneNotification`
- * consumes it to surface "Connection closed" rather than masquerading
- * a missing notification as a timeout.
- */
-export interface NotificationBuffer {
 ```
 
 ### [`CONVERSATION_FAMILY_PROPERTIES`](./conversation-family.ts#L453)
@@ -387,22 +328,6 @@ _Property_
 
 ```ts
   readonly notifications: NotificationBuffer;
-};
-
-/**
- * Historical notification buffer used by `awaitOneNotification`. Holds
- * every inbound notification arriving on a single client's
- * `subscribeAll()` Stream until a consumer pulls a matching frame.
- *
- * The `snapshot` and `closed` fields are the only public surfaces;
- * the pump fiber that feeds them is interrupted by the enclosing
- * Scope finalizer installed by `makeNotificationBuffer`. `closed` is
- * set to true when the transport-side stream terminates (either via
- * `TransportClosedError` or normal exhaustion); `awaitOneNotification`
- * consumes it to surface "Connection closed" rather than masquerading
- * a missing notification as a timeout.
- */
-export interface NotificationBuffer {
 ```
 
 Per-client historical notification buffer: `subscribe`

--- a/packages/protocol/src/testing/conformance/transport/MODULE.md
+++ b/packages/protocol/src/testing/conformance/transport/MODULE.md
@@ -85,7 +85,6 @@ _Property_
 
 ```ts
   readonly proxy: ToxiproxyProxy;
-  readonly unavailable: (reason: string) => PropertyUnavailable;
 ```
 
 ### [`proxyName`](./_helpers.ts#L48)

--- a/packages/server/src/dispatch/MODULE.md
+++ b/packages/server/src/dispatch/MODULE.md
@@ -564,10 +564,6 @@ export type LeaseState =
   | "EXPIRED"
   | "ABANDONED"
   | "HOLD";
-
-/** Verdict shapes accepted by `resolve` — mirrors the wire decision. */
-export type LeaseVerdict =
-  | { readonly _tag: "grant"; readonly leaseTimeoutMs?: number }
 ```
 
 Discriminated state of a lease. The registry's `Ref.modify`

--- a/packages/server/src/network/MODULE.md
+++ b/packages/server/src/network/MODULE.md
@@ -232,16 +232,6 @@ _TypeAlias_
 
 ```ts
 export type DeliveryError = RecipientNotResolved | WriteFailed;
-
-// ---------------------------------------------------------------------------
-// Service
-// ---------------------------------------------------------------------------
-
-interface BroadcastOptions {
-  readonly forConversation?: ConversationId;
-  readonly excludeConnectionId?: ConnectionId;
-  readonly messageId?: MessageId;
-}
 ```
 
 ### [`NetworkSendService`](./network-send.ts#L87)

--- a/packages/server/src/network/presence/MODULE.md
+++ b/packages/server/src/network/presence/MODULE.md
@@ -77,44 +77,6 @@ _TypeAlias_
 
 ```ts
 export type DerivedPresenceStatus = "online" | "working" | "offline";
-
-/**
- * Per-agent presence entry. An agent may hold multiple simultaneous
- * WebSocket connections (web tab + CLI + mobile — see
- * `AgentEndpointResolver`'s module JSDoc), so the entry tracks the
- * full set of live connections + the active leases keyed by which
- * connection holds them.
- *
- * - `liveConns` — every WS connection the
- *   agent is currently authenticated on.
- * - `leasesByConn` — per-connection breakdown of active leases
- *   (GRANTED or CLAIMED), keyed by connection.
- *   When a connection disconnects, its bucket is dropped wholesale so
- *   the leases bound to the dead conn don't keep the agent in
- *   `working` forever.
- *
- * Invariant: every key in `leasesByConn` MUST be present in
- * `liveConns`. A lease callback that arrives bound to a
- * `recipientConnId` not in `liveConns` is a fast-reconnect race ghost
- * and no-ops (audited as `LeaseCallbackFromStaleConnection`).
- *
- * Status derivation: `working` if any live connection holds at least
- * one active lease; `online` if the entry exists but holds no active
- * leases anywhere; `offline` if the entry is absent. See
- * {@link deriveEntryStatus}.
- *
- * The multi-connection shape is correctness-by-construction: a second
- * simultaneous connection ADDS to `liveConns` rather than clobbering
- * the agent's lease set, so the original conn's active leases stay
- * accounted-for.
- *
- * "offline" is represented by entry absence; presence state NEVER
- * holds an entry whose `liveConns` is empty.
- */
-export interface AgentPresenceEntry {
-  readonly liveConns: ReadonlySet<ConnectionId>;
-  readonly leasesByConn: ReadonlyMap<ConnectionId, ReadonlySet<LeaseId>>;
-}
 ```
 
 Derived presence status. Three-state set:

--- a/packages/server/src/socket/MODULE.md
+++ b/packages/server/src/socket/MODULE.md
@@ -57,16 +57,6 @@ _TypeAlias_
 
 ```ts
 export type AgentStatus = "active" | "suspended";
-
-/**
- * Principal context arms stored on authenticated socket connections. Handlers
- * receive the arm selected by each method's `requires` head.
- */
-export class AgentContext extends Data.TaggedClass("AgentContext")<{
-  readonly agentId: AgentId;
-  readonly agentStatus: AgentStatus;
-  readonly ownerUserId: UserId;
-}> {}
 ```
 
 Closed agent lifecycle states. Mirrors
@@ -105,15 +95,6 @@ export type Connection =
   | UnauthenticatedConnection
   | AgentConnection
   | AppConnection;
-
-/**
- * Outcome of `ConnectionManager.authenticate`'s atomic transition. The
- * success arms are split per minted arm so the Connect handler's
- * `Match.value(outcome).pipe(Match.when({ kind: "ok-agent" }, ...))` narrows
- * `authed` structurally — no `as AgentConnection` cast.
- */
-export type TransitionOutcome =
-  | { readonly kind: "not-connected" }
 ```
 
 The three-arm connection state — the connections map's only entry shape.
@@ -283,19 +264,6 @@ _TypeAlias_
 
 ```ts
 export type Originator = ReverseClient;
-
-/**
- * The per-connection socket handle registered with `ConnectionManager`.
- */
-export interface WebSocketRef {
-  /**
-   * Write a raw frame to this connection. Fails with SocketError on send
-   * failure or if the socket is already closed.
-   */
-  readonly write: (raw: string) => Effect.Effect<void, SocketError>;
-  /** Close this connection's scope, tearing down the underlying socket. */
-  readonly shutdown: Effect.Effect<void>;
-}
 ```
 
 The per-connection reverse `RpcClient&lt;ReverseRpcGroup>` the server fires

--- a/packages/server/src/test-utils/MODULE.md
+++ b/packages/server/src/test-utils/MODULE.md
@@ -24,7 +24,7 @@ task-callback RPC at construction time — adding a new entry to
 `appCallbackMethods` becomes a compile error at every endpoint
 construction site.
 
-### [`AwaitNotificationError`](./helpers.ts#L56)
+### [`AwaitNotificationError`](./helpers.ts#L57)
 
 _TypeAlias_
 
@@ -32,55 +32,9 @@ _TypeAlias_
 export type AwaitNotificationError =
   | AwaitNotificationTimeoutError
   | AwaitNotificationClosedError;
-
-/**
- * Stream-based one-shot waiter. Consumes `client.subscribe(def)` via
- * `Stream.runHead`, failing with `AwaitNotificationTimeoutError` on timeout
- * and `AwaitNotificationClosedError` when the transport closed before a
- * matching frame arrived. Distinguishing close from timeout keeps a dead
- * connection from masquerading as a missing notification.
- */
-export function awaitOneNotification<D extends AnyNotificationDefinition>(
-  client: Pick<TestAgentClient, "subscribe">,
-  definition: D,
-  timeoutMs: number = DEFAULT_AWAIT_NOTIFICATION_TIMEOUT_MS,
-): Effect.Effect<NotificationDelivery<D>, AwaitNotificationError> {
-  const closed = () =>
-    new AwaitNotificationClosedError({
-      definition: definition.name,
-    });
-  return client.subscribe(definition).pipe(
-    Stream.map(
-      (params): NotificationDelivery<D> => ({
-        definition,
-        method: definition.name,
-        params,
-      }),
-    ),
-    Stream.runHead,
-    Effect.either,
-    Effect.flatMap(
-      Either.match({
-        onLeft: () => Effect.fail(closed()),
-        onRight: Option.match({
-          onNone: () => Effect.fail(closed()),
-          onSome: (notification) => Effect.succeed(notification),
-        }),
-      }),
-    ),
-    Effect.timeoutFail({
-      duration: Duration.millis(timeoutMs),
-      onTimeout: () =>
-        new AwaitNotificationTimeoutError({
-          definition: definition.name,
-          durationMs: timeoutMs,
-        }),
-    }),
-  );
-}
 ```
 
-### [`awaitOneNotification`](./helpers.ts#L67)
+### [`awaitOneNotification`](./helpers.ts#L68)
 
 _Function_
 
@@ -98,7 +52,7 @@ and `AwaitNotificationClosedError` when the transport closed before a
 matching frame arrived. Distinguishing close from timeout keeps a dead
 connection from masquerading as a missing notification.
 
-### [`closeAllClients`](./helpers.ts#L170)
+### [`closeAllClients`](./helpers.ts#L171)
 
 _Function_
 
@@ -106,7 +60,7 @@ _Function_
 export function closeAllClients(): Effect.Effect<void, never>
 ```
 
-### [`connectAppClient`](./helpers.ts#L278)
+### [`connectAppClient`](./helpers.ts#L281)
 
 _Function_
 
@@ -118,7 +72,7 @@ export function connectAppClient(
 ): Effect.Effect<TestAppClient, Error>
 ```
 
-### [`ConnectedAgent`](./helpers.ts#L106)
+### [`ConnectedAgent`](./helpers.ts#L107)
 
 _Interface_
 
@@ -131,7 +85,7 @@ export interface ConnectedAgent {
 }
 ```
 
-### [`connectTestClient`](./helpers.ts#L219)
+### [`connectTestClient`](./helpers.ts#L220)
 
 _Function_
 
@@ -151,8 +105,6 @@ _TypeAlias_
 export type CoreSchemaSqlLoadError =
   | CoreSchemaSqlAccessError
   | CoreSchemaSqlReadError;
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 ```
 
 ### [`CoreTestDatabasePort`](./ports.ts#L22)
@@ -198,19 +150,6 @@ _TypeAlias_
 
 ```ts
 export type CoreTestServer = CoreTestServerPort;
-
-/**
- * Start a test server and expose its package-owned integration ports.
- * @param opts Test server configuration.
- * @returns A promise for the running server's integration ports.
- */
-export function startCoreTestServer(opts: StartCoreTestServerOptions = {}) {
-  return Effect.runPromise(
-    startCoreTestServerEffect(opts).pipe(
-      Effect.map((server) => server.testPort),
-    ),
-  );
-}
 ```
 
 Canonical published handle for a running core test server.
@@ -290,7 +229,7 @@ export interface CoreTestSpanExporterPort {
 
 Trace-capture operations available to test-harness consumers.
 
-### [`createTestAgent`](./helpers.ts#L196)
+### [`createTestAgent`](./helpers.ts#L197)
 
 _Function_
 
@@ -451,15 +390,9 @@ export type PgliteHarnessError =
   | PgliteCreateError
   | PgliteExecError
   | PgliteCloseError;
-
-const SQL_PREVIEW_MAX_CHARS = 160;
-
-function sqlPreview(sql: string): string {
-  return sql.replace(/\s+/g, " ").trim().slice(0, SQL_PREVIEW_MAX_CHARS);
-}
 ```
 
-### [`postJson`](./helpers.ts#L311)
+### [`postJson`](./helpers.ts#L314)
 
 _Function_
 
@@ -475,7 +408,7 @@ POST `body` as JSON to `${baseUrl}${path}` and resolve with
 `{status, json}`. HTTP integration tests import this helper to avoid
 repeated request/JSON boilerplate.
 
-### [`registerAgent`](./helpers.ts#L177)
+### [`registerAgent`](./helpers.ts#L178)
 
 _Function_
 
@@ -487,7 +420,7 @@ export function registerAgent(
 ): Effect.Effect<TestAgent, Error>
 ```
 
-### [`registerAndConnect`](./helpers.ts#L295)
+### [`registerAndConnect`](./helpers.ts#L298)
 
 _Function_
 
@@ -499,7 +432,7 @@ export function registerAndConnect(
 
 Register and connect an agent. Tracked for automatic cleanup.
 
-### [`registerApp`](./helpers.ts#L253)
+### [`registerApp`](./helpers.ts#L256)
 
 _Function_
 
@@ -522,7 +455,7 @@ _Function_
 export function resetCoreTestDb()
 ```
 
-### [`setupAgentGroup`](./helpers.ts#L411)
+### [`setupAgentGroup`](./helpers.ts#L414)
 
 _Function_
 
@@ -542,7 +475,7 @@ export function setupAgentGroup(
 
 Create N agents, all connected. Optionally create a group conversation.
 
-### [`setupAgentPair`](./helpers.ts#L399)
+### [`setupAgentPair`](./helpers.ts#L402)
 
 _Function_
 
@@ -607,7 +540,7 @@ _Function_
 export function stopCoreTestServer()
 ```
 
-### [`trackClient`](./helpers.ts#L166)
+### [`trackClient`](./helpers.ts#L167)
 
 _Function_
 

--- a/packages/server/src/test-utils/helpers.ts
+++ b/packages/server/src/test-utils/helpers.ts
@@ -28,6 +28,7 @@ import type {
   AppCallbackContext,
   AppCallbackHandlers,
 } from "@moltzap/protocol/socket";
+import { serverBaseUrl } from "@moltzap/protocol/network";
 import type {
   AgentId,
   AgentKey,
@@ -229,8 +230,10 @@ export function connectTestClient(opts: {
   }).pipe(Effect.withSpan("connectTestClient"));
 }
 
+// The harness hands out the server's socket endpoint; the client takes the
+// base and dials the route itself.
 function testClientServerUrl(wsUrl: string): string {
-  return wsUrl.replace(/\/ws$/, "").replace(/^ws:/, "http:");
+  return serverBaseUrl(wsUrl).replace(/^ws/, "http");
 }
 
 class AppRegistrationError extends Data.TaggedError("AppRegistrationError")<{

--- a/packages/testbed/src/MODULE.md
+++ b/packages/testbed/src/MODULE.md
@@ -8,7 +8,7 @@ Public exports for launching and supervising connected-agent testbeds.
 
 ## Public surface
 
-### [`AgentName`](./runtime.ts#L7)
+### [`AgentName`](./runtime.ts#L8)
 
 _TypeAlias_
 
@@ -16,7 +16,7 @@ _TypeAlias_
 export type AgentName = string & Brand.Brand<"AgentName">;
 ```
 
-### [`AgentName`](./runtime.ts#L7)
+### [`AgentName`](./runtime.ts#L8)
 
 _Variable_
 
@@ -66,16 +66,9 @@ _TypeAlias_
 
 ```ts
 export type InstallMode = "published" | "workspace";
-
-const CHANNEL_PACKAGE_NAME = "@moltzap/openclaw-channel";
-
-interface InstallModeResolverDeps {
-  readonly resolveChannelPackageRoot: () => string;
-  readonly workspacePackagesDir: string | null;
-}
 ```
 
-### [`launchTestbed`](./testbed.ts#L370)
+### [`launchTestbed`](./testbed.ts#L393)
 
 _Function_
 
@@ -100,7 +93,7 @@ Sibling: launchTestbedWithProcessSignals adds SIGINT
 / SIGTERM handlers so Ctrl-C during startup interrupts cleanly via
 `TestbedStartupInterrupted`.
 
-### [`launchTestbedWithProcessSignals`](./testbed.ts#L476)
+### [`launchTestbedWithProcessSignals`](./testbed.ts#L511)
 
 _Function_
 
@@ -134,7 +127,7 @@ flowchart TD
 
 - `TestbedStartupInterrupted` — a signal arrives during testbed startup
 
-### [`LogSlice`](./runtime.ts#L49)
+### [`LogSlice`](./runtime.ts#L57)
 
 _Interface_
 
@@ -431,7 +424,7 @@ export interface OpenClawAdapterOptions {
 }
 ```
 
-### [`ReadyOutcome`](./runtime.ts#L63)
+### [`ReadyOutcome`](./runtime.ts#L71)
 
 _TypeAlias_
 
@@ -440,7 +433,7 @@ export type ReadyOutcome =
   | { readonly _tag: "Ready" }
 ```
 
-### [`Runtime`](./runtime.ts#L82)
+### [`Runtime`](./runtime.ts#L90)
 
 _Interface_
 
@@ -498,7 +491,7 @@ Raised by `startPendingRuntimeAgent` when `waitUntilReady` returns
 `exitCode` is `null` only if the process exited via signal.
 Caller action: inspect `stderr`; check binary auth config.
 
-### [`RuntimeKind`](./testbed.ts#L65)
+### [`RuntimeKind`](./testbed.ts#L67)
 
 _TypeAlias_
 
@@ -545,7 +538,7 @@ has been torn down before the failure reaches the caller.
 Caller action: increase `readyTimeoutMs`, or enable process-level
 diagnostics at the adapter boundary.
 
-### [`RuntimeServerHandle`](./runtime.ts#L20)
+### [`RuntimeServerHandle`](./runtime.ts#L28)
 
 _Interface_
 
@@ -571,35 +564,34 @@ export interface RuntimeServerHandle {
 }
 ```
 
-### [`RuntimeStartOptions`](./testbed.ts#L67)
+### [`RuntimeStartOptions`](./testbed.ts#L69)
 
 _TypeAlias_
 
 ```ts
 export type RuntimeStartOptions = RuntimeStartOptionsBase & RuntimeSelection;
-
-interface TestbedLaunchOptionsBase {
-  readonly server: RuntimeServerHandle;
-  readonly agents: ReadonlyArray<TestbedAgentSpec>;
-  readonly readyTimeoutMs: number;
-  readonly concurrency?: number | "unbounded";
-}
 ```
 
-### [`ServerUrl`](./runtime.ts#L8)
+### [`ServerUrl`](./runtime.ts#L20)
 
 _TypeAlias_
 
 ```ts
-export type ServerUrl = string & Brand.Brand<"ServerUrl">;
+export type ServerUrl = ServerBaseUrl;
 ```
 
-### [`ServerUrl`](./runtime.ts#L8)
+The address an adapter hands its child process: the protocol's path-free
+base, under this package's long-standing name. The child's client appends
+the socket route itself, so a value carrying one dials `/ws/ws` and never
+authenticates. Accepts either form a caller is likely to hold — the base
+URL or the socket endpoint — and throws on any other path.
+
+### [`ServerUrl`](./runtime.ts#L20)
 
 _Variable_
 
 ```ts
-export type ServerUrl = string & Brand.Brand<"ServerUrl">
+export type ServerUrl = ServerBaseUrl
 ```
 
 ### [`SpawnFailed`](./errors.ts#L16)
@@ -621,7 +613,7 @@ failure, state-dir creation failure.
 `cause` carries the underlying Error.
 Caller action: surface to user. No retry — binary or config is wrong.
 
-### [`SpawnInput`](./runtime.ts#L40)
+### [`SpawnInput`](./runtime.ts#L48)
 
 _Interface_
 
@@ -630,13 +622,13 @@ export interface SpawnInput {
   readonly agentName: AgentName;
   readonly apiKey: AgentKey;
   readonly agentId: AgentId;
-  readonly serverUrl: ServerUrl;
+  readonly serverUrl: ServerBaseUrl;
   readonly workspaceFiles?: ReadonlyArray<WorkspaceFile>;
   readonly modelId?: string;
 }
 ```
 
-### [`startRuntimeAgent`](./testbed.ts#L339)
+### [`startRuntimeAgent`](./testbed.ts#L357)
 
 _Function_
 
@@ -670,7 +662,7 @@ coordinated startup.
 - `RuntimeReadyTimedOut` — `waitUntilReady` exceeds `readyTimeoutMs`
 - `RuntimeExitedBeforeReady` — the process exits before signaling ready (inspect `stderr`)
 
-### [`Testbed`](./testbed.ts#L87)
+### [`Testbed`](./testbed.ts#L89)
 
 _Interface_
 
@@ -682,7 +674,7 @@ export interface Testbed {
 }
 ```
 
-### [`TestbedAgent`](./testbed.ts#L82)
+### [`TestbedAgent`](./testbed.ts#L84)
 
 _Interface_
 
@@ -693,7 +685,7 @@ export interface TestbedAgent {
 }
 ```
 
-### [`TestbedAgentSpec`](./testbed.ts#L32)
+### [`TestbedAgentSpec`](./testbed.ts#L34)
 
 _Interface_
 
@@ -708,19 +700,15 @@ export interface TestbedAgentSpec {
 }
 ```
 
-### [`TestbedLaunchOptions`](./testbed.ts#L76)
+### [`TestbedLaunchOptions`](./testbed.ts#L78)
 
 _TypeAlias_
 
 ```ts
 export type TestbedLaunchOptions = TestbedLaunchOptionsBase & RuntimeSelection;
-
-export type TestbedProcessSignalOptions = TestbedLaunchOptions & {
-  readonly signals?: ReadonlyArray<Signal>;
-};
 ```
 
-### [`TestbedProcessSignalOptions`](./testbed.ts#L78)
+### [`TestbedProcessSignalOptions`](./testbed.ts#L80)
 
 _TypeAlias_
 
@@ -730,7 +718,7 @@ export type TestbedProcessSignalOptions = TestbedLaunchOptions & {
 };
 ```
 
-### [`TestbedStartupInterrupted`](./testbed.ts#L93)
+### [`TestbedStartupInterrupted`](./testbed.ts#L95)
 
 _Class_
 
@@ -743,7 +731,7 @@ export class TestbedStartupInterrupted extends Data.TaggedError(
 }> {}
 ```
 
-### [`WorkspaceFile`](./runtime.ts#L15)
+### [`WorkspaceFile`](./runtime.ts#L23)
 
 _Interface_
 

--- a/packages/testbed/src/nanoclaw-process.test.ts
+++ b/packages/testbed/src/nanoclaw-process.test.ts
@@ -17,6 +17,7 @@ import {
   nanoclawInstallSlug,
   NANOCLAW_EVAL_AGENT_GROUP_ID,
 } from "./nanoclaw-process.js";
+import { ServerUrl } from "./runtime.js";
 
 const FIRST_RUNTIME_DIR = "isolated/moltzap-nanoclaw-first";
 const SECOND_RUNTIME_DIR = "isolated/moltzap-nanoclaw-second";
@@ -193,7 +194,7 @@ function normalizesServerUrlForRuntime() {
           TEST_BASE_CHILD_ENVIRONMENT,
         );
         const secure = buildNanoclawProcessPlan(
-          { ...stubStartOptions(), serverUrl: SECURE_SERVER_URL },
+          { ...stubStartOptions(), serverUrl: ServerUrl(SECURE_SERVER_URL) },
           path.resolve(SECOND_RUNTIME_DIR),
           install,
           TEST_BASE_CHILD_ENVIRONMENT,
@@ -299,7 +300,7 @@ function stubStartOptions(
     agentName: TEST_AGENT_NAME,
     agentId: agentId(id),
     apiKey: redactedAgentKey(agentKeyString(91)),
-    serverUrl: "ws://localhost:9999/ws",
+    serverUrl: ServerUrl("ws://localhost:9999/ws"),
     autoRegisterConversations,
   };
 }

--- a/packages/testbed/src/nanoclaw-process.ts
+++ b/packages/testbed/src/nanoclaw-process.ts
@@ -268,11 +268,10 @@ function waitForOnecliReadiness() {
   });
 }
 
-function normalizeNanoclawServerUrl(serverUrl: string): string {
-  return serverUrl
-    .replace(/\/ws$/, "")
-    .replace(/^ws:/, "http:")
-    .replace(/^wss:/, "https:");
+// The container registers over HTTP before its client opens the socket. The
+// address arrives path-free from `SpawnInput`, so only the scheme changes.
+function nanoclawHttpServerUrl(serverUrl: string): string {
+  return serverUrl.replace(/^ws/, "http");
 }
 
 // Runtime dirs are docker bind-mount sources (agent-runner src, group and
@@ -403,7 +402,7 @@ function buildNanoclawChildEnvironment(
     ...baseEnvironment,
     MOLTZAP_PROFILE: TESTBED_PROFILE_NAME,
     MOLTZAP_CONFIG_HOME: join(runtimeDir, ".moltzap"),
-    MOLTZAP_SERVER_URL: normalizeNanoclawServerUrl(opts.serverUrl),
+    MOLTZAP_SERVER_URL: nanoclawHttpServerUrl(opts.serverUrl),
     MOLTZAP_EVAL_MODE: opts.autoRegisterConversations ? "1" : "0",
     CONTAINER_RUNTIME: "docker",
     CONTAINER_IMAGE: install.containerImage,

--- a/packages/testbed/src/runtime.ts
+++ b/packages/testbed/src/runtime.ts
@@ -1,16 +1,24 @@
 import { Brand, type Effect } from "effect";
 import type { AgentId, AgentKey } from "@moltzap/protocol/identity";
+import { serverBaseUrl, type ServerBaseUrl } from "@moltzap/protocol/network";
 import type { SpawnFailed } from "./errors.js";
 
 // Branded types for Runtime inputs.
 
 export type AgentName = string & Brand.Brand<"AgentName">;
-export type ServerUrl = string & Brand.Brand<"ServerUrl">;
 const AgentNameBrand = Brand.nominal<AgentName>();
-const ServerUrlBrand = Brand.nominal<ServerUrl>();
 
 export const AgentName = (value: string): AgentName => AgentNameBrand(value);
-export const ServerUrl = (value: string): ServerUrl => ServerUrlBrand(value);
+
+/**
+ * The address an adapter hands its child process: the protocol's path-free
+ * base, under this package's long-standing name. The child's client appends
+ * the socket route itself, so a value carrying one dials `/ws/ws` and never
+ * authenticates. Accepts either form a caller is likely to hold — the base
+ * URL or the socket endpoint — and throws on any other path.
+ */
+export type ServerUrl = ServerBaseUrl;
+export const ServerUrl = serverBaseUrl;
 
 export interface WorkspaceFile {
   readonly relativePath: string;
@@ -41,7 +49,7 @@ export interface SpawnInput {
   readonly agentName: AgentName;
   readonly apiKey: AgentKey;
   readonly agentId: AgentId;
-  readonly serverUrl: ServerUrl;
+  readonly serverUrl: ServerBaseUrl;
   readonly workspaceFiles?: ReadonlyArray<WorkspaceFile>;
   readonly modelId?: string;
 }

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -63,6 +63,7 @@ const PROCESS_SPAWN_AGENT_NAME = "process-spawn-agent";
 const TEST_API_KEY = redactedAgentKey(agentKeyString(70));
 const TEST_AGENT_ID = agentId("11111111-1111-4111-8111-111111111111");
 const TEST_SERVER_URL = "ws://localhost:9999/ws";
+const TEST_SERVER_BASE_URL = "ws://localhost:9999";
 const ALICE_AGENT_NAME = "alice";
 const SPAWN_FAILED_MESSAGE = "ENOENT";
 const SIGTERM_SIGNAL = "SIGTERM";
@@ -349,9 +350,9 @@ describe("branded types", () => {
     expect(Redacted.value(TEST_API_KEY)).toBe(agentKeyString(70));
   });
 
-  it("ServerUrl brand compiles and round-trips", () => {
-    const url = ServerUrl(TEST_SERVER_URL);
-    expect(url).toBe(TEST_SERVER_URL);
+  it("ServerUrl is the protocol's path-free base constructor", () => {
+    expect(ServerUrl(TEST_SERVER_URL)).toBe(TEST_SERVER_BASE_URL);
+    expect(() => ServerUrl(`${TEST_SERVER_BASE_URL}/elsewhere`)).toThrow();
   });
 });
 

--- a/packages/testbed/src/testbed.test.ts
+++ b/packages/testbed/src/testbed.test.ts
@@ -7,7 +7,7 @@ import {
   it,
   vi,
 } from "vitest";
-import { Deferred, Effect, Either, Exit, Fiber, Option } from "effect";
+import { Cause, Deferred, Effect, Either, Exit, Fiber, Option } from "effect";
 import {
   agentId,
   agentKeyString,
@@ -23,8 +23,13 @@ import {
   type TestbedAgentSpec,
   type TestbedLaunchOptions,
 } from "./testbed.js";
-import type { ReadyOutcome, Runtime, RuntimeServerHandle } from "./runtime.js";
-import { RuntimeReadyTimedOut } from "./errors.js";
+import type {
+  ReadyOutcome,
+  Runtime,
+  RuntimeServerHandle,
+  SpawnInput,
+} from "./runtime.js";
+import { RuntimeReadyTimedOut, SpawnFailed } from "./errors.js";
 import { createOpenClawAdapter } from "./openclaw-adapter.js";
 
 const testbedRuntimeFactoryState = vi.hoisted(() => ({
@@ -42,6 +47,8 @@ const TEST_AGENT_NAME = "test-agent";
 const TEST_API_KEY = redactedAgentKey(agentKeyString(80));
 const TEST_AGENT_ID = agentId("11111111-1111-4111-8111-111111111111");
 const TEST_SERVER_URL = "ws://localhost:9999/ws";
+const TEST_SERVER_BASE_URL = "ws://localhost:9999";
+const PATH_BEARING_SERVER_URL = "ws://localhost:9999/elsewhere";
 const ALPHA_AGENT_NAME = "alpha";
 const ALPHA_AGENT_ID = agentId("22222222-2222-4222-8222-222222222222");
 const BETA_AGENT_NAME = "beta";
@@ -128,6 +135,21 @@ describe("testbed lifecycle", () => {
   );
 });
 
+describe("testbed server URL", () => {
+  it(
+    "hands the adapter a path-free address whichever form the caller holds",
+    adapterReceivesPathFreeServerUrl,
+  );
+  it(
+    "fails the launch when the address carries any other path",
+    launchFailsOnServerUrlWithPath,
+  );
+  it(
+    "rejects every agent's address before starting the first one",
+    launchRejectsBadAddressBeforeAnySpawn,
+  );
+});
+
 describe("testbed runtime options", () => {
   it(
     "resolves one install mode and shares it with every adapter",
@@ -148,6 +170,90 @@ describe("testbed runtime options", () => {
     >().not.toMatchTypeOf<TestbedLaunchOptions>();
   });
 });
+
+function adapterReceivesPathFreeServerUrl() {
+  return runTest(
+    Effect.gen(function* () {
+      for (const held of [
+        TEST_SERVER_URL,
+        `${TEST_SERVER_URL}/`,
+        TEST_SERVER_BASE_URL,
+      ]) {
+        const mock = yield* createMockRuntime({
+          readyEffect: Effect.succeed({ _tag: READY_TAG }),
+        });
+        setMockTestbedRuntimes(mock.runtime);
+
+        yield* startRuntimeAgent({
+          kind: OPENCLAW_KIND,
+          server: stubServer(),
+          agent: stubTestbedAgentSpec({ serverUrl: held }),
+          readyTimeoutMs: READY_TIMEOUT_MS,
+        }).pipe(Effect.orDie);
+
+        expect(mock.stats.spawnInputs.map((input) => input.serverUrl)).toEqual([
+          TEST_SERVER_BASE_URL,
+        ]);
+      }
+    }),
+  );
+}
+
+function launchFailsOnServerUrlWithPath() {
+  return runTest(
+    Effect.gen(function* () {
+      const mock = yield* createMockRuntime({
+        readyEffect: Effect.succeed({ _tag: READY_TAG }),
+      });
+      setMockTestbedRuntimes(mock.runtime);
+
+      const exit = yield* startRuntimeAgent({
+        kind: OPENCLAW_KIND,
+        server: stubServer(),
+        agent: stubTestbedAgentSpec({ serverUrl: PATH_BEARING_SERVER_URL }),
+        readyTimeoutMs: READY_TIMEOUT_MS,
+      }).pipe(Effect.exit);
+
+      const failure = Exit.isFailure(exit)
+        ? Option.getOrNull(Cause.failureOption(exit.cause))
+        : null;
+      expect(failure).toBeInstanceOf(SpawnFailed);
+      expect(failure?.message).toContain(PATH_BEARING_SERVER_URL);
+      expect(mock.stats.spawnCalls).toBe(0);
+    }),
+  );
+}
+
+function launchRejectsBadAddressBeforeAnySpawn() {
+  return runTest(
+    Effect.gen(function* () {
+      const first = yield* createMockRuntime({
+        readyEffect: Effect.succeed({ _tag: READY_TAG }),
+      });
+      const second = yield* createMockRuntime({
+        readyEffect: Effect.succeed({ _tag: READY_TAG }),
+      });
+      setMockTestbedRuntimes(first.runtime, second.runtime);
+
+      const exit = yield* launchTestbed({
+        kind: OPENCLAW_KIND,
+        server: stubServer(),
+        agents: [
+          stubTestbedAgentSpec({ agentName: ALPHA_AGENT_NAME }),
+          stubTestbedAgentSpec({
+            agentName: BETA_AGENT_NAME,
+            serverUrl: PATH_BEARING_SERVER_URL,
+          }),
+        ],
+        readyTimeoutMs: READY_TIMEOUT_MS,
+      }).pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(first.stats.spawnCalls).toBe(0);
+      expect(second.stats.spawnCalls).toBe(0);
+    }),
+  );
+}
 
 function testbedSharesOneInstallModeAcrossAdapters() {
   return runTest(
@@ -401,6 +507,7 @@ interface MockRuntimeStats {
   spawnCalls: number;
   waitCalls: number;
   teardownCalls: number;
+  spawnInputs: SpawnInput[];
 }
 
 interface MockRuntimeHandle {
@@ -464,13 +571,15 @@ function createMockRuntime(options: {
       spawnCalls: 0,
       waitCalls: 0,
       teardownCalls: 0,
+      spawnInputs: [],
     };
     const waitStarted = yield* Deferred.make<void, never>();
 
     const runtime: Runtime = {
-      spawn: () =>
+      spawn: (input) =>
         Effect.sync(() => {
           stats.spawnCalls += 1;
+          stats.spawnInputs.push(input);
         }),
       waitUntilReady: () =>
         Deferred.succeed(waitStarted, undefined).pipe(

--- a/packages/testbed/src/testbed.ts
+++ b/packages/testbed/src/testbed.ts
@@ -1,13 +1,16 @@
 /* eslint-disable jsdoc/text-escaping -- mermaid sequenceDiagram blocks need literal `<br>` (HTML5) for renderer compatibility; the escape would render as literal text. */
 export type { InstallMode } from "./install-mode.js";
 
-import { Data, Effect, Exit, Fiber } from "effect";
+import { Data, Effect, Exit, Fiber, Schema } from "effect";
 import type { Signal } from "@effect/platform/CommandExecutor";
 import type { AgentId, AgentKey } from "@moltzap/protocol/identity";
+import { ServerBaseUrl } from "@moltzap/protocol/network";
 import {
   RuntimeExitedBeforeReady,
   RuntimeReadyTimedOut,
+  spawnFailed,
   type RuntimeLaunchFailed,
+  type SpawnFailed,
 } from "./errors.js";
 import {
   NanoclawAdapter,
@@ -19,7 +22,6 @@ import {
 } from "./openclaw-adapter.js";
 import {
   AgentName,
-  ServerUrl,
   type Runtime,
   type RuntimeServerHandle,
   type SpawnInput,
@@ -153,17 +155,32 @@ function installModeOverride(
   }
 }
 
-function toSpawnInput(agent: TestbedAgentSpec): SpawnInput {
-  return {
-    agentName: AgentName(agent.agentName),
-    apiKey: agent.apiKey,
-    agentId: agent.agentId,
-    serverUrl: ServerUrl(agent.serverUrl),
-    ...(agent.workspaceFiles !== undefined
-      ? { workspaceFiles: agent.workspaceFiles }
-      : {}),
-    ...(agent.modelId !== undefined ? { modelId: agent.modelId } : {}),
-  };
+const decodeServerUrl = Schema.decodeEither(ServerBaseUrl);
+
+/** One agent's spec paired with the `SpawnInput` decoded from it. */
+interface DecodedAgent {
+  readonly agent: TestbedAgentSpec;
+  readonly spawnInput: SpawnInput;
+}
+
+// `TestbedAgentSpec` is the package boundary, so the address is decoded here
+// rather than trusted; downstream every adapter holds a path-free `ServerUrl`.
+function toSpawnInput(
+  agent: TestbedAgentSpec,
+): Effect.Effect<SpawnInput, SpawnFailed> {
+  return decodeServerUrl(agent.serverUrl).pipe(
+    Effect.mapError((cause) => spawnFailed(agent.agentName, cause)),
+    Effect.map((serverUrl) => ({
+      agentName: AgentName(agent.agentName),
+      apiKey: agent.apiKey,
+      agentId: agent.agentId,
+      serverUrl,
+      ...(agent.workspaceFiles !== undefined
+        ? { workspaceFiles: agent.workspaceFiles }
+        : {}),
+      ...(agent.modelId !== undefined ? { modelId: agent.modelId } : {}),
+    })),
+  );
 }
 
 /**
@@ -216,16 +233,17 @@ function runtimeStartOptionsForAgent(
 function startTestbedAgent(
   options: TestbedLaunchOptions,
   startedAgents: StartedRuntimeAgent[],
-  agent: TestbedAgentSpec,
+  decoded: DecodedAgent,
   installMode: InstallMode,
 ) {
   return Effect.gen(function* () {
     const pending = yield* startPendingRuntimeAgent(
-      runtimeStartOptionsForAgent(options, agent),
+      runtimeStartOptionsForAgent(options, decoded.agent),
       installMode,
+      decoded.spawnInput,
     );
     const startedAgent = {
-      spec: agent,
+      spec: decoded.agent,
       runtime: pending.runtime,
     } satisfies StartedRuntimeAgent;
     startedAgents.push(startedAgent);
@@ -267,9 +285,9 @@ function toTestbed(started: ReadonlyArray<StartedRuntimeAgent>): Testbed {
 function startPendingRuntimeAgent(
   options: RuntimeStartOptions,
   installMode: InstallMode,
+  spawnInput: SpawnInput,
 ) {
   const runtime = createRuntime(options, installMode);
-  const spawnInput = toSpawnInput(options.agent);
   return Effect.gen(function* () {
     let cleanupArmed = true;
     const [closeStartupScope] = yield* Effect.withEarlyRelease(
@@ -341,10 +359,15 @@ export function startRuntimeAgent(
 ): Effect.Effect<Runtime, RuntimeLaunchFailed, never> {
   return Effect.scoped(
     Effect.gen(function* () {
+      const spawnInput = yield* toSpawnInput(options.agent);
       const installMode = yield* resolveInstallMode(
         installModeOverride(options),
       );
-      const pending = yield* startPendingRuntimeAgent(options, installMode);
+      const pending = yield* startPendingRuntimeAgent(
+        options,
+        installMode,
+        spawnInput,
+      );
       yield* pending.releaseStartupCleanup;
       return pending.runtime;
     }),
@@ -373,13 +396,25 @@ export function launchTestbed(
   return Effect.scoped(
     Effect.gen(function* () {
       const startedAgents: StartedRuntimeAgent[] = [];
+      // Every address is decoded before the first process starts: a bad one
+      // discovered mid-launch would cost the spawn and teardown of every
+      // agent ahead of it.
+      const decoded = yield* Effect.forEach(
+        options.agents,
+        (agent) =>
+          Effect.map(
+            toSpawnInput(agent),
+            (spawnInput): DecodedAgent => ({ agent, spawnInput }),
+          ),
+        { concurrency: 1 },
+      );
       const installMode = yield* resolveInstallMode(
         installModeOverride(options),
       );
       const started = yield* Effect.forEach(
-        options.agents,
-        (agent) =>
-          startTestbedAgent(options, startedAgents, agent, installMode),
+        decoded,
+        (entry) =>
+          startTestbedAgent(options, startedAgents, entry, installMode),
         {
           concurrency: options.concurrency ?? 1,
         },


### PR DESCRIPTION
Closes #846
Also closes #851's instance on `main` (see site 6 in the table).

Plan: <https://github.com/chughtapan/moltzap/issues/846> plus its site-by-site
comment <https://github.com/chughtapan/moltzap/issues/846#issuecomment-5085022849>.
Parent epic: <https://github.com/chughtapan/moltzap/issues/809>.

## What changed

`@moltzap/protocol` gains `ServerBaseUrl`: a refined branded string that cannot
hold a path. Construction normalizes the `/ws` socket route away and rejects
every other path, query, or fragment. `webSocketUrl` takes it, so the value it
appends `/ws` to is proven path-free at the type level.

A brand already existed — `testbed/src/runtime.ts → ServerUrl`, built with
`Brand.nominal` — and performed no validation. That is why `ServerUrl("ws://h/ws")`
succeeded and the `/ws/ws` defect reached a live path twice with the value
branded the whole way.

### Normalize or reject

Construction **normalizes the socket route and rejects everything else**, and
returns scheme + authority rebuilt from the parsed URL rather than sliced out of
the input.

That rebuild is load-bearing, not cosmetic. Validating one spelling and
returning another let addresses through that the brand promised were dialable
and were not: `HTTP://host` passes the scheme check (URL lower-cases
`protocol`) but `webSocketUrl`'s `/^http/` swap does not match the raw input, so
the endpoint came out as `HTTP://host/ws` — which no socket opens.
`http://host//` and space-padded input had the same validate-versus-return
mismatch. Rebuilding also means the authority form cannot carry credentials, so
those are rejected rather than silently dropped.

- `webSocketUrl` appends a fixed route, so a server published under a path
  prefix is not addressable through this package at all. Discarding `/ws`
  cannot lose a deployment the client could have reached; the "silently guesses
  wrong" objection in the issue's option 2 does not apply to this contract.
- Every pre-existing copy of the rule already normalized. A reject-only
  constructor would push the strip back out to five call sites and rebuild the
  divergence the issue is about.
- Anything else carrying a path has no defined meaning here, so it fails at
  construction with the offending value named in the message.

### Sites collapsed

The issue comment's table was compiled against the unmerged simulator stack. On
`main` there are **five** copies of the strip rule, not three — the two extra
ones are in `server-core`'s and `protocol`'s own test utilities.

| # | Site | Was | Now |
|---|---|---|---|
| 1 | `client/src/test-utils/index.ts → stripWsPath` | `/\/ws\/?$/` | `serverBaseUrl`; returns `ServerBaseUrl` |
| 2 | `server/src/test-utils/helpers.ts → testClientServerUrl` | `/\/ws$/` + scheme | `serverBaseUrl` + scheme |
| 3 | `protocol/src/testing/conformance/_shared/driver/test-client.ts → clientBaseUrl` | `/\/ws\/?$/` + scheme | `serverBaseUrl` + scheme |
| 4 | `openclaw-channel/src/test-utils/container-core.ts → normalizeContainerServerUrl` | `/\/ws$/` + scheme + docker host | `serverBaseUrl` + scheme + docker host |
| 5 | `testbed/src/nanoclaw-process.ts → normalizeNanoclawServerUrl` | `/\/ws$/` + scheme | renamed `nanoclawHttpServerUrl`; the strip is deleted because the address arrives path-free |
| 6 | `testbed/src/openclaw-adapter.ts` (`MOLTZAP_SERVER_URL`) | unnormalized — the #851 defect | fixed by construction: `SpawnInput.serverUrl` is the refined brand, so no code change was needed |
| 7 | `testbed/src/testbed.ts → toSpawnInput` | `ServerUrl(agent.serverUrl)` on a raw string | decodes at the package boundary, failing with the existing `SpawnFailed` |

`stripWsPath`'s `/\/ws\/?$/` is the adopted rule, so the trailing-slash case is
handled everywhere. A bare trailing `/` is also stripped, which no copy did
(`ws://h/` would have dialled `ws://h//ws`).

### Fail-fast on multi-agent launch

`launchTestbed` decodes every agent's address before starting the first process.
Decoding inside the per-agent loop (which is sequential by default) would only
discover a bad address on agent *k* after agents 1..k-1 had each been spawned,
driven to ready, and then torn down — for the nanoclaw adapter that is a
container build and start per agent, to surface a failure detectable in ~1 µs.

## Public surface

Additive only; nothing breaking.

- **New** on `@moltzap/protocol/network`: `ServerBaseUrl` (type + schema),
  `serverBaseUrl`, `webSocketUrl`.
- `AgentClientOptions.serverUrl` / `AppClientOptions.serverUrl` stay `string`.
  The lifecycle decodes at its own seam and maps a malformed address onto the
  `NotConnectedError` already in that channel — no new error type, no widened
  union. Such an address used to produce a 10s connect timeout; it now fails
  immediately with the offending value named.
- `@moltzap/testbed`'s `ServerUrl` keeps its name and its
  `(value: string) => ServerUrl` signature; it is now the protocol brand's
  constructor. Behaviour change for direct callers: it throws on an address
  carrying a path instead of silently branding it.
- `stripWsPath` returns `ServerBaseUrl` instead of `string` (assignable to
  `string`, so no consumer breaks).

### Why `network/` and not `socket/`

`socket/index.ts` is at its architecture budget: adding a fourteenth local
re-export module trips `no-large-public-surface` (twice) and
`require-curated-public-facade`, and clearing them would need three budget
bumps. `network/` already owns connect, and a server address is where you
connect; `socket/lifecycle.ts` already imports `#network`. The folder gained a
README per `folder-readme-required`.

## Doc-generator fix (incidental, same PR)

`scripts/docs/modules.ts → extractBalancedBody` cut a declaration's snippet at
the first line boundary where bracket depth returned to zero *after* a bracket
had opened. A declaration with no brackets at all (`export type Foo = Bar;`)
never opened one, so the scan ran on until some **later** declaration did,
swallowing everything in between. Visible in the diff: `testbed/src/MODULE.md`'s
`ServerUrl` block was eating the unrelated `WorkspaceFile` interface, and
`server/src/dispatch/MODULE.md`'s `LeaseState` was eating `LeaseVerdict`.

The fix cuts at the declaration's own top-level `;` when nothing has opened —
the behaviour the function's own doc comment already claimed. It removes eight
other pre-existing over-captures across `server-core` and `protocol` MODULE.md
pages; those are the unrelated `.mdx`/`MODULE.md` lines in this diff. Regression
test added; `findOutsideStrings` became dead and is deleted.

## Codex review — GATE: PASS

**First pass** found two, both fixed in `219a84a6` and pinned by tests:

- **[P1] `URL.parse` needs Node 22.1, the package declares `>=22.0.0`.** On
  22.0.x every decode would have thrown before validating, so no client could
  connect. Now `URL.canParse` + `new URL` (both available since 18.17). This one
  I would not have caught: it is invisible on any machine running a current 22.x.
- **[P2] Validation and output disagreed.** `serverBaseUrl("http://localhost//")`
  returned a path-bearing string, so `webSocketUrl` produced `ws://localhost//ws`
  instead of the server's `/ws` route; leading/trailing spaces behaved the same
  way. Fixed by the rebuild described above. Both cases are now in the
  canonicalization table.

I found the case-variant scheme break (`HTTP://host`) independently while codex
was still running; same class, same fix.

**Second pass against the final tree: zero [P1], one [P2]** — and it is the
`getHttpUrl` gap already documented below as out of scope. Codex sharpens it:
because sockets now accept `WS://host`, `getHttpUrl`'s case-sensitive swap can
leave a literal `WS:` scheme on the registration URL, not just an unstripped
`/ws`. Independent confirmation that this is the right next issue, and that it
is a contract call rather than an implementation one.

## Tests

- `protocol/src/network/server-url.test.ts` — accept/normalize table (including
  `ws://…/ws/`, the case only `stripWsPath` handled, and a bare trailing `/`),
  reject table (other paths, query, fragment, non-`http`/`ws` scheme,
  unparseable, empty), the failure message naming the offending value, and two
  `fast-check` properties over base × `{"", "/", "/ws", "/ws/"}`: normalization
  is idempotent, and the endpoint is identical for every form a caller may hold
  and never contains `/ws/ws`.
- `protocol/src/network/server-url.types-check.ts` — canary pinning that a plain
  `string` no longer compiles at `webSocketUrl`, plus a positive control.
- A canonicalization table covering case-variant schemes, upper-case hosts,
  default ports, `//`, `//ws`, and space-padding; a rejection row for embedded
  credentials; and a property asserting the derived endpoint's scheme is always
  `ws:` or `wss:` — the invariant that makes the brand's promise real.
- `testbed/src/testbed.test.ts` — the adapter receives the path-free address
  whichever form the caller holds; a path-bearing address fails with
  `SpawnFailed` before `spawn` is called; and a bad address on the *second*
  agent stops the launch before the *first* one spawns.
- `testbed/src/runtimes.test.ts` — the `ServerUrl` brand test pins normalization
  and rejection instead of nominal round-tripping.
- `protocol/scripts/docs/__tests__/signature-extract.test.ts` — a bracket-free
  alias stops before the next declaration.

Full unit suite run serially: 81 files, 761 tests, all passing. Root `pnpm lint`
(knip + `arch:check` + oxlint + per-package eslint) exit 0, `format:check` clean,
`nx run-many -t typecheck:tests` clean, all three docs gates clean.

## Left out of scope

The `ws:`→`http:` scheme conversion is still open-coded in five places
(`client/src/config.ts → getHttpUrl` plus four call sites above). That is the
second half of the issue's "related surface" note and a different rule from the
path defect.

**Worth its own issue** (codex's remaining [P2]): `client/src/config.ts →
getHttpUrl` swaps the scheme without stripping the route, so
`MOLTZAP_SERVER_URL=ws://host/ws` yields `http://host/ws` for `registerAgent`,
and an upper-case `WS://host` keeps a literal `WS:` scheme. That is the HTTP
twin of this defect on a production path, and this PR does not close it — every
producer of that env var in this repo now hands over a path-free base, but a
hand-set value still reaches it.

I left it out deliberately rather than by omission. `getServerUrl` is
`Effect<string, never>`; making it decode means either widening a published
client API's error channel or silently falling back on a bad value, and picking
between those is a contract decision, not an implementation one.

`simulator/provisioning.ts → httpBaseFromServerUrl` exists only on the unmerged
simulator stack and is out of reach here.

Two smaller follow-ups: `SOCKET_ROUTE` is private to `network/server-url.ts`
while `server/src/http/routes.ts` hardcodes `/ws` independently; and
`server/src/test-utils/helpers.ts → testClientServerUrl` and
`protocol/.../test-client.ts → clientBaseUrl` are now byte-identical in two
packages, which cannot be shared without new public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
