### PR TITLE
[impl-senior] Cover v2/ in the mermaid gate and make its Chrome deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
       - run: pnpm docs:check:drift
       - run: pnpm docs:check
       - run: pnpm docs:check:mermaid
-        env:
-          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
       - run: pnpm docs:check:gates-test
 
   test:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs:generate": "pnpm --filter @moltzap/protocol docs:generate && pnpm --filter @moltzap/client docs:generate && pnpm --filter @moltzap/server-core exec tsx ../../scripts/generate-constants-snippets.ts",
     "docs:check": "cd docs && mint broken-links",
     "docs:check:drift": "pnpm docs:generate && git diff --exit-code docs/ 'packages/**/MODULE.md' README.md && pnpm docs:check:no-hardcoded-constants && pnpm docs:check:doc-imports-resolve",
-    "docs:check:mermaid": "pnpm --filter @moltzap/protocol exec tsx scripts/check-mermaid.ts",
+    "docs:check:mermaid": "puppeteer browsers install chrome && pnpm --filter @moltzap/protocol exec tsx scripts/check-mermaid.ts",
     "docs:check:no-hardcoded-constants": "pnpm --filter @moltzap/server-core exec tsx ../../scripts/check-no-hardcoded-constants.ts",
     "docs:check:doc-imports-resolve": "pnpm --filter @moltzap/server-core exec tsx ../../scripts/check-doc-imports-resolve.ts",
     "docs:check:gates-test": "pnpm --filter @moltzap/server-core exec tsx ../../scripts/__tests__/gates.test.ts",
@@ -43,6 +43,7 @@
     "nx": "^22.7.5",
     "oxfmt": "^0.7.0",
     "oxlint": "^0.16.0",
+    "puppeteer": "24.43.1",
     "typedoc": "^0.28.19",
     "typescript": "^5"
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs:generate": "pnpm --filter @moltzap/protocol docs:generate && pnpm --filter @moltzap/client docs:generate && pnpm --filter @moltzap/server-core exec tsx ../../scripts/generate-constants-snippets.ts",
     "docs:check": "cd docs && mint broken-links",
     "docs:check:drift": "pnpm docs:generate && git diff --exit-code docs/ 'packages/**/MODULE.md' README.md && pnpm docs:check:no-hardcoded-constants && pnpm docs:check:doc-imports-resolve",
-    "docs:check:mermaid": "puppeteer browsers install chrome && pnpm --filter @moltzap/protocol exec tsx scripts/check-mermaid.ts",
+    "docs:check:mermaid": "puppeteer browsers install chrome-headless-shell && pnpm --filter @moltzap/protocol exec tsx scripts/check-mermaid.ts",
     "docs:check:no-hardcoded-constants": "pnpm --filter @moltzap/server-core exec tsx ../../scripts/check-no-hardcoded-constants.ts",
     "docs:check:doc-imports-resolve": "pnpm --filter @moltzap/server-core exec tsx ../../scripts/check-doc-imports-resolve.ts",
     "docs:check:gates-test": "pnpm --filter @moltzap/server-core exec tsx ../../scripts/__tests__/gates.test.ts",

--- a/packages/protocol/scripts/check-mermaid.ts
+++ b/packages/protocol/scripts/check-mermaid.ts
@@ -1,7 +1,8 @@
 /**
  * @file Entry point for `pnpm docs:check:mermaid`. Walks every tree in
  * `MERMAID_ROOTS` for fenced ```mermaid blocks, pipes each through
- * `mmdc`, exits non-zero if any block fails to parse.
+ * `mmdc`, exits non-zero if any block fails to parse — or if any of them
+ * could not be read in the first place.
  */
 import { FileSystem, Path } from "@effect/platform";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
@@ -9,11 +10,14 @@ import { Effect } from "effect";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  extractMermaidBlocks,
+  collectBlocks,
+  collectMarkdownFiles,
   lintBlock,
   MERMAID_ROOTS,
+  requireRoots,
   type MermaidBlock,
   type MermaidFailure,
+  type MermaidGateError,
 } from "./docs/mermaid-lint.js";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -31,39 +35,11 @@ const program = Effect.gen(function* () {
   const roots = MERMAID_ROOTS.map((r) => resolve(WORKSPACE_ROOT, r));
   yield* requireRoots(fs, roots);
   const files = yield* collectMarkdownFiles(fs, path, roots);
-  const blocks = yield* collectBlocks(fs, path, files);
+  const blocks = yield* collectBlocks(fs, path, WORKSPACE_ROOT, files);
   yield* announce(blocks.length, files.length);
   const failures = yield* lintAll(blocks);
   yield* report(failures);
-});
-
-/**
- * Fail loudly when a configured root is missing. The walk tolerates
- * unreadable directories, so a renamed or deleted root would otherwise
- * shrink coverage silently and still exit zero.
- */
-const requireRoots = (
-  fs: FileSystem.FileSystem,
-  roots: ReadonlyArray<string>,
-): Effect.Effect<void, never, never> =>
-  Effect.gen(function* () {
-    const missing: string[] = [];
-    for (const root of roots) {
-      const stat = yield* fs
-        .stat(root)
-        .pipe(Effect.catchAll(() => Effect.succeed(null)));
-      if (stat === null || stat.type !== "Directory") missing.push(root);
-    }
-    if (missing.length === 0) return;
-    yield* Effect.sync(() => {
-      for (const root of missing) {
-        process.stderr.write(
-          `Mermaid lint: configured root missing: ${root}\n`,
-        );
-      }
-      process.exit(1);
-    });
-  });
+}).pipe(Effect.catchTag("MermaidGateError", reportUninspectable));
 
 const announce = (
   blocks: number,
@@ -75,28 +51,11 @@ const announce = (
     ),
   );
 
-const collectBlocks = (
-  fs: FileSystem.FileSystem,
-  path: Path.Path,
-  files: ReadonlyArray<string>,
-): Effect.Effect<ReadonlyArray<MermaidBlock>, never, never> =>
-  Effect.gen(function* () {
-    const out: MermaidBlock[] = [];
-    for (const file of files) {
-      const source = yield* fs
-        .readFileString(file)
-        .pipe(Effect.catchAll(() => Effect.succeed("")));
-      const workspaceRelative = path.relative(WORKSPACE_ROOT, file);
-      out.push(...extractMermaidBlocks(workspaceRelative, source));
-    }
-    return out;
-  });
-
 const lintAll = (
   blocks: ReadonlyArray<MermaidBlock>,
 ): Effect.Effect<
   ReadonlyArray<MermaidFailure>,
-  never,
+  MermaidGateError,
   | FileSystem.FileSystem
   | Path.Path
   | import("@effect/platform").Command.CommandExecutor
@@ -127,57 +86,20 @@ const report = (
     process.exit(1);
   });
 
-const collectMarkdownFiles = (
-  fs: FileSystem.FileSystem,
-  path: Path.Path,
-  roots: ReadonlyArray<string>,
-): Effect.Effect<ReadonlyArray<string>, never, never> =>
-  Effect.gen(function* () {
-    const ctx: WalkCtx = { fs, path, out: [] };
-    for (const root of roots) {
-      yield* walkInto(ctx, root);
-    }
-    return ctx.out.sort();
-  });
-
-const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
-
-interface WalkCtx {
-  readonly fs: FileSystem.FileSystem;
-  readonly path: Path.Path;
-  readonly out: string[];
+/**
+ * An input the run could not inspect is reported as its own outcome, never
+ * folded into the block tally: "0 failures" would claim the input was
+ * checked and clean.
+ */
+function reportUninspectable(
+  error: MermaidGateError,
+): Effect.Effect<never, never, never> {
+  return Effect.sync(() => {
+    process.stderr.write(`Mermaid lint: ${error.reason}: ${error.path}\n`);
+    process.stderr.write(`    ${String(error.cause)}\n`);
+    process.stderr.write("Mermaid lint: FAIL (inputs left unchecked)\n");
+    process.exit(1);
+  }) as Effect.Effect<never, never, never>;
 }
-
-const walkInto = (
-  ctx: WalkCtx,
-  dir: string,
-): Effect.Effect<void, never, never> =>
-  Effect.gen(function* () {
-    const entries = yield* ctx.fs
-      .readDirectory(dir)
-      .pipe(Effect.catchAll(() => Effect.succeed([] as ReadonlyArray<string>)));
-    for (const name of entries) {
-      yield* visitEntry(ctx, dir, name);
-    }
-  });
-
-const visitEntry = (
-  ctx: WalkCtx,
-  dir: string,
-  name: string,
-): Effect.Effect<void, never, never> =>
-  Effect.gen(function* () {
-    if (SKIP_DIRS.has(name)) return;
-    const full = ctx.path.resolve(dir, name);
-    const stat = yield* ctx.fs
-      .stat(full)
-      .pipe(Effect.catchAll(() => Effect.succeed(null)));
-    if (stat === null) return;
-    if (stat.type === "Directory") {
-      yield* walkInto(ctx, full);
-      return;
-    }
-    if (name.endsWith(".md") || name.endsWith(".mdx")) ctx.out.push(full);
-  });
 
 NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)));

--- a/packages/protocol/scripts/check-mermaid.ts
+++ b/packages/protocol/scripts/check-mermaid.ts
@@ -1,7 +1,7 @@
 /**
- * @file Entry point for `pnpm docs:check:mermaid`. Walks docs/ +
- * packages/ for fenced ```mermaid blocks, pipes each through `mmdc`,
- * exits non-zero if any block fails to parse.
+ * @file Entry point for `pnpm docs:check:mermaid`. Walks every tree in
+ * `MERMAID_ROOTS` for fenced ```mermaid blocks, pipes each through
+ * `mmdc`, exits non-zero if any block fails to parse.
  */
 import { FileSystem, Path } from "@effect/platform";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import {
   extractMermaidBlocks,
   lintBlock,
+  MERMAID_ROOTS,
   type MermaidBlock,
   type MermaidFailure,
 } from "./docs/mermaid-lint.js";
@@ -27,16 +28,42 @@ const TEMP_DIR = resolve(
 const program = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const roots = [
-    resolve(WORKSPACE_ROOT, "docs"),
-    resolve(WORKSPACE_ROOT, "packages"),
-  ];
+  const roots = MERMAID_ROOTS.map((r) => resolve(WORKSPACE_ROOT, r));
+  yield* requireRoots(fs, roots);
   const files = yield* collectMarkdownFiles(fs, path, roots);
   const blocks = yield* collectBlocks(fs, path, files);
   yield* announce(blocks.length, files.length);
   const failures = yield* lintAll(blocks);
   yield* report(failures);
 });
+
+/**
+ * Fail loudly when a configured root is missing. The walk tolerates
+ * unreadable directories, so a renamed or deleted root would otherwise
+ * shrink coverage silently and still exit zero.
+ */
+const requireRoots = (
+  fs: FileSystem.FileSystem,
+  roots: ReadonlyArray<string>,
+): Effect.Effect<void, never, never> =>
+  Effect.gen(function* () {
+    const missing: string[] = [];
+    for (const root of roots) {
+      const stat = yield* fs
+        .stat(root)
+        .pipe(Effect.catchAll(() => Effect.succeed(null)));
+      if (stat === null || stat.type !== "Directory") missing.push(root);
+    }
+    if (missing.length === 0) return;
+    yield* Effect.sync(() => {
+      for (const root of missing) {
+        process.stderr.write(
+          `Mermaid lint: configured root missing: ${root}\n`,
+        );
+      }
+      process.exit(1);
+    });
+  });
 
 const announce = (
   blocks: number,

--- a/packages/protocol/scripts/docs/__tests__/mermaid-extract.test.ts
+++ b/packages/protocol/scripts/docs/__tests__/mermaid-extract.test.ts
@@ -1,5 +1,30 @@
+import { statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { extractMermaidBlocks } from "../mermaid-lint.js";
+import { extractMermaidBlocks, MERMAID_ROOTS } from "../mermaid-lint.js";
+
+const WORKSPACE_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+);
+
+describe("MERMAID_ROOTS", () => {
+  // The gate tolerates unreadable directories while walking, so a root
+  // that does not exist yields zero blocks and still exits zero. Pin the
+  // roots to real directories so that failure mode stays impossible.
+  it.each(MERMAID_ROOTS)("resolves %s to a real directory", (root) => {
+    expect(statSync(resolve(WORKSPACE_ROOT, root)).isDirectory()).toBe(true);
+  });
+
+  it("covers the v2 track", () => {
+    expect(MERMAID_ROOTS).toContain("v2");
+  });
+});
 
 describe("extractMermaidBlocks", () => {
   it("returns empty list when the source has no fenced blocks", () => {

--- a/packages/protocol/scripts/docs/__tests__/mermaid-extract.test.ts
+++ b/packages/protocol/scripts/docs/__tests__/mermaid-extract.test.ts
@@ -14,9 +14,9 @@ const WORKSPACE_ROOT = resolve(
 );
 
 describe("MERMAID_ROOTS", () => {
-  // The gate tolerates unreadable directories while walking, so a root
-  // that does not exist yields zero blocks and still exits zero. Pin the
-  // roots to real directories so that failure mode stays impossible.
+  // A root naming a tree that does not exist contributes no blocks. The
+  // gate's own `requireRoots` turns that into a hard failure at runtime;
+  // this pins the same invariant at the list, where the typo would land.
   it.each(MERMAID_ROOTS)("resolves %s to a real directory", (root) => {
     expect(statSync(resolve(WORKSPACE_ROOT, root)).isDirectory()).toBe(true);
   });

--- a/packages/protocol/scripts/docs/__tests__/mermaid-gate.test.ts
+++ b/packages/protocol/scripts/docs/__tests__/mermaid-gate.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @file The gate's job is to fail. These exercise the paths where an input
+ * cannot be inspected at all — an unreadable directory, an unreadable file,
+ * an unwritable temp slot — because each one used to be swallowed into an
+ * empty value and reported as a clean pass.
+ */
+import { FileSystem, Path } from "@effect/platform";
+import { NodeContext } from "@effect/platform-node";
+import { Effect, Either } from "effect";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  collectBlocks,
+  collectMarkdownFiles,
+  lintBlock,
+  MermaidGateError,
+  requireRoots,
+} from "../mermaid-lint.js";
+
+const BLOCK = ["```mermaid", "flowchart TD", "  A --> B", "```", ""].join("\n");
+
+let sandbox: string;
+
+beforeAll(() => {
+  sandbox = mkdtempSync(join(tmpdir(), "mermaid-gate-"));
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+const runGate = <A>(
+  body: (
+    fs: FileSystem.FileSystem,
+    path: Path.Path,
+  ) => Effect.Effect<A, MermaidGateError, never>,
+): Promise<Either.Either<A, MermaidGateError>> =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      return yield* body(fs, path);
+    }).pipe(Effect.provide(NodeContext.layer), Effect.either),
+  );
+
+const failure = <A>(result: Either.Either<A, MermaidGateError>) => {
+  if (Either.isRight(result)) {
+    throw new Error("expected the gate to fail, but it succeeded");
+  }
+  return result.left;
+};
+
+describe("requireRoots", () => {
+  it("accepts a real directory", async () => {
+    const dir = join(sandbox, "real-root");
+    mkdirSync(dir, { recursive: true });
+    const result = await runGate((fs) => requireRoots(fs, [dir]));
+    expect(Either.isRight(result)).toBe(true);
+  });
+
+  it("fails and names a root that does not exist", async () => {
+    const missing = join(sandbox, "absent-root");
+    const error = failure(await runGate((fs) => requireRoots(fs, [missing])));
+    expect(error._tag).toBe("MermaidGateError");
+    expect(error.path).toBe(missing);
+  });
+
+  it("fails when a root is a file rather than a directory", async () => {
+    const file = join(sandbox, "root-is-a-file.md");
+    writeFileSync(file, BLOCK);
+    const error = failure(await runGate((fs) => requireRoots(fs, [file])));
+    expect(error.reason).toContain("not a directory");
+    expect(error.path).toBe(file);
+  });
+});
+
+describe("collectMarkdownFiles", () => {
+  it("descends subdirectories and skips node_modules", async () => {
+    const root = join(sandbox, "tree");
+    mkdirSync(join(root, "nested"), { recursive: true });
+    mkdirSync(join(root, "node_modules"), { recursive: true });
+    writeFileSync(join(root, "top.md"), BLOCK);
+    writeFileSync(join(root, "nested", "deep.mdx"), BLOCK);
+    writeFileSync(join(root, "node_modules", "vendor.md"), BLOCK);
+
+    const result = await runGate((fs, path) =>
+      collectMarkdownFiles(fs, path, [root]),
+    );
+    if (Either.isLeft(result)) throw result.left;
+    expect(result.right).toEqual([
+      join(root, "nested", "deep.mdx"),
+      join(root, "top.md"),
+    ]);
+  });
+
+  it("fails instead of yielding no files when a directory cannot be listed", async () => {
+    const absent = join(sandbox, "absent-tree");
+    const error = failure(
+      await runGate((fs, path) => collectMarkdownFiles(fs, path, [absent])),
+    );
+    expect(error.reason).toContain("cannot read directory");
+    expect(error.path).toBe(absent);
+  });
+
+  // The finding this guards is an *existing* but unreadable subtree, which
+  // only permissions can produce. Root ignores the mode bits, so the check
+  // cannot be expressed there.
+  const unreadable = process.getuid?.() === 0 ? it.skip : it;
+  unreadable(
+    "fails on a subtree that exists but cannot be opened",
+    async () => {
+      const root = join(sandbox, "locked-tree");
+      const locked = join(root, "locked");
+      mkdirSync(locked, { recursive: true });
+      writeFileSync(join(locked, "hidden.md"), BLOCK);
+      chmodSync(locked, 0o000);
+      try {
+        const error = failure(
+          await runGate((fs, path) => collectMarkdownFiles(fs, path, [root])),
+        );
+        expect(error.path).toBe(locked);
+      } finally {
+        chmodSync(locked, 0o755);
+      }
+    },
+  );
+});
+
+describe("collectBlocks", () => {
+  it("extracts blocks labelled relative to the workspace root", async () => {
+    const root = join(sandbox, "blocks");
+    mkdirSync(root, { recursive: true });
+    const file = join(root, "doc.md");
+    writeFileSync(file, BLOCK);
+
+    const result = await runGate((fs, path) =>
+      collectBlocks(fs, path, root, [file]),
+    );
+    if (Either.isLeft(result)) throw result.left;
+    expect(result.right).toHaveLength(1);
+    expect(result.right[0]?.file).toBe("doc.md");
+  });
+
+  it("fails instead of yielding no blocks when a file cannot be read", async () => {
+    const absent = join(sandbox, "absent-doc.md");
+    const error = failure(
+      await runGate((fs, path) => collectBlocks(fs, path, sandbox, [absent])),
+    );
+    expect(error.reason).toContain("cannot read file");
+    expect(error.path).toBe(absent);
+  });
+});
+
+describe("lintBlock", () => {
+  // Staging fails before mmdc is ever spawned, so this needs no browser.
+  it("fails when the temp input cannot be staged", async () => {
+    const tempDir = join(sandbox, "temp-is-a-file");
+    writeFileSync(tempDir, "not a directory");
+    const result = await Effect.runPromise(
+      lintBlock(
+        { file: "doc.md", startLine: 1, body: "flowchart TD\n  A --> B" },
+        tempDir,
+      ).pipe(Effect.provide(NodeContext.layer), Effect.either),
+    );
+    const error = failure(result);
+    expect(error.reason).toContain("temp");
+    expect(error.path).toContain(tempDir);
+  });
+});

--- a/packages/protocol/scripts/docs/__tests__/mermaid-gate.test.ts
+++ b/packages/protocol/scripts/docs/__tests__/mermaid-gate.test.ts
@@ -12,6 +12,7 @@ import {
   mkdirSync,
   mkdtempSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -71,6 +72,9 @@ describe("requireRoots", () => {
     const error = failure(await runGate((fs) => requireRoots(fs, [missing])));
     expect(error._tag).toBe("MermaidGateError");
     expect(error.path).toBe(missing);
+    // The underlying error is what tells a reader why the path was
+    // unreachable, and it is what the run prints under the header.
+    expect(String(error.cause)).toContain(missing);
   });
 
   it("fails when a root is a file rather than a directory", async () => {
@@ -108,6 +112,20 @@ describe("collectMarkdownFiles", () => {
     );
     expect(error.reason).toContain("cannot read directory");
     expect(error.path).toBe(absent);
+  });
+
+  // Reaches the per-entry `stat`, which the unreadable-directory cases never
+  // do: they fail listing the directory, having stat'ed it successfully.
+  it("fails on an entry that cannot be stat'ed", async () => {
+    const root = join(sandbox, "dangling-tree");
+    mkdirSync(root, { recursive: true });
+    const dangling = join(root, "dangling.md");
+    symlinkSync(join(sandbox, "no-such-target"), dangling);
+    const error = failure(
+      await runGate((fs, path) => collectMarkdownFiles(fs, path, [root])),
+    );
+    expect(error.reason).toBe("cannot stat");
+    expect(error.path).toBe(dangling);
   });
 
   // The finding this guards is an *existing* but unreadable subtree, which
@@ -160,18 +178,41 @@ describe("collectBlocks", () => {
 });
 
 describe("lintBlock", () => {
-  // Staging fails before mmdc is ever spawned, so this needs no browser.
-  it("fails when the temp input cannot be staged", async () => {
+  const BLOCK_UNDER_TEST = {
+    file: "doc.md",
+    startLine: 1,
+    body: "flowchart TD\n  A --> B",
+  };
+
+  // Mirrors the temp name lintBlock derives from the block. If that rule
+  // changes, the staged obstacle stops obstructing and the write succeeds,
+  // so the test fails rather than quietly stopping testing anything.
+  const stagedInputName = "doc_md-1.mmd";
+
+  // Staging fails before mmdc is spawned, so neither case needs a browser.
+  const stage = (tempDir: string) =>
+    Effect.runPromise(
+      lintBlock(BLOCK_UNDER_TEST, tempDir).pipe(
+        Effect.provide(NodeContext.layer),
+        Effect.either,
+      ),
+    );
+
+  it("fails when the temp directory cannot be created", async () => {
     const tempDir = join(sandbox, "temp-is-a-file");
     writeFileSync(tempDir, "not a directory");
-    const result = await Effect.runPromise(
-      lintBlock(
-        { file: "doc.md", startLine: 1, body: "flowchart TD\n  A --> B" },
-        tempDir,
-      ).pipe(Effect.provide(NodeContext.layer), Effect.either),
-    );
-    const error = failure(result);
-    expect(error.reason).toContain("temp");
-    expect(error.path).toContain(tempDir);
+    const error = failure(await stage(tempDir));
+    expect(error.reason).toBe("cannot create temp directory");
+    expect(error.path).toBe(tempDir);
+  });
+
+  // Separate from the case above: there the directory step fails first, so
+  // it would stay green with the write left swallowed.
+  it("fails when the input itself cannot be written", async () => {
+    const tempDir = join(sandbox, "temp-write-blocked");
+    mkdirSync(join(tempDir, stagedInputName), { recursive: true });
+    const error = failure(await stage(tempDir));
+    expect(error.reason).toBe("cannot write temp input");
+    expect(error.path).toBe(join(tempDir, stagedInputName));
   });
 });

--- a/packages/protocol/scripts/docs/mermaid-lint.ts
+++ b/packages/protocol/scripts/docs/mermaid-lint.ts
@@ -1,10 +1,10 @@
 /**
- * @file Validate every fenced ```mermaid block under the trees named by
- * `MERMAID_ROOTS` by piping each block through `mmdc` (the official
- * Mermaid CLI). Returns the list of failures grouped by file.
+ * @file Collect every fenced ```mermaid block under the trees named by
+ * `MERMAID_ROOTS` and validate each by piping it through `mmdc` (the
+ * official Mermaid CLI). Returns the list of failures grouped by file.
  */
 import { Command, FileSystem, Path } from "@effect/platform";
-import { Effect, Either, Stream } from "effect";
+import { Data, Effect, Either, Stream } from "effect";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,6 +14,27 @@ import { fileURLToPath } from "node:url";
  * contributes zero blocks and the gate passes without having looked.
  */
 export const MERMAID_ROOTS = ["docs", "packages", "v2"] as const;
+
+/**
+ * Something the gate was asked to inspect but could not.
+ *
+ * Every filesystem step here answers "what am I checking?", so a failure
+ * means some input went unchecked. Substituting an empty default — no
+ * entries, no source text, no temp file — makes that indistinguishable
+ * from a clean result, which is precisely the blind-gate failure this
+ * gate exists to catch. The path travels with the error because a run
+ * that cannot say which input it skipped has not reported anything.
+ */
+export class MermaidGateError extends Data.TaggedError("MermaidGateError")<{
+  readonly reason: string;
+  readonly path: string;
+  readonly cause: unknown;
+}> {}
+
+const gateError =
+  (reason: string, path: string) =>
+  (cause: unknown): MermaidGateError =>
+    new MermaidGateError({ reason, path, cause });
 
 export interface MermaidBlock {
   readonly file: string;
@@ -25,6 +46,111 @@ export interface MermaidFailure {
   readonly block: MermaidBlock;
   readonly message: string;
 }
+
+/** Directories that never hold reviewable documentation. */
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
+
+interface WalkCtx {
+  readonly fs: FileSystem.FileSystem;
+  readonly path: Path.Path;
+  readonly out: string[];
+}
+
+/**
+ * Reject any configured root that is not a usable directory. A root that
+ * is missing, unreadable, or a plain file contributes no files, so without
+ * this the run would report a clean pass over a tree it never opened.
+ */
+export const requireRoots = (
+  fs: FileSystem.FileSystem,
+  roots: ReadonlyArray<string>,
+): Effect.Effect<void, MermaidGateError, never> =>
+  Effect.forEach(
+    roots,
+    (root) =>
+      fs.stat(root).pipe(
+        Effect.mapError(gateError("cannot open configured root", root)),
+        Effect.flatMap((info) =>
+          info.type === "Directory"
+            ? Effect.void
+            : Effect.fail(
+                new MermaidGateError({
+                  reason: "configured root is not a directory",
+                  path: root,
+                  cause: info.type,
+                }),
+              ),
+        ),
+      ),
+    // Sequential so the first unusable root is the one reported, in the
+    // order the list declares them.
+    { discard: true, concurrency: 1 },
+  );
+
+/** Every `.md` and `.mdx` file below `roots`, sorted for stable output. */
+export const collectMarkdownFiles = (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  roots: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyArray<string>, MermaidGateError, never> =>
+  Effect.gen(function* () {
+    const ctx: WalkCtx = { fs, path, out: [] };
+    for (const root of roots) {
+      yield* walkInto(ctx, root);
+    }
+    return ctx.out.sort();
+  });
+
+const walkInto = (
+  ctx: WalkCtx,
+  dir: string,
+): Effect.Effect<void, MermaidGateError, never> =>
+  Effect.gen(function* () {
+    const entries = yield* ctx.fs
+      .readDirectory(dir)
+      .pipe(Effect.mapError(gateError("cannot read directory", dir)));
+    for (const name of entries) {
+      yield* visitEntry(ctx, dir, name);
+    }
+  });
+
+const visitEntry = (
+  ctx: WalkCtx,
+  dir: string,
+  name: string,
+): Effect.Effect<void, MermaidGateError, never> =>
+  Effect.gen(function* () {
+    if (SKIP_DIRS.has(name)) return;
+    const full = ctx.path.resolve(dir, name);
+    const info = yield* ctx.fs
+      .stat(full)
+      .pipe(Effect.mapError(gateError("cannot stat", full)));
+    if (info.type === "Directory") {
+      yield* walkInto(ctx, full);
+      return;
+    }
+    if (name.endsWith(".md") || name.endsWith(".mdx")) ctx.out.push(full);
+  });
+
+/** Extract every fenced block from `files`, labelled relative to the root. */
+export const collectBlocks = (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  workspaceRoot: string,
+  files: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyArray<MermaidBlock>, MermaidGateError, never> =>
+  Effect.gen(function* () {
+    const out: MermaidBlock[] = [];
+    for (const file of files) {
+      const source = yield* fs
+        .readFileString(file)
+        .pipe(Effect.mapError(gateError("cannot read file", file)));
+      out.push(
+        ...extractMermaidBlocks(path.relative(workspaceRoot, file), source),
+      );
+    }
+    return out;
+  });
 
 interface ExtractorState {
   inFence: boolean;
@@ -130,7 +256,7 @@ export const lintBlock = (
   tempDir: string,
 ): Effect.Effect<
   MermaidFailure | null,
-  never,
+  MermaidGateError,
   FileSystem.FileSystem | Path.Path | Command.CommandExecutor
 > =>
   Effect.gen(function* () {
@@ -145,19 +271,27 @@ export const lintBlock = (
     return interpretResult(block, result);
   });
 
+/**
+ * Stage one block for `mmdc`. The temp path is derived from the block's
+ * file and line, so a discarded write error would leave whatever the last
+ * run put there and `mmdc` would happily validate that instead — passing
+ * the block that was never written.
+ */
 const prepareInput = (
   fs: FileSystem.FileSystem,
   tempDir: string,
   inputPath: string,
   body: string,
-): Effect.Effect<void, never, never> =>
+): Effect.Effect<void, MermaidGateError, never> =>
   Effect.gen(function* () {
     yield* fs
       .makeDirectory(tempDir, { recursive: true })
-      .pipe(Effect.catchAll(() => Effect.void));
+      .pipe(
+        Effect.mapError(gateError("cannot create temp directory", tempDir)),
+      );
     yield* fs
       .writeFileString(inputPath, body)
-      .pipe(Effect.catchAll(() => Effect.void));
+      .pipe(Effect.mapError(gateError("cannot write temp input", inputPath)));
   });
 
 /**
@@ -200,6 +334,12 @@ const runMmdc = (
     }),
   ).pipe(Effect.either);
 
+/**
+ * Best-effort, unlike the write above: a block that fails to parse leaves
+ * no SVG behind, so removing it is expected to fail and says nothing about
+ * whether the block was checked. Leftovers cannot mask a bad block either,
+ * since every run fails outright if it cannot overwrite its input.
+ */
 const cleanup = (
   fs: FileSystem.FileSystem,
   inputPath: string,

--- a/packages/protocol/scripts/docs/mermaid-lint.ts
+++ b/packages/protocol/scripts/docs/mermaid-lint.ts
@@ -1,10 +1,19 @@
 /**
- * @file Validate every fenced ```mermaid block under the docs +
- * packages trees by piping each block through `mmdc` (the official
+ * @file Validate every fenced ```mermaid block under the trees named by
+ * `MERMAID_ROOTS` by piping each block through `mmdc` (the official
  * Mermaid CLI). Returns the list of failures grouped by file.
  */
 import { Command, FileSystem, Path } from "@effect/platform";
-import { Effect, Either } from "effect";
+import { Effect, Either, Stream } from "effect";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Workspace-relative trees the gate walks. Every documented tree must be
+ * listed here: a tree left out is not reported as skipped, it simply
+ * contributes zero blocks and the gate passes without having looked.
+ */
+export const MERMAID_ROOTS = ["docs", "packages", "v2"] as const;
 
 export interface MermaidBlock {
   readonly file: string;
@@ -95,6 +104,23 @@ function handleFence(
 const MMDC_BIN = "mmdc";
 
 /**
+ * Chrome launch flags for the renderer. `mmdc` merges this file into its
+ * `puppeteer.launch()` options.
+ */
+const PUPPETEER_CONFIG = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "mermaid-puppeteer.json",
+);
+
+/** Lines of mmdc stderr kept in a failure message; the rest is stack noise. */
+const STDERR_LINES_KEPT = 6;
+
+interface MmdcRun {
+  readonly exitCode: number;
+  readonly stderr: string;
+}
+
+/**
  * Validate `block.body` by writing it to a temp file and shelling out
  * to `mmdc`. Returns null on success or a `MermaidFailure` carrying
  * mmdc's exit context on failure.
@@ -134,22 +160,45 @@ const prepareInput = (
       .pipe(Effect.catchAll(() => Effect.void));
   });
 
+/**
+ * Run one block through `mmdc`, keeping its stderr. mmdc reports both
+ * diagram syntax errors and browser launch failures there, and the exit
+ * code alone cannot tell those apart.
+ */
 const runMmdc = (
   inputPath: string,
   outputPath: string,
 ): Effect.Effect<
-  Either.Either<number, unknown>,
+  Either.Either<MmdcRun, unknown>,
   never,
   Command.CommandExecutor
 > =>
-  Command.make(
-    MMDC_BIN,
-    "--input",
-    inputPath,
-    "--output",
-    outputPath,
-    "--quiet",
-  ).pipe(Command.exitCode, Effect.either);
+  Effect.scoped(
+    Effect.gen(function* () {
+      const proc = yield* Command.make(
+        MMDC_BIN,
+        "--input",
+        inputPath,
+        "--output",
+        outputPath,
+        "--puppeteerConfigFile",
+        PUPPETEER_CONFIG,
+        "--quiet",
+      ).pipe(
+        // stdout stays inherited so only stderr needs draining; a piped
+        // stdout nobody reads can wedge the child once its buffer fills.
+        Command.stdout("inherit"),
+        Command.stderr("pipe"),
+        Command.start,
+      );
+      const stderr = yield* proc.stderr.pipe(
+        Stream.decodeText(),
+        Stream.mkString,
+      );
+      const exitCode = yield* proc.exitCode;
+      return { exitCode, stderr } satisfies MmdcRun;
+    }),
+  ).pipe(Effect.either);
 
 const cleanup = (
   fs: FileSystem.FileSystem,
@@ -163,11 +212,27 @@ const cleanup = (
 
 function interpretResult(
   block: MermaidBlock,
-  result: Either.Either<number, unknown>,
+  result: Either.Either<MmdcRun, unknown>,
 ): MermaidFailure | null {
   return Either.match(result, {
     onLeft: (e) => ({ block, message: `mmdc launch failed: ${String(e)}` }),
-    onRight: (code) =>
-      code === 0 ? null : { block, message: `mmdc exited ${String(code)}` },
+    onRight: (run) =>
+      run.exitCode === 0
+        ? null
+        : {
+            block,
+            message: `mmdc exited ${String(run.exitCode)}${formatStderr(run.stderr)}`,
+          },
   });
+}
+
+/** Indent the leading lines of mmdc stderr under the failure's header. */
+function formatStderr(stderr: string): string {
+  const lines = stderr
+    .split("\n")
+    .map((l) => l.trimEnd())
+    .filter((l) => l.length > 0)
+    .slice(0, STDERR_LINES_KEPT);
+  if (lines.length === 0) return "";
+  return `\n${lines.map((l) => `    ${l}`).join("\n")}`;
 }

--- a/packages/protocol/scripts/docs/mermaid-lint.ts
+++ b/packages/protocol/scripts/docs/mermaid-lint.ts
@@ -226,12 +226,16 @@ function interpretResult(
   });
 }
 
-/** Indent the leading lines of mmdc stderr under the failure's header. */
+/**
+ * Indent the leading lines of mmdc stderr under the failure's header.
+ * Stack frames are dropped: a browser launch failure buries its one useful
+ * line under a deep trace, and that trace repeats for every block.
+ */
 function formatStderr(stderr: string): string {
   const lines = stderr
     .split("\n")
     .map((l) => l.trimEnd())
-    .filter((l) => l.length > 0)
+    .filter((l) => l.length > 0 && !/^\s*at\s/.test(l))
     .slice(0, STDERR_LINES_KEPT);
   if (lines.length === 0) return "";
   return `\n${lines.map((l) => `    ${l}`).join("\n")}`;

--- a/packages/protocol/scripts/docs/mermaid-puppeteer.json
+++ b/packages/protocol/scripts/docs/mermaid-puppeteer.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--no-sandbox"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: 4.7.1(eslint@9.39.4(jiti@1.21.7))
       '@mermaid-js/mermaid-cli':
         specifier: ^11.15.0
-        version: 11.15.0(@types/react@19.2.14)(playwright-core@1.60.0)(puppeteer@22.14.0(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)
+        version: 11.15.0(@types/react@19.2.14)(playwright-core@1.60.0)(puppeteer@24.43.1(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)
       '@moltzap/cc-judge':
         specifier: 0.0.3
-        version: 0.0.3(f1c29f5dbb917c2de98bf272db37f0a7)
+        version: 0.0.3(d1deaeb92125062b60f8e74ea1493263)
       '@typescript-eslint/parser':
         specifier: ^8.58.2
         version: 8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
@@ -44,6 +44,9 @@ importers:
       oxlint:
         specifier: ^0.16.0
         version: 0.16.12
+      puppeteer:
+        specifier: 24.43.1
+        version: 24.43.1(typescript@5.9.3)
       typedoc:
         specifier: ^0.28.19
         version: 0.28.19(typescript@5.9.3)
@@ -2785,6 +2788,11 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@puppeteer/browsers@2.3.0':
     resolution: {integrity: sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==}
     engines: {node: '>=18'}
@@ -4462,6 +4470,11 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -5020,6 +5033,9 @@ packages:
 
   devtools-protocol@0.0.1312386:
     resolution: {integrity: sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==}
+
+  devtools-protocol@0.0.1608973:
+    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -7818,10 +7834,19 @@ packages:
     resolution: {integrity: sha512-rl4tOY5LcA3e374GAlsGGHc05HL3eGNf5rZ+uxkl6id9zVZKcwcp1Z+Nd6byb6WPiPeecT/dwz8f/iUm+AZQSw==}
     engines: {node: '>=18'}
 
+  puppeteer-core@24.43.1:
+    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
+    engines: {node: '>=18'}
+
   puppeteer@22.14.0:
     resolution: {integrity: sha512-MGTR6/pM8zmWbTdazb6FKnwIihzsSEXBPH49mFFU96DNZpQOevCAZMnjBZGlZRGRzRK6aADCavR6SQtrbv5dQw==}
     engines: {node: '>=18'}
     deprecated: < 24.15.0 is no longer supported
+    hasBin: true
+
+  puppeteer@24.43.1:
+    resolution: {integrity: sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   pure-rand@6.1.0:
@@ -8886,6 +8911,9 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
+
   typedoc@0.28.19:
     resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
     engines: {node: '>= 18', pnpm: '>= 10'}
@@ -9218,6 +9246,9 @@ packages:
   web-tree-sitter@0.26.9:
     resolution: {integrity: sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==}
 
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -9469,6 +9500,9 @@ packages:
   zod@3.24.0:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -9488,14 +9522,14 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@1.0.22(zod@3.21.4)':
+  '@ai-sdk/provider-utils@1.0.22(zod@3.24.0)':
     dependencies:
       '@ai-sdk/provider': 0.0.26
       eventsource-parser: 1.1.2
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
     optionalDependencies:
-      zod: 3.21.4
+      zod: 3.24.0
 
   '@ai-sdk/provider@0.0.26':
     dependencies:
@@ -9505,47 +9539,47 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@0.0.70(react@19.2.3)(zod@3.21.4)':
+  '@ai-sdk/react@0.0.70(react@19.2.3)(zod@3.24.0)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
       swr: 2.4.2(react@19.2.3)
       throttleit: 2.1.0
     optionalDependencies:
       react: 19.2.3
-      zod: 3.21.4
+      zod: 3.24.0
 
-  '@ai-sdk/solid@0.0.54(zod@3.21.4)':
+  '@ai-sdk/solid@0.0.54(zod@3.24.0)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/svelte@0.0.57(svelte@5.56.7(@typescript-eslint/types@8.59.3))(zod@3.21.4)':
+  '@ai-sdk/svelte@0.0.57(svelte@5.56.7(@typescript-eslint/types@8.59.3))(zod@3.24.0)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
       sswr: 2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3))
     optionalDependencies:
       svelte: 5.56.7(@typescript-eslint/types@8.59.3)
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/ui-utils@0.0.50(zod@3.21.4)':
+  '@ai-sdk/ui-utils@0.0.50(zod@3.24.0)':
     dependencies:
       '@ai-sdk/provider': 0.0.26
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
       json-schema: 0.4.0
       secure-json-parse: 2.7.0
-      zod-to-json-schema: 3.25.2(zod@3.21.4)
+      zod-to-json-schema: 3.25.2(zod@3.24.0)
     optionalDependencies:
-      zod: 3.21.4
+      zod: 3.24.0
 
-  '@ai-sdk/vue@0.0.59(vue@3.5.40(typescript@5.9.3))(zod@3.21.4)':
+  '@ai-sdk/vue@0.0.59(vue@3.5.40(typescript@5.9.3))(zod@3.24.0)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
       swrv: 1.2.0(vue@3.5.40(typescript@5.9.3))
     optionalDependencies:
       vue: 3.5.40(typescript@5.9.3)
@@ -9564,9 +9598,9 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
 
-  '@anthropic-ai/claude-agent-sdk@0.1.45(zod@3.21.4)':
+  '@anthropic-ai/claude-agent-sdk@0.1.45(zod@3.24.0)':
     dependencies:
-      zod: 3.21.4
+      zod: 3.24.0
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -11334,7 +11368,7 @@ snapshots:
       mermaid: 11.15.0
     optional: true
 
-  '@mermaid-js/mermaid-cli@11.15.0(@types/react@19.2.14)(playwright-core@1.60.0)(puppeteer@22.14.0(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)':
+  '@mermaid-js/mermaid-cli@11.15.0(@types/react@19.2.14)(playwright-core@1.60.0)(puppeteer@24.43.1(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)':
     dependencies:
       '@fortawesome/fontawesome-free': 7.2.0
       '@mermaid-js/layout-elk': 0.2.1(mermaid@11.15.0)
@@ -11345,7 +11379,7 @@ snapshots:
       katex: 0.16.45
       mermaid: 11.15.0
       p-limit: 6.2.0
-      puppeteer: 22.14.0(typescript@5.9.3)
+      puppeteer: 24.43.1(typescript@5.9.3)
     optionalDependencies:
       '@mermaid-js/layout-tidy-tree': 0.2.2(mermaid@11.15.0)
     transitivePeerDependencies:
@@ -11875,14 +11909,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@moltzap/cc-judge@0.0.3(f1c29f5dbb917c2de98bf272db37f0a7)':
+  '@moltzap/cc-judge@0.0.3(d1deaeb92125062b60f8e74ea1493263)':
     dependencies:
-      '@anthropic-ai/claude-agent-sdk': 0.1.45(zod@3.21.4)
+      '@anthropic-ai/claude-agent-sdk': 0.1.45(zod@3.24.0)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.0))(@effect/printer-ansi@0.50.0(@effect/typeclass@0.41.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.50.0(@effect/typeclass@0.41.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
       '@effect/platform': 0.96.1(effect@3.21.0)
       '@effect/platform-node': 0.106.0(@effect/cluster@0.60.0(@effect/platform@0.96.1(effect@3.21.0))(@effect/rpc@0.76.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.52.0(@effect/experimental@0.61.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.19.0(@effect/experimental@0.61.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.1(effect@3.21.0))(@effect/rpc@0.76.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.1(effect@3.21.0))(@effect/rpc@0.76.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.52.0(@effect/experimental@0.61.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
       '@sinclair/typebox': 0.33.22
-      braintrust: 0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.21.4)
+      braintrust: 0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.24.0)
       dockerode: 5.0.0
       effect: 3.21.0
       glob: 11.0.0
@@ -12438,6 +12472,21 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@puppeteer/browsers@2.13.2':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.8.0
+      tar-fs: 3.1.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
   '@puppeteer/browsers@2.3.0':
     dependencies:
@@ -13847,26 +13896,26 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
-  ai@3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.21.4):
+  ai@3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.24.0):
     dependencies:
       '@ai-sdk/provider': 0.0.26
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
-      '@ai-sdk/react': 0.0.70(react@19.2.3)(zod@3.21.4)
-      '@ai-sdk/solid': 0.0.54(zod@3.21.4)
-      '@ai-sdk/svelte': 0.0.57(svelte@5.56.7(@typescript-eslint/types@8.59.3))(zod@3.21.4)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
-      '@ai-sdk/vue': 0.0.59(vue@3.5.40(typescript@5.9.3))(zod@3.21.4)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/react': 0.0.70(react@19.2.3)(zod@3.24.0)
+      '@ai-sdk/solid': 0.0.54(zod@3.24.0)
+      '@ai-sdk/svelte': 0.0.57(svelte@5.56.7(@typescript-eslint/types@8.59.3))(zod@3.24.0)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+      '@ai-sdk/vue': 0.0.59(vue@3.5.40(typescript@5.9.3))(zod@3.24.0)
       '@opentelemetry/api': 1.9.0
       eventsource-parser: 1.1.2
       json-schema: 0.4.0
       jsondiffpatch: 0.6.0
       secure-json-parse: 2.7.0
-      zod-to-json-schema: 3.25.2(zod@3.21.4)
+      zod-to-json-schema: 3.25.2(zod@3.24.0)
     optionalDependencies:
       react: 19.2.3
       sswr: 2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3))
       svelte: 5.56.7(@typescript-eslint/types@8.59.3)
-      zod: 3.21.4
+      zod: 3.24.0
     transitivePeerDependencies:
       - solid-js
       - vue
@@ -14205,13 +14254,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.21.4):
+  braintrust@0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.24.0):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@braintrust/core': 0.0.74
       '@next/env': 14.2.35
       '@vercel/functions': 1.6.0(@aws-sdk/credential-provider-web-identity@3.972.28)
-      ai: 3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.21.4)
+      ai: 3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.24.0)
       argparse: 2.0.1
       chalk: 4.1.2
       cli-progress: 3.12.0
@@ -14226,8 +14275,8 @@ snapshots:
       slugify: 1.6.9
       source-map: 0.7.6
       uuid: 9.0.1
-      zod: 3.21.4
-      zod-to-json-schema: 3.25.2(zod@3.21.4)
+      zod: 3.24.0
+      zod-to-json-schema: 3.25.2(zod@3.24.0)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
       - openai
@@ -14397,6 +14446,12 @@ snapshots:
       mitt: 3.0.1
       urlpattern-polyfill: 10.0.0
       zod: 3.23.8
+
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
+    dependencies:
+      devtools-protocol: 0.0.1608973
+      mitt: 3.0.1
+      zod: 3.25.76
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -14929,6 +14984,8 @@ snapshots:
       dequal: 2.0.3
 
   devtools-protocol@0.0.1312386: {}
+
+  devtools-protocol@0.0.1608973: {}
 
   didyoumean@1.2.2: {}
 
@@ -18745,12 +18802,46 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  puppeteer-core@24.43.1:
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      debug: 4.4.3(supports-color@8.1.1)
+      devtools-protocol: 0.0.1608973
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
   puppeteer@22.14.0(typescript@5.9.3):
     dependencies:
       '@puppeteer/browsers': 2.3.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
       devtools-protocol: 0.0.1312386
       puppeteer-core: 22.14.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  puppeteer@24.43.1(typescript@5.9.3):
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      devtools-protocol: 0.0.1608973
+      puppeteer-core: 24.43.1
+      typed-query-selector: 2.12.2
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -20252,6 +20343,8 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typed-query-selector@2.12.2: {}
+
   typedoc@0.28.19(typescript@5.9.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
@@ -20665,6 +20758,8 @@ snapshots:
 
   web-tree-sitter@0.26.9: {}
 
+  webdriver-bidi-protocol@0.4.1: {}
+
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
@@ -20884,9 +20979,9 @@ snapshots:
     dependencies:
       zod: 3.24.0
 
-  zod-to-json-schema@3.25.2(zod@3.21.4):
+  zod-to-json-schema@3.25.2(zod@3.24.0):
     dependencies:
-      zod: 3.21.4
+      zod: 3.24.0
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
@@ -20901,6 +20996,8 @@ snapshots:
   zod@3.23.8: {}
 
   zod@3.24.0: {}
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 11.15.0(@types/react@19.2.14)(playwright-core@1.60.0)(puppeteer@24.43.1(typescript@5.9.3))(tsx@4.21.0)(yaml@2.9.0)
       '@moltzap/cc-judge':
         specifier: 0.0.3
-        version: 0.0.3(d1deaeb92125062b60f8e74ea1493263)
+        version: 0.0.3(f1c29f5dbb917c2de98bf272db37f0a7)
       '@typescript-eslint/parser':
         specifier: ^8.58.2
         version: 8.58.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
@@ -9522,14 +9522,14 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@1.0.22(zod@3.24.0)':
+  '@ai-sdk/provider-utils@1.0.22(zod@3.21.4)':
     dependencies:
       '@ai-sdk/provider': 0.0.26
       eventsource-parser: 1.1.2
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
     optionalDependencies:
-      zod: 3.24.0
+      zod: 3.21.4
 
   '@ai-sdk/provider@0.0.26':
     dependencies:
@@ -9539,47 +9539,47 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@0.0.70(react@19.2.3)(zod@3.24.0)':
+  '@ai-sdk/react@0.0.70(react@19.2.3)(zod@3.21.4)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
       swr: 2.4.2(react@19.2.3)
       throttleit: 2.1.0
     optionalDependencies:
       react: 19.2.3
-      zod: 3.24.0
+      zod: 3.21.4
 
-  '@ai-sdk/solid@0.0.54(zod@3.24.0)':
+  '@ai-sdk/solid@0.0.54(zod@3.21.4)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/svelte@0.0.57(svelte@5.56.7(@typescript-eslint/types@8.59.3))(zod@3.24.0)':
+  '@ai-sdk/svelte@0.0.57(svelte@5.56.7(@typescript-eslint/types@8.59.3))(zod@3.21.4)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
       sswr: 2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3))
     optionalDependencies:
       svelte: 5.56.7(@typescript-eslint/types@8.59.3)
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/ui-utils@0.0.50(zod@3.24.0)':
+  '@ai-sdk/ui-utils@0.0.50(zod@3.21.4)':
     dependencies:
       '@ai-sdk/provider': 0.0.26
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
       json-schema: 0.4.0
       secure-json-parse: 2.7.0
-      zod-to-json-schema: 3.25.2(zod@3.24.0)
+      zod-to-json-schema: 3.25.2(zod@3.21.4)
     optionalDependencies:
-      zod: 3.24.0
+      zod: 3.21.4
 
-  '@ai-sdk/vue@0.0.59(vue@3.5.40(typescript@5.9.3))(zod@3.24.0)':
+  '@ai-sdk/vue@0.0.59(vue@3.5.40(typescript@5.9.3))(zod@3.21.4)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
       swrv: 1.2.0(vue@3.5.40(typescript@5.9.3))
     optionalDependencies:
       vue: 3.5.40(typescript@5.9.3)
@@ -9598,9 +9598,9 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
 
-  '@anthropic-ai/claude-agent-sdk@0.1.45(zod@3.24.0)':
+  '@anthropic-ai/claude-agent-sdk@0.1.45(zod@3.21.4)':
     dependencies:
-      zod: 3.24.0
+      zod: 3.21.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -11909,14 +11909,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@moltzap/cc-judge@0.0.3(d1deaeb92125062b60f8e74ea1493263)':
+  '@moltzap/cc-judge@0.0.3(f1c29f5dbb917c2de98bf272db37f0a7)':
     dependencies:
-      '@anthropic-ai/claude-agent-sdk': 0.1.45(zod@3.24.0)
+      '@anthropic-ai/claude-agent-sdk': 0.1.45(zod@3.21.4)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.0))(@effect/printer-ansi@0.50.0(@effect/typeclass@0.41.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.50.0(@effect/typeclass@0.41.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
       '@effect/platform': 0.96.1(effect@3.21.0)
       '@effect/platform-node': 0.106.0(@effect/cluster@0.60.0(@effect/platform@0.96.1(effect@3.21.0))(@effect/rpc@0.76.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.52.0(@effect/experimental@0.61.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.19.0(@effect/experimental@0.61.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.1(effect@3.21.0))(@effect/rpc@0.76.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.1(effect@3.21.0))(@effect/rpc@0.76.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.52.0(@effect/experimental@0.61.0(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.1(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
       '@sinclair/typebox': 0.33.22
-      braintrust: 0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.24.0)
+      braintrust: 0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.21.4)
       dockerode: 5.0.0
       effect: 3.21.0
       glob: 11.0.0
@@ -13896,26 +13896,26 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
-  ai@3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.24.0):
+  ai@3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.21.4):
     dependencies:
       '@ai-sdk/provider': 0.0.26
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.0)
-      '@ai-sdk/react': 0.0.70(react@19.2.3)(zod@3.24.0)
-      '@ai-sdk/solid': 0.0.54(zod@3.24.0)
-      '@ai-sdk/svelte': 0.0.57(svelte@5.56.7(@typescript-eslint/types@8.59.3))(zod@3.24.0)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.0)
-      '@ai-sdk/vue': 0.0.59(vue@3.5.40(typescript@5.9.3))(zod@3.24.0)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.21.4)
+      '@ai-sdk/react': 0.0.70(react@19.2.3)(zod@3.21.4)
+      '@ai-sdk/solid': 0.0.54(zod@3.21.4)
+      '@ai-sdk/svelte': 0.0.57(svelte@5.56.7(@typescript-eslint/types@8.59.3))(zod@3.21.4)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.21.4)
+      '@ai-sdk/vue': 0.0.59(vue@3.5.40(typescript@5.9.3))(zod@3.21.4)
       '@opentelemetry/api': 1.9.0
       eventsource-parser: 1.1.2
       json-schema: 0.4.0
       jsondiffpatch: 0.6.0
       secure-json-parse: 2.7.0
-      zod-to-json-schema: 3.25.2(zod@3.24.0)
+      zod-to-json-schema: 3.25.2(zod@3.21.4)
     optionalDependencies:
       react: 19.2.3
       sswr: 2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3))
       svelte: 5.56.7(@typescript-eslint/types@8.59.3)
-      zod: 3.24.0
+      zod: 3.21.4
     transitivePeerDependencies:
       - solid-js
       - vue
@@ -14254,13 +14254,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.24.0):
+  braintrust@0.0.180(@aws-sdk/credential-provider-web-identity@3.972.28)(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.21.4):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@braintrust/core': 0.0.74
       '@next/env': 14.2.35
       '@vercel/functions': 1.6.0(@aws-sdk/credential-provider-web-identity@3.972.28)
-      ai: 3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.24.0)
+      ai: 3.4.33(react@19.2.3)(sswr@2.2.0(svelte@5.56.7(@typescript-eslint/types@8.59.3)))(svelte@5.56.7(@typescript-eslint/types@8.59.3))(vue@3.5.40(typescript@5.9.3))(zod@3.21.4)
       argparse: 2.0.1
       chalk: 4.1.2
       cli-progress: 3.12.0
@@ -14275,8 +14275,8 @@ snapshots:
       slugify: 1.6.9
       source-map: 0.7.6
       uuid: 9.0.1
-      zod: 3.24.0
-      zod-to-json-schema: 3.25.2(zod@3.24.0)
+      zod: 3.21.4
+      zod-to-json-schema: 3.25.2(zod@3.21.4)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
       - openai
@@ -20979,9 +20979,9 @@ snapshots:
     dependencies:
       zod: 3.24.0
 
-  zod-to-json-schema@3.25.2(zod@3.24.0):
+  zod-to-json-schema@3.25.2(zod@3.21.4):
     dependencies:
-      zod: 3.24.0
+      zod: 3.21.4
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
Closes #884. Parent epic #883.

Two defects in the documentation gate, both live on `v2` as of `b9dbfc71`.

## Defect 1 — the gate never walked `v2/`

`check-mermaid.ts` built its roots as `docs/` and `packages/`. The `v2/` tree
was never walked, so three fenced mermaid blocks under `v2/drafts/` were
unvalidated while `AGENTS.md` and `README.md` both tell contributors that
`pnpm docs:check:mermaid` validates *every* fenced block. On the v2 track that
claim was false: the command exited zero without having looked.

Roots now come from an exported `MERMAID_ROOTS`, and **a configured root that
is not a directory fails the run**. The walk deliberately swallows unreadable
directories, so without that guard a renamed or deleted root would quietly
contribute zero blocks and still exit zero — the same bug relocated. A unit
test pins every entry in `MERMAID_ROOTS` to a real directory.

Neither `AGENTS.md` nor `README.md` needed an edit: both already promised
"every fenced block", and this change is what makes that promise true.

### Before / after

| | blocks | files |
|---|---|---|
| before (`docs/` + `packages/`) | 34 | 294 |
| after (`+ v2/`) | **37** | **316** |

All three real `v2/drafts/` blocks parse. The STOP RULE on #884 did not
trigger — no frozen design diagram is malformed, and none was touched.

## Defect 2 — puppeteer pinned to a floating browser

CI set `PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome` — a runner binary
that refreshes weekly — while the lockfile resolved `puppeteer@22.14.0`, whose
supported Chrome is 127. The gate passed today and would rot with no commit of
ours touching it.

Digging in surfaced a second, related problem: `22.14.0` was **outside**
`@mermaid-js/mermaid-cli@11.15.0`'s declared peer range of `^23 || ^24`. Nothing
declared puppeteer directly; `autoInstallPeers: true` silently satisfied the
peer with the `22.14.0` that `@mintlify/scraping` (via `mint`) pulls in. So the
renderer ran against an out-of-range puppeteer *and* an unrelated package's
transitive dependency was choosing our browser.

### Mechanism chosen: resolve the browser through a pinned puppeteer

- `puppeteer` becomes a **pinned direct devDependency at `24.43.1`** — inside
  mermaid-cli's peer range, and now chosen by us rather than inherited from
  mintlify.
- `docs:check:mermaid` runs `puppeteer browsers install chrome-headless-shell`
  first. That resolves the exact build in `PUPPETEER_REVISIONS` for the
  installed puppeteer — **148.0.7778.97** — so the browser is a pure function
  of the lockfile. It is idempotent and needs no network once cached (the
  version is exact, not a `stable` alias).
- `PUPPETEER_EXECUTABLE_PATH` is gone from CI.

It is the **headless shell**, not full `chrome`, because mermaid-cli hardcodes
`headless: "shell"` in its launch options, which resolves the
`chrome-headless-shell` binary. Installing `chrome` leaves the gate without the
browser it actually launches. This was caught in review and is exactly the kind
of bug a warm local cache hides — see the clean-cache check below.

**Why not "upgrade puppeteer alongside the runner Chrome"** (the other option
offered on the issue): the runner's Chrome floats weekly regardless of what we
pin, so that path cannot be deterministic — it only re-times the same rot.
Pinning the browser to the lockfile removes the runner image from the equation,
and the same build is used locally and in CI.

**Why `--no-sandbox`** (new `mermaid-puppeteer.json`, passed via
`--puppeteerConfigFile`): a downloaded Chrome-for-Testing binary ships no
AppArmor profile, and Ubuntu 23.10+ — which includes `ubuntu-latest` runners —
restricts unprivileged user namespaces. The system `google-chrome` `.deb` was
carrying the profile that made the old setup work. Verified locally: without
the flag the browser aborts with `No usable sandbox!`. The gate renders
repo-owned markdown in a short-lived headless process, so the Chrome sandbox is
not a trust boundary here; running the identical browser everywhere is worth
more than a sandbox around our own committed docs.

### Clean-cache check

The determinism claim is only meaningful against a cold runner, so it was run
that way — empty `PUPPETEER_CACHE_DIR`, nothing pre-warmed:

```
# installing `chrome` — what this PR originally did
Checking 37 Mermaid block(s) across 316 file(s)...
docs/architecture.mdx:10 — mmdc exited 1
    Error: Could not find Chrome (ver. 148.0.7778.97). This can occur if either
     1. you did not perform an installation before running the script
        (e.g. `npx puppeteer browsers install chrome-headless-shell`) or
     2. your cache path is incorrectly configured

# installing `chrome-headless-shell` — what it does now
chrome-headless-shell@148.0.7778.97 .../chrome-headless-shell-linux64/chrome-headless-shell
Checking 37 Mermaid block(s) across 316 file(s)...
Mermaid lint: PASS
```

## Gate-can-fail proof

Turning on a root that silently finds nothing would be the same bug in a new
place, so the gate was watched failing on the newly covered tree. A temporary
`v2/drafts/GATE-CAN-FAIL-PROBE.md` was added carrying a malformed block — a new
file, so no frozen prose was touched — and removed afterwards. It is not in
this diff.

Block count rose 37 → 38, confirming the probe was actually picked up:

```
$ pnpm docs:check:mermaid; echo "GATE_EXIT=$?"
Checking 38 Mermaid block(s) across 317 file(s)...
v2/drafts/GATE-CAN-FAIL-PROBE.md:3 — mmdc exited 1
    Error: Parse error on line 3:
    ...o    Bob -->> Alice    note over Alice
    ----------------------^
    Expecting 'TXT', got 'NEWLINE'
Mermaid lint: FAIL (1)
GATE_EXIT=1
```

Non-zero exit, attributed to the exact file and line under `v2/`.

### The error text is itself a fix

That parse error is legible only because this PR also makes the helper keep
`mmdc`'s stderr. Previously every failure rendered as the bare string
`mmdc exited 1`. Not hypothetical: on a machine without a usable browser the
old gate reported `FAIL (34)` — every block — with no hint that the cause was a
browser launch failure rather than 34 broken diagrams.
`v2/inputs/strict-enforcement-debt-20260718.md` records a prior auditor losing
time to exactly this. The exit code cannot separate a malformed diagram from a
browser that never started; the stderr can, so it is reported now (leading
lines, stack frames dropped — a launch failure otherwise repeats one deep trace
per block).

## Verification

Local, all green:

- `pnpm build` (typecheck) · `pnpm lint` · `pnpm format:check`
- `pnpm docs:check:drift` · `pnpm docs:check:mermaid` (37 blocks, PASS) ·
  `pnpm docs:check:gates-test`
- `pnpm exec nx affected -t typecheck:tests test` — 6 projects pass
- `pnpm install --frozen-lockfile` clean against the updated lockfile
- cold-cache run above

## Review notes

A codex `gstack-review` pass at `ultra` reasoning ran against this diff. Its
blocking finding — full `chrome` vs `chrome-headless-shell` — is fixed above.
Two other findings are also applied: the lockfile is regenerated with
`--lockfile-only` so it no longer drags unrelated AI-SDK peers off zod 3.21.4
(the remaining `zod@3.25.76` addition is `chromium-bidi`, a puppeteer-core
dependency), and a stale test comment that contradicted the new `requireRoots`
behaviour is rewritten.

Two findings are deliberately not applied:

- *"stderr is not retained through the piped Effect process."* Not reproducible
  here. Both failure classes surface their reason — see the parse error above,
  and a launch failure forced with `PUPPETEER_EXECUTABLE_PATH=/nonexistent`
  prints `Error: Tried to find the browser at the configured path ...` under
  each block. mmdc writes diagnostics to stderr and nothing to stdout under
  `--quiet`, which is why stdout is left inherited.
- *"cache the puppeteer browser in CI."* Deliberately skipped. The install is
  idempotent and costs seconds; a partially restored cache would leave a
  version directory that `browsers install` treats as satisfied and skips,
  producing a browser nobody verified. That is the failure class this PR
  exists to remove, and trading it for a few seconds is the wrong side of the
  trade.

## Review round 2 — the gate could still pass over what it never read

An independent codex pass (#886) returned three BLOCKING findings, all one
defect: three filesystem steps collapsed a real failure into an empty value.

```ts
.pipe(Effect.catchAll(() => Effect.succeed([] as ReadonlyArray<string>))) // walkInto
.pipe(Effect.catchAll(() => Effect.succeed("")))                          // collectBlocks
.pipe(Effect.catchAll(() => Effect.void))                                 // writeInput
```

This is the bug this PR exists to remove, reproduced inside the fix. The
original defect was a gate passing over a tree it never walked; these are a
gate passing over a directory it could not open, a file it could not read, or
a block it could not stage. `requireRoots` only ever covered a root that was
*missing* — never one *present and unreadable*.

**Demonstrated, not argued.** An unreadable directory holding a document was
placed under `packages/`, and the same tree run against both commits:

```
# 6067034d — before this round
Checking 37 Mermaid block(s) across 316 file(s)...
Mermaid lint: PASS
OLD_GATE_EXIT=0

# after
Mermaid lint: cannot read directory: .../packages/protocol/scripts/__tmp_locked__
    SystemError: PermissionDenied: FileSystem.readDirectory (...): EACCES: permission denied
Mermaid lint: FAIL (inputs left unchecked)
GATE_EXIT=1
```

Note the old run's block count is unchanged at 37 — it did not notice the
document existed. That is what a silent catch buys.

All three now fail with a typed `MermaidGateError` carrying reason, path, and
cause. It is reported as its own outcome rather than folded into the block
tally, because `FAIL (0)` would still claim the input was checked and clean.
`stat` during the walk is fixed as the same class — an entry that cannot be
stat'ed is the same blind spot, and patching only the three named sites would
have left the pattern alive one line away.

`cleanup` stays best-effort deliberately, and now says why in the code: a block
that fails to parse leaves no SVG, so removing it is *expected* to fail and
says nothing about whether the block was checked. Leftovers can no longer mask
anything either, now that a failed write aborts the run.

### The tests were checked by breaking the fix

Walking and block collection moved into `mermaid-lint.ts` so these paths are
importable. `mermaid-gate.test.ts` covers each one, and each test was verified
non-vacuous by reverting its fix and confirming it goes red:

A follow-up read-only codex pass found the first attempt at this table was
itself unsound, and it was right on both counts:

- The staging test pointed the temp directory at a *file*, so `makeDirectory`
  failed first. Reverting only the swallowed **write** left it green. The
  original mutation check reverted both temp lines together and so never saw
  it. Now split: the write case blocks the input path with a directory, so
  `makeDirectory` succeeds and the write is what fails.
- Walk-time `stat` had **no** test. The unreadable-directory fixture stats the
  directory fine and fails listing it, so restoring the old catch-and-skip on
  `stat` left every test green. A dangling symlink reaches that path.

Every site is now re-checked by reverting it **alone**:

| reverted fix | tests that fail |
|---|---|
| `readDirectory` → `succeed([])` | 2 (`cannot be listed`, `exists but cannot be opened`) |
| `readFileString` → `succeed("")` | 1 (`file cannot be read`) |
| `stat` → `succeed(null)` + skip | 1 (`entry that cannot be stat'ed`) |
| `makeDirectory` → `Effect.void` | 1 (`temp directory cannot be created`) |
| `writeFileString` → `Effect.void` | 1 (`input itself cannot be written`) |

The suite also pins the positive behaviour the old tests never asserted: that
the walker actually descends subdirectories, skips `node_modules`, and labels
blocks relative to the root, plus that `cause` survives onto the error. The
permissions-based case skips under uid 0, where mode bits do not apply.

## Lockfile: not reducible, and why

The second non-blocking finding asked whether the parallel puppeteer 22/24
trees could be collapsed. They cannot:

```
@mintlify/scraping → "puppeteer": "22.14.0"   # exact, a direct dependency
```

It is an exact pin, not a range, so no single version satisfies both it and
our `24.43.1`. The only lever is a `pnpm.overrides` entry forcing Mintlify off
the version it pinned — which would silently re-point the docs tooling that
`pnpm docs:check` runs in this same CI job, to tidy a lockfile.

The cost is bounded and JS-only: `puppeteer@22` + `puppeteer-core@22` +
`@puppeteer/browsers@2.3.0` ≈ 10.3 MB. No browser is downloaded for it — CI
fetches only the v24 headless shell. Left as-is, on the reviewer's own terms
that an honest note beats a forced dedup.

Worth stating plainly: before this PR there was only *one* puppeteer tree,
because mermaid-cli's peer was being satisfied by Mintlify's copy. The second
tree is the price of not letting an unrelated package choose our browser.

## Scope

Touched: `.github/workflows/ci.yml`, `check-mermaid.ts`, `mermaid-lint.ts`,
its tests, the new `mermaid-puppeteer.json`, and `package.json` /
`pnpm-lock.yaml` for the puppeteer pin. No frozen Gate 1 design document was
modified — `docs/decisions/`, `docs/spec/`, `docs/architecture/`,
`v2/VISION.md`, and all existing `v2/drafts/` prose are untouched.

### Noted, not fixed

`packages/protocol/scripts/` sits outside every tsconfig (`rootDir: ./src`), so
nothing in it is type-checked by `pnpm build` or `typecheck:tests`. That
predates this PR and is why the pre-existing `Command.CommandExecutor` type
reference in `mermaid-lint.ts` has never been flagged. Wiring the directory
into a typecheck is its own change, not this one.

