### PR TITLE
chore(lint): update agent-code-guard to 0.0.20

### DIFF
--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -151,9 +151,6 @@ const makeStrictRules = ({ maxLines = 1050 } = {}) => ({
   // Disabled: knip runs once at the workspace root (whole-monorepo)
   // via `pnpm lint`; per-package lint scripts run eslint only.
   "agent-code-guard/require-knip-in-lint": "off",
-  // Nx owns the workspace task graph; this package-script rule cannot resolve
-  // Nx targets without producing false negatives.
-  "agent-code-guard/require-typescript-quality-gate": "off",
   "local-guard/gen-finally": "error",
 });
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@mermaid-js/mermaid-cli": "^11.15.0",
     "@types/node": "^25.5.0",
     "eslint": "^9",
-    "eslint-plugin-agent-code-guard": "0.0.18",
+    "eslint-plugin-agent-code-guard": "0.0.20",
     "husky": "^9.0.0",
     "mint": "4.2.749",
     "nx": "^22.7.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@mermaid-js/mermaid-cli": "^11.15.0",
     "@types/node": "^25.5.0",
     "eslint": "^9",
-    "eslint-plugin-agent-code-guard": "0.0.16",
+    "eslint-plugin-agent-code-guard": "0.0.18",
     "husky": "^9.0.0",
     "mint": "4.2.749",
     "nx": "^22.7.5",

--- a/packages/client/src/channel-base/lease.ts
+++ b/packages/client/src/channel-base/lease.ts
@@ -51,10 +51,9 @@ function isLeaseInvalidData(data: unknown): boolean {
   if (typeof data !== "object" || data === null) {
     return false;
   }
-  const reason = (
+  const reason =
     /* Safe because the surrounding invariant establishes this asserted shape. */
-    data as { readonly reason?: unknown }
-  ).reason;
+    (data as { readonly reason?: unknown }).reason;
   return reason === "LeaseInvalid";
 }
 

--- a/packages/client/src/channel-core-context.test.ts
+++ b/packages/client/src/channel-core-context.test.ts
@@ -212,8 +212,8 @@ function doesNotCommitWhenThereAreNoContextEntries() {
     fake.state.setConversation("conv-1", { type: "dm", participants: [] });
     fake.state.setAgentName("agent-alice", "Alice");
     // Install a peekContextEntries that records commit calls.
+    /* Safe because the test fixture establishes this asserted shape. */
     (
-      /* Safe because the test fixture establishes this asserted shape. */
       fake.service as {
         peekContextEntries: (id: string) => {
           entries: CrossConversationEntry[];

--- a/packages/client/src/channel-core-dispatch.test.ts
+++ b/packages/client/src/channel-core-dispatch.test.ts
@@ -422,10 +422,8 @@ function preservesServiceBindingForDispatchAdmissionMethods() {
         fake.service,
       );
     fake.service.requestDispatch = function (request) {
-      (
-        /* Safe because the test fixture establishes this asserted shape. */
-        this as ChannelService & { admissionCalls: number }
-      ).admissionCalls += 1;
+      /* Safe because the test fixture establishes this asserted shape. */
+      (this as ChannelService & { admissionCalls: number }).admissionCalls += 1;
       return installed(request);
     };
 

--- a/packages/client/src/channel-core-test-support.ts
+++ b/packages/client/src/channel-core-test-support.ts
@@ -270,8 +270,8 @@ export function customSetup(): {
  * @param fake Value supplied to the operation.
  */
 export function forceResolveAgentNamePath(fake: FakeChannelService): void {
+  /* Safe because the surrounding invariant establishes this asserted shape. */
   (
-    /* Safe because the surrounding invariant establishes this asserted shape. */
     fake.service as { getAgentName: (id: string) => string | undefined }
   ).getAgentName = () => undefined;
 }

--- a/packages/client/src/service-event-trace.ts
+++ b/packages/client/src/service-event-trace.ts
@@ -18,9 +18,7 @@ export function getClientEventLogDir(
 ): string | undefined {
   const provider = configProvider ?? ConfigProvider.fromEnv();
   const directory = Option.getOrUndefined(
-    Effect.runSync(
-      clientEventLogDir.pipe(Effect.withConfigProvider(provider)),
-    ),
+    Effect.runSync(clientEventLogDir.pipe(Effect.withConfigProvider(provider))),
   );
   return directory === "" ? undefined : directory;
 }

--- a/packages/client/src/service.test.ts
+++ b/packages/client/src/service.test.ts
@@ -279,16 +279,12 @@ function sendToAgentCachesPerAgentName() {
         (typeof sendCalls)[number],
       ];
     expect(
-      (
-        /* Safe because the test fixture establishes this asserted shape. */
-        firstSend.params as { conversationId: string }
-      ).conversationId,
+      /* Safe because the test fixture establishes this asserted shape. */
+      (firstSend.params as { conversationId: string }).conversationId,
     ).toBe(CONVERSATION_ALICE_ID);
     expect(
-      (
-        /* Safe because the test fixture establishes this asserted shape. */
-        secondSend.params as { conversationId: string }
-      ).conversationId,
+      /* Safe because the test fixture establishes this asserted shape. */
+      (secondSend.params as { conversationId: string }).conversationId,
     ).toBe(CONVERSATION_BOB_ID);
   });
 }

--- a/packages/nanoclaw-channel/src/__tests__/echo.integration.test.ts
+++ b/packages/nanoclaw-channel/src/__tests__/echo.integration.test.ts
@@ -110,8 +110,8 @@ function decodeInjectedAgentKey(key: string): AgentKey {
 function contentText(msg: InboundMessage): string {
   return (
     /* Safe because the test fixture establishes this asserted shape. */
-    msg.content as { readonly text: string }
-  ).text;
+    (msg.content as { readonly text: string }).text
+  );
 }
 
 function channelSenderId(agentId: string): string {
@@ -402,10 +402,8 @@ function deliversInbound() {
     );
     expect(seen?.jid).toBe(h.chatJid);
     expect(
-      (
-        /* Safe because the test fixture establishes this asserted shape. */
-        seen!.msg.content as { senderId: string }
-      ).senderId,
+      /* Safe because the test fixture establishes this asserted shape. */
+      (seen!.msg.content as { senderId: string }).senderId,
     ).toBe(channelSenderId(h.peerAgentId));
   });
 }

--- a/packages/openclaw-channel/src/__tests__/test-helpers.ts
+++ b/packages/openclaw-channel/src/__tests__/test-helpers.ts
@@ -52,8 +52,8 @@ export function extractMessage(event: MessageReceivedNotification): Message {
 export function extractConvId(result: unknown): string {
   return (
     /* Safe because the test fixture establishes this asserted shape. */
-    result as { conversation: { id: string } }
-  ).conversation.id;
+    (result as { conversation: { id: string } }).conversation.id
+  );
 }
 
 /** Describes task binding. */

--- a/packages/openclaw-channel/src/openclaw-entry.directory.test.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.directory.test.ts
@@ -116,10 +116,9 @@ function directoryCallDefinition<D extends RpcDefinitionAny>(
         }),
       );
     }
-    const cursor = (
+    const cursor =
       /* Safe because the test fixture establishes this asserted shape. */
-      params as { readonly cursor?: string }
-    ).cursor ?? "";
+      (params as { readonly cursor?: string }).cursor ?? "";
     return Effect.succeed(rpcResult<D>(agentsPage(cursor)));
   }
   return Effect.succeed(rpcResult<D>({}));

--- a/packages/server/src/__tests__/integration/app/messages-authorize/messages-authorize.integration.test.ts
+++ b/packages/server/src/__tests__/integration/app/messages-authorize/messages-authorize.integration.test.ts
@@ -302,19 +302,15 @@ function expectHookBlocked(
 
 function expectDecisionTag(decision: unknown, tag: string): void {
   expect(
-    (
-      /* Safe because the test fixture establishes this asserted shape. */
-      decision as { tag?: string }
-    ).tag,
+    /* Safe because the test fixture establishes this asserted shape. */
+    (decision as { tag?: string }).tag,
   ).toBe(tag);
 }
 
 function expectDecisionReason(decision: unknown, reason: string): void {
   expect(
-    (
-      /* Safe because the test fixture establishes this asserted shape. */
-      decision as { reason?: string }
-    ).reason,
+    /* Safe because the test fixture establishes this asserted shape. */
+    (decision as { reason?: string }).reason,
   ).toBe(reason);
 }
 
@@ -323,10 +319,8 @@ function expectDecisionRecipients(
   recipients: readonly string[],
 ) {
   expect(
-    (
-      /* Safe because the test fixture establishes this asserted shape. */
-      decision as { recipients?: readonly string[] }
-    ).recipients,
+    /* Safe because the test fixture establishes this asserted shape. */
+    (decision as { recipients?: readonly string[] }).recipients,
   ).toEqual(recipients);
 }
 

--- a/packages/server/src/__tests__/integration/network/presence-subscribe-policy.test.ts
+++ b/packages/server/src/__tests__/integration/network/presence-subscribe-policy.test.ts
@@ -108,10 +108,8 @@ function extractTaggedRpcError(exit: Exit.Exit<unknown, unknown>): {
   }
   const err = failureOpt.value;
   expect(
-    (
-      /* Safe because the test fixture establishes this asserted shape. */
-      err as { _tag?: unknown }
-    )._tag,
+    /* Safe because the test fixture establishes this asserted shape. */
+    (err as { _tag?: unknown })._tag,
   ).toBeTypeOf("string");
   return /* Safe because the test fixture establishes this asserted shape. */ err as {
     readonly _tag: string;

--- a/packages/server/src/__tests__/integration/socket/reconnection.test.ts
+++ b/packages/server/src/__tests__/integration/socket/reconnection.test.ts
@@ -132,10 +132,9 @@ function expectReconnectedHistory(client: TestAgentClient, binding: DmBinding) {
 }
 
 function messageText(params: unknown): string {
-  const parts = (
+  const parts =
     /* Safe because the test fixture establishes this asserted shape. */
-    params as { message: { parts: Array<{ text: string }> } }
-  ).message.parts;
+    (params as { message: { parts: Array<{ text: string }> } }).message.parts;
   const firstPart = parts[0];
   if (firstPart === undefined) {
     throw new Error("Expected a message text part.");

--- a/packages/server/src/__tests__/integration/task/agent-to-agent.test.ts
+++ b/packages/server/src/__tests__/integration/task/agent-to-agent.test.ts
@@ -108,10 +108,10 @@ function sendText(
 }
 
 function notificationText(notification: { params: unknown }): string {
-  const parts = (
+  const parts =
     /* Safe because the test fixture establishes this asserted shape. */
-    notification.params as { message: { parts: Array<{ text: string }> } }
-  ).message.parts;
+    (notification.params as { message: { parts: Array<{ text: string }> } })
+      .message.parts;
   const firstPart = parts[0];
   if (firstPart === undefined) {
     throw new Error("Expected a notification text part.");

--- a/packages/server/src/__tests__/integration/task/messages-offline-delivery.test.ts
+++ b/packages/server/src/__tests__/integration/task/messages-offline-delivery.test.ts
@@ -196,10 +196,9 @@ function broadcastsWhenParticipantsAreOnline() {
     expect(sent.message.parts).toEqual([{ type: "text", text: HAPPY_TEXT }]);
 
     const received = yield* Fiber.join(receivedFiber);
-    const receivedMsg = (
+    const receivedMsg =
       /* Safe because the test fixture establishes this asserted shape. */
-      received.params as { message: Message }
-    ).message;
+      (received.params as { message: Message }).message;
     expect(receivedMsg.id).toBe(sent.message.id);
 
     const rows = yield* messageRowsForConversation(binding.conversationId);

--- a/packages/server/src/__tests__/integration/task/trace-spans.test.ts
+++ b/packages/server/src/__tests__/integration/task/trace-spans.test.ts
@@ -105,10 +105,8 @@ function expectHookBlocked(outcome: Either.Either<unknown, unknown>): void {
   Either.match(outcome, {
     onLeft: (error) => {
       expect(
-        (
-          /* Safe because the test fixture establishes this asserted shape. */
-          error as { _tag?: string }
-        )._tag,
+        /* Safe because the test fixture establishes this asserted shape. */
+        (error as { _tag?: string })._tag,
       ).toBe(WIRE_ERROR_TAG.HookBlocked);
     },
     onRight: () => expect.fail("expected HookBlockedError"),

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -199,10 +199,8 @@ function rejectsInvalidPort() {
       // port: -1 is rejected by structural validation (TypeBox, minimum: 1)
       // before the Effect Config decode, so it surfaces as kind "validation".
       expect(
-        (
-          /* Safe because the test fixture establishes this asserted shape. */
-          err as ConfigLoadError
-        ).kind,
+        /* Safe because the test fixture establishes this asserted shape. */
+        (err as ConfigLoadError).kind,
       ).toBe(VALIDATION_ERROR_KIND);
     }),
   );
@@ -311,10 +309,8 @@ function expectValidationRejection(body: string) {
       const err = expectFailureValue(exit);
       expect(err).toBeInstanceOf(ConfigLoadError);
       expect(
-        (
-          /* Safe because the test fixture establishes this asserted shape. */
-          err as ConfigLoadError
-        ).kind,
+        /* Safe because the test fixture establishes this asserted shape. */
+        (err as ConfigLoadError).kind,
       ).toBe(VALIDATION_ERROR_KIND);
     }),
   );

--- a/packages/server/src/db/effect-kysely-toolkit.test.ts
+++ b/packages/server/src/db/effect-kysely-toolkit.test.ts
@@ -44,10 +44,8 @@ describe("catchSqlErrorAsDefect pass-through", () => {
       const failure = expectFailure(yield* Effect.exit(program));
       expect(failure).toBeInstanceOf(ConflictError);
       expect(
-        (
-          /* Safe because the test fixture establishes this asserted shape. */
-          failure as ConflictError
-        ).message,
+        /* Safe because the test fixture establishes this asserted shape. */
+        (failure as ConflictError).message,
       ).toBe(TYPED_CONFLICT_MESSAGE);
     }));
 

--- a/packages/server/src/db/effect-kysely-toolkit.ts
+++ b/packages/server/src/db/effect-kysely-toolkit.ts
@@ -83,10 +83,8 @@ function commitViaExecute(this: {
  */
 function patchPrototype(prototype: object): void {
   Object.assign(prototype, Effectable.CommitPrototype);
-  (
-    /* Safe because the surrounding invariant establishes this asserted shape. */
-    prototype as { commit: unknown }
-  ).commit = commitViaExecute;
+  /* Safe because the surrounding invariant establishes this asserted shape. */
+  (prototype as { commit: unknown }).commit = commitViaExecute;
 }
 
 // Patch all compilable builder prototypes at module load. `SelectQueryBuilder`
@@ -236,10 +234,8 @@ export const transaction = <A, DB>(
 ): Effect.Effect<A, SqlError> =>
   Effect.tryPromise({
     try: () =>
-      (
-        /* Safe because the surrounding invariant establishes this asserted shape. */
-        db as Kysely<DB>
-      )
+      /* Safe because the surrounding invariant establishes this asserted shape. */
+      (db as Kysely<DB>)
         .transaction()
         .execute((trx) => Effect.runPromise(fn(trx))),
     catch: (cause) =>

--- a/packages/server/src/identity/contacts/contact.service.test.ts
+++ b/packages/server/src/identity/contacts/contact.service.test.ts
@@ -42,10 +42,9 @@ function rpcFailureTag(exit: Exit.Exit<unknown, unknown>): string | null {
   if (typeof value !== "object" || value === null) {
     return null;
   }
-  const tag = (
+  const tag =
     /* Safe because the test fixture establishes this asserted shape. */
-    value as { readonly _tag?: unknown }
-  )._tag;
+    (value as { readonly _tag?: unknown })._tag;
   return typeof tag === "string" ? tag : null;
 }
 

--- a/packages/server/src/task/task.service.test.ts
+++ b/packages/server/src/task/task.service.test.ts
@@ -100,10 +100,9 @@ function rpcFailureTag(exit: Exit.Exit<unknown, unknown>): string | null {
   if (typeof v !== "object" || v === null) {
     return null;
   }
-  const tag = (
+  const tag =
     /* Safe because the test fixture establishes this asserted shape. */
-    v as { readonly _tag?: unknown }
-  )._tag;
+    (v as { readonly _tag?: unknown })._tag;
   return typeof tag === "string" ? tag : null;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^9
         version: 9.39.4(jiti@1.21.7)
       eslint-plugin-agent-code-guard:
-        specifier: 0.0.16
-        version: 0.0.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+        specifier: 0.0.18
+        version: 0.0.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       husky:
         specifier: ^9.0.0
         version: 9.1.7
@@ -3605,10 +3605,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.59.3':
-    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.65.0':
     resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5128,8 +5124,8 @@ packages:
       eslint-plugin-import-x:
         optional: true
 
-  eslint-plugin-agent-code-guard@0.0.16:
-    resolution: {integrity: sha512-QqIvmn58wfJif6js1eZO3MlgDmB5VTfkq1XmWtcHEcIfYXU7oBRh0SmcK6gE3ViR9R22lQqlTL84BM1zGBPbfg==}
+  eslint-plugin-agent-code-guard@0.0.18:
+    resolution: {integrity: sha512-D3Ch3tDLr9rhh/07tnt4xsWhocyX1LBVzbO+qbZdYPZ71ZphEK43n4grFx5rvkWyX1luZicV5U9iiLPgzuDKIw==}
     hasBin: true
     peerDependencies:
       eslint: '>=9'
@@ -9939,7 +9935,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.86.0':
     dependencies:
       '@types/estree': 1.0.9
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/types': 8.65.0
       comment-parser: 1.4.6
       esquery: 1.7.0
       jsdoc-type-pratt-parser: 7.2.0
@@ -12956,8 +12952,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.59.3': {}
-
   '@typescript-eslint/types@8.65.0': {}
 
   '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
@@ -14558,7 +14552,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-agent-code-guard@0.0.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+  eslint-plugin-agent-code-guard@0.0.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@9.39.4(jiti@1.21.7))
       '@typescript-eslint/utils': 8.65.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
@@ -14579,7 +14573,7 @@ snapshots:
 
   eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/types': 8.65.0
       comment-parser: 1.4.6
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@1.21.7)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^9
         version: 9.39.4(jiti@1.21.7)
       eslint-plugin-agent-code-guard:
-        specifier: 0.0.18
-        version: 0.0.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+        specifier: 0.0.20
+        version: 0.0.20(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       husky:
         specifier: ^9.0.0
         version: 9.1.7
@@ -5124,8 +5124,8 @@ packages:
       eslint-plugin-import-x:
         optional: true
 
-  eslint-plugin-agent-code-guard@0.0.18:
-    resolution: {integrity: sha512-D3Ch3tDLr9rhh/07tnt4xsWhocyX1LBVzbO+qbZdYPZ71ZphEK43n4grFx5rvkWyX1luZicV5U9iiLPgzuDKIw==}
+  eslint-plugin-agent-code-guard@0.0.20:
+    resolution: {integrity: sha512-mzlJ4tI8BJ3oxrGYn4tATgM9UXiN+W7/chiidyfGxIiASsOlEEL/4/ehg/S0SmXXGeN3MgDNOKQ/KORKFbUJdA==}
     hasBin: true
     peerDependencies:
       eslint: '>=9'
@@ -14552,7 +14552,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-agent-code-guard@0.0.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+  eslint-plugin-agent-code-guard@0.0.20(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@9.39.4(jiti@1.21.7))
       '@typescript-eslint/utils': 8.65.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- pin `eslint-plugin-agent-code-guard` 0.0.20 and remove the deleted quality-gate override
- apply the existing Oxfmt cleanup requested across the affected TypeScript files
- retain Nx as the workspace task runner; no formatting gate is added
- consume the ACG assertion-rationale fix validated against this exact formatted corpus

## Verification

- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`