### PR TITLE
feat(skills): vendor the cold-read gate into the repo

### DIFF
--- a/.claude/skills/cold-read/SKILL.md
+++ b/.claude/skills/cold-read/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: cold-read
+description: |
+  Read a published artifact — a decision record, spec chapter, PR body, or
+  design doc — with NO prior session context, and report how a cold-start
+  reader would fare. Scores clarity, completeness, actionability, and trust,
+  lists friction with evidence, and emits SHIP / REVISE / REJECT. With
+  --questions, answers a fixed question set instead of the default rubric;
+  that is how the blind review gate for decision records runs.
+  Use before handing an artifact off. Do NOT use to rewrite it — this reads.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Agent
+---
+
+<!--
+Vendored from safer-by-default `dogfood` 0.5.0 (github.com/chughtapan/safer-by-default),
+forked 2026-08-05. Edit this file directly; it is no longer generated from an
+upstream template, and the plugin's bin/ utilities are deliberately absent.
+-->
+
+# cold-read
+
+## Iron rule
+
+> **Read the artifact as if you have never seen this project before. Any
+> context borrowed from conversation is a bug in the artifact.**
+
+The enforcement is architectural, not aspirational. You dispatch a subagent via
+the `Agent` tool with a self-contained prompt: artifact content, question set,
+output schema. No session history, no parent epic, no conversation crumbs. If
+the subagent needs context to act, the artifact did not carry its own weight —
+that is the finding.
+
+This is why the skill is worth more than a careful re-read by the author. An
+author cannot un-know the conversation that produced the artifact; a fresh
+subagent has never had it.
+
+## Role
+
+You are the cold-start reader. Given an artifact reference you:
+
+1. Resolve it to a single self-contained text payload.
+2. Spawn a subagent with ONLY that payload, the question set, and the schema.
+3. Collect the structured report.
+4. Write it where the caller asked, or print it.
+5. Report the verdict.
+
+You do not rewrite the artifact, open a PR against it, or explain what the
+author meant. Every attempt to fill in context is the debt this surfaces.
+
+## Inputs
+
+- One of `--file PATH`, `--issue N`, `--pr N`.
+- `--questions PATH` — use a fixed question set instead of the default rubric.
+- `--out PATH` — write the report here instead of stdout.
+- `--repo owner/name` — override the current repo.
+- `gh` authenticated, for `--issue` / `--pr`.
+- The `Agent` tool available in the running harness. Without it this skill
+  cannot enforce its own iron rule; stop rather than reading the artifact
+  yourself.
+
+## Scope
+
+**In scope:** reading a published artifact cold and reporting what a fresh
+reader cannot do with it.
+
+**Forbidden:** editing the artifact; consulting the conversation that produced
+it; reading sibling artifacts to fill a gap; softening a finding because you
+know what was meant.
+
+## Workflow
+
+### Phase 1 — Resolve inputs
+
+```bash
+KIND=""; ID=""; FILE_PATH=""; QUESTIONS=""; OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --file)      KIND="file"; FILE_PATH="$2"; shift 2 ;;
+    --issue)     KIND="issue"; ID="$2"; shift 2 ;;
+    --pr)        KIND="pr"; ID="$2"; shift 2 ;;
+    --questions) QUESTIONS="$2"; shift 2 ;;
+    --out)       OUT="$2"; shift 2 ;;
+    --repo)      REPO="$2"; shift 2 ;;
+    *) echo "ERROR: unknown arg: $1"; exit 1 ;;
+  esac
+done
+[ -z "$KIND" ] && { echo "ERROR: one of --file PATH, --issue N, --pr N required"; exit 1; }
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo unknown/unknown)}"
+```
+
+### Phase 2 — Fetch the payload
+
+Every byte a cold reader would see, and nothing else.
+
+```bash
+PAYLOAD=$(mktemp)
+case "$KIND" in
+  file)
+    [ -f "$FILE_PATH" ] || { echo "ERROR: no such file: $FILE_PATH"; exit 1; }
+    { echo "# Artifact: $FILE_PATH"; echo; cat "$FILE_PATH"; } > "$PAYLOAD"
+    ARTIFACT_REF="$FILE_PATH" ;;
+  issue|pr)
+    { echo "# Artifact: $KIND $REPO#$ID"; echo
+      gh "$KIND" view "$ID" --repo "$REPO" --json title,body \
+        -q '"## Title\n\(.title)\n\n## Body\n\(.body)"'; } > "$PAYLOAD"
+    ARTIFACT_REF="$KIND #$ID in $REPO" ;;
+esac
+[ -s "$PAYLOAD" ] || { echo "REJECT: artifact is empty"; exit 1; }
+```
+
+An empty payload fires the stop rule. Do not dispatch a subagent against
+nothing — it will produce a plausible report about an absence.
+
+### Phase 3 — Build the self-contained prompt
+
+Write a prompt file containing ONLY: the framing, the question set or rubric,
+the output schema, and the payload. No repo name in the framing, no issue
+number, no "as we discussed".
+
+When `--questions` is set, read that file and use its questions verbatim in
+place of the rubric; the schema becomes one section per question plus an
+overall verdict. Otherwise use the default rubric:
+
+```
+Score each axis 0-10, integer, citing evidence from the artifact.
+- Clarity        can a cold reader understand it without asking?
+- Completeness   is every fact needed to act on it present?
+- Actionability  is the next step obvious?
+- Trust          is every claim backed by something checkable?
+
+Friction is a list, not a score. Each entry names a location and why a
+reader stumbles there.
+
+Verdict:
+- SHIP    every axis >= 8 and no friction entry blocks action.
+- REVISE  any axis <= 6, or a friction entry blocks action. Name the fixes.
+- REJECT  clarity or completeness <= 4. Not publishable as is.
+```
+
+Stop rules for the subagent, included in the prompt:
+
+1. If you notice yourself drawing on knowledge outside the payload, say so in
+   the friction log — that is the artifact failing to carry its context.
+2. If the payload references a document it does not contain ("see the plan"),
+   name each one.
+3. Answer "the artifact does not say" rather than inferring. A confident guess
+   is the failure mode this exists to catch.
+
+### Phase 4 — Dispatch cold
+
+Read the prompt file, then call `Agent` with exactly these parameters:
+
+```
+Agent({
+  description: "Cold-start artifact read",
+  subagent_type: "general-purpose",
+  prompt: <the text of the prompt file>
+})
+```
+
+The description stays generic so no project context leaks through the
+subagent's bootstrap. **This skill's body never reads `$PAYLOAD` beyond piping
+it into the prompt file.** The subagent is the only reader of the artifact.
+That is the architectural enforcement, and reading the payload yourself to
+"check" the subagent breaks it.
+
+If the reply does not match the schema, re-invoke once with: "Your previous
+reply did not match the output schema. Emit only the schema block." Two failed
+attempts is a signal about the artifact, not a reason to write the report
+yourself.
+
+### Phase 5 — Validate
+
+- Starts with `# Cold read — `.
+- Exactly one of `SHIP`, `REVISE`, `REJECT`.
+- Default rubric: four scored axes, each an integer 0-10.
+- `--questions`: one section per question, none blank.
+
+A report that fails validation twice is emitted as-is with a note. Never
+rewrite a finding to make it pass.
+
+### Phase 6 — Emit
+
+With `--out PATH`, write the report there. Otherwise print it. For `--issue` /
+`--pr`, `gh issue comment` / `gh pr comment` publishes it to the thread.
+
+Decision-record reviews are filed under `docs/decision-evidence/` as
+`<candidate>-cold-review.md`, alongside the trajectories they check.
+
+### Phase 7 — Report the verdict
+
+One line to the caller: verdict, the artifact ref, and where the report went.
+Do not summarize the findings — the caller reads the report. Summarizing is how
+a REVISE quietly becomes "mostly fine".
+
+## Stop rules
+
+Stop and report rather than working around any of these:
+
+- The `Agent` tool is unavailable. Reading the artifact yourself is not a
+  degraded version of this skill; it is the opposite of it.
+- The artifact is empty or unreachable.
+- You are asked to fix what the report found. That is a separate change by the
+  author, not a follow-on here.
+
+## Anti-patterns
+
+- Reading the payload yourself "just to sanity-check" the subagent.
+- Passing the artifact's issue number or branch name in the prompt framing.
+- Re-running until the verdict improves.
+- Treating SHIP as the goal. The goal is an accurate read.

--- a/.claude/skills/cold-read/references/questions.md
+++ b/.claude/skills/cold-read/references/questions.md
@@ -1,0 +1,55 @@
+# Blind review questions for a decision record
+
+Passed to `cold-read` as `--questions`. Ask these verbatim. Do not add
+context, name the author, or hint at an expected answer — a material hint
+invalidates the run.
+
+1. What decision does this candidate make current, what problem does it
+   resolve, and which statements are binding versus context or non-normative
+   explanation?
+
+2. What earlier outcomes does it replace, retain, or leave untouched, and where
+   does the current normative contract live?
+
+3. What must an implementer now do or avoid, which layers or consumers are
+   affected, and under what fault, trust, safety, liveness, and compatibility
+   assumptions?
+
+4. Which humans are named as decision-makers, which source events does the
+   compacted trajectory cite for their calls, alternatives, reversals, and
+   deferrals, and what source gaps does it explicitly record? Report only what
+   the event ledger states; do not infer motives, confidence, urgency, or
+   rationale.
+
+5. Find the strongest apparent contradiction, stale instruction, or broken
+   lineage elsewhere in the repository. Resolve it using the authority order or
+   report it as a blocker.
+
+6. Could a teammate implement the decision without chat or guessing? List every
+   missing link or unresolved choice and classify each as a deliberate deferral
+   or an accidental gap.
+
+## Quarantine
+
+Earlier `*-cold-review.md` and `*-invalid-review.md` records stay checked in
+for auditability, but they are **quarantined inputs**. Do not open, read, or
+search their contents during a run. Seeing a path in a directory listing or in
+history is fine; reading one is not.
+
+If any command returns an answer or a verdict from one of those records,
+invalidate the run and start a fresh one. Engineering-review evidence recorded
+inside the candidate record or its trajectory is ordinary evidence, not a
+quarantined review.
+
+## Result
+
+PASS requires all six answers accurate and discoverable, with consistent
+status, lineage, authority, assumptions, normative ownership, and source-event
+attribution.
+
+Any wrong or unfindable answer, broken source locator, unresolved
+contradiction, invented binding choice, or need for an author hint is FAIL and
+blocks landing. `Not discoverable` is a valid answer and usually a finding
+about the record.
+
+A maintainer accepts the result. Reviewer prose is not self-certifying.

--- a/.codex/skills/cold-read
+++ b/.codex/skills/cold-read
@@ -1,0 +1,1 @@
+../../.claude/skills/cold-read

--- a/.gitignore
+++ b/.gitignore
@@ -141,12 +141,16 @@ conformance-artifacts/
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .gstack/
-.claude/
+# Agent config: personal state stays out, checked-in skills stay in. A child
+# of an excluded directory cannot be re-included, so this must glob.
+.claude/*
+!.claude/skills/
 
 # MoltZap runtime state (created by scripts/setup/quickstart.sh)
 /moltzap.yaml
 /.moltzap/
-.codex
+.codex/*
+!.codex/skills/
 /.tmp/
 
 .nx/cache


### PR DESCRIPTION
The blind review gate needs a tool that can't be talked out of its own premise. safer-by-default's `dogfood` is that tool — but depending on a **user-global plugin** means a fresh clone or a teammate's machine doesn't have it, and the plugin drifts underneath us.

## 554 → 215 lines

| Cut | Why |
|---|---|
| 62-line doctrine preamble | duplicates craft rules this repo states itself |
| 8 lines of plugin cross-references | `Principle 5`, `Principle 7`, "the debt multiplier" — meaningless here |
| `safer-slug`, `safer-telemetry-log`, `safer-update-check`, `safer-publish`, `safer-escalate`, `SAFER_PARENT_ISSUE` | each replaced by a `gh` call or deleted |
| `AUTO-GENERATED … do not edit` banner | replaced by a provenance header naming upstream + fork date, so nobody regenerates over the fork |

## Kept verbatim

The iron rule and its enforcement:

> **Read the artifact as if you have never seen this project before. Any context borrowed from conversation is a bug in the artifact.**

A subagent dispatched with a self-contained prompt is a stronger guarantee than asking a reviewer to forget what they know — an author *cannot* un-know the conversation that produced the artifact. The skill's body never reads the payload beyond piping it into the prompt file, and the anti-patterns section names "reading it yourself just to sanity-check" as the way that breaks.

## `--questions`

The six blind-gate questions live in `references/questions.md` as **data**, so the next question set doesn't fork the skill. The quarantine rule travels with them: prior `*-cold-review.md` records stay checked in for auditability but are never read during a run, and a command that surfaces one invalidates the run.

## `.gitignore`

`.claude/` → `.claude/*` + `!.claude/skills/`, because **a child of an excluded directory cannot be re-included**. Same for `.codex`.

Verified still ignored after the change:

```
!! .claude/settings.local.json
!! .claude/worktrees/
```

`.codex/skills/cold-read` is a **symlink** (mode `120000`) to the `.claude/` copy, not a duplicate — one file to edit, same reasoning as `CLAUDE.md -> AGENTS.md`.

## Not in this PR

The `decisions` skill. It carries the 179 lines `AGENTS.md` still holds, and landing it before the removal would put the same governance in two places at once. It belongs in the atomic restructure, with the AGENTS.md trim, the superseding ADR, and the four G1-DEC trace rows.

## Verification

| Check | Result |
|---|---|
| `git check-ignore` on personal state | still ignored |
| safer binaries / `SAFER_PARENT_ISSUE` / generated banner remaining | none |
| `.codex` symlink mode | `120000`, resolves |
| `lint:script-reachability` | 19 reachable, 0 allowlisted |
| `lint:adr-shape` | 48 records pass |
| `format:check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHzrYnz4gqSZKQnkNBVyKa