### PR TITLE
feat(repo): gate work on a verified agent setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,37 @@ Before cutover, v1 authority stays on `main` and v2 authority stays on
 and pass their review gates on `v2`; they do not require a duplicate
 main-branch copy.
 
+## Prerequisites
+
+Run `pnpm check:agent-setup` once at the start of a session — not per
+command, which is how the old 165s pre-commit happened. It names what is
+missing and how to fix it.
+
+Refuse the operation when its row is unmet. Refusal is scoped: a missing
+`codex` must never block editing a file or fixing the setup itself.
+
+| Required | Refuse to |
+|---|---|
+| Node per `.node-version`, pnpm | do anything |
+| `pnpm nx` for every task, never the underlying tool | build, test, lint, typecheck |
+| Effect and `@effect/*` as the runtime idiom | add a non-Effect alternative |
+| `/simplify`, `/ship`, `/review` | open a PR |
+| `/plan-eng-review` | start implementing a feature |
+| `/land-and-deploy` | merge |
+| `codex`, authenticated and in quota | call review complete |
+
+The rule these share: **refuse where the failure is silent, warn where it
+is loud.** A missing binary that errors on first use needs no rule.
+`/review` without codex quietly becomes a single-model pass *and `/ship`
+still records a clean Eng Review entry* — the merge bar drops and nothing
+says so. That is the case worth a gate.
+
+Connected sources — Notion, Gmail, Discord, GitHub — are yours to name at
+the start of work that may have been decided elsewhere; offer to read them
+directly rather than asking for a paste. This is agent law rather than a
+`SessionStart` hook because an agent can see its own connected MCP servers
+and a shell hook cannot.
+
 ## Constitution (v2 design law; v1 is not retrofitted)
 
 1. Endpoints | control plane + storage | data plane. Registry, Router,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "docs:check:doc-imports-resolve": "pnpm exec tsx scripts/docs/check-doc-imports-resolve.ts",
     "docs:check:gates-test": "pnpm exec tsx scripts/__tests__/gates.test.ts",
     "test:compute-next-version": "bash scripts/release/compute-next-version.test.sh",
+    "check:agent-setup": "bash scripts/repo/check-agent-setup.sh",
     "simulator:example": "pnpm simulator:example:check && node --experimental-strip-types examples/simulator/hello.ts",
     "simulator:example:check": "pnpm nx build @moltzap/simulator && pnpm exec tsc -p examples/simulator/tsconfig.json",
     "test:pack:simulator": "pnpm nx build @moltzap/simulator && node scripts/test/simulator-packages.mjs",

--- a/scripts/repo/check-agent-setup.sh
+++ b/scripts/repo/check-agent-setup.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# check-agent-setup.sh — verify the environment an agent needs before it can
+# honestly claim a change is reviewed.
+#
+# Two people working this repo should get the same behavior. The failures this
+# guards against are the silent ones: `/review` degrades to a single model when
+# codex is absent and still records a clean Eng Review entry, so a missing tool
+# lowers the merge bar without anyone seeing it happen.
+#
+# Loud failures need no entry here. A missing pnpm errors on first use; that is
+# self-reporting and costs nothing to discover.
+#
+# Run once per session, not per command — a per-command check is how the old
+# 165s pre-commit happened.
+#
+# Exits 0 when every required item is present, 1 otherwise. Advisory items
+# print a note and never change the exit code.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+RED=$'\033[0;31m'; YEL=$'\033[0;33m'; GRN=$'\033[0;32m'; NC=$'\033[0m'
+MISSING=0
+
+ok()   { printf "  ${GRN}ok${NC}    %-26s %s\n" "$1" "${2:-}"; }
+gone() { printf "  ${RED}MISS${NC}  %-26s %s\n" "$1" "$2"; MISSING=$((MISSING + 1)); }
+note() { printf "  ${YEL}note${NC}  %-26s %s\n" "$1" "$2"; }
+
+echo "Agent setup — $REPO_ROOT"
+echo ""
+
+# ── toolchain ───────────────────────────────────────────────────────────────
+if command -v node >/dev/null 2>&1; then
+  node_major=$(node -p 'process.versions.node.split(".")[0]')
+  # engines: >=22.19.0 <25
+  if [ "$node_major" -ge 22 ] && [ "$node_major" -lt 25 ]; then
+    ok "node" "$(node -v)"
+  else
+    gone "node" "$(node -v) is outside the engines range >=22.19.0 <25"
+  fi
+else
+  gone "node" "not on PATH"
+fi
+
+command -v pnpm >/dev/null 2>&1 && ok "pnpm" "$(pnpm --version)" || gone "pnpm" "not on PATH — see packageManager in package.json"
+
+# ── review path ─────────────────────────────────────────────────────────────
+# Only file-backed skills can be probed. /simplify ships with the harness and
+# has no SKILL.md on disk, so testing for one would report a permanent false
+# absence. Its presence is the harness's problem, not this repo's.
+for skill in plan-eng-review review ship land-and-deploy codex; do
+  if [ -f "$HOME/.claude/skills/$skill/SKILL.md" ]; then
+    ok "/$skill" ""
+  else
+    gone "/$skill" "expected ~/.claude/skills/$skill/SKILL.md — install or update gstack"
+  fi
+done
+
+# codex backs /review's always-on adversarial pass and /plan-eng-review's
+# outside voice. Installed is checkable; having quota is not, and a rate-limited
+# codex fails the same way a missing one does — quietly, one model instead of
+# two.
+if command -v codex >/dev/null 2>&1; then
+  ok "codex" "$(codex --version 2>/dev/null | head -1)"
+  note "codex quota" "not probed — a rate-limited codex degrades review silently"
+else
+  gone "codex" "not on PATH — /review falls back to a single model"
+fi
+
+# ── hook freshness ──────────────────────────────────────────────────────────
+# .husky/pre-commit is tracked, so every branch carries its own copy and a fix
+# on main reaches nobody until they merge. This repo has had 70 worktrees on a
+# stale 165s hook at once. Advisory: a branch may differ on purpose.
+if git rev-parse --verify -q origin/main >/dev/null 2>&1; then
+  local_hook=$(git hash-object .husky/pre-commit 2>/dev/null || echo none)
+  main_hook=$(git rev-parse "origin/main:.husky/pre-commit" 2>/dev/null || echo none)
+  if [ "$local_hook" = "$main_hook" ]; then
+    ok "hooks" "match origin/main"
+  else
+    note "hooks" ".husky/pre-commit differs from origin/main — stale hooks run the slow path"
+  fi
+else
+  note "hooks" "no origin/main ref to compare against"
+fi
+
+echo ""
+if [ "$MISSING" -gt 0 ]; then
+  printf "%s%s required item(s) missing.%s Fix these before claiming a change is reviewed.\n" \
+    "$RED" "$MISSING" "$NC"
+  exit 1
+fi
+printf "%sSetup complete.%s\n" "$GRN" "$NC"


### PR DESCRIPTION
Two people working this repo should get the same behavior. What breaks that is the **silent** failure: `/review` degrades to a single model when codex is absent, and `/ship` still records a clean Eng Review entry. The merge bar drops and nothing says so.

## What lands

`scripts/repo/check-agent-setup.sh` + `pnpm check:agent-setup` — verifies node, pnpm, the file-backed gstack skills, and codex; names each gap and its fix; exits non-zero.

`AGENTS.md → Prerequisites` — the refusal table:

| Required | Refuse to |
|---|---|
| Node per `.node-version`, pnpm | do anything |
| `pnpm nx` for every task | build, test, lint, typecheck |
| Effect and `@effect/*` as the runtime idiom | add a non-Effect alternative |
| `/simplify`, `/ship`, `/review` | open a PR |
| `/plan-eng-review` | start implementing a feature |
| `/land-and-deploy` | merge |
| `codex`, authenticated and in quota | call review complete |

**Refusal is scoped to the operation.** A missing `codex` must never block editing a file — or fixing the setup itself.

**The governing rule: refuse where the failure is silent, warn where it is loud.** A missing binary that errors on first use is self-reporting and needs no gate.

## Two things it deliberately does not check

**`/simplify`.** It ships with the harness and has no `SKILL.md` on disk. Probing `~/.claude/skills/simplify/SKILL.md` would report a permanent false absence — a check that cries wolf gets ignored, then removed. Its presence is the harness's problem, not this repo's.

**codex quota.** A rate-limited codex fails exactly like a missing one — quietly, one model instead of two — but detecting it costs a request per session. The script prints a note naming the gap rather than pretending it's covered. This is not hypothetical: codex has been over quota for this entire work stream, which is why the last three PRs shipped without a cross-model pass.

## Hook freshness (advisory)

Comes from finding **70 of 85 worktrees** running a stale 165s `pre-commit`. `.husky/pre-commit` is tracked, so every branch carries its own copy and a fix on `main` reaches nobody until they merge. The check compares against `origin/main` and prints a note — advisory, because a branch may differ on purpose.

## Connector disclosure

Naming connected sources (Notion, Gmail, Discord, GitHub) and offering to read them directly, rather than asking for a paste. This is agent law rather than a `SessionStart` hook because **an agent can see its own connected MCP servers and a shell hook cannot**.

## Verification

| Check | Result |
|---|---|
| `pnpm check:agent-setup`, this machine | exit 0, all rows ok |
| failure path (`HOME` pointed elsewhere) | exit 1, 5 missing items each named with its fix |
| `bash -n` | clean |
| `lint:script-reachability` | 18 reachable, 0 allowlisted |
| `format:check` | clean |

## Note on size

`AGENTS.md` grows to 362 lines here, against a plan that ends at ~110. PR 8 does that restructure; this section is written to survive it — the table and the silent-vs-loud rule move as-is, and the prose around them is already minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHzrYnz4gqSZKQnkNBVyKa