### PR TITLE
chore(nx): cache pre-commit checks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 set -e
 
-pnpm exec oxfmt .
-pnpm docs:generate
+pnpm nx run workspace:format
+pnpm nx run workspace:docs:generate
 
 if ! git diff --quiet; then
   echo ""
@@ -10,13 +10,4 @@ if ! git diff --quiet; then
   exit 1
 fi
 
-# The CI `docs:check:drift` gate is more than the regen-idempotency check above:
-# it also rejects hardcoded constants in docs and unresolvable doc imports. Run
-# those two here so the hook catches what CI does, not just generated-file drift.
-pnpm docs:check:no-hardcoded-constants
-pnpm docs:check:doc-imports-resolve
-
-pnpm check
-pnpm build
-pnpm exec nx run-many -t typecheck:tests
-./scripts/sloppy-code-guard.sh
+pnpm nx run workspace:precommit

--- a/nx.json
+++ b/nx.json
@@ -13,6 +13,30 @@
       "!{projectRoot}/vitest.config.mjs",
       "!{projectRoot}/vitest.integration.config.mjs"
     ],
+    "workspaceFiles": [
+      "{workspaceRoot}/**/*"
+    ],
+    "docsGeneration": [
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/pnpm-lock.yaml",
+      "{workspaceRoot}/typedoc.json",
+      "{workspaceRoot}/scripts/generate-constants-snippets.ts",
+      "{workspaceRoot}/packages/**/*.json",
+      "{workspaceRoot}/packages/**/*.ts",
+      "!{workspaceRoot}/packages/**/*.test.ts",
+      "!{workspaceRoot}/packages/**/src/__tests__/**/*",
+      "!{workspaceRoot}/packages/**/dist/**/*",
+      "!{workspaceRoot}/packages/**/src/**/MODULE.md",
+      "{workspaceRoot}/docs/**/*",
+      "!{workspaceRoot}/docs/modules/**/*",
+      "!{workspaceRoot}/docs/protocol/methods/**/*",
+      "!{workspaceRoot}/docs/protocol/notifications/**/*",
+      "!{workspaceRoot}/docs/cli/reference.mdx",
+      "!{workspaceRoot}/docs/snippets/cli-commands-table.mdx",
+      "!{workspaceRoot}/docs/snippets/cli-global-flags.mdx",
+      "!{workspaceRoot}/docs/snippets/constants/**/*",
+      "!{workspaceRoot}/docs/snippets/ws-connect-example.mdx"
+    ],
     "sharedGlobals": [
       "{workspaceRoot}/tsconfig.base.json",
       "{workspaceRoot}/tsconfig.json"
@@ -74,6 +98,17 @@
       "cache": true
     },
     "arch:check": {
+      "dependsOn": [
+        {
+          "target": "arch:config:generate",
+          "projects": "workspace"
+        }
+      ],
+      "options": {
+        "env": {
+          "NODE_OPTIONS": "--max-old-space-size=8192"
+        }
+      },
       "inputs": [
         "default",
         "{projectRoot}/safer-architecture.config.json"

--- a/packages/simulator/src/package-exports.test.ts
+++ b/packages/simulator/src/package-exports.test.ts
@@ -57,7 +57,7 @@ describe("@moltzap/simulator package exports", () => {
     expect(ledgerApi).not.toHaveProperty("makeRunLedger");
   });
 
-  it("exposes one definition constructor through Simulator", () => {
+  it("exposes one definition constructor through simulator", () => {
     expect(customerApi).not.toHaveProperty("defineSimulator");
     expect(customerApi.simulator).toHaveProperty("define");
   });

--- a/scripts/test-simulator-packages.mjs
+++ b/scripts/test-simulator-packages.mjs
@@ -92,7 +92,7 @@ async function verifyConsumerImports(extractedPackage) {
       'import * as simulator from "@moltzap/simulator";',
       'import * as network from "@moltzap/simulator/network";',
       'import * as ledger from "@moltzap/simulator/ledger";',
-      'for (const name of ["Simulator", "effectRuntime", "openClawRuntime", "nanoclawRuntime", "simulatorLayer"]) {',
+      'for (const name of ["simulator", "effectRuntime", "openClawRuntime", "nanoclawRuntime", "simulatorLayer"]) {',
       "  if (!(name in simulator)) throw new Error(`missing root export ${name}`);",
       "}",
       'if (!("RouterProvider" in network)) throw new Error("missing network RouterProvider");',

--- a/tools/workspace/project.json
+++ b/tools/workspace/project.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "workspace",
+  "targets": {
+    "format": {
+      "cache": false,
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "oxfmt ."
+      }
+    },
+    "format:check": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "oxfmt --check ."
+      }
+    },
+    "docs:generate": {
+      "cache": true,
+      "dependsOn": [
+        {
+          "target": "build",
+          "projects": "@moltzap/client"
+        }
+      ],
+      "inputs": [
+        "docsGeneration"
+      ],
+      "outputs": [
+        "{workspaceRoot}/docs",
+        "{workspaceRoot}/packages/**/src/**/MODULE.md"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "parallel": false,
+        "commands": [
+          "pnpm --filter @moltzap/protocol docs:generate",
+          "pnpm --filter @moltzap/client exec tsx scripts/generate-cli-docs.ts",
+          "pnpm --filter @moltzap/server-core exec tsx ../../scripts/generate-constants-snippets.ts"
+        ]
+      }
+    },
+    "docs:check:no-hardcoded-constants": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "pnpm --filter @moltzap/server-core exec tsx ../../scripts/check-no-hardcoded-constants.ts"
+      }
+    },
+    "docs:check:doc-imports-resolve": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "pnpm --filter @moltzap/server-core exec tsx ../../scripts/check-doc-imports-resolve.ts"
+      }
+    },
+    "arch:config:generate": {
+      "cache": true,
+      "inputs": [
+        "{workspaceRoot}/scripts/gen-architecture-configs.mjs"
+      ],
+      "outputs": [
+        "{workspaceRoot}/packages/*/safer-architecture.config.json"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "node scripts/gen-architecture-configs.mjs"
+      }
+    },
+    "arch:config:check": {
+      "cache": false,
+      "dependsOn": [
+        "arch:config:generate"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "git diff --exit-code -- 'packages/*/safer-architecture.config.json'"
+      }
+    },
+    "lint:architecture-boundaries": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "node scripts/check-architecture-boundaries.js"
+      }
+    },
+    "lint:typescript": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "tsc --noEmit -p tsconfig.eslint.json"
+      }
+    },
+    "lint:dead-code": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "agent-code-guard-knip --treat-config-hints-as-errors"
+      }
+    },
+    "lint:eslint": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "eslint . --cache --max-warnings=0"
+      }
+    },
+    "lint:oxlint": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "oxlint . --deny-warnings"
+      }
+    },
+    "lint:sloppy-code-guard": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "./scripts/sloppy-code-guard.sh"
+      }
+    },
+    "lint:root": {
+      "cache": false,
+      "dependsOn": [
+        "lint:typescript",
+        "lint:dead-code",
+        "lint:eslint"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "node -e \"\""
+      }
+    },
+    "lint": {
+      "cache": false,
+      "dependsOn": [
+        "lint:architecture-boundaries",
+        "arch:config:check",
+        "lint:root",
+        "lint:oxlint",
+        {
+          "target": "arch:check",
+          "projects": "@moltzap/*"
+        },
+        {
+          "target": "lint",
+          "projects": "@moltzap/*"
+        }
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "node -e \"\""
+      }
+    },
+    "check": {
+      "cache": false,
+      "dependsOn": [
+        "lint",
+        "format:check"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "node -e \"\""
+      }
+    },
+    "precommit": {
+      "cache": false,
+      "dependsOn": [
+        "docs:check:no-hardcoded-constants",
+        "docs:check:doc-imports-resolve",
+        "check",
+        "lint:sloppy-code-guard",
+        {
+          "target": "build",
+          "projects": "@moltzap/*"
+        },
+        {
+          "target": "typecheck:tests",
+          "projects": "@moltzap/*"
+        }
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "node -e \"\""
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- model the root formatting, documentation, lint, architecture, build, and test-typecheck work as Nx targets
- keep Oxfmt as an uncached writer and keep Git drift checks uncached
- route the pre-commit hook through the resolved Nx project graph so package work is cacheable

## Verification

- cold `nx run workspace:precommit`
- warm run restored 50 of 55 tasks from cache
- direct `.husky/pre-commit` run
- generated-document tamper/regeneration probe

No CI formatting gate was added.