### PR TITLE
docs(harness): reconcile implementation slate with lease-free production

### DIFF
--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -1,6 +1,6 @@
 # Components
 
-Status: GATE 1 CANDIDATE — BLIND REVIEW REQUIRED
+Status: GATE 1 AUTHORITY REVIEWED — IMPLEMENTATION READINESS VARIES BY OWNER
 
 Decision owners:
 [`20260728-six-deep-packages-one-version.md`](../decisions/20260728-six-deep-packages-one-version.md),

--- a/docs/architecture/first-implementation.md
+++ b/docs/architecture/first-implementation.md
@@ -2,7 +2,7 @@
 
 {/* @bake-constants: V2_PROTOCOL_VERSION */}
 
-Status: **HARNESS AUTHORITY CANDIDATE — BLIND REVIEW REQUIRED BEFORE HARNESS CODE**
+Status: **HARNESS AUTHORITY REVIEWED — IMPLEMENTATION READINESS VARIES BY OWNER**
 
 The complete approved L1 and L2 handoff is
 [`l1-l2-implementation-ask.md`](./l1-l2-implementation-ask.md). That

--- a/docs/architecture/harness-implementation-slate.md
+++ b/docs/architecture/harness-implementation-slate.md
@@ -25,9 +25,10 @@ NanoClaw ── HarnessClient ────────┘      ├─ /register/
   `HarnessManagement` service.
 - Backings retain different raw MCP messages and implementations while their
   `HarnessClient` service values interoperate structurally at compile time.
-- There is no runtime generation selection, shared production implementation
-  package, FastMCP dependency, bespoke CLI, Unix RPC socket, second MCP
-  process, or generic send.
+- The target state has no runtime generation selection, shared production
+  implementation package, FastMCP dependency, bespoke CLI, Unix RPC socket,
+  second MCP process, or generic send. The implementation-state section below
+  distinguishes that target from landed production and open candidate work.
 
 ## Scope rule
 
@@ -51,6 +52,33 @@ The retained clean-slate MCP, OpenFloor, Ledger, reply receipt, retry,
 reconciliation, supervision, and explicit resource-limit deferrals remain the
 implementation baseline.
 
+## Implementation state
+
+This section reports repository state as of 2026-08-04. It does not admit or
+supersede a contract.
+
+- **Landed production:** `origin/main@27bd6f4e` includes the daemon-owned
+  receive/reply foundation from #942. Production has no dispatch package,
+  `LeaseId`, `conversation_busy`, server-side reply grant, or local
+  duplicate-reply guard. The daemon publishes one nonempty same-conversation
+  `Message` batch, and `HarnessClient` retains the originating
+  `ConversationId` privately for `reply(payload)`. Every reply invocation
+  sends.
+- **Open production candidates:** #943 isolates presentation state; #944 adds
+  paginated MCP search/history; #945 reconstructs context with an injected
+  local Effect `KeyValueStore`; #946 adds MCP-local conversation participants
+  and the public presentation turn; #947 packages `moltzapd`; and #948 adds
+  `start_conversation`. None of these candidates is present in `origin/main`.
+- **Still pending in production:** durable profile-to-MCP endpoint
+  acquisition, registration through `/register/mcp`, OpenClaw and NanoClaw
+  cutover, replacement of every remaining operator workflow, and deletion of
+  the generic send, bespoke CLI, and Unix socket.
+- **Clean-slate:** `origin/v2@7329cfb0` contains the reviewed Harness
+  vocabulary and package rename, but `v2/harness` remains a scaffold and its
+  `moltzapd` executable is not implemented. `v2/transcript` is also a scaffold;
+  its exact representation owner and public Ledger contract remain
+  prerequisites for a real clean-slate Harness composition.
+
 ## Local MCP and management
 
 One `moltzapd` listener serves a registration path and an active path.
@@ -68,30 +96,37 @@ formed from:
 - `start_conversation`; and
 - backing-specific raw `reply`.
 
-Receive remains `subscriptions/listen`, not a tool. Search uses `search_*`,
-returns pages, and introduces no Harness-specific agent/conversation summary or
-new domain value. Empty-query behavior and the exact backing-owned agent and
-conversation result projections remain owner decisions; this slate does not
-close them.
+Receive remains `subscriptions/listen`, not a tool. On landed production, the
+active catalog contains only `status` and `reply`; the registration catalog is
+empty. Candidate #944 adds `search_agents`, `search_conversations`, and
+`read_conversation` using the selected production exact-match/blank-browse
+paginated behavior. Candidate #948 adds `start_conversation`. Those candidates
+do not assign the clean-slate backing's result representations or errors.
+
+Candidate #946 enriches the production MCP-local `Conversation` passed to the
+`HarnessClient` implementation with participants. Participants are local
+presentation data: the canonical production `Conversation` and the main
+WebSocket protocol remain unchanged, and the client does not write the
+enrichment back onto that wire.
 
 The lower-layer Registry, Router, and Ledger method names and network contracts
 do not change. The local MCP presentation does not create a new network plane.
 
 ### Branch-owned registration work
 
-The clean-slate daemon presents its already accepted Registry bootstrap through
+The clean-slate daemon presents its accepted Registry bootstrap through
 `/register/mcp`; its OperationId, admission, verification, and recovery
-contracts do not change.
+contracts remain clean-slate-owned.
 
-The production migration has a separate `main`-owned requirement selected in
-the source review: registration is idempotent and crash-recoverable, using a
-stable OperationId and client-owned recoverable credential so intent can be
-persisted before the server call. Identical retries
-recover the same identity and credential. The exact credential generation,
-staging file, fingerprint, changed-input behavior, and storage algorithm were
-not selected and are not part of this slate. This v2 authority candidate
-records that dependency but does not amend the production branch's public
-contract.
+Production registration is not implemented at `/register/mcp`.
+`origin/main` still uses the existing HTTP bootstrap and CLI profile
+persistence. This slate does not introduce a production OperationId,
+crash-recovery, credential-staging, fingerprint, changed-input, or storage
+contract. Production must either translate already owned behavior or wait for
+a separately admitted `main`-owned registration contract. The current
+clean-slate management spec describes a selected production recovery contract;
+that cross-branch authority mismatch requires reconciliation before
+implementation relies on it.
 
 ## HarnessClient boundary
 
@@ -106,20 +141,22 @@ Registration, status, search, and history are MCP management operations, not
 public `HarnessClient` methods. The client uses conversation search and history
 privately for checkpoint reconstruction.
 
-Raw provider correlation stays private to the implementation. The production
-client captures its dispatch lease. The clean-slate client captures its TxnId;
-its payload-only action selection remains excluded when several legal actions
-are present until the OpenFloor/task owner decides that mapping. OpenClaw and
-NanoClaw see none of those fields and never construct daemon or protocol
-services.
+Raw backing correlation stays private. The production client retains the
+originating `ConversationId` in private MCP request metadata and every call to
+the bound `reply(payload)` closure sends. It has no dispatch lease, reply token,
+action identifier, turn identifier, or duplicate-reply suppression. The
+clean-slate client retains its backing-owned TxnId and action selection
+internally; plural-action projection remains with the OpenFloor/task owner.
+OpenClaw and NanoClaw see none of those fields and never construct daemon or
+protocol services.
 
-`HarnessClient` owns cross-conversation presentation state. Content-only
-observations update context and never invoke the model. A later grant remains
-eligible even when its content was already observed. Stable local presentation
-checkpoints advance immediately before a turn is emitted. After restart, the
-client rebuilds context through search and history reads, which never recreate
-a grant. A crash after checkpoint advancement but before runtime receipt can
-lose that context; the client does not add a runtime acknowledgment or replay.
+Production notifications are reply-capable nonempty coalesced `Message`
+batches, not separate content and grant events. Candidate #945 reconstructs
+other-conversation content from search/history and stores stable presentation
+checkpoints through an injected local `KeyValueStore`; candidate #946 projects
+that state into the public turn. The checkpoint storage path and durable
+profile integration remain unselected. The clean-slate backing retains its
+separately owned content/grant and recovery mechanics.
 
 ## Runtime slice 1: dispatch and ingress
 
@@ -128,25 +165,33 @@ common client behavior.
 
 Production work:
 
-1. Move ownership of `MoltZapService`, `MoltZapChannelCore`, the long-lived
-   network connection, and dispatch leases into `moltzapd`.
-2. Make the server reserve by ConversationId so a second live request returns
-   `conversation_busy` and creates no lease.
-3. Keep blocked work pending for local retry without blocking other
-   conversations.
-4. Emit conversation-labelled content and lease-backed grant observations over
-   the production-owned MCP extension.
-5. Implement the production `HarnessClient` context/checkpoint projection.
+1. Treat #942's daemon-owned receive/reply foundation as landed.
+2. Do not recreate dispatch leases, `conversation_busy`, server-side
+   reservation, grants, holds, or local duplicate-reply suppression removed by
+   #941.
+3. Land the read, reconstruction, participant-enrichment, and public-turn
+   candidates in dependency order (#943 through #946).
+4. Preserve the production event as one nonempty same-conversation raw
+   `Message` batch whose reply closure privately retains its originating
+   `ConversationId`.
+5. Add durable profile-to-MCP endpoint acquisition before adapters depend on
+   the packaged daemon.
 
 Clean-slate work:
 
-1. Build the real `v2/harness` daemon and client composition around the
-   accepted Registry, Router, Ledger, SharedCore, and OpenFloor services.
-2. Retain per-conversation grants, TxnId/action authority, Ledger recovery, the
+1. Admit the Transcript representation owner and exact public Ledger contract,
+   then implement `v2/transcript`; do not invent those representations inside
+   `v2/harness`.
+2. Admit the exact management projections, content-only ingress,
+   `HarnessClient` contract, checkpoint representation, and any required
+   plural-action mapping before implementing those respective surfaces.
+3. Build only admitted `v2/harness` daemon and client slices around the
+   implemented Registry, Router, Ledger, SharedCore, and OpenFloor services.
+4. Retain per-conversation grants, TxnId/action authority, Ledger recovery, the
    accepted MCP subscription, and raw reply behavior.
-3. Move runtime context presentation from daemon attention watermarks to the
+5. Move runtime context presentation from daemon attention watermarks to the
    clean-slate `HarnessClient` checkpoints.
-4. Keep the raw extension backing-owned; do not introduce a shared replacement
+6. Keep the raw extension backing-owned; do not introduce a shared replacement
    wire in this slice.
 
 The clean-slate conversation-search projection waits for its Transcript-owned
@@ -156,29 +201,33 @@ persistence to close that dependency.
 
 Common acceptance:
 
-- after each backing owns its content-only representation, content without
-  authority never runs a model and a later grant is not lost with duplicate
-  content;
-- one conversation never has two live authorities;
-- different conversations can progress as allowed by the retained backings;
+- production serializes and coalesces inbound work in its endpoint-local
+  consumer and routes every bound reply invocation to the originating
+  conversation;
+- clean-slate same-conversation authority remains governed by its retained
+  grant/TxnId mechanics;
+- no production lease, `conversation_busy`, or server grant is recreated;
 - listen remains sole-owner, acknowledgment-first, transient, and at most
   once; and
-- after search/history representations are admitted, restart rebuilds context
-  but never reconstructs an old grant.
+- after each backing's search/history representation exists, restart can
+  rebuild presentation context without reconstructing reply authority.
 
 ## Runtime slice 2: model output
 
 Production work:
 
-1. Expose conversation start with other-agent names and initial content using
-   the production domain's already owned mechanics; do not invent a new
-   production atomicity or recovery contract.
-2. Replace adapter-visible lease/send calls with the turn-bound
-   `reply(payload)` closure.
+1. Land #948's `start_conversation` candidate: other-agent names plus required
+   initial content, self implicit, using existing create-then-send mechanics
+   without a new atomicity or recovery promise.
+2. Migrate OpenClaw and NanoClaw from direct
+   `MoltZapService`/`MoltZapChannelCore` ownership to `HarnessClient` and prove
+   each real daemon/MCP path.
 3. Remove generic send from the production server, protocol, client, CLI,
-   exports, and all first-party callers.
-4. Preserve the existing production dispatch lease internally until its
-   separate retirement.
+   exports, and first-party callers only after start and bound reply cover
+   their required model-output behavior.
+4. Remove the bespoke CLI and Unix RPC only after every first-party operator
+   workflow has an MCP replacement. There is no production lease-retirement
+   step; #941 already removed that system.
 
 Clean-slate work:
 
@@ -191,51 +240,62 @@ Clean-slate work:
 
 Common acceptance:
 
-- a runtime starts with names and initial content and replies with payload only
-  when its authority identifies one action unambiguously or the owner has
-  admitted a payload-to-action mapping;
-- a delayed reply retains the authority of its originating turn;
+- a production runtime starts with names and initial content and replies with
+  payload only;
+- the clean-slate client exposes payload-only reply only when the backing
+  identifies one legal action unambiguously or its owner admits the
+  payload-to-action mapping;
+- a delayed production reply retains its originating `ConversationId`, while
+  the clean-slate backing retains its own raw authority privately;
+- production reply has no server grant and every invocation sends; the
+  clean-slate backing continues to enforce its retained authority;
 - no ungranted fallback or generic send remains; and
 - the clean-slate raw wire conformance suite stays unchanged.
 
 ## Delivery order
 
-1. Treat the admitted ADR/spec candidate and the clean-slate deep-package
-   rename as preparatory work already completed on the clean-slate branch.
-2. Refactor the production implementation in-line on `main`: enforce its
-   conversation dispatch authority, build the one-listener `moltzapd` MCP
-   boundary, move service/core ownership into the daemon, and implement its
-   `HarnessClient` projection.
-3. Implement the production model-output slice, migrate OpenClaw and NanoClaw
-   to `HarnessClient`, and remove generic send, the bespoke CLI, and Unix RPC
-   only after their MCP replacements are operational.
-4. Keep implementation of each unassigned surface out of scope until its
-   owner admits it: exact `HarnessClient` Effect signatures/errors, management
-   MCP Schemas/errors, agent/conversation search results and empty-query
-   behavior, clean-slate content-only event representation, and
-   payload-to-action mapping for plural legal actions.
-5. Forward-merge the completed production changes according to the
-   repository's branch policy.
-6. Build the clean-slate `moltzapd` composition and its independently owned
-   `HarnessClient` using only retained profile, transport, raw START/reply,
-   grant-listen, Registry, Router, Ledger, SharedCore, and OpenFloor contracts.
-7. Finish clean-slate parity without `v2/* -> packages/*` imports, runtime
+1. Treat the clean-slate authority/package rename (#938) and the landed
+   production receive/reply foundation (#942) as completed prerequisites.
+2. Land #943 through #948 in stack order, preserving their distinction from
+   `origin/main` until each PR merges.
+3. Add a production profile-to-MCP endpoint acquisition contract. Candidate
+   #947 currently requires a caller-supplied nonzero port; production profiles
+   do not yet store or discover one.
+4. Cut OpenClaw and NanoClaw to `HarnessClient` and add behavioral fake-client
+   tests plus real daemon/MCP adapter integration.
+5. Implement production registration and remaining operator MCP tools, then
+   delete generic send, the bespoke CLI, and Unix RPC after all first-party
+   replacements are operational.
+6. Forward-merge landed production changes under repository branch policy.
+7. Before clean-slate implementation relies on production claims, reconcile
+   the current v2 ADR/spec references to production dispatch leases,
+   `conversation_busy`, and a selected production registration-recovery
+   contract with lease-free `main` and its unselected registration contract.
+   This slate records those mismatches but does not amend or supersede those
+   authorities.
+8. Admit the Transcript representation owner and exact public Ledger contract,
+   then implement `v2/transcript` and the Ledger process.
+9. Admit the remaining exact clean-slate management, content-ingress,
+   `HarnessClient`, checkpoint, and plural-action contracts before composing
+   their corresponding Harness slices. Transcript readiness is not the only
+   gate.
+10. Finish clean-slate parity without `v2/* -> packages/*` imports, runtime
    generation selection, or a shared backing implementation.
 
 ## Verification
 
 | Level | Required evidence |
 |---|---|
-| Unit | After the exact client contract lands, pure context grouping/deduplication, checkpoint transition, admitted bound-turn behavior, and ConversationId reservation using fake capabilities. |
-| Server integration | Branch-owned same-conversation exclusion, distinct-conversation progress, existing raw START/reply/receipt behavior, and management projections after their Schemas are admitted. |
-| Production registration integration | Lost-response and daemon-restart retries recover the same production identity and credential without importing clean-slate code; no unselected changed-input behavior is asserted. |
+| Unit | After the exact client contract lands, pure context grouping/deduplication, checkpoint transition, and lease-free bound-reply behavior using fake capabilities. |
+| Server integration | Existing production message delivery plus clean-slate backing-owned authority tests; do not require a production `conversation_busy` path. |
+| Production registration integration | Add lost-response/restart assertions only after a `main`-owned registration recovery contract is admitted; this slate selects none. |
 | MCP integration | Real loopback HTTP/SSE, retained discovery/acknowledgment/listener behavior, plus backing-specific observations and generic management tools only after their representations are admitted. |
 | Restart integration | Context reconstruction from stable checkpoints and history without grant reconstruction; retained daemon/Ledger recovery. |
 | Adapter unit | Fake `HarnessClient` turns drive observable OpenClaw and NanoClaw session/callback behavior. |
 | Adapter integration | A real peer message reaches each runtime through server, `moltzapd`, MCP, and `HarnessClient`; reply returns through its originating authority. |
 | Conformance | After both exact branch-owned contracts land, the two service values pass the same consumer suite and bidirectional positive type canary. |
 | Architecture | Adapters cannot import or construct daemon internals; clean-slate code cannot import production packages; deleted CLI/socket/send exports are absent. |
-| Package/process | Packed installation starts `moltzapd`, exposes MCP without a Unix socket, and contains no second MoltZap MCP/CLI executable. |
+| Package/process | Candidate #947 proves packed `moltzapd`, direct WebSocket ownership, clean shutdown, and no daemon-created Unix socket. Final evidence must additionally prove profile-based endpoint acquisition and absence of the transitional `moltzap` executable. |
 
 Import or constructor inspection is an architecture check, not a unit test.
 Transport and process ownership are integration or package tests, not unit
@@ -243,8 +303,10 @@ tests.
 
 ## Completion criteria
 
-- The exact ADR/spec candidate passes the repository's isolated six-question
-  blind review.
+- The clean-slate authority/package-rename prerequisite is landed. Any
+  semantic ADR/spec reconciliation required by current production state must
+  pass its own repository review gate before clean-slate implementation relies
+  on it.
 - Issue #926 mirrors this transcript-scoped slate.
 - Both runtime slices pass their behavioral, integration, conformance,
   architecture, and package gates.


### PR DESCRIPTION
## What changed

- Reconciles the non-normative Harness implementation slate with lease-free production after #941 and the daemon receive/reply foundation in #942.
- Separates landed production from open candidates #943 through #948 and from the target state.
- Records participant enrichment as loopback-MCP-only presentation data passed to the HarnessClient implementation; the canonical production Conversation and main WebSocket wire remain unchanged.
- Records the still-unselected production profile-to-MCP acquisition and durable checkpoint composition instead of inventing them.
- Makes the clean-slate prerequisites explicit: v2/transcript and v2/harness remain scaffolds, and Transcript/Ledger plus the remaining management, ingress, HarnessClient, checkpoint, and plural-action contracts must be admitted before their corresponding implementation slices.
- Flags existing v2 authority drift around production leases and registration recovery without changing an ADR or normative spec.

## Why

The previous slate still described dispatch leases, conversation_busy, server grants, duplicate-reply suppression, and selected production registration recovery. Those claims no longer match current main or do not have a main-owned contract. The implementation handoff needs to describe current evidence without silently turning unresolved mechanics into requirements.

## Scope

This is an implementation-state and sequencing update only. It does not modify an ADR, normative specification, main-wire schema, runtime code, or clean-slate contract.

## Validation

- `pnpm nx run workspace:precommit`
- `pnpm docs:check:drift`
- `git diff --check`
- Independent factual review, followed by a clean re-review after both findings were corrected

## Related

- Tracks #926
- Production candidate stack: #943, #944, #945, #946, #947, #948
- Upstream v1 control-plane simplification: https://github.com/chughtapan/moltzap/pull/924
