### PR TITLE
fix(nx): build packages before test typechecking

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -58,6 +58,7 @@
     },
     "typecheck:tests": {
       "dependsOn": [
+        "build",
         "^build"
       ],
       "inputs": [


### PR DESCRIPTION
## Summary

- make each `typecheck:tests` task depend on its own package build
- prevent cold Nx runs from resolving package self-imports before `dist` exists

## Verification

- resolved graph contains `@moltzap/protocol:build -> @moltzap/protocol:typecheck:tests`
- uncached protocol test typecheck passes
- full workspace pre-commit graph passes

This fixes the cold-run race exposed by the v2 merge CI.