### PR TITLE
feat(agents): require gbrain; keep rationale out of code bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ env:
   NX_SELF_HOSTED_REMOTE_CACHE_SERVER: https://nx-cache-server-production.up.railway.app
   NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: ${{ secrets.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
   NX_SKIP_REMOTE_CACHE: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'true' || 'false' }}
+  # Decision provenance resolves against the brain, so `pnpm lint` needs a
+  # connection. Fork PRs receive no secrets and will fail this check; that is
+  # accepted rather than degraded, because a provenance check that silently
+  # skips is the failure mode the check exists to prevent.
+  GBRAIN_DATABASE_URL: ${{ secrets.GBRAIN_DATABASE_URL }}
 
 jobs:
   ci:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,23 +1,26 @@
 #!/usr/bin/env sh
-set -e
-
+#
 # Everything here is gated on what is staged, so a commit that touches nothing
 # relevant pays nothing. The heavy checks live at pre-push and in CI.
-ROOT="$(git rev-parse --show-toplevel)"
-
+#
 # Decision records are checked at commit time because the changelog rule needs
 # the diff: a body edit with no status change and no dated row is a silent
-# rewrite, and it is invisible in review because it looks like a typo fix.
+# rewrite, invisible in review because it looks like a typo fix.
+#
+# Formatting never fails a commit. Small, frequent commits are the norm here and
+# a fix-then-retry cycle would multiply across every one of them. Re-staging is
+# scoped to paths already staged, so an unrelated working-tree edit can never be
+# swept in. oxfmt is resolved by absolute path because git invokes hooks without
+# node_modules/.bin on PATH.
+set -e
+
+ROOT="$(git rev-parse --show-toplevel)"
+
 if git diff --cached --name-only --diff-filter=ACMR \
   | grep -qE '^docs/(decisions|decision-evidence)/'; then
   "$ROOT/node_modules/.bin/tsx" "$ROOT/scripts/docs/adr/check-shape.ts" --staged
 fi
 
-# Format the staged files and re-stage exactly those paths. Formatting never
-# fails a commit: small, frequent commits are the norm here, and a
-# fix-then-retry cycle would multiply across every one of them. Re-staging is
-# scoped to paths already staged so an unrelated working-tree edit can never be
-# swept into the commit.
 STAGED=$(mktemp)
 trap 'rm -f "$STAGED"' EXIT
 
@@ -26,7 +29,5 @@ git diff --cached --name-only --diff-filter=ACMR -z \
 
 [ -s "$STAGED" ] || exit 0
 
-# Resolve the binary explicitly: git invokes hooks without node_modules/.bin on
-# PATH, so a bare `oxfmt` works from a pnpm-run commit and fails from an editor.
 xargs -0 "$ROOT/node_modules/.bin/oxfmt" < "$STAGED"
 xargs -0 git add -- < "$STAGED"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,8 +1,9 @@
 #!/usr/bin/env sh
-set -e
-
+#
 # The batch boundary. These are too slow to pay per commit and cheap enough to
 # pay once per push; CI stays the full gate. sloppy-code-guard also runs in CI
 # via the workspace lint target, so a bypass here is caught rather than lost.
+set -e
+
 pnpm nx run workspace:lint:sloppy-code-guard
 pnpm exec nx affected -t typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ the setup itself.
 | `/plan-eng-review` | start implementing a feature |
 | `/land-and-deploy` | merge |
 | `codex`, authenticated and in quota | call review complete |
+| `gbrain`, connected | verify decision provenance, or run the blind gate |
 
 **Refuse where the failure is silent; warn where it is loud.** A missing binary
 that errors on first use needs no rule. `/review` without codex quietly becomes
@@ -81,12 +82,14 @@ review gate. `scripts/docs/adr/check-shape.ts` enforces the mechanical half in
   this) → LSP. Grep/Explore only for breadth or text search.
 - Cite by symbol name (`file.ts → handleFrame`), never by line;
   `file.ts:NNN` only in PRs and reviews.
-- Comments serve a cold reader, in present tense: why the code is
-  shaped this way, non-obvious invariants, surprising constants.
-  Never: issue/spec/phase numbers, change narration (formerly, no
-  longer, renamed from), design alternatives, or restating the next
-  lines. Rewrite touched comments in the same PR; history lives in
-  git, not code.
+- Rationale goes in JSDoc on the symbol it explains, in the commit
+  message, or in a docs file — never scattered inline through a body.
+  A shell script's header block is its JSDoc. Write for a cold reader
+  in present tense: why the code is shaped this way, non-obvious
+  invariants, surprising constants. Never issue/spec/phase numbers,
+  change narration (formerly, no longer, renamed from), design
+  alternatives, or restating the next lines. Rewrite touched comments
+  in the same PR; history lives in git, not code.
 - Fix every instance, not the reported one. When a pattern is wrong,
   grep `packages/`, `v2/`, `scripts/`, and `test/` and fix all of it in
   the same change; one corrected call site with five untouched siblings

--- a/scripts/docs/adr/check-shape.ts
+++ b/scripts/docs/adr/check-shape.ts
@@ -76,6 +76,15 @@ const recordFiles = (): readonly string[] =>
     .split("\n")
     .filter((p) => p.length > 0 && !p.endsWith("README.md"));
 
+/**
+ * Check one record against the mechanical rules.
+ *
+ * `isNew` gates the required-sections rule. The `decisions` skill requires the
+ * three sections of *new* records and says older admitted records retain their
+ * historical body shape; 26 of the existing 48 carry consequences as a
+ * paragraph inside Decision Outcome, which that clause permits. Enforcing the
+ * heading on them would be this gate overruling the rule it implements.
+ */
 const checkRecord = (
   path: string,
   indexBody: string,
@@ -124,11 +133,6 @@ const checkRecord = (
     );
   }
 
-  // The `decisions` skill requires the three sections of *new* records and says older
-  // admitted records retain their historical body shape. 26 of the existing 48
-  // carry consequences as a paragraph inside Decision Outcome, which that
-  // clause permits; enforcing the heading on them would be this gate
-  // overruling the rule it implements.
   if (isNew) {
     for (const section of REQUIRED_SECTIONS) {
       if (!new RegExp(`^#{2,3}\\s+${section}\\s*$`, "m").test(text)) {
@@ -197,13 +201,14 @@ const checkRecord = (
  * A staged record whose body changed, whose status did not, and which gained
  * no changelog row. The `decisions` skill permits editing a record in place
  * only with a dated receipt.
+ *
+ * `git show` stderr is silenced: a record new in this commit makes it fail by
+ * design, and "exists on disk, but not in HEAD" reads like a gate failure.
  */
 const checkChangelogRow = (path: string): Violation | undefined => {
   const name = path.slice(DECISIONS.length + 1);
   let previous: string;
   try {
-    // stderr is silenced because a new record makes this fail by design, and
-    // git's "exists on disk, but not in HEAD" reads like a gate failure.
     previous = execFileSync("git", ["-C", repoRoot, "show", `HEAD:${path}`], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
@@ -239,6 +244,10 @@ const checkChangelogRow = (path: string): Violation | undefined => {
   };
 };
 
+/**
+ * Only a record added in this commit counts as new; a modified one keeps
+ * whatever body shape it was admitted with.
+ */
 const main = (): void => {
   const staged = process.argv.includes("--staged");
   const indexBody = readFileSync(
@@ -251,8 +260,6 @@ const main = (): void => {
     p.endsWith(".md") &&
     !p.endsWith("README.md");
 
-  // Only a record added in this commit is "new". A modified one keeps whatever
-  // body shape it was admitted with.
   const added = new Set<string>();
   let targets: readonly string[];
   if (staged) {

--- a/scripts/repo/check-agent-setup.sh
+++ b/scripts/repo/check-agent-setup.sh
@@ -15,6 +15,20 @@
 #
 # Exits 0 when every required item is present, 1 otherwise. Advisory items
 # print a note and never change the exit code.
+#
+# Two probes are deliberately absent. /simplify ships with the harness and has
+# no SKILL.md on disk, so testing for one would report a permanent false
+# absence. codex quota is not probed either: a rate-limited codex fails exactly
+# like a missing one, quietly, but detecting it costs a request per session.
+#
+# gbrain carries the decision-evidence corpus, so provenance verification and
+# the blind gate's source-event question both resolve against it. An absent
+# brain is not a degraded experience, it is an unanswerable question.
+#
+# Hook freshness is advisory. .husky/pre-commit is tracked, so every branch
+# carries its own copy and a fix on main reaches nobody until they merge; this
+# repo has had 70 worktrees on a stale 165s hook at once. A branch may differ
+# on purpose.
 
 set -uo pipefail
 
@@ -47,9 +61,6 @@ fi
 command -v pnpm >/dev/null 2>&1 && ok "pnpm" "$(pnpm --version)" || gone "pnpm" "not on PATH — see packageManager in package.json"
 
 # ── review path ─────────────────────────────────────────────────────────────
-# Only file-backed skills can be probed. /simplify ships with the harness and
-# has no SKILL.md on disk, so testing for one would report a permanent false
-# absence. Its presence is the harness's problem, not this repo's.
 for skill in plan-eng-review review ship land-and-deploy codex; do
   if [ -f "$HOME/.claude/skills/$skill/SKILL.md" ]; then
     ok "/$skill" ""
@@ -58,10 +69,6 @@ for skill in plan-eng-review review ship land-and-deploy codex; do
   fi
 done
 
-# codex backs /review's always-on adversarial pass and /plan-eng-review's
-# outside voice. Installed is checkable; having quota is not, and a rate-limited
-# codex fails the same way a missing one does — quietly, one model instead of
-# two.
 if command -v codex >/dev/null 2>&1; then
   ok "codex" "$(codex --version 2>/dev/null | head -1)"
   note "codex quota" "not probed — a rate-limited codex degrades review silently"
@@ -69,10 +76,17 @@ else
   gone "codex" "not on PATH — /review falls back to a single model"
 fi
 
+if command -v gbrain >/dev/null 2>&1; then
+  if gbrain doctor --json >/dev/null 2>&1; then
+    ok "gbrain" "$(gbrain --version 2>/dev/null | head -1)"
+  else
+    gone "gbrain" "installed but not reachable — run 'gbrain doctor' for the engine error"
+  fi
+else
+  gone "gbrain" "not on PATH — run /setup-gbrain; provenance and the blind gate resolve against it"
+fi
+
 # ── hook freshness ──────────────────────────────────────────────────────────
-# .husky/pre-commit is tracked, so every branch carries its own copy and a fix
-# on main reaches nobody until they merge. This repo has had 70 worktrees on a
-# stale 165s hook at once. Advisory: a branch may differ on purpose.
 if git rev-parse --verify -q origin/main >/dev/null 2>&1; then
   local_hook=$(git hash-object .husky/pre-commit 2>/dev/null || echo none)
   main_hook=$(git rev-parse "origin/main:.husky/pre-commit" 2>/dev/null || echo none)

--- a/scripts/repo/check-script-reachability.ts
+++ b/scripts/repo/check-script-reachability.ts
@@ -50,6 +50,10 @@ const git = (args: readonly string[]): string =>
  * `git grep` exits 1 to mean "no match", which `execFileSync` raises as an
  * error. Only that exit code is benign; anything else is a real failure and
  * must not be swallowed into a false "unreferenced" verdict.
+ *
+ * This file is excluded from its own search: it names every allowlisted path,
+ * so counting it as a reference would make each allowlist entry
+ * self-justifying.
  */
 const gitGrepFiles = (needle: string): readonly string[] => {
   try {
@@ -61,8 +65,6 @@ const gitGrepFiles = (needle: string): readonly string[] => {
       "--",
       ".",
       ":(exclude)scripts/__tests__",
-      // This file names every allowlisted path, so counting it as a reference
-      // would make each allowlist entry look self-justifying.
       ":(exclude)scripts/repo/check-script-reachability.ts",
     ]).split("\n");
   } catch (error) {


### PR DESCRIPTION
Two changes to agent law. The second lands on code written today.

## gbrain becomes required

Decision provenance and the blind gate's source-event question both resolve against the brain. An absent brain isn't a degraded experience — it's an **unanswerable question**.

- `AGENTS.md` prerequisites gains a row: `gbrain, connected` → refuse to *verify decision provenance, or run the blind gate*
- `check-agent-setup.sh` fails without it
- `GBRAIN_DATABASE_URL` added as a repo secret (piped via stdin, never in argv or a transcript)
- `ci.yml` passes it through

**Fork PRs will fail this check.** That's accepted rather than degraded: a provenance check that silently skips is precisely the failure it exists to prevent. Same shape as the Nx Cloud auth gotcha this repo already hit — local degrades quietly, CI hard-fails — so it's stated in the workflow comment rather than discovered later.

## Rationale leaves code bodies

Old rule permitted any comment serving a cold reader. In practice that meant explanation landed wherever the writing happened.

New rule: **rationale goes in JSDoc on the symbol it explains, the commit message, or a docs file — never scattered inline through a body.** A shell script's header block is its JSDoc.

All six files added today violated it. Eleven inline comments relocated:

| File | Moved |
|---|---|
| `check-shape.ts` | `isNew` rationale → `checkRecord` JSDoc; `git show` stderr note → `checkChangelogRow` |
| `check-script-reachability.ts` | self-exclusion note → `gitGrepFiles` |
| `.husky/pre-commit`, `.husky/pre-push`, `check-agent-setup.sh` | body comments → header blocks |

Zero inline rationale remains in any of them.

**One judgment call:** the three `# ── toolchain ──` dividers in `check-agent-setup.sh` stay. They mark *where*, not *why* — structural headings rather than rationale. Easy to remove if that reads wrong.

## Verification

| Check | Result |
|---|---|
| `check-agent-files`, `check-shape`, `check-script-reachability` | PASS |
| `pnpm check:agent-setup` | exit 0, gbrain row green |
| `tsc --noEmit` | exit 0 |
| `format:check` | clean |
| pre-commit hook | 86ms |
| inline rationale, all 6 files | 0 |

## Not in this PR

`check-shape.ts` still resolves provenance with `existsSync` against the repo. Moving trajectories to Supabase changes that, and it changes provenance (G1-DEC-009) and the blind gate (G1-DEC-006, -010) — so it needs an ADR and a gate run of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHzrYnz4gqSZKQnkNBVyKa