### PR TITLE
test(simulator): prove the OpenClaw plugin acquires its own client

### DIFF
--- a/docs/modules/client/src.mdx
+++ b/docs/modules/client/src.mdx
@@ -92,7 +92,7 @@ export interface ConversationMeta {
 
 Describes conversation meta.
 
-### [`ConversationWithParticipants`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/harness/runtime.ts#L133)
+### [`ConversationWithParticipants`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/harness/runtime.ts#L138)
 
 _TypeAlias_
 
@@ -102,7 +102,10 @@ export type ConversationWithParticipants = Schema.Schema.Type<
 >;
 ```
 
-Conversation projection carried only between the daemon and HarnessClient.
+Conversation plus its membership, assembled by the daemon because the
+canonical Conversation sent over the network carries no participants. It
+crosses only the loopback MCP boundary, and it is public because it names
+what `HarnessClientService.startConversation` hands back to an adapter.
 
 ### [`HarnessClient`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/harness-client.ts#L58)
 

--- a/docs/modules/openclaw-channel/src.mdx
+++ b/docs/modules/openclaw-channel/src.mdx
@@ -15,7 +15,7 @@ runtime entries from `index.*` at the extension root only, so the built
 
 ## Public surface
 
-### [`createMoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L929)
+### [`createMoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L934)
 
 _Function_
 
@@ -63,7 +63,7 @@ to `agent:&lt;name>`. Other colon-prefixed shapes are rejected.
 
 **Returns:** The created moltzap channel plugin.
 
-### [`default`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L958)
+### [`default`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L963)
 
 _Variable_
 
@@ -71,7 +71,7 @@ _Variable_
 const plugin =
 ```
 
-### [`moltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L955)
+### [`moltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L960)
 
 _Variable_
 
@@ -84,7 +84,7 @@ Shared singleton so a single registration reuses the same `activeClients`
 closure across `startAccount` and `sendText`. Tests import this directly
 to assert against that shared state.
 
-### [`MoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L946)
+### [`MoltzapChannelPlugin`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L951)
 
 _TypeAlias_
 
@@ -113,7 +113,7 @@ export interface OpenClawConfig {
 
 OpenClaw's config object; the plugin reads only its `channels.moltzap` section.
 
-### [`OpenClawResolveTargetParams`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L255)
+### [`OpenClawResolveTargetParams`](https://github.com/chughtapan/moltzap/blob/main/packages/openclaw-channel/src/openclaw-entry.ts#L260)
 
 _Interface_
 

--- a/packages/client/src/MODULE.md
+++ b/packages/client/src/MODULE.md
@@ -87,7 +87,7 @@ export interface ConversationMeta {
 
 Describes conversation meta.
 
-### [`ConversationWithParticipants`](./harness/runtime.ts#L133)
+### [`ConversationWithParticipants`](./harness/runtime.ts#L138)
 
 _TypeAlias_
 
@@ -97,7 +97,10 @@ export type ConversationWithParticipants = Schema.Schema.Type<
 >;
 ```
 
-Conversation projection carried only between the daemon and HarnessClient.
+Conversation plus its membership, assembled by the daemon because the
+canonical Conversation sent over the network carries no participants. It
+crosses only the loopback MCP boundary, and it is public because it names
+what `HarnessClientService.startConversation` hands back to an adapter.
 
 ### [`HarnessClient`](./harness-client.ts#L58)
 

--- a/packages/client/src/harness/runtime.ts
+++ b/packages/client/src/harness/runtime.ts
@@ -129,7 +129,12 @@ export type HarnessTurnEvent = Schema.Schema.Type<
   typeof harnessTurnEventSchema
 >;
 
-/** Conversation projection carried only between the daemon and HarnessClient. */
+/**
+ * Conversation plus its membership, assembled by the daemon because the
+ * canonical Conversation sent over the network carries no participants. It
+ * crosses only the loopback MCP boundary, and it is public because it names
+ * what `HarnessClientService.startConversation` hands back to an adapter.
+ */
 export type ConversationWithParticipants = Schema.Schema.Type<
   typeof conversationWithParticipantsSchema
 >;

--- a/packages/evals/AGENTS.md
+++ b/packages/evals/AGENTS.md
@@ -1,0 +1,15 @@
+# @moltzap/evals
+
+Private, unpublished. One code-first customer of `@moltzap/simulator`:
+it defines behavioral cases, runs mixed societies through the production
+router, grades durable ledger evidence, stores resumable reports, and
+publishes completed results to Phoenix.
+
+Being a customer is the point. Everything here reaches the system the way
+an external consumer would — the production router, the runtime-native
+gateway, the same protocol on every leg. A shortcut that reaches past
+those surfaces stops the package measuring what it exists to measure.
+
+Cases pair with OpenClaw and NanoClaw target conditions, and every society
+also contains autonomous in-process Effect peers. `README.md` carries the
+execution model and the grading reference.

--- a/packages/evals/CLAUDE.md
+++ b/packages/evals/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/openclaw-channel/src/MODULE.md
+++ b/packages/openclaw-channel/src/MODULE.md
@@ -10,7 +10,7 @@ runtime entries from `index.*` at the extension root only, so the built
 
 ## Public surface
 
-### [`createMoltzapChannelPlugin`](./openclaw-entry.ts#L929)
+### [`createMoltzapChannelPlugin`](./openclaw-entry.ts#L934)
 
 _Function_
 
@@ -58,7 +58,7 @@ to `agent:&lt;name>`. Other colon-prefixed shapes are rejected.
 
 **Returns:** The created moltzap channel plugin.
 
-### [`default`](./openclaw-entry.ts#L958)
+### [`default`](./openclaw-entry.ts#L963)
 
 _Variable_
 
@@ -66,7 +66,7 @@ _Variable_
 const plugin =
 ```
 
-### [`moltzapChannelPlugin`](./openclaw-entry.ts#L955)
+### [`moltzapChannelPlugin`](./openclaw-entry.ts#L960)
 
 _Variable_
 
@@ -79,7 +79,7 @@ Shared singleton so a single registration reuses the same `activeClients`
 closure across `startAccount` and `sendText`. Tests import this directly
 to assert against that shared state.
 
-### [`MoltzapChannelPlugin`](./openclaw-entry.ts#L946)
+### [`MoltzapChannelPlugin`](./openclaw-entry.ts#L951)
 
 _TypeAlias_
 
@@ -108,7 +108,7 @@ export interface OpenClawConfig {
 
 OpenClaw's config object; the plugin reads only its `channels.moltzap` section.
 
-### [`OpenClawResolveTargetParams`](./openclaw-entry.ts#L255)
+### [`OpenClawResolveTargetParams`](./openclaw-entry.ts#L260)
 
 _Interface_
 

--- a/packages/openclaw-channel/src/openclaw-entry.ts
+++ b/packages/openclaw-channel/src/openclaw-entry.ts
@@ -241,9 +241,14 @@ interface InboundDispatchInput {
 
 interface MoltzapChannelPluginDeps {
   /**
-   * Selects a caller-acquired client for one configured account. The plugin
-   * owns only its turn drain and never discovers, acquires, or closes the
-   * returned client.
+   * Substitutes the account's client so a suite can drive a turn stream
+   * without a daemon. Tests only: production supplies no deps and the plugin
+   * acquires the slot's own client, which
+   * `harness-adapters.integration.test.ts` proves end to end. The substitute
+   * is still a `HarnessClientService`, so this is not a second route to the
+   * daemon — the plugin owns only its turn drain and never discovers,
+   * acquires, or closes an injected client.
+   * @internal
    */
   readonly harnessClientForAccount?: (
     profileName: string,

--- a/packages/openclaw-channel/src/test-utils/harness-fixture.ts
+++ b/packages/openclaw-channel/src/test-utils/harness-fixture.ts
@@ -1,12 +1,14 @@
 /**
  * Shared OpenClaw gateway fixture.
  *
- * The plugin reaches its client only through the caller-owned
- * `harnessClientForAccount` seam, so every gateway suite needs the same three
- * things: an injected client whose turn stream the test drives, OpenClaw's
- * fixed `startAccount` argument shape, and a teardown that leaves the client
- * untouched. They live here so each suite asserts behaviour instead of
- * rebuilding the seam.
+ * These suites assert presentation behaviour, so they substitute the account's
+ * client through the plugin's test-only `harnessClientForAccount` seam rather
+ * than spawning a daemon. Each needs the same three things: a client whose
+ * turn stream the test drives, OpenClaw's fixed `startAccount` argument shape,
+ * and a teardown that leaves the client untouched. They live here so each
+ * suite asserts behaviour instead of rebuilding the seam. The production path,
+ * where nothing is injected, is covered by
+ * `harness-adapters.integration.test.ts`.
  */
 
 import type {

--- a/packages/simulator/CLAUDE.md
+++ b/packages/simulator/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/simulator/src/runtime/harness-adapters.integration.test.ts
+++ b/packages/simulator/src/runtime/harness-adapters.integration.test.ts
@@ -22,7 +22,6 @@ import {
   conversationList,
   type ConversationId,
 } from "@moltzap/protocol/conversation";
-import { agentName } from "@moltzap/protocol/identity";
 import {
   messageReceivedNotificationDefinition,
   messagesSend,
@@ -42,7 +41,6 @@ import {
   Effect,
   Fiber,
   Option,
-  Schema,
   Stream,
   type Scope,
 } from "effect";
@@ -51,7 +49,6 @@ import { describe, expect, it } from "vitest";
 
 const WAIT_TIMEOUT = Duration.seconds(20);
 const CONVERSATION_LIST_LIMIT = 100;
-const INITIAL_CONTENT = "hello from the harness owner";
 const PEER_CONTENT = "hello through the packaged harness";
 const OPENCLAW_REPLY = "reply through OpenClaw";
 const NANOCLAW_REPLY = "reply through NanoClaw";
@@ -101,7 +98,7 @@ interface PeerExchange extends Omit<AdapterExchange, "harness"> {
   readonly inboundText: Deferred.Deferred<string>;
 }
 
-interface OpenClawExchange extends AdapterExchange {
+interface OpenClawExchange extends Omit<AdapterExchange, "harness"> {
   readonly profileName: string;
 }
 
@@ -203,34 +200,26 @@ const messageText = (message: Message): string =>
     .flatMap((part) => (part.type === "text" ? [part.text] : []))
     .join("");
 
-const assertConversationBoundary = (
-  harness: HarnessClientService,
-  owner: RegisterResponse,
+// One slot names one loopback port, so the plugin is the only thing that may
+// acquire its client. The peer therefore opens the conversation, and the
+// membership boundary is asserted from the peer's side of the wire.
+const assertPeerConversationBoundary = (
   peer: ConnectedHarnessAgent,
-  peerName: string,
+  owner: RegisterResponse,
+  conversationId: ConversationId,
 ) =>
   Effect.gen(function* () {
-    const conversation = yield* harness.startConversation(
-      [Schema.decodeSync(agentName)(peerName)],
-      INITIAL_CONTENT,
-    );
-
-    expect(new Set(conversation.participants)).toEqual(
-      new Set([owner.agentId, peer.agentId]),
-    );
-
     const listed = yield* peer.client.sendRpc(conversationList, {
       limit: CONVERSATION_LIST_LIMIT,
     });
     const item = listed.items.find(
-      (candidate) => candidate.conversation.id === conversation.id,
+      (candidate) => candidate.conversation.id === conversationId,
     );
     expect(item).toBeDefined();
     expect(item?.conversation).not.toHaveProperty("participants");
     expect(new Set(item?.participants)).toEqual(
       new Set([owner.agentId, peer.agentId]),
     );
-    return conversation.id;
   });
 
 const runPeerExchange = (exchange: PeerExchange) =>
@@ -365,16 +354,12 @@ const makeOpenClawStatusHandler =
     }
   };
 
-const startOpenClawGateway = (
-  harness: HarnessClientService,
-  profileName: string,
-  fixture: OpenClawFixture,
-) =>
+// No injected client: the plugin resolves the slot from the account id and
+// acquires its own HarnessClient, exactly as a real OpenClaw install does.
+const startOpenClawGateway = (profileName: string, fixture: OpenClawFixture) =>
   Effect.gen(function* () {
     const abortController = new AbortController();
-    const plugin = createMoltzapChannelPlugin({
-      harnessClientForAccount: () => harness,
-    });
+    const plugin = createMoltzapChannelPlugin();
     const startFiber = yield* Effect.fork(
       tryPromise(() =>
         plugin.gateway.startAccount({
@@ -411,11 +396,7 @@ const startOpenClawGateway = (
 const runOpenClawExchange = (exchange: OpenClawExchange) =>
   Effect.gen(function* () {
     const fixture = yield* prepareOpenClawFixture;
-    yield* startOpenClawGateway(
-      exchange.harness,
-      exchange.profileName,
-      fixture,
-    );
+    yield* startOpenClawGateway(exchange.profileName, fixture);
     yield* awaitDeferred(
       fixture.connected,
       "OpenClaw Harness gateway readiness",
@@ -589,20 +570,18 @@ const createPeerDm = (
 
 // The OpenClaw plugin takes an injected client, so the test acquires the
 // slot's client itself and asserts the conversation boundary through it.
+// The production composition end to end: the plugin's own daemon, the endpoint
+// derived from the slot, and a real file-backed checkpoint store — no
+// test-only acquisition path anywhere in the chain.
 const runOpenClawCase = (input: CaseInput) =>
   Effect.gen(function* () {
-    // The production composition end to end: the slot's own daemon, the
-    // endpoint derived from the slot, and a real file-backed checkpoint
-    // store — no test-only acquisition path.
-    const harness = yield* harnessClientForProfile(input.profileName);
-    const conversationId = yield* assertConversationBoundary(
-      harness,
-      input.owner,
+    const conversationId = yield* createPeerDm(input.peer, input.owner);
+    yield* assertPeerConversationBoundary(
       input.peer,
-      input.peerName,
+      input.owner,
+      conversationId,
     );
     yield* runOpenClawExchange({
-      harness,
       peer: input.peer,
       owner: input.owner,
       conversationId,


### PR DESCRIPTION
Closes the last three open items from the slate's verification table.

## 1. The decisive assertion now runs

The plan's step-10 gate ends with: *`harness-adapters.integration.test.ts → startOpenClawGateway` constructs the plugin as `createMoltzapChannelPlugin()` with **no injected client** and still completes the round trip.* The OpenClaw case injected one, so that assertion had never executed — the only end-to-end proof of the production acquisition path was the NanoClaw case.

The plugin now acquires the slot's client itself. One slot names one loopback port, so nothing else may open a second daemon against it: the peer opens the conversation and the membership boundary is asserted from the peer's side, which is the shape `runNanoClawCase` already had. `assertConversationBoundary` is replaced by `assertPeerConversationBoundary`.

Coverage moved, not lost: `HarnessClientService.startConversation` is still exercised by `moltzapd.integration.test.ts → starts a conversation and round-trips a bound reply through MCP only` and by `harness-client.test.ts`.

## 2. `harnessClientForAccount` stays — a recommendation I reversed

I previously said this should be deleted, and step 10's grep does list it. Having looked at what depends on it, deleting it is the wrong call:

- It returns **`HarnessClientService`** — the sanctioned adapter-facing capability. It is not a second route to the daemon the way the deleted `createService` / `createCore` were, which returned `MoltZapService` / `MoltZapChannelCore`.
- Four OpenClaw suites drive **pure presentation logic** (inbound projection, delivery formatting, contract properties) through a fake turn stream. Deleting the seam converts all four into daemon-spawning integration tests, for no safety gain.

So the field stays, marked `@internal` and documented as test-only in both the plugin type and the fixture header. `git grep harnessClientForAccount -- packages/ | grep -v '\.test\.ts\|test-utils/'` returns only the declaration and its own read — **no shipped source supplies it**, and #962's `checkAdapterFile` rule already blocks the real bypasses by symbol and subpath.

I'd rather flag this as a plan step that stopped making sense than execute it and degrade the test suite.

## 3. Divergence ledger — rows 1 and 6 closed

**Row 1** was the corpus's only confirmed *binding* divergence and was still open: `packages/evals` had neither `AGENTS.md` nor `CLAUDE.md`, `packages/simulator` had no `CLAUDE.md`. All seven packages now carry both.

**Row 6** — `ConversationWithParticipants` has **zero consumers outside `packages/client`**, but it names the return type of `HarnessClientService.startConversation`, so the export is correct and the doc comment was the wrong half. Rewritten to say what is true.

Rows 2 and 3 remain: contested, v2-owned, unresolvable until a main-resident `HarnessClient` contract is admitted. Row 5 was withdrawn (v2 renamed on its own branch; main's table matches main's tree). Row 7 closed in #961.

Full re-derived ledger and the per-row verification table are posted to #926: https://github.com/chughtapan/moltzap/issues/926#issuecomment-5198106049

## Verification

Run against the new gate shape, since `workspace:precommit` no longer exists after main's hook retiering:

- `pnpm typecheck` — 0
- `pnpm lint` — 0 (includes `arch:check` across 9 projects and the new `lint:script-reachability`)
- `pnpm format:check` — 0
- `pnpm docs:generate` — no drift
- simulator integration suite — **3/3**, OpenClaw 59s, NanoClaw 45s, restart 46s

One miss worth recording: deleting `assertConversationBoundary` orphaned `Schema`, `agentName`, and `INITIAL_CONTENT`. The integration test passed regardless — only `pnpm lint` catches that, and I reported the item done before running it.