### PR TITLE
[impl-junior] Stop openclaw's onboarding ritual hijacking the agent's first reply

### DIFF
--- a/docs/modules/testbed/src.mdx
+++ b/docs/modules/testbed/src.mdx
@@ -42,7 +42,7 @@ export function awaitAgentReadyByPolling(
 ): Effect.Effect<ReadyOutcome, never, never>
 ```
 
-### [`createOpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L576)
+### [`createOpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L636)
 
 _Function_
 
@@ -305,7 +305,7 @@ export interface NanoclawAdapterOptions {
 }
 ```
 
-### [`OpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L479)
+### [`OpenClawAdapter`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L539)
 
 _Class_
 
@@ -419,7 +419,7 @@ Readiness signal: server-side WS authentication event surfaces via
 (boot) or `RuntimeExitedBeforeReady` / `RuntimeReadyTimedOut`
 (post-spawn, surfaced by `processExitLoop`).
 
-### [`OpenClawAdapterDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L176)
+### [`OpenClawAdapterDeps`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L181)
 
 _Interface_
 
@@ -432,7 +432,7 @@ export interface OpenClawAdapterDeps {
 }
 ```
 
-### [`OpenClawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L183)
+### [`OpenClawAdapterOptions`](https://github.com/chughtapan/moltzap/blob/main/packages/testbed/src/openclaw-adapter.ts#L188)
 
 _Interface_
 

--- a/packages/testbed/src/MODULE.md
+++ b/packages/testbed/src/MODULE.md
@@ -37,7 +37,7 @@ export function awaitAgentReadyByPolling(
 ): Effect.Effect<ReadyOutcome, never, never>
 ```
 
-### [`createOpenClawAdapter`](./openclaw-adapter.ts#L576)
+### [`createOpenClawAdapter`](./openclaw-adapter.ts#L636)
 
 _Function_
 
@@ -300,7 +300,7 @@ export interface NanoclawAdapterOptions {
 }
 ```
 
-### [`OpenClawAdapter`](./openclaw-adapter.ts#L479)
+### [`OpenClawAdapter`](./openclaw-adapter.ts#L539)
 
 _Class_
 
@@ -414,7 +414,7 @@ Readiness signal: server-side WS authentication event surfaces via
 (boot) or `RuntimeExitedBeforeReady` / `RuntimeReadyTimedOut`
 (post-spawn, surfaced by `processExitLoop`).
 
-### [`OpenClawAdapterDeps`](./openclaw-adapter.ts#L176)
+### [`OpenClawAdapterDeps`](./openclaw-adapter.ts#L181)
 
 _Interface_
 
@@ -427,7 +427,7 @@ export interface OpenClawAdapterDeps {
 }
 ```
 
-### [`OpenClawAdapterOptions`](./openclaw-adapter.ts#L183)
+### [`OpenClawAdapterOptions`](./openclaw-adapter.ts#L188)
 
 _Interface_
 

--- a/packages/testbed/src/openclaw-adapter.ts
+++ b/packages/testbed/src/openclaw-adapter.ts
@@ -683,6 +683,10 @@ export function buildOpenClawConfig(
         model: { primary: opts.modelId ?? DEFAULT_OPENCLAW_MODEL_ID },
         workspace: workspaceDir,
         compaction: { mode: "safeguard" },
+        // Left unset, openclaw seeds BOOTSTRAP.md into the empty per-agent
+        // workspace and runs its first-run onboarding ritual, whose scripted
+        // opening line the agent sends in place of answering the step.
+        skipBootstrap: true,
       },
     },
     commands: { native: "auto", nativeSkills: "auto", restart: true },

--- a/packages/testbed/src/openclaw-adapter.ts
+++ b/packages/testbed/src/openclaw-adapter.ts
@@ -1,8 +1,10 @@
 /* eslint-disable jsdoc/text-escaping -- mermaid sequenceDiagram blocks need literal `<br>` (HTML5) for renderer compatibility; the escape would render as literal text. */
+import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { Command, FileSystem, Path, SocketServer } from "@effect/platform";
 import type { Process } from "@effect/platform/CommandExecutor";
+import type { PlatformError } from "@effect/platform/Error";
 import { Config, Data, Effect, Exit, Fiber, Option, Scope } from "effect";
 import { NodeContext, NodeSocketServer } from "@effect/platform-node";
 import type { MoltzapChannelPlugin } from "@moltzap/openclaw-channel";
@@ -46,6 +48,9 @@ const OPENCLAW_CHANNEL_ID = "moltzap" satisfies MoltzapChannelPlugin["id"];
 const OPENCLAW_EXTENSION_NAME = "openclaw-channel";
 const TOKEN_RADIX = 36;
 const JSON_INDENT_SPACES = 2;
+const OPENCLAW_WORKSPACE_DIRNAME = "workspace";
+const OPENCLAW_ATTESTATION_DIRNAME = "workspace-attestations";
+const OPENCLAW_ATTESTATION_SUFFIX = ".attested";
 
 class PortAllocationFailed extends Data.TaggedError("PortAllocationFailed")<{
   readonly message: string;
@@ -325,7 +330,61 @@ function seedModelAuthProfile(
   );
 }
 
-function configureOpenClawStateDir(
+function openClawWorkspaceDir(stateDir: string): string {
+  return join(stateDir, OPENCLAW_WORKSPACE_DIRNAME);
+}
+
+/**
+ * Occupies the attestation paths OpenClaw derives for this run's workspace
+ * with directories. `lstat` succeeds and `isFile()` is false, so OpenClaw
+ * reads the workspace as never attested and writes no marker of its own.
+ *
+ * OpenClaw's guard refuses to reseed a workspace that was attested recently
+ * and is now empty, which protects a durable operator workspace from silent
+ * reseeding. A simulated agent's workspace is per-run, empty unless the
+ * scenario declares files, and the agent may delete anything in it: one
+ * create-then-delete otherwise leaves the guard throwing for the rest of the
+ * episode, uncaught, and the run records that as agent silence.
+ *
+ * OpenClaw consults a third candidate under its legacy home state dir. That
+ * path is the operator's rather than the run's, so it is left alone. Of the
+ * two occupied here only the first is one OpenClaw ever writes; the sibling
+ * marker it reads but never writes is held defensively.
+ *
+ * The derivation is OpenClaw's own, recomputed because no public entry
+ * exports it, and it fails unsafely: a sentinel at the wrong path leaves
+ * OpenClaw free to write a real attestation at the right one. Only directories
+ * work. Blocking a path instead, by permissions or by an `ENOTDIR` parent,
+ * makes OpenClaw trust what it cannot read as attested and arms the guard on
+ * the first turn.
+ */
+function disarmOpenClawAttestationGuard(
+  stateDir: string,
+): Effect.Effect<void, PlatformError, FileSystem.FileSystem> {
+  const resolvedWorkspaceDir = resolve(openClawWorkspaceDir(stateDir));
+  const key = createHash("sha256").update(resolvedWorkspaceDir).digest("hex");
+  const sentinels = [
+    join(
+      stateDir,
+      OPENCLAW_ATTESTATION_DIRNAME,
+      `${key}${OPENCLAW_ATTESTATION_SUFFIX}`,
+    ),
+    `${resolvedWorkspaceDir}${OPENCLAW_ATTESTATION_SUFFIX}`,
+  ];
+  return FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) =>
+      Effect.all(
+        sentinels.map((sentinel) =>
+          fileSystem.makeDirectory(sentinel, { recursive: true }),
+        ),
+        { concurrency: sentinels.length, discard: true },
+      ),
+    ),
+  );
+}
+
+/** @internal */
+export function configureOpenClawStateDir(
   deps: OpenClawAdapterDeps,
   input: SpawnInput,
   stateDir: string,
@@ -340,10 +399,11 @@ function configureOpenClawStateDir(
         modelId: input.modelId,
         mcpServers: deps.mcpServers,
       }),
-      seedWorkspaceFiles(join(stateDir, "workspace"), input.workspaceFiles),
+      seedWorkspaceFiles(openClawWorkspaceDir(stateDir), input.workspaceFiles),
       seedModelAuthProfile(stateDir),
+      disarmOpenClawAttestationGuard(stateDir),
     ],
-    { concurrency: 3, discard: true },
+    { concurrency: 4, discard: true },
   ).pipe(
     Effect.zipRight(
       installChannelPlugin({
@@ -627,7 +687,7 @@ function writeOpenClawConfig(opts: {
   return Effect.gen(function* () {
     const path = yield* Path.Path;
     const fileSystem = yield* FileSystem.FileSystem;
-    const workspaceDir = path.join(opts.stateDir, "workspace");
+    const workspaceDir = openClawWorkspaceDir(opts.stateDir);
     const config = buildOpenClawConfig(opts, workspaceDir);
 
     yield* Effect.all([

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -216,45 +216,69 @@ describe("buildOpenClawConfig bootstrap", () => {
     "leaves openclaw's bootstrap prompt out of a fresh workspace",
     openClawSeedsNoBootstrapPrompt,
   );
+
+  // Without this control the assertion above would hold just as well if
+  // openclaw had stopped seeding for a reason that has nothing to do with the
+  // config this package writes.
+  it(
+    "still seeds the prompt when the gate is left open",
+    openClawSeedsBootstrapPromptWhenGated,
+  );
 });
 
 function openClawSeedsNoBootstrapPrompt() {
+  const config = buildOpenClawConfig(
+    { agentName: "alice" },
+    CONFIG_WORKSPACE_DIR,
+  );
   return runTest(
-    Effect.scoped(
-      Effect.gen(function* () {
-        const fileSystem = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        const workspaceDir = yield* fileSystem.makeTempDirectoryScoped({
-          prefix: "testbed-openclaw-workspace-",
-        });
-        const config = buildOpenClawConfig(
-          { agentName: "alice" },
-          workspaceDir,
-        );
-        // openclaw exports the seeding function only from its compat bridge,
-        // which drags the whole embedded agent runtime along; importing it
-        // here keeps several seconds of module load out of the collection of
-        // every other test in this file.
-        const { ensureAgentWorkspace } = yield* Effect.tryPromise(
-          () => import("openclaw/extension-api"),
-        );
-
-        yield* Effect.tryPromise(() =>
-          ensureAgentWorkspace({
-            dir: workspaceDir,
-            // The gate openclaw derives from this key when it prepares a
-            // workspace for a reply.
-            ensureBootstrapFiles: !config.agents?.defaults?.skipBootstrap,
-          }),
-        );
-
-        const seeded = yield* fileSystem.exists(
-          path.join(workspaceDir, OPENCLAW_BOOTSTRAP_FILENAME),
-        );
+    bootstrapPromptSeeded(!config.agents?.defaults?.skipBootstrap).pipe(
+      Effect.map((seeded) => {
         expect(seeded).toBe(false);
       }),
-    ).pipe(Effect.provide(NodeContext.layer), Effect.orDie),
+    ),
   );
+}
+
+function openClawSeedsBootstrapPromptWhenGated() {
+  return runTest(
+    bootstrapPromptSeeded(true).pipe(
+      Effect.map((seeded) => {
+        expect(seeded).toBe(true);
+      }),
+    ),
+  );
+}
+
+// `ensureBootstrapFiles` is what openclaw's reply path derives from
+// `agents.defaults.skipBootstrap` before it prepares a workspace.
+function bootstrapPromptSeeded(
+  ensureBootstrapFiles: boolean,
+): Effect.Effect<boolean, never, never> {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const workspaceDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "testbed-openclaw-workspace-",
+      });
+      // openclaw exports the seeding function only from its compat bridge,
+      // which drags the whole embedded agent runtime along; importing it here
+      // keeps several seconds of module load out of the collection of every
+      // other test in this file.
+      const { ensureAgentWorkspace } = yield* Effect.tryPromise(
+        () => import("openclaw/extension-api"),
+      );
+
+      yield* Effect.tryPromise(() =>
+        ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles }),
+      );
+
+      return yield* fileSystem.exists(
+        path.join(workspaceDir, OPENCLAW_BOOTSTRAP_FILENAME),
+      );
+    }),
+  ).pipe(Effect.provide(NodeContext.layer), Effect.orDie);
 }
 
 // The gateway child reads MOLTZAP_SERVER_URL through the moltzap client,

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -7,7 +7,6 @@ import {
   Deferred,
   Effect,
   Either,
-  FastCheck as fc,
   Fiber,
   Option,
   Redacted,
@@ -18,9 +17,6 @@ import {
   agentKeyString,
   redactedAgentKey,
 } from "@moltzap/protocol/testing";
-// The seeding function has no focused plugin-sdk subpath; the compat bridge is
-// the only public surface openclaw exposes for it.
-import { ensureAgentWorkspace } from "openclaw/extension-api";
 import { OpenClawSchema } from "openclaw/plugin-sdk/config-schema";
 
 import {
@@ -160,6 +156,8 @@ describe("OpenClawAdapter.spawn", () => {
 const CONFIG_WORKSPACE_DIR = "/workspaces/testbed-agent";
 const CUSTOM_MODEL_ID = "custom/model";
 const DISABLED_MDNS_MODE = "off";
+// openclaw treats this file's presence in a workspace as "onboarding pending".
+const OPENCLAW_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 
 describe("buildOpenClawConfig", () => {
   it("keys the moltzap account under the testbed profile", () => {
@@ -201,72 +199,61 @@ describe("buildOpenClawConfig", () => {
   });
 });
 
-// openclaw treats this file's presence in a workspace as "onboarding pending".
-const OPENCLAW_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
-
 describe("buildOpenClawConfig bootstrap", () => {
   // openclaw's config schema is strict, so a misspelled or misplaced knob is
   // rejected outright rather than carried along as an inert key.
   it("carries skipBootstrap through openclaw's own config schema", () => {
-    fc.assert(
-      fc.property(
-        fc.string({ minLength: 1 }),
-        fc.option(fc.string({ minLength: 1 }), { nil: undefined }),
-        fc.string({ minLength: 1 }),
-        (agentName, modelId, workspaceDir) => {
-          const parsed = OpenClawSchema.safeParse(
-            buildOpenClawConfig({ agentName, modelId }, workspaceDir),
-          );
-          expect(parsed.success).toBe(true);
-          expect(
-            parsed.success && parsed.data.agents?.defaults?.skipBootstrap,
-          ).toBe(true);
-        },
-      ),
+    const parsed = OpenClawSchema.safeParse(
+      buildOpenClawConfig({ agentName: "alice" }, CONFIG_WORKSPACE_DIR),
     );
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.agents?.defaults?.skipBootstrap).toBe(true);
   });
 
-  it("leaves openclaw's bootstrap prompt out of a fresh workspace", () =>
-    Effect.runPromise(
-      openClawSeededBootstrapPrompt().pipe(
-        Effect.map((seeded) => {
-          expect(seeded).toBe(false);
-        }),
-      ),
-    ));
+  it(
+    "leaves openclaw's bootstrap prompt out of a fresh workspace",
+    openClawSeedsNoBootstrapPrompt,
+  );
 });
 
-function openClawSeededBootstrapPrompt(): Effect.Effect<boolean, never, never> {
-  return Effect.scoped(Effect.gen(bootstrapSeedingCheck)).pipe(
-    Effect.provide(NodeContext.layer),
-    Effect.orDie,
-  );
-}
+function openClawSeedsNoBootstrapPrompt() {
+  return runTest(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const workspaceDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "testbed-openclaw-workspace-",
+        });
+        const config = buildOpenClawConfig(
+          { agentName: "alice" },
+          workspaceDir,
+        );
+        // openclaw exports the seeding function only from its compat bridge,
+        // which drags the whole embedded agent runtime along; importing it
+        // here keeps several seconds of module load out of the collection of
+        // every other test in this file.
+        const { ensureAgentWorkspace } = yield* Effect.tryPromise(
+          () => import("openclaw/extension-api"),
+        );
 
-function* bootstrapSeedingCheck() {
-  const fileSystem = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const workspaceDir = yield* fileSystem.makeTempDirectory({
-    prefix: "testbed-openclaw-workspace-",
-  });
-  yield* Effect.addFinalizer(() =>
-    fileSystem
-      .remove(workspaceDir, { recursive: true, force: true })
-      .pipe(Effect.catchAll(() => Effect.void)),
-  );
-  const config = buildOpenClawConfig({ agentName: "alice" }, workspaceDir);
+        yield* Effect.tryPromise(() =>
+          ensureAgentWorkspace({
+            dir: workspaceDir,
+            // The gate openclaw derives from this key when it prepares a
+            // workspace for a reply.
+            ensureBootstrapFiles: !config.agents?.defaults?.skipBootstrap,
+          }),
+        );
 
-  yield* Effect.tryPromise(() =>
-    ensureAgentWorkspace({
-      dir: workspaceDir,
-      // The gate openclaw derives from this key when it prepares a workspace
-      // for a reply.
-      ensureBootstrapFiles: !config.agents?.defaults?.skipBootstrap,
-    }),
-  );
-
-  return yield* fileSystem.exists(
-    path.join(workspaceDir, OPENCLAW_BOOTSTRAP_FILENAME),
+        const seeded = yield* fileSystem.exists(
+          path.join(workspaceDir, OPENCLAW_BOOTSTRAP_FILENAME),
+        );
+        expect(seeded).toBe(false);
+      }),
+    ).pipe(Effect.provide(NodeContext.layer), Effect.orDie),
   );
 }
 

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -7,6 +7,7 @@ import {
   Deferred,
   Effect,
   Either,
+  FastCheck as fc,
   Fiber,
   Option,
   Redacted,
@@ -159,8 +160,6 @@ describe("OpenClawAdapter.spawn", () => {
 const CONFIG_WORKSPACE_DIR = "/workspaces/testbed-agent";
 const CUSTOM_MODEL_ID = "custom/model";
 const DISABLED_MDNS_MODE = "off";
-// openclaw treats this file's presence in a workspace as "onboarding pending".
-const OPENCLAW_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 
 describe("buildOpenClawConfig", () => {
   it("keys the moltzap account under the testbed profile", () => {
@@ -200,55 +199,76 @@ describe("buildOpenClawConfig", () => {
 
     expect(config.discovery?.mdns?.mode).toBe(DISABLED_MDNS_MODE);
   });
+});
 
-  // openclaw's config schema is strict, so a misspelled knob is rejected
-  // rather than carried silently as an inert key.
+// openclaw treats this file's presence in a workspace as "onboarding pending".
+const OPENCLAW_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
+
+describe("buildOpenClawConfig bootstrap", () => {
+  // openclaw's config schema is strict, so a misspelled or misplaced knob is
+  // rejected outright rather than carried along as an inert key.
   it("carries skipBootstrap through openclaw's own config schema", () => {
-    const parsed = OpenClawSchema.safeParse(
-      buildOpenClawConfig({ agentName: "alice" }, CONFIG_WORKSPACE_DIR),
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1 }),
+        fc.option(fc.string({ minLength: 1 }), { nil: undefined }),
+        fc.string({ minLength: 1 }),
+        (agentName, modelId, workspaceDir) => {
+          const parsed = OpenClawSchema.safeParse(
+            buildOpenClawConfig({ agentName, modelId }, workspaceDir),
+          );
+          expect(parsed.success).toBe(true);
+          expect(
+            parsed.success && parsed.data.agents?.defaults?.skipBootstrap,
+          ).toBe(true);
+        },
+      ),
     );
-
-    expect(parsed.success).toBe(true);
-    if (!parsed.success) return;
-    expect(parsed.data.agents?.defaults?.skipBootstrap).toBe(true);
   });
 
   it("leaves openclaw's bootstrap prompt out of a fresh workspace", () =>
     Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const fileSystem = yield* FileSystem.FileSystem;
-          const path = yield* Path.Path;
-          const workspaceDir = yield* fileSystem.makeTempDirectory({
-            prefix: "testbed-openclaw-workspace-",
-          });
-          yield* Effect.addFinalizer(() =>
-            fileSystem
-              .remove(workspaceDir, { recursive: true, force: true })
-              .pipe(Effect.catchAll(() => Effect.void)),
-          );
-          const config = buildOpenClawConfig(
-            { agentName: "alice" },
-            workspaceDir,
-          );
-
-          yield* Effect.tryPromise(() =>
-            ensureAgentWorkspace({
-              dir: workspaceDir,
-              // The gate openclaw derives from this key when it prepares a
-              // workspace for a reply.
-              ensureBootstrapFiles: !config.agents?.defaults?.skipBootstrap,
-            }),
-          );
-
-          const seeded = yield* fileSystem.exists(
-            path.join(workspaceDir, OPENCLAW_BOOTSTRAP_FILENAME),
-          );
+      openClawSeededBootstrapPrompt().pipe(
+        Effect.map((seeded) => {
           expect(seeded).toBe(false);
         }),
-      ).pipe(Effect.provide(NodeContext.layer), Effect.orDie),
+      ),
     ));
 });
+
+function openClawSeededBootstrapPrompt(): Effect.Effect<boolean, never, never> {
+  return Effect.scoped(Effect.gen(bootstrapSeedingCheck)).pipe(
+    Effect.provide(NodeContext.layer),
+    Effect.orDie,
+  );
+}
+
+function* bootstrapSeedingCheck() {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const workspaceDir = yield* fileSystem.makeTempDirectory({
+    prefix: "testbed-openclaw-workspace-",
+  });
+  yield* Effect.addFinalizer(() =>
+    fileSystem
+      .remove(workspaceDir, { recursive: true, force: true })
+      .pipe(Effect.catchAll(() => Effect.void)),
+  );
+  const config = buildOpenClawConfig({ agentName: "alice" }, workspaceDir);
+
+  yield* Effect.tryPromise(() =>
+    ensureAgentWorkspace({
+      dir: workspaceDir,
+      // The gate openclaw derives from this key when it prepares a workspace
+      // for a reply.
+      ensureBootstrapFiles: !config.agents?.defaults?.skipBootstrap,
+    }),
+  );
+
+  return yield* fileSystem.exists(
+    path.join(workspaceDir, OPENCLAW_BOOTSTRAP_FILENAME),
+  );
+}
 
 // The gateway child reads MOLTZAP_SERVER_URL through the moltzap client,
 // which appends the `/ws` endpoint path itself.

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -163,6 +163,7 @@ const CUSTOM_MODEL_ID = "custom/model";
 const DISABLED_MDNS_MODE = "off";
 // openclaw treats this file's presence in a workspace as "onboarding pending".
 const OPENCLAW_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
+const OPENCLAW_STATE_DIR_VAR = "OPENCLAW_STATE_DIR";
 
 describe("buildOpenClawConfig", () => {
   it("keys the moltzap account under the testbed profile", () => {
@@ -264,9 +265,12 @@ function bootstrapPromptSeeded(
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
-      const workspaceDir = yield* fileSystem.makeTempDirectoryScoped({
-        prefix: "testbed-openclaw-workspace-",
+      const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "testbed-openclaw-state-",
       });
+      yield* scopedOpenClawStateDir(stateDir);
+      const workspaceDir = path.join(stateDir, "workspace");
+
       yield* Effect.tryPromise(() =>
         ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles }),
       );
@@ -276,6 +280,23 @@ function bootstrapPromptSeeded(
       );
     }),
   ).pipe(Effect.provide(NodeContext.layer), Effect.orDie);
+}
+
+// Seeding a workspace writes an attestation next to openclaw's state, which
+// defaults to the operator's own `~/.openclaw` and is never cleaned up. Point
+// it inside the scoped temp dir so the test leaves nothing behind.
+function scopedOpenClawStateDir(
+  stateDir: string,
+): Effect.Effect<void, never, Scope.Scope> {
+  return Effect.acquireRelease(
+    Effect.sync(() => {
+      vi.stubEnv(OPENCLAW_STATE_DIR_VAR, stateDir);
+    }),
+    () =>
+      Effect.sync(() => {
+        vi.unstubAllEnvs();
+      }),
+  );
 }
 
 // The gateway child reads MOLTZAP_SERVER_URL through the moltzap client,

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -1,5 +1,6 @@
 import { FileSystem, Path } from "@effect/platform";
 import type { Signal } from "@effect/platform/CommandExecutor";
+import type { PlatformError } from "@effect/platform/Error";
 import { NodeContext } from "@effect/platform-node";
 import { tmpdir } from "node:os";
 import { describe, it, expect, vi } from "vitest";
@@ -10,6 +11,7 @@ import {
   Fiber,
   Option,
   Redacted,
+  Schema,
   Scope,
 } from "effect";
 import {
@@ -27,6 +29,7 @@ import { OpenClawSchema } from "openclaw/plugin-sdk/config-schema";
 import {
   buildOpenClawConfig,
   buildOpenClawProcessPlan,
+  configureOpenClawStateDir,
   createOpenClawAdapter,
   OpenClawAdapter,
   type OpenClawAdapterDeps,
@@ -164,6 +167,23 @@ const DISABLED_MDNS_MODE = "off";
 // openclaw treats this file's presence in a workspace as "onboarding pending".
 const OPENCLAW_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 const OPENCLAW_STATE_DIR_VAR = "OPENCLAW_STATE_DIR";
+const OPENCLAW_HOME_VAR = "OPENCLAW_HOME";
+const OPENCLAW_WORKSPACE_DIRNAME = "workspace";
+const OPENCLAW_SCRATCH_FILENAME = "notes.txt";
+// Where openclaw keeps the attestation the adapter's sentinel occupies. The
+// blocked arm below asserts this is the path openclaw reads, so a rename here
+// or in the adapter's derivation fails rather than passing quietly.
+const OPENCLAW_ATTESTATION_DIRNAME = "workspace-attestations";
+
+// openclaw stamps this code on the throw its workspace-vanished guard raises.
+const decodeWorkspaceVanished = Schema.decodeUnknown(
+  Schema.Struct({ code: Schema.Literal("WORKSPACE_VANISHED") }),
+);
+
+type WorkspaceTurn = "ok" | "vanished";
+
+/** What occupies openclaw's attestation path before the turns run. */
+type AttestationSentinel = "adapter" | "blocked" | "none";
 
 describe("buildOpenClawConfig", () => {
   it("keys the moltzap account under the testbed profile", () => {
@@ -269,7 +289,7 @@ function bootstrapPromptSeeded(
         prefix: "testbed-openclaw-state-",
       });
       yield* scopedOpenClawStateDir(stateDir);
-      const workspaceDir = path.join(stateDir, "workspace");
+      const workspaceDir = path.join(stateDir, OPENCLAW_WORKSPACE_DIRNAME);
 
       yield* Effect.tryPromise(() =>
         ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles }),
@@ -283,19 +303,176 @@ function bootstrapPromptSeeded(
 }
 
 // Seeding a workspace writes an attestation next to openclaw's state, which
-// defaults to the operator's own `~/.openclaw` and is never cleaned up. Point
-// it inside the scoped temp dir so the test leaves nothing behind.
+// defaults to the operator's own `~/.openclaw` and is never cleaned up.
+// `OPENCLAW_HOME` moves the legacy state dirs openclaw also consults, so both
+// are pointed inside the scoped temp dir and the test leaves nothing behind.
 function scopedOpenClawStateDir(
   stateDir: string,
 ): Effect.Effect<void, never, Scope.Scope> {
   return Effect.acquireRelease(
     Effect.sync(() => {
       vi.stubEnv(OPENCLAW_STATE_DIR_VAR, stateDir);
+      vi.stubEnv(OPENCLAW_HOME_VAR, stateDir);
     }),
     () =>
       Effect.sync(() => {
         vi.unstubAllEnvs();
       }),
+  );
+}
+
+describe("configureOpenClawStateDir attestation sentinel", () => {
+  it(
+    "keeps openclaw serving turns after an agent empties its own workspace",
+    expectWorkspaceTurns("adapter", ["ok", "ok", "ok", "ok"]),
+  );
+
+  // The control. Openclaw attests a workspace the moment it holds content, and
+  // never withdraws the attestation, so without the sentinel one
+  // create-then-delete makes every later turn of the episode throw.
+  it(
+    "reproduces the guard's permanent throw with no sentinel in place",
+    expectWorkspaceTurns("none", ["ok", "ok", "vanished", "vanished"]),
+  );
+
+  // The inversion, and the reason the sentinel has to be a directory.
+  // `hasRecentWorkspaceAttestation` reads the primary path as attested
+  // whenever it fails for anything other than ENOENT, so blocking that path
+  // arms the guard on the first turn rather than disarming it.
+  it(
+    "arms the guard when the attestation path is blocked instead of occupied",
+    expectWorkspaceTurns("blocked", ["vanished", "ok", "vanished", "vanished"]),
+  );
+});
+
+function expectWorkspaceTurns(
+  sentinel: AttestationSentinel,
+  expected: ReadonlyArray<WorkspaceTurn>,
+) {
+  return () =>
+    runTest(
+      workspaceTurnsUnder(sentinel).pipe(
+        Effect.map((turns) => {
+          expect(turns).toEqual(expected);
+        }),
+      ),
+    );
+}
+
+// Drives the real `ensureAgentWorkspace` through the sequence an agent that
+// writes a scratch file and later removes it produces, on the gate the adapter
+// derives from `skipBootstrap`.
+function workspaceTurnsUnder(
+  sentinel: AttestationSentinel,
+): Effect.Effect<ReadonlyArray<WorkspaceTurn>, never, never> {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "testbed-openclaw-state-",
+      });
+      yield* scopedOpenClawStateDir(stateDir);
+      const workspaceDir = path.join(stateDir, OPENCLAW_WORKSPACE_DIRNAME);
+      yield* fileSystem.makeDirectory(workspaceDir, { recursive: true });
+      yield* applyAttestationSentinel(sentinel, stateDir);
+
+      const scratchFile = path.join(workspaceDir, OPENCLAW_SCRATCH_FILENAME);
+      const mutations = [
+        Effect.void,
+        fileSystem.writeFileString(scratchFile, "notes"),
+        fileSystem.remove(scratchFile),
+        Effect.void,
+      ];
+
+      return yield* Effect.forEach(
+        mutations,
+        (mutate) =>
+          mutate.pipe(Effect.zipRight(ensureWorkspaceTurn(workspaceDir))),
+        { concurrency: 1 },
+      );
+    }),
+  ).pipe(Effect.provide(NodeContext.layer), Effect.orDie);
+}
+
+function applyAttestationSentinel(
+  sentinel: AttestationSentinel,
+  stateDir: string,
+): Effect.Effect<
+  void,
+  unknown,
+  FileSystem.FileSystem | Path.Path | Scope.Scope
+> {
+  switch (sentinel) {
+    case "adapter":
+      return configureStateDirThroughAdapter(stateDir);
+    case "blocked":
+      return configureStateDirThroughAdapter(stateDir).pipe(
+        Effect.zipRight(blockOpenClawAttestationPath(stateDir)),
+      );
+    case "none":
+      return Effect.void;
+    default:
+      return absurd(sentinel);
+  }
+}
+
+// Entering through the adapter's own state-dir setup is what puts the
+// production derivation under test: a sentinel the adapter stops writing, or
+// writes at a path openclaw does not read, shows up as a throw below.
+function configureStateDirThroughAdapter(
+  stateDir: string,
+): Effect.Effect<
+  void,
+  unknown,
+  FileSystem.FileSystem | Path.Path | Scope.Scope
+> {
+  return Effect.gen(function* () {
+    const fixture = yield* createOpenClawChannelFixture();
+    yield* configureOpenClawStateDir(
+      { ...stubDeps(), channelDistDir: fixture.channelDist },
+      stubSpawnInput(),
+      stateDir,
+    );
+  });
+}
+
+// Leaves a file where openclaw expects the directory holding its attestation,
+// so every read of that path fails with ENOTDIR rather than ENOENT.
+function blockOpenClawAttestationPath(
+  stateDir: string,
+): Effect.Effect<void, PlatformError, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const attestationDir = path.join(stateDir, OPENCLAW_ATTESTATION_DIRNAME);
+    yield* fileSystem.remove(attestationDir, { recursive: true, force: true });
+    yield* fileSystem.writeFileString(attestationDir, "");
+  });
+}
+
+// Openclaw throws its own Error subclass out of `ensureAgentWorkspace`, so the
+// code it stamps on the throw is the only contract this test can hold it to.
+// Anything else keeps its original error rather than collapsing into a turn
+// outcome, so an unrelated failure reports itself instead of the assertion.
+function ensureWorkspaceTurn(
+  workspaceDir: string,
+): Effect.Effect<WorkspaceTurn, unknown, never> {
+  return Effect.tryPromise({
+    try: () =>
+      ensureAgentWorkspace({
+        dir: workspaceDir,
+        ensureBootstrapFiles: false,
+      }),
+    catch: (thrown) => thrown,
+  }).pipe(
+    Effect.as<WorkspaceTurn>("ok"),
+    Effect.catchAll((thrown) =>
+      decodeWorkspaceVanished(thrown).pipe(
+        Effect.as<WorkspaceTurn>("vanished"),
+        Effect.orElseFail(() => thrown),
+      ),
+    ),
   );
 }
 
@@ -602,7 +779,7 @@ function openClawProcessSpawnFailureCleansState() {
     Effect.scoped(
       Effect.gen(function* () {
         const path = yield* Path.Path;
-        const fixture = yield* createOpenClawSpawnFailureFixture();
+        const fixture = yield* createOpenClawChannelFixture();
 
         const stateDirsBefore = yield* listTestStateDirs(
           PROCESS_SPAWN_AGENT_NAME,
@@ -642,12 +819,12 @@ function openClawProcessSpawnFailureCleansState() {
   );
 }
 
-function createOpenClawSpawnFailureFixture() {
+function createOpenClawChannelFixture() {
   return Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const root = yield* fileSystem.makeTempDirectory({
-      prefix: "testbed-openclaw-spawn-fixture-",
+      prefix: "testbed-openclaw-channel-fixture-",
     });
     yield* Effect.addFinalizer(() =>
       fileSystem
@@ -662,7 +839,7 @@ function createOpenClawSpawnFailureFixture() {
       fileSystem.writeFileString(
         path.join(channelPackage, "package.json"),
         JSON.stringify({
-          name: "testbed-openclaw-spawn-fixture",
+          name: "testbed-openclaw-channel-fixture",
           type: "module",
           dependencies: {},
         }),

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -377,6 +377,11 @@ function workspaceTurnsUnder(
       yield* fileSystem.makeDirectory(workspaceDir, { recursive: true });
       yield* applyAttestationSentinel(sentinel, stateDir);
 
+      // A sentinel that landed inside the workspace would be content evidence
+      // to openclaw, which suppresses the guard for a reason the turns below
+      // cannot tell apart from the sentinel working.
+      expect(yield* fileSystem.readDirectory(workspaceDir)).toEqual([]);
+
       const scratchFile = path.join(workspaceDir, OPENCLAW_SCRATCH_FILENAME);
       const mutations = [
         Effect.void,

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -17,6 +17,11 @@ import {
   agentKeyString,
   redactedAgentKey,
 } from "@moltzap/protocol/testing";
+// The seeding function has no focused plugin-sdk subpath, so the compat bridge
+// is the only public surface for it. It drags openclaw's embedded agent runtime
+// along, which is seconds of module load; that cost belongs to collection,
+// where there is no per-test timeout to blow.
+import { ensureAgentWorkspace } from "openclaw/extension-api";
 import { OpenClawSchema } from "openclaw/plugin-sdk/config-schema";
 
 import {
@@ -262,14 +267,6 @@ function bootstrapPromptSeeded(
       const workspaceDir = yield* fileSystem.makeTempDirectoryScoped({
         prefix: "testbed-openclaw-workspace-",
       });
-      // openclaw exports the seeding function only from its compat bridge,
-      // which drags the whole embedded agent runtime along; importing it here
-      // keeps several seconds of module load out of the collection of every
-      // other test in this file.
-      const { ensureAgentWorkspace } = yield* Effect.tryPromise(
-        () => import("openclaw/extension-api"),
-      );
-
       yield* Effect.tryPromise(() =>
         ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles }),
       );

--- a/packages/testbed/src/runtimes.test.ts
+++ b/packages/testbed/src/runtimes.test.ts
@@ -17,6 +17,10 @@ import {
   agentKeyString,
   redactedAgentKey,
 } from "@moltzap/protocol/testing";
+// The seeding function has no focused plugin-sdk subpath; the compat bridge is
+// the only public surface openclaw exposes for it.
+import { ensureAgentWorkspace } from "openclaw/extension-api";
+import { OpenClawSchema } from "openclaw/plugin-sdk/config-schema";
 
 import {
   buildOpenClawConfig,
@@ -155,6 +159,8 @@ describe("OpenClawAdapter.spawn", () => {
 const CONFIG_WORKSPACE_DIR = "/workspaces/testbed-agent";
 const CUSTOM_MODEL_ID = "custom/model";
 const DISABLED_MDNS_MODE = "off";
+// openclaw treats this file's presence in a workspace as "onboarding pending".
+const OPENCLAW_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 
 describe("buildOpenClawConfig", () => {
   it("keys the moltzap account under the testbed profile", () => {
@@ -194,6 +200,54 @@ describe("buildOpenClawConfig", () => {
 
     expect(config.discovery?.mdns?.mode).toBe(DISABLED_MDNS_MODE);
   });
+
+  // openclaw's config schema is strict, so a misspelled knob is rejected
+  // rather than carried silently as an inert key.
+  it("carries skipBootstrap through openclaw's own config schema", () => {
+    const parsed = OpenClawSchema.safeParse(
+      buildOpenClawConfig({ agentName: "alice" }, CONFIG_WORKSPACE_DIR),
+    );
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.agents?.defaults?.skipBootstrap).toBe(true);
+  });
+
+  it("leaves openclaw's bootstrap prompt out of a fresh workspace", () =>
+    Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const workspaceDir = yield* fileSystem.makeTempDirectory({
+            prefix: "testbed-openclaw-workspace-",
+          });
+          yield* Effect.addFinalizer(() =>
+            fileSystem
+              .remove(workspaceDir, { recursive: true, force: true })
+              .pipe(Effect.catchAll(() => Effect.void)),
+          );
+          const config = buildOpenClawConfig(
+            { agentName: "alice" },
+            workspaceDir,
+          );
+
+          yield* Effect.tryPromise(() =>
+            ensureAgentWorkspace({
+              dir: workspaceDir,
+              // The gate openclaw derives from this key when it prepares a
+              // workspace for a reply.
+              ensureBootstrapFiles: !config.agents?.defaults?.skipBootstrap,
+            }),
+          );
+
+          const seeded = yield* fileSystem.exists(
+            path.join(workspaceDir, OPENCLAW_BOOTSTRAP_FILENAME),
+          );
+          expect(seeded).toBe(false);
+        }),
+      ).pipe(Effect.provide(NodeContext.layer), Effect.orDie),
+    ));
 });
 
 // The gateway child reads MOLTZAP_SERVER_URL through the moltzap client,


### PR DESCRIPTION
Addresses the first of the two separable causes in #858, with the amendment the architect verdict asks for (#858 comment `5087312046`).

## What changed

`openclaw-adapter.ts` does two things in one module.

`buildOpenClawConfig` writes `agents.defaults.skipBootstrap: true`. Left unset, openclaw's reply path computes `ensureBootstrapFiles: !cfg.agents?.defaults?.skipBootstrap`, `ensureAgentWorkspace` seeds `BOOTSTRAP.md` into the empty per-agent workspace the adapter creates, and `isWorkspaceBootstrapPending` then reports the workspace as onboarding-pending. The agent runs the first-run ritual and sends that template's scripted opening line — `Hey. I just came online. Who am I? Who are you?` — instead of answering the step.

`configureOpenClawStateDir` then calls `disarmOpenClawAttestationGuard`, which occupies openclaw's two run-local attestation paths with **directories** before the gateway spawns. That is what keeps the empty-by-default workspace from arming openclaw's workspace-vanished guard; without it, one create-then-delete by the agent leaves every later turn of the episode throwing, uncaught, and the simulator scores an infrastructure fault as agent non-response.

## Mechanism, verified in the pinned package

`openclaw@2026.6.33`, read directly rather than taken from the issue.

**The bootstrap gate.**

- `dist/get-reply-*.js` — `const agentCfg = cfg.agents?.defaults`, then `ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv`.
- `agents.defaults` is the complete knob: openclaw's strict `AgentEntrySchema` rejects a per-agent `skipBootstrap`, so there is no second place to set it.
- `dist/workspace-*.js` — `ensureAgentWorkspace` returns `{ dir }` immediately when `ensureBootstrapFiles` is false; otherwise it writes `BOOTSTRAP.md` from `docs/reference/templates/BOOTSTRAP.md`, whose line 20 is the greeting.
- `dist/workspace-*.js` — `resolveWorkspaceBootstrapStatus` returns `complete` when `BOOTSTRAP.md` is absent, so no bootstrap prompt is injected.
- Driven both ways against a temp dir: `ensureBootstrapFiles: false` leaves the workspace empty; `true` seeds `AGENTS.md`, `BOOTSTRAP.md`, `HEARTBEAT.md`, `IDENTITY.md`, `SOUL.md`, `TOOLS.md`, `USER.md`, `.git`.

`--allow-unconfigured` is unchanged; it is not the trigger.

**The attestation guard.** Three facts make the directory sentinel work:

- `writeWorkspaceAttestation` reads the marker status first and returns without writing unless the status is `missing`; a directory yields `not-marker`. Its `O_EXCL` open is never reached, and `maybeWriteWorkspaceAttestation` swallows failures anyway.
- `hasRecentWorkspaceAttestation` `lstat`s the path and returns `false` when `isFile()` is false. A directory reads as absent.
- The reachable `WorkspaceVanishedError` throws on the `skipBootstrap` path are gated on `recentAttestationPath` being non-null.

Executed against the pinned package, four arms, state and `HOME` scoped to a temp dir:

```
A. no sentinel
  turn 1 (empty)             : OK
  turn 2 (agent wrote file)  : OK          <- openclaw attests here
  turn 3 (agent deleted file): THREW WorkspaceVanishedError code=WORKSPACE_VANISHED
  turn 4 (still empty)       : THREW WorkspaceVanishedError code=WORKSPACE_VANISHED

B. directory sentinel (this PR)
  turn 1..4                  : OK          (openclaw wrote nothing)

C. path blocked, not occupied (a file where openclaw expects the enclosing dir)
  turn 1 (empty)             : THREW WorkspaceVanishedError code=WORKSPACE_VANISHED
  turn 2 (agent wrote file)  : OK
  turn 3 (agent deleted file): THREW WorkspaceVanishedError code=WORKSPACE_VANISHED
  turn 4 (still empty)       : THREW WorkspaceVanishedError code=WORKSPACE_VANISHED
```

A reproduces the escalation's sequence exactly. C is the inversion: `hasRecentWorkspaceAttestation` is called with `trustUnknown: true` for the primary path, and its `catch` returns `true` on any error other than `ENOENT`, so blocking the path by permissions or `ENOTDIR` arms the guard on turn one instead of disarming it. Only a directory is safe.

## What the sentinel closes, and what it does not

**It closes the sequence an agent reaches by accident**: write a scratch file, delete it, keep answering. That is the sequence the escalation reproduced and the one a simulated agent hits without trying.

**It does not close the class, and this PR does not claim it does.** The deliberate path stays open until R2:

- `resolveWorkspaceAttestationPaths` returns a third candidate under openclaw's legacy home state dir (`<home>/.clawdbot/workspace-attestations/<sha>.attested`). That path is the operator's, not the run's, so the adapter leaves it alone. It is read with `trustUnknown: false`, so an `ENOENT` there reads as absent — but a real recent marker there would still arm the guard.
- An agent with shell access can delete or replace the sentinels, or make any attestation path unreadable, which per arm C arms the guard rather than disarming it.
- Arm C's inversion is not only adversarial. `trustUnknown: true` turns *any* non-`ENOENT` `lstat` failure on the primary path into "attested", so a transient `EMFILE`, `EAGAIN`, or `EIO` under load arms the guard with no agent involved.
- `pathExists` swallows non-`ENOENT` errors, so a workspace the agent makes unreadable can still reach a throw when any candidate reads as attested.

The durable closure is observation, not sentinels: `SimulatorRuntime.awaitFault` → `RuntimeFaulted` → `runtime-faulted`, so a runtime that breaks after readiness seals as infrastructure instead of as `timeout`. That is R2 in the architect's design and is separately dispatched. This row reduces the frequency of the accidental path; it does not replace R2.

## Scope

- Module: `packages/testbed/src/openclaw-adapter.ts` (+ its test file). The other two files are `packages/testbed/src/MODULE.md` and `docs/modules/testbed/src.mdx`, both generated by `pnpm docs:generate` and both carrying nothing but shifted line anchors — the `@internal` export does not appear in either, which is its own evidence about the documented surface. `docs:check:drift` fails without them.
- `safer-diff-scope --base integration/live-attempt` reports **`senior`** — 4 files, 2 modules, 1 exported signature, 0 new deps. Read the next bullet before treating that as a tier decision.
- `safer-diff-scope` with its default `--base origin/main` reports `staff` (188 files, 449 exports); that is the whole stacked branch, not this diff.
- The one export is `configureOpenClawStateDir` going from module-private to `/** @internal */ export`, which is the test seam. It is not re-exported from `packages/testbed/src/index.ts`, so the package's public surface is byte-identical; `buildOpenClawProcessPlan` in the same file already carries that exact pattern for the same reason. The tool counts any exported-signature delta, `@internal` included, so the reading is correct and the tier question is a reviewer call rather than something this row settles. Entering the regression test through this function rather than through the sentinel helper is what puts the production derivation under test at all, which is the reason the amendment exists.
- New deps: none.

## Tests

Six in `packages/testbed/src/runtimes.test.ts`.

**The bootstrap knob**, three tests, all run with and without the one-line config change:

- `carries skipBootstrap through openclaw's own config schema` — parses the adapter's config through `OpenClawSchema` from `openclaw/plugin-sdk/config-schema` and reads `skipBootstrap` back out. The schema is strict, so this also rejects a misspelled or misplaced knob that would otherwise sit inert in the JSON. Without the fix: `expected undefined to be true`.
- `leaves openclaw's bootstrap prompt out of a fresh workspace` — calls the real `ensureAgentWorkspace` from the pinned package with the gate openclaw derives from this config, against a temp workspace, and asserts `BOOTSTRAP.md` is absent. Without the fix: `expected true to be false`.
- `still seeds the prompt when the gate is left open` — the positive control. It passes with and without the fix, by design: it asserts openclaw *does* seed when `ensureBootstrapFiles` is true, so the absence assertion above cannot pass vacuously if openclaw stops seeding for a reason unrelated to this config.

**The attestation sentinel**, three arms under `describe("configureOpenClawStateDir attestation sentinel")`. Each drives the real `ensureAgentWorkspace` through empty → wrote a file → deleted it → still empty, and records one outcome per turn.

- `keeps openclaw serving turns after an agent empties its own workspace` — enters through the adapter's own `configureOpenClawStateDir`, expects `["ok","ok","ok","ok"]`.
- `reproduces the guard's permanent throw with no sentinel in place` — the control, expects `["ok","ok","vanished","vanished"]`.
- `arms the guard when the attestation path is blocked instead of occupied` — the inversion, expects `["vanished","ok","vanished","vanished"]`.

The adapter arm runs the production entry point rather than the sentinel helper, so the derivation is under test rather than recomputed. Three mutations, each run:

| Mutation to `openclaw-adapter.ts` | Adapter arm |
|---|---|
| drop the `disarmOpenClawAttestationGuard` call from `configureOpenClawStateDir` | fails `["ok","ok","vanished","vanished"]` |
| hash `` `${resolvedWorkspaceDir}/` `` instead of `resolvedWorkspaceDir` (one character of derivation drift) | fails `["ok","ok","vanished","vanished"]` |
| block the primary path instead of occupying it | fails `["vanished","ok","vanished","vanished"]` |
| put the primary sentinel inside the workspace | fails `expected [ 'workspace-attestations' ] to deeply equal []` |

The control arm passes under all four and the inversion arm under the first two, because neither runs the adapter's derivation — the adapter arm is what covers wiring and drift, and the inversion arm is what covers the non-`ENOENT` direction. The inversion arm and the control differ only in whether the primary path reads `ENOTDIR` or `ENOENT`, which is the direction the vendor's `trustUnknown` branch turns on.

Every arm asserts the workspace is empty before its turns begin. Without that, a sentinel that drifted *into* the workspace would be content evidence to openclaw, which suppresses the guard for a reason the turn outcomes cannot tell apart from the sentinel working — the fourth mutation above is that false pass.

`ensureWorkspaceTurn` decodes the thrown value against openclaw's `WORKSPACE_VANISHED` code and re-fails with the original throw on anything else, so an unrelated failure reports itself rather than collapsing into a turn outcome.

**State containment.** The tests scope `OPENCLAW_STATE_DIR` and `OPENCLAW_HOME` into a scoped temp dir, the second because `resolveWorkspaceAttestationPaths` also consults openclaw's legacy home state dirs and because `seedModelAuthProfile` otherwise reads the operator's real store. `~/.openclaw` and `~/.clawdbot` are byte-identical before and after the executed reproduction, the full `@moltzap/testbed` suite, and the live run below — checked by `find -maxdepth 2` diff, not asserted.

**What the tests do not cover.** None is a live run. They do not exercise a gateway, a model, or the wire, so they cannot show what the agent actually replies. The bootstrap tests reconstruct openclaw's `!skipBootstrap` derivation rather than observing the reply path make it; the strict-schema test is what guards the key's spelling and placement instead. The sentinel tests cover the primary attestation path only: the sibling `<workspaceDir>.attested` marker is occupied defensively and is unexercised, because the pinned openclaw reads it but never writes it, and the legacy-home candidate is deliberately not occupied.

## Live run

One live run on this branch, product path, `TMPDIR=/Users/tapanc/live-attempt-tmp-868`, same spec shape as #858's (openclaw runtime, `runtime.config: {}`, **no `workspaceFiles`**), server `sha256:fc405312…`, `readyTimeoutMs: 420000`, `doneSignal: last-step-answered`.

The agent answers the task:

```
transcript.message  "Reply with the single word ACK and nothing else."
transcript.message  "ACK"
```

Exit 0. `recording check --require-completed` → `sealed  episode completed`. `result.json` outcome `{"_tag":"episode","termination":"completed"}`, `teardownComplete: true`. `grep -c "I just came online" events.ndjson` → `0`. `grep -c WORKSPACE_VANISHED events.ndjson` → `0`.

Before the `skipBootstrap` change, this spec shape produced the greeting on three separate runs (#858's runs A and B, plus run 1 in the live-attempt artifact). The greeting is a template, not a sample, so it does not vary between runs.

The episode is single-turn, so it does not exercise the write-then-delete sequence the sentinel exists for. What it shows is that the sentinel does not break the path that already worked. The sequence itself is covered by execution against the pinned package and by the regression test, not by this run.

## What this does not fix

#858's second cause is untouched and fully intact. `drivers.ts → LAST_STEP_ANSWERED_DONE_SIGNAL` and `REPLIES_DONE_SIGNAL` still fire on traffic shape — sender, conversation, ordering — and never on content. A run still seals `termination: "completed"` on any committed message from the agent, whether or not it has anything to do with the step. This PR removes one specific source of off-task messages; it does not give the simulator a predicate meaning "the task was performed", so `completed` remains the strongest claim a recording can carry and it stays weaker than a grader will read it as. Do not read this PR as closing that half.

`contextInjection` stays at its default `"always"`, so the second half of the escalation is also open. With `skipBootstrap`, all seven bootstrap files report missing and openclaw renders each as `[MISSING] Expected at: <absolute mkdtemp path>` into the prompt. `BOOTSTRAP.md` is still named in the agent's prompt, now alongside seven per-spawn absolute paths in a harness whose recordings are compared across runs. `contextInjection: "never"` is ruled out with evidence in the architect design: it would also suppress an `AGENTS.md` seeded through `workspaceFiles`, which is the escape hatch this PR points authors at. Routing that is Q1 on #858 and is the user's call.

#863 (a lost step delivered-span kills `last-step-answered` for the rest of the episode) is untouched.

Two more gaps this diff deliberately does not cross, both outside this module:

- `packages/openclaw-channel/src/test-utils/container-core.ts → buildOpenClawConfig` is a second openclaw config builder, used by that package's integration global setup, with the same `agents.defaults` triple and no `skipBootstrap`. Its containers still get the full template seed, and no attestation sentinel. Same-named function, two answers to "which knobs a moltzap-driven agent needs."
- `SpawnInput.workspaceFiles` means "workspace root files" to the openclaw adapter and "container skills" to `nanoclaw-process.ts → writeRuntimeWorkspaceFiles`. Nanoclaw also regenerates `groups/<folder>/CLAUDE.md` per spawn and mounts it into the agent, so runtime-authored prompt content reaches a nanoclaw agent that no scenario declares. That is a contract divergence (R3 in the architect design), not this bug.

## Side effects of the knob

`skipBootstrap: true` also stops openclaw seeding `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, and a git repo. Agents now start with a literally empty workspace unless the scenario declares `workspaceFiles`. That is the intended trade: a scenario that wants persona scaffolding declares it in the run spec, where it is visible and reproducible, instead of getting it authored at runtime by the harness.

The knob is not derived from `workspaceFiles` being empty, and should not be. `run-spec.ts → Agent` defaults `workspaceFiles` to `[]`, so "declared nothing" and "declared empty" are already indistinguishable; and the agent that declares no files is exactly the one most exposed to the hijack.

The sentinel directories live inside the per-spawn state dir, which `removeOpenClawStateDir` deletes wholesale at teardown, so nothing leaks past a run.

## Confidence

HIGH on the mechanism, the fix, and the trap's counterfactual. The gate expression, the early return, the `BOOTSTRAP.md` template line, the marker-status check, and the `trustUnknown` catch are read in the pinned package; `ensureAgentWorkspace` was then driven through all four arms above, so the trap, its counterfactual, and the inversion are executed rather than inferred. The tests fail before each change and pass after, run both ways, plus three mutations.

Named as read rather than executed, and weighted accordingly: the claim that no public openclaw entry exports `resolveWorkspaceAttestationPaths` or `WORKSPACE_VANISHED_ERROR_CODE` (checked against the package's `exports` map and the public `.d.ts` files); the claim that the legacy-home candidate is the only third path openclaw consults; and the claim that no reply-path code removes or rewrites an attestation directory (`shouldRemoveWorkspaceAttestation` has callers only in the agent-delete, cleanup, and onboarding commands). Each is source-reading on a minified bundle, which is a weaker evidence class than the executed arms.

The live evidence is n=1 after against n=3 before, on a single-turn episode that does not reach the write-then-delete sequence.

## Codex

`codex exec --sandbox read-only`, six named attacks: derivation equivalence against openclaw's own `resolveWorkspaceAttestationPaths`, residual reachable throws, side effects of a directory at those paths, whether the regression test is load-bearing or vacuous, whether anything writes outside the run's state dir, and the Effect code.

**No P1 findings.** Two P2s:

- The sibling `<workspaceDir>.attested` sentinel is uncovered — removing or drifting only that one still passes, because the primary sentinel alone is sufficient. Named here and in the code comment; the sibling stays because the architect's recipe names both paths, and openclaw does read it. Codex added a second half to this one: a sentinel that drifted inside the workspace could false-pass by becoming content evidence. That is now the fourth mutation above and the workspace-emptiness precondition closes it.
- Any non-`ENOENT` `lstat` failure on the primary sentinel still arms the guard, including transient `EMFILE`/`EAGAIN`/`EIO`. Not fixable at the adapter: that is the inversion arm C pins, and closing it is R2's observation seam. Folded into "what it does not close" above.

Verified by codex against the pinned bundle: the primary and sibling derivations match openclaw byte-for-byte for the absolute temp state dirs `allocateOpenClawStateDir` produces; openclaw's cleanup, onboarding, and agent-delete paths skip directory sentinels because `shouldRemoveWorkspaceAttestation` returns false; neither sentinel counts as workspace content; production and test writes stay inside their scoped state dirs and the legacy home candidate is read-only; the blocked arm genuinely exercises `ENOTDIR`; removing the disarm call fails the adapter arm; and `Schema.decodeUnknown` reads the thrown `Error`'s own `code` property, so the turn decode discriminates as the test assumes.

Codex could not run vitest itself — its read-only sandbox blocks Vite's temp-dir creation — so the test evidence above is from this row's runs, not codex's.

## Pre-PR gates

`/simplify` (four passes: reuse, simplification, efficiency, altitude) found nine items; six applied, three skipped. Applied: the `openClawWorkspaceDir` helper collapsing three copies of the workspace-path derivation into one, so the sentinel's hash input cannot drift from the config's `workspace` field; the three test arms folded into one table-driven factory; the channel fixture reused from `createOpenClawChannelFixture` (renamed from `createOpenClawSpawnFailureFixture`, which now has three consumers) instead of a second copy; the JSDoc trimmed of design narration; a turn outcome that swallowed unrelated throws replaced with a re-fail that keeps the original error; and the unused return value of `disarmOpenClawAttestationGuard` dropped. Skipped: promoting `sha256Hex` out of `nanoclaw-install.ts` (second module, out of tier); merging the scoped-state-dir preamble with `bootstrapPromptSeeded` (they parameterize on different things, and the wrapper costs more indirection than the eight shared lines); and `concurrency: "unbounded"` on the state-dir `Effect.all` (ACG's `no-unbounded-concurrency` rejects it, so the literal stays).
