### PR TITLE
feat(docs): gate decision-record shape at commit and in lint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,23 @@
 #!/usr/bin/env sh
 set -e
 
+# Everything here is gated on what is staged, so a commit that touches nothing
+# relevant pays nothing. The heavy checks live at pre-push and in CI.
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Decision records are checked at commit time because the changelog rule needs
+# the diff: a body edit with no status change and no dated row is a silent
+# rewrite, and it is invisible in review because it looks like a typo fix.
+if git diff --cached --name-only --diff-filter=ACMR \
+  | grep -qE '^docs/(decisions|decision-evidence)/'; then
+  "$ROOT/node_modules/.bin/tsx" "$ROOT/scripts/docs/adr/check-shape.ts" --staged
+fi
+
 # Format the staged files and re-stage exactly those paths. Formatting never
 # fails a commit: small, frequent commits are the norm here, and a
 # fix-then-retry cycle would multiply across every one of them. Re-staging is
 # scoped to paths already staged so an unrelated working-tree edit can never be
-# swept into the commit. Everything heavier runs at pre-push or in CI.
+# swept into the commit.
 STAGED=$(mktemp)
 trap 'rm -f "$STAGED"' EXIT
 
@@ -16,7 +28,5 @@ git diff --cached --name-only --diff-filter=ACMR -z \
 
 # Resolve the binary explicitly: git invokes hooks without node_modules/.bin on
 # PATH, so a bare `oxfmt` works from a pnpm-run commit and fails from an editor.
-OXFMT="$(git rev-parse --show-toplevel)/node_modules/.bin/oxfmt"
-
-xargs -0 "$OXFMT" < "$STAGED"
+xargs -0 "$ROOT/node_modules/.bin/oxfmt" < "$STAGED"
 xargs -0 git add -- < "$STAGED"

--- a/scripts/docs/adr/check-shape.ts
+++ b/scripts/docs/adr/check-shape.ts
@@ -1,0 +1,303 @@
+#!/usr/bin/env tsx
+/**
+ * @file Decision-record shape gate. Checks the mechanical rules AGENTS.md
+ * states for `docs/decisions/`, so review can spend its attention on whether
+ * a decision is right rather than whether it is well-formed.
+ *
+ * Two modes:
+ *   (no args)  every record — wired into `pnpm lint`.
+ *   --staged   only records staged for commit, plus the changelog rule, which
+ *              needs a diff to evaluate. Wired into `.husky/pre-commit`, which
+ *              invokes it only when staged paths touch the decision trees, so
+ *              an ordinary commit pays nothing.
+ *
+ * The changelog rule is the one with teeth. AGENTS.md forbids silently
+ * rewriting an admitted decision, and allows a point correction — a moved
+ * path, a renamed term — that appends a dated row to `Record changelog`.
+ * A body edit with neither a status change nor a new row is exactly the
+ * silent rewrite the rule exists to prevent, and it is invisible in review
+ * because it looks like a typo fix.
+ *
+ * What it deliberately cannot check: whether a Decision Outcome is correct,
+ * whether a changelog row honestly describes its edit, or whether an excerpt
+ * was faithfully quoted. Those need a reader.
+ *
+ * Exit codes: 0 clean, 1 violations (each printed with its remedy).
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+const git = (args: readonly string[]): string =>
+  execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf8" });
+
+const DECISIONS = "docs/decisions";
+const EVIDENCE = "docs/decision-evidence";
+const STATUSES = ["accepted", "partially-superseded", "superseded"] as const;
+const FILENAME = /^(\d{8})-[a-z0-9]+(?:-[a-z0-9]+)*\.md$/;
+const REQUIRED_SECTIONS = [
+  "Context and Problem Statement",
+  "Decision Outcome",
+  "Consequences",
+] as const;
+
+interface Violation {
+  readonly record: string;
+  readonly problem: string;
+  readonly remedy: string;
+}
+
+/**
+ * Markdown links in this corpus wrap across lines, so every pattern that
+ * spans a link must run against whitespace-collapsed text. A line-anchored
+ * regex silently reports a missing link for a record that has one.
+ */
+const collapse = (text: string): string => text.replace(/\s*\n\s*/g, " ");
+
+/** GitHub's heading-to-anchor slug, close enough for link checking. */
+const slug = (heading: string): string =>
+  heading
+    .trim()
+    .toLowerCase()
+    .replace(/[`*_[\]()]/g, "")
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+const frontmatterField = (text: string, key: string): string | undefined =>
+  new RegExp(`^${key}:\\s*(.+)$`, "m").exec(text)?.[1]?.trim();
+
+const recordFiles = (): readonly string[] =>
+  git(["ls-files", `${DECISIONS}/*.md`])
+    .split("\n")
+    .filter((p) => p.length > 0 && !p.endsWith("README.md"));
+
+const checkRecord = (
+  path: string,
+  indexBody: string,
+  isNew: boolean,
+): Violation[] => {
+  const name = path.slice(DECISIONS.length + 1);
+  const out: Violation[] = [];
+  const add = (problem: string, remedy: string): void => {
+    out.push({ record: name, problem, remedy });
+  };
+
+  const filename = FILENAME.exec(name);
+  if (!filename) {
+    add(
+      "filename is not YYYYMMDD-short-kebab-title.md",
+      "rename it; dates avoid the merge collisions sequence numbers cause",
+    );
+  }
+
+  const text = readFileSync(join(repoRoot, path), "utf8");
+  const joined = collapse(text);
+
+  const date = frontmatterField(text, "date");
+  if (!date) add("frontmatter has no `date`", "add `date: YYYY-MM-DD`");
+  else if (filename && date.replace(/-/g, "") !== filename[1]) {
+    add(
+      `frontmatter date ${date} disagrees with the filename`,
+      "make them match; the filename date is the record's identity",
+    );
+  }
+
+  const status = frontmatterField(text, "status");
+  if (!status)
+    add("frontmatter has no `status`", "add one of: " + STATUSES.join(", "));
+  else if (!STATUSES.includes(status as (typeof STATUSES)[number])) {
+    add(
+      `status \`${status}\` is not a permitted value`,
+      "use one of: " + STATUSES.join(", "),
+    );
+  }
+
+  if (!frontmatterField(text, "decision-makers")) {
+    add(
+      "frontmatter has no `decision-makers`",
+      "name the humans accountable for the call",
+    );
+  }
+
+  // AGENTS.md requires the three sections of *new* records and says older
+  // admitted records retain their historical body shape. 26 of the existing 48
+  // carry consequences as a paragraph inside Decision Outcome, which that
+  // clause permits; enforcing the heading on them would be this gate
+  // overruling the rule it implements.
+  if (isNew) {
+    for (const section of REQUIRED_SECTIONS) {
+      if (!new RegExp(`^#{2,3}\\s+${section}\\s*$`, "m").test(text)) {
+        add(
+          `no \`${section}\` section`,
+          "add it; a cold reader needs all three",
+        );
+      }
+    }
+  }
+
+  const link =
+    /Decision provenance:.*?\]\((\.\.\/decision-evidence\/[^)]+)\)/.exec(
+      joined,
+    );
+  if (!link) {
+    add(
+      "no `Decision provenance` link to a compacted trajectory",
+      `link a source-event ledger under ${EVIDENCE}/`,
+    );
+  } else {
+    const [target, anchor] = link[1].replace("../", "").split("#");
+    const evidencePath = join(repoRoot, "docs", target);
+    if (!existsSync(evidencePath)) {
+      add(`provenance target \`${target}\` does not exist`, "fix the path");
+    } else if (anchor) {
+      const evidence = readFileSync(evidencePath, "utf8");
+      const headings = new Set(
+        [...evidence.matchAll(/^#{1,6}\s+(.*)$/gm)].map((m) => slug(m[1])),
+      );
+      if (!evidence.includes(`id="${anchor}"`) && !headings.has(anchor)) {
+        add(
+          `provenance anchor \`#${anchor}\` resolves to nothing`,
+          "a dangling anchor makes the citation unverifiable",
+        );
+      }
+    }
+  }
+
+  if (status === "superseded" || status === "partially-superseded") {
+    if (!frontmatterField(text, "superseded-by")) {
+      add(
+        `status is \`${status}\` but there is no \`superseded-by\``,
+        "name the replacement",
+      );
+    }
+    if (!/^##\s+Supersession\s*$/m.test(text)) {
+      add(
+        `status is \`${status}\` but there is no \`Supersession\` section`,
+        "say what remains current, what was replaced, and where the contract now lives",
+      );
+    }
+  }
+
+  if (!indexBody.includes(`(${name})`)) {
+    add(
+      "no row in docs/decisions/README.md",
+      "add one; the index is how a cold reader finds this record",
+    );
+  }
+
+  return out;
+};
+
+/**
+ * A staged record whose body changed, whose status did not, and which gained
+ * no changelog row. AGENTS.md permits editing a record in place only with a
+ * dated receipt.
+ */
+const checkChangelogRow = (path: string): Violation | undefined => {
+  const name = path.slice(DECISIONS.length + 1);
+  let previous: string;
+  try {
+    previous = git(["show", `HEAD:${path}`]);
+  } catch {
+    return undefined; // new record; nothing to have rewritten
+  }
+  const current = readFileSync(join(repoRoot, path), "utf8");
+  if (current === previous) return undefined;
+
+  if (
+    frontmatterField(current, "status") !== frontmatterField(previous, "status")
+  ) {
+    return undefined; // a status change is a supersession, reviewed on its own terms
+  }
+
+  const rows = (t: string): number =>
+    (/^##\s+Record changelog\s*$/m.test(t)
+      ? (t.split(/^##\s+Record changelog\s*$/m)[1] ?? "").match(
+          /^\|\s*\d{4}-\d{2}-\d{2}\s*\|/gm,
+        )?.length
+      : 0) ?? 0;
+
+  if (rows(current) > rows(previous)) return undefined;
+
+  return {
+    record: name,
+    problem:
+      "body changed, status did not, and no `Record changelog` row was added",
+    remedy:
+      "append a dated row saying what moved and why the Decision Outcome is untouched — " +
+      "without it the edit is indistinguishable from a silent rewrite",
+  };
+};
+
+const main = (): void => {
+  const staged = process.argv.includes("--staged");
+  const indexBody = readFileSync(
+    join(repoRoot, DECISIONS, "README.md"),
+    "utf8",
+  );
+
+  const isRecord = (p: string): boolean =>
+    p.startsWith(`${DECISIONS}/`) &&
+    p.endsWith(".md") &&
+    !p.endsWith("README.md");
+
+  // Only a record added in this commit is "new". A modified one keeps whatever
+  // body shape it was admitted with.
+  const added = new Set<string>();
+  let targets: readonly string[];
+  if (staged) {
+    const entries = git([
+      "diff",
+      "--cached",
+      "--name-status",
+      "--diff-filter=ACMR",
+    ])
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => l.split("\t"));
+    for (const [flag, path] of entries) {
+      if (path && isRecord(path) && flag?.startsWith("A")) added.add(path);
+    }
+    targets = entries
+      .map(([, p]) => p)
+      .filter((p): p is string => Boolean(p) && isRecord(p));
+  } else {
+    targets = recordFiles();
+  }
+
+  if (targets.length === 0) {
+    console.log("[check-adr-shape] no records to check.");
+    process.exit(0);
+  }
+
+  const violations = targets.flatMap((p) =>
+    checkRecord(p, indexBody, added.has(p)),
+  );
+  if (staged) {
+    violations.push(
+      ...targets.map(checkChangelogRow).filter((v) => v !== undefined),
+    );
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `[check-adr-shape] PASS — ${targets.length} record(s) well-formed.`,
+    );
+    process.exit(0);
+  }
+
+  console.error(`[check-adr-shape] FAIL — ${violations.length} problem(s):\n`);
+  for (const v of violations) {
+    console.error(`  ${v.record}`);
+    console.error(`    ${v.problem}`);
+    console.error(`    → ${v.remedy}\n`);
+  }
+  process.exit(1);
+};
+
+main();

--- a/tools/workspace/project.json
+++ b/tools/workspace/project.json
@@ -208,6 +208,7 @@
         "lint:oxlint",
         "lint:sloppy-code-guard",
         "lint:script-reachability",
+        "lint:adr-shape",
         {
           "target": "arch:check",
           "projects": "@moltzap/*"
@@ -221,6 +222,17 @@
       "options": {
         "cwd": ".",
         "command": "node -e \"\""
+      }
+    },
+    "lint:adr-shape": {
+      "cache": true,
+      "inputs": [
+        "workspaceFiles"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": ".",
+        "command": "pnpm exec tsx scripts/docs/adr/check-shape.ts"
       }
     }
   }


### PR DESCRIPTION
Review should spend its attention on whether a decision is *right*, not on whether it is well-formed.

`scripts/docs/adr/check-shape.ts` enforces the mechanical rules AGENTS.md already states — filename/frontmatter date agreement, the status enum, `decision-makers`, provenance link **and anchor** resolution, the `superseded-by`/`Supersession` pairing, and an index row in `README.md`.

Two modes: no args checks every record (wired into `pnpm lint` via `lint:adr-shape`); `--staged` checks staged records plus the changelog rule (wired into `.husky/pre-commit`).

## The rule with teeth

AGENTS.md forbids silently rewriting an admitted decision, and now permits a point correction that appends a dated `Record changelog` row. **A body edit with neither a status change nor a new row is exactly the silent rewrite that rule exists to prevent** — and review can't catch it, because it looks like a typo fix.

It only works at commit time, because it needs the diff.

| Case | Result |
|---|---|
| body edit, no status change, no row | **FAIL** with the remedy |
| same edit + a dated row | PASS |
| status change, no row | PASS — that's a supersession, reviewed on its own terms |

## Two things the corpus taught

**Markdown links here wrap across lines.** My first pass used a line-anchored regex and reported "no provenance link" for two records that have one, plus four bogus dangling anchors. Everything spanning a link now runs against whitespace-collapsed text. All six were artifacts of the checker, not the corpus.

**The three-section rule applies to new records only.** AGENTS.md: *"Every **new** record contains … Older admitted records retain their historical body shape."* **26 of 48** carry consequences as a paragraph inside `Decision Outcome`. Enforcing the heading on them would be this gate overruling the rule it implements, so the section check fires only for records added in the commit.

All 48 existing records pass — this lands as a ratchet, not a cleanup.

## A hook bug this surfaced

`.husky/pre-commit` exited early when no JS/TS was staged, which would have skipped this check on **every docs-only commit** — i.e. exactly the commits that touch decision records. Both gates are now independently conditioned on staged paths.

| Path | Time |
|---|---|
| a decision record is staged | 194ms |
| nothing relevant staged | 51ms |

## What it deliberately cannot check

Whether a Decision Outcome is correct, whether a changelog row honestly describes its edit, or whether an excerpt was faithfully quoted. Those need a reader — which is what the cold-read gate in PR 7 is for.

## Verification

| Check | Result |
|---|---|
| full corpus | PASS — 48 records |
| `--staged`, three cases above | all as expected |
| `nx run workspace:lint:adr-shape` | exit 0 |
| `tsc --noEmit -p tsconfig.eslint.json` | exit 0 |
| `lint:script-reachability` | 19 reachable, 0 allowlisted |
| `format:check` | clean |

**Cross-model review did not run** — codex has been over its usage limit throughout this work stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHzrYnz4gqSZKQnkNBVyKa