### PR TITLE
fix(openclaw): release the gateway binding when the status callback throws

### DIFF
--- a/docs/modules/openclaw-channel/src.mdx
+++ b/docs/modules/openclaw-channel/src.mdx
@@ -15,7 +15,7 @@ runtime entries from `index.*` at the extension root only, so the built
 
 ## Public surface
 
-### [`createMoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1226)
+### [`createMoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1235)
 
 _Function_
 
@@ -63,7 +63,7 @@ to `agent:&lt;name>`. Other colon-prefixed shapes are rejected.
 
 **Returns:** The created moltzap channel plugin.
 
-### [`default`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1256)
+### [`default`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1265)
 
 _Variable_
 
@@ -71,7 +71,7 @@ _Variable_
 const plugin =
 ```
 
-### [`moltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1253)
+### [`moltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1262)
 
 _Variable_
 
@@ -84,7 +84,7 @@ Shared singleton so a single registration reuses the same `activeClients`
 closure across `startAccount` and `sendText`. Tests import this directly
 to assert against that shared state.
 
-### [`MoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1244)
+### [`MoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L1253)
 
 _TypeAlias_
 

--- a/packages/openclaw-channel/src/MODULE.md
+++ b/packages/openclaw-channel/src/MODULE.md
@@ -10,7 +10,7 @@ runtime entries from `index.*` at the extension root only, so the built
 
 ## Public surface
 
-### [`createMoltzapChannelPlugin`](./openclaw-entry.ts#L1226)
+### [`createMoltzapChannelPlugin`](./openclaw-entry.ts#L1235)
 
 _Function_
 
@@ -58,7 +58,7 @@ to `agent:&lt;name>`. Other colon-prefixed shapes are rejected.
 
 **Returns:** The created moltzap channel plugin.
 
-### [`default`](./openclaw-entry.ts#L1256)
+### [`default`](./openclaw-entry.ts#L1265)
 
 _Variable_
 
@@ -66,7 +66,7 @@ _Variable_
 const plugin =
 ```
 
-### [`moltzapChannelPlugin`](./openclaw-entry.ts#L1253)
+### [`moltzapChannelPlugin`](./openclaw-entry.ts#L1262)
 
 _Variable_
 
@@ -79,7 +79,7 @@ Shared singleton so a single registration reuses the same `activeClients`
 closure across `startAccount` and `sendText`. Tests import this directly
 to assert against that shared state.
 
-### [`MoltzapChannelPlugin`](./openclaw-entry.ts#L1244)
+### [`MoltzapChannelPlugin`](./openclaw-entry.ts#L1253)
 
 _TypeAlias_
 

--- a/packages/openclaw-channel/src/openclaw-entry.delivery.test.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.delivery.test.ts
@@ -52,6 +52,9 @@ const OUTBOUND_TEXT = "Hello from outbound";
 const AGENT_TEXT = "Hello nova";
 const BEFORE_STOP_TEXT = "before stop";
 const AFTER_STOP_TEXT = "after stop";
+const AFTER_STATUS_FAILURE_TEXT = "after status failure";
+const STATUS_FAILURE_ACCOUNT_ID = "status-failure-test";
+const STATUS_CALLBACK_MESSAGE = "status callback failed";
 const LOOKUP_FAILED_MESSAGE = "lookup failed";
 const SERVER_REJECTED_MESSAGE = "Server rejected";
 const INTERNAL_SERVER_ERROR_MESSAGE = "Internal server error";
@@ -160,6 +163,10 @@ describe("Flow 6: Outbound delivery - deliver callback + sendText", () => {
   it("deliver reports transient RPC send failures", sendFailureIsReported);
   it("a later delivery retries after a send failure", retriesAfterSendFailure);
   it("stopAccount removes client from active pool", stopRemovesClient);
+  it(
+    "releases the gateway when the status callback throws",
+    statusFailureReleasesGateway,
+  );
   it(
     "property: resolveTarget normalizes generated agent names",
     plainAgentNamesResolve,
@@ -611,6 +618,54 @@ function stopRemovesClient() {
       accountId: ACCOUNT_ID,
     });
     expectFailureMessage(afterResult, /not connected/i);
+  });
+}
+
+// The host's setStatus is arbitrary caller code. Effect.sync surfaces a throw
+// from it as a defect, which the connect path's catchAll does not observe, so
+// this asserts on the binding rather than on the raised error.
+function statusFailureReleasesGateway() {
+  return Effect.gen(function* () {
+    const fixture = createFakeChannelService({ ownAgentId: SELF_AGENT_ID });
+    const setStatus = vi.fn(() => {
+      throw new Error(STATUS_CALLBACK_MESSAGE);
+    });
+    const plugin = createMoltzapChannelPlugin({
+      createService: () => fixture.service,
+    });
+    const abortController = new AbortController();
+    abortControllers.push(abortController);
+
+    yield* Effect.ignore(
+      Effect.tryPromise({
+        try: () =>
+          plugin.gateway.startAccount({
+            cfg: makeCfg(),
+            accountId: STATUS_FAILURE_ACCOUNT_ID,
+            account: makeAccount(),
+            abortSignal: abortController.signal,
+            log: testLogger(),
+            setStatus,
+          }),
+        catch: (cause) => cause,
+      }),
+    );
+
+    expect(setStatus).toHaveBeenCalledTimes(1);
+    expect(fixture.state.closeCalls.count).toBe(1);
+
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        plugin.outbound.sendText({
+          cfg: makeCfg(),
+          to: STOP_TARGET,
+          text: AFTER_STATUS_FAILURE_TEXT,
+          accountId: STATUS_FAILURE_ACCOUNT_ID,
+        }),
+      catch: (cause) =>
+        new DeliveryTestError({ message: "sendText failed", cause }),
+    });
+    expectFailureMessage(result, /not connected/i);
   });
 }
 

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -769,7 +769,14 @@ function startGatewayAccountEffect(
       },
       { once: true },
     );
-    yield* connectGatewayCore(core, service, ctx, setStatus);
+    // The binding is registered before connecting, so anything that escapes the
+    // connect path — including a host setStatus callback that throws, which
+    // Effect.sync surfaces as a defect rather than a failure — must release it.
+    yield* connectGatewayCore(core, service, ctx, setStatus).pipe(
+      Effect.onError(() =>
+        Effect.ignore(disconnectAndRemove(core, activeClients, accountId)),
+      ),
+    );
   });
 }
 
@@ -799,9 +806,11 @@ function disconnectAndRemove(
   activeClients: Map<string, OpenClawClientService>,
   accountId: string,
 ) {
+  // A disconnect that fails must still drop the binding; leaving it registered
+  // would strand the account with no route to recovery.
   return core
     .disconnect()
-    .pipe(Effect.tap(() => Effect.sync(() => activeClients.delete(accountId))));
+    .pipe(Effect.ensuring(Effect.sync(() => activeClients.delete(accountId))));
 }
 
 interface RegisterInboundHandlerParams {


### PR DESCRIPTION
Plan step 2. Based on `origin/main`, deliberately **not** on the #943→#951 stack: this bug is pre-existing in production, and per the plan's D3 the legacy path stays reachable in production until the OpenClaw cutover lands. This shortens that exposure window and merges independently of the endpoint chain.

## The bug

`startGatewayAccountEffect` registers the account in `activeClients` *before* connecting, then ends with `connectGatewayCore(...)` and no cleanup.

The host's `setStatus` is arbitrary caller code. `reportConnected` invokes it inside `Effect.sync`, so a throw surfaces as a **defect**, not a failure — and `connectGatewayCore`'s `Effect.catchAll` only observes failures. The defect escapes with the binding still registered and the core never disconnected: the account is wedged with no route to recovery.

## The fix

Two changes, same defect class:

1. Release the binding on anything escaping the connect path (`Effect.onError`, which observes defects as well as failures).
2. `disconnectAndRemove` uses `Effect.ensuring` instead of `Effect.tap`, so a *failing* disconnect still drops the entry. This matches `disconnectCoreOnAbort`, which already used `Effect.ensuring` — that inconsistency was the tell.

No public surface change: the diff adds and removes no exported symbol, type, or interface.

## Non-vacuity

The new test **fails against the pre-fix source** with `expected +0 to be 1` — `closeCalls.count` was 0, i.e. the core was never disconnected. Verified by reverting only `openclaw-entry.ts` to `origin/main` and re-running with the test in place.

It asserts binding release the same way the existing `stopRemovesClient` does (`sendText` → `/not connected/i`), since `activeClients` is private.

## Gates

- `pnpm nx run @moltzap/openclaw-channel:test` — 67 passed / 7 files
- `pnpm typecheck --skip-nx-cache` — green
- `pnpm lint` — 0 warnings, 0 errors
- `git diff origin/main | grep -c ActiveLegacyGateway` → **0**, and the diff touches exactly 2 source files

The `ActiveLegacyGateway<Service>` retype from the adapters worktree is deliberately **dropped**: `openclaw-gateway-lifecycle.ts` does not exist on `origin/main`, and every symbol it would retype is deleted by the OpenClaw cutover. Generated `MODULE.md` / `src.mdx` churn is line-number shift only.

## ADR conformance (R-pass)

| Governing outcome | Record | Owner | Binds this diff? | Verdict | Evidence |
|---|---|---|---|---|---|
| — none found — | n/a | n/a | n/a | `CONFORMS` (vacuously) | Discovered from `docs/decisions/README.md` on `main` (49 records). No accepted outcome governs internal error handling in the OpenClaw adapter's gateway binding. `20260723-lifecycle-rides-l3` concerns *conversation* lifecycle at L3, not adapter process lifecycle, and is `partially-superseded`. |

Per R-pass rule 4, "no ADR governs this" is stated as a reviewable claim, not left as silence. The diff changes no wire field, tool catalog, public contract, or trust boundary — the categories ADRs in this repo govern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P76aaa1STr3WPZ3nDascta