### PR TITLE
chore(hooks): tier verification across commit, push, and CI

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,13 +1,22 @@
 #!/usr/bin/env sh
 set -e
 
-pnpm nx run workspace:format
-pnpm nx run workspace:docs:generate
+# Format the staged files and re-stage exactly those paths. Formatting never
+# fails a commit: small, frequent commits are the norm here, and a
+# fix-then-retry cycle would multiply across every one of them. Re-staging is
+# scoped to paths already staged so an unrelated working-tree edit can never be
+# swept into the commit. Everything heavier runs at pre-push or in CI.
+STAGED=$(mktemp)
+trap 'rm -f "$STAGED"' EXIT
 
-if ! git diff --quiet; then
-  echo ""
-  echo "pre-commit updated generated/formatted files. Run: git add -u && git add docs/protocol && git commit"
-  exit 1
-fi
+git diff --cached --name-only --diff-filter=ACMR -z \
+  | grep -z -E '\.(m?[jt]sx?|cjs)$' > "$STAGED" || true
 
-pnpm nx run workspace:precommit
+[ -s "$STAGED" ] || exit 0
+
+# Resolve the binary explicitly: git invokes hooks without node_modules/.bin on
+# PATH, so a bare `oxfmt` works from a pnpm-run commit and fails from an editor.
+OXFMT="$(git rev-parse --show-toplevel)/node_modules/.bin/oxfmt"
+
+xargs -0 "$OXFMT" < "$STAGED"
+xargs -0 git add -- < "$STAGED"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -e
+
+# The batch boundary. These are too slow to pay per commit and cheap enough to
+# pay once per push; CI stays the full gate. sloppy-code-guard also runs in CI
+# via the workspace lint target, so a bypass here is caught rather than lost.
+pnpm nx run workspace:lint:sloppy-code-guard
+pnpm exec nx affected -t typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,6 +284,11 @@ candidate.
 - Before v2 implementation changes, the governing spec and decision
   traceability must be complete. No binding decision may exist only in
   chat, an issue comment, or an agent-private state directory.
+- Generated docs (MODULE.md pages, protocol reference, constants
+  snippets) are refreshed before merge, not on every commit: run
+  `pnpm docs:generate` and commit the result. Its inputs cover every
+  `.ts` file under `packages/`, so per-commit regeneration never hits
+  the Nx cache. `pnpm docs:check:drift` is the CI backstop.
 - Flow diagrams are Mermaid in JSDoc above the owning symbol;
   generated MODULE.md pages surface them. Change a flow → update its
   diagram in the same PR. Cross-package flows are documented once at

--- a/tools/workspace/project.json
+++ b/tools/workspace/project.json
@@ -195,53 +195,13 @@
         "arch:config:check",
         "lint:root",
         "lint:oxlint",
+        "lint:sloppy-code-guard",
         {
           "target": "arch:check",
           "projects": "@moltzap/*"
         },
         {
           "target": "lint",
-          "projects": "@moltzap/*"
-        }
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": ".",
-        "command": "node -e \"\""
-      }
-    },
-    "check": {
-      "cache": false,
-      "dependsOn": [
-        "lint",
-        "format:check"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": ".",
-        "command": "node -e \"\""
-      }
-    },
-    "precommit": {
-      "cache": false,
-      "dependsOn": [
-        "docs:check:no-hardcoded-constants",
-        "docs:check:doc-imports-resolve",
-        "check",
-        "lint:sloppy-code-guard",
-        {
-          "target": "build",
-          "projects": "@moltzap/*"
-        },
-        {
-          "target": "typecheck",
-          "projects": [
-            "@moltzap/v2-identity",
-            "@moltzap/v2-router"
-          ]
-        },
-        {
-          "target": "typecheck:tests",
           "projects": "@moltzap/*"
         }
       ],


### PR DESCRIPTION
Every commit paid a **165s floor** before the monorepo build even started. Measured:

| Step | Time |
|---|---|
| `oxfmt` over the whole repo | 10s |
| `docs:generate` | 150s |
| `sloppy-code-guard` | 5s |
| then `workspace:precommit` (`cache: false`) | build **all** `@moltzap/*` + `typecheck:tests` for all |

It also **failed the commit** whenever formatting changed a file, printing `git add -u` as the remedy — which forces a second commit and sweeps unrelated working-tree edits in.

`v2/inputs/debt-inventory-20260718.md:180` catalogued this three weeks ago, including that it "pushes people toward `--no-verify`."

## Three tiers

| Tier | Contents |
|---|---|
| pre-commit | format staged paths only, re-stage exactly those |
| pre-push | `sloppy-code-guard`, `nx affected -t typecheck` |
| CI | unchanged full gate, **plus `lint:sloppy-code-guard`** |

## The check that only ran in the hook

`lint:sloppy-code-guard` appeared in exactly two places: its definition at `tools/workspace/project.json:167` and `precommit`'s `dependsOn`. The workspace `lint` target did not include it, so **`pnpm lint` in CI never ran it** — and every `--no-verify` bypass skipped a 284-line guard (type safety, mock imports, test integrity, Effect hygiene) with no backstop anywhere.

Wiring it into `lint` moves the gate somewhere it cannot be bypassed. The hooks get weaker; the gate gets stronger.

## Why `docs:generate` leaves the hooks entirely

Not to pre-push either. It looks cached (`cache: true`, `inputs: ["docsGeneration"]`), but that named input in `nx.json` includes `{workspaceRoot}/packages/**/*.ts` — so any TypeScript edit invalidates it. The cache is correct and practically never hits. `docs:check:drift` already runs `docs:generate && git diff --exit-code` in CI.

`AGENTS.md` now records the before-merge step.

## Also removed

`precommit` and `check` targets, both unreferenced after this change.

## Verification

- `pnpm lint` → **exit 0**, with the guard now inside the graph (`nx run workspace:"lint:sloppy-code-guard"` visible in `run-many -t lint`)
- `pnpm docs:check:gates-test` → **exit 0**
- `nx affected -t typecheck test` → no tasks (correct; no project with test targets is touched)
- pre-commit: **157ms** empty path, **16ms** to format one file; unrelated dirty files left untouched
- pre-push: exercised by the push that opened this PR

## Not done

**Cross-model review did not run.** `codex exec review` hit its usage limit (resets Aug 7), so this had a single-model review only. Flagging rather than letting a clean-looking result imply coverage it does not have.

Follow-up issue worth filing: `sloppy-code-guard`'s `raw-rpc-method-string` check is a silent no-op — `check-rpc-method-strings.js` scans `packages/protocol/src/{network,task,app}/methods/`, none of which exist (`debt-inventory-20260718.md:75`). Now that the guard runs in CI, that no-op gives false assurance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHzrYnz4gqSZKQnkNBVyKa