### PR TITLE
feat(simulator): streamable-http MCP servers and workspace-file reachability for container agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added: streamable-HTTP MCP servers for container agents
+
+An MCP server on either container runtime may now be a remote
+`{ name, url }` endpoint alongside the stdio `{ name, command, args, env }`
+shape. OpenClaw renders it as its native `streamable-http` transport;
+NanoClaw passes it through its application config. Remote URLs may embed
+per-agent capability tokens, so sanitized configurations digest them by
+origin only and record the URL as redacted, and unparseable URLs are
+refused when the runtime is defined. OpenClaw definitions also now refuse
+workspace files that could never reach the model (outside the
+context-injection set with every tool denied), warn when such files are
+merely tool-reachable, and carry a drift canary that fails loudly if a
+packaged OpenClaw changes its injection set.
+
 ### Added: container societies on Kubernetes
 
 The simulator runs a society of container agents on Kubernetes through one

--- a/packages/simulator/src/agents/nanoclaw/runtime.test.ts
+++ b/packages/simulator/src/agents/nanoclaw/runtime.test.ts
@@ -49,6 +49,7 @@ const BRIDGE_HOST = "127.0.0.2";
 const MODEL_ID = "claude-sonnet-4-5";
 const WORKSPACE_CONTENT = "Alice";
 const MCP_SECRET = "secret-mcp-value";
+const MCP_URL = "https://calendar.test/mcp/opaque-token";
 
 const connection: AgentConnection<"alice"> = {
   agent: makeAgentHandle("alice", AGENT_ID),
@@ -66,12 +67,15 @@ const renderedRuntimeConfig = Schema.parseJson(
     autoRegisterConversations: Schema.Boolean,
     modelId: Schema.optional(Schema.String),
     mcpServers: Schema.Array(
-      Schema.Struct({
-        name: Schema.String,
-        command: Schema.String,
-        args: Schema.Array(Schema.String),
-        env: Schema.Record({ key: Schema.String, value: Schema.String }),
-      }),
+      Schema.Union(
+        Schema.Struct({
+          name: Schema.String,
+          command: Schema.String,
+          args: Schema.Array(Schema.String),
+          env: Schema.Record({ key: Schema.String, value: Schema.String }),
+        }),
+        Schema.Struct({ name: Schema.String, url: Schema.String }),
+      ),
     ),
   }),
 );
@@ -137,6 +141,7 @@ function makeFixture() {
           args: ["--stdio"],
           env: { PRIVATE_TOKEN: MCP_SECRET },
         },
+        { name: "calendar", url: MCP_URL },
       ],
     });
     const capability = containerRuntimeFor(runtime);
@@ -190,10 +195,15 @@ function assertBootstrap(fixture: Fixture): void {
   assert.strictEqual(runtimeConfig.stateDirectory, STATE_DIR);
   assert.strictEqual(runtimeConfig.modelId, MODEL_ID);
   assert.isTrue(runtimeConfig.autoRegisterConversations);
-  assert.strictEqual(
-    runtimeConfig.mcpServers[0]?.env.PRIVATE_TOKEN,
-    MCP_SECRET,
-  );
+  assert.deepStrictEqual(runtimeConfig.mcpServers, [
+    {
+      name: "private-tool",
+      command: "tool-server",
+      args: ["--stdio"],
+      env: { PRIVATE_TOKEN: MCP_SECRET },
+    },
+    { name: "calendar", url: MCP_URL },
+  ]);
   assert.strictEqual(profile.profiles["simulator-agent"].agentId, AGENT_ID);
   assert.strictEqual(
     profile.profiles["simulator-agent"].apiKey,
@@ -209,6 +219,10 @@ function assertBootstrap(fixture: Fixture): void {
   assert.notInclude(
     JSON.stringify(runtimeConfigurationProjection(runtime)),
     AGENT_KEY_TEXT,
+  );
+  assert.notInclude(
+    JSON.stringify(runtimeConfigurationProjection(runtime)),
+    MCP_URL,
   );
   assert.notInclude(
     JSON.stringify(runtimeConfigurationProjection(runtime)),

--- a/packages/simulator/src/agents/nanoclaw/runtime.ts
+++ b/packages/simulator/src/agents/nanoclaw/runtime.ts
@@ -92,7 +92,7 @@ export interface NanoClawRuntimeOptions {
    */
   readonly autoRegisterConversations?: boolean;
 
-  /** Stdio MCP servers mounted into the NanoClaw container workspace. */
+  /** MCP servers reachable from the NanoClaw container. */
   readonly mcpServers?: readonly McpServer[];
 }
 
@@ -156,12 +156,7 @@ function runtimeConfig(
       workspaceDirectory: NANOCLAW_WORKSPACE_DIR,
       autoRegisterConversations: settings.autoRegisterConversations,
       ...(settings.modelId === undefined ? {} : { modelId: settings.modelId }),
-      mcpServers: (settings.mcpServers ?? []).map((server) => ({
-        name: server.name,
-        command: server.command,
-        args: [...server.args],
-        env: { ...server.env },
-      })),
+      mcpServers: settings.mcpServers ?? [],
     },
     null,
     2,

--- a/packages/simulator/src/agents/openclaw/configuration.test.ts
+++ b/packages/simulator/src/agents/openclaw/configuration.test.ts
@@ -1,0 +1,56 @@
+import { Redacted } from "effect";
+import { assert, describe, it } from "@effect/vitest";
+import { agentName } from "@moltzap/protocol/testing";
+import { buildOpenClawConfig } from "./configuration.js";
+
+const CALENDAR_URL = "https://calendar.test/mcp/opaque-token";
+
+function mcpSection(
+  mcpServers: Parameters<typeof buildOpenClawConfig>[0]["mcpServers"],
+) {
+  const config = buildOpenClawConfig(
+    {
+      agentName: agentName("alice"),
+      gatewayToken: Redacted.make("token"),
+      mcpServers,
+    },
+    "/var/run/moltzap/bootstrap/workspace",
+  );
+  return config.mcp?.servers;
+}
+
+describe("buildOpenClawConfig MCP servers", () => {
+  it("renders a command definition as a stdio transport", () => {
+    assert.deepStrictEqual(
+      mcpSection([
+        {
+          name: "files",
+          command: "files-mcp",
+          args: ["--root", "."],
+          env: { A: "1" },
+        },
+      ]),
+      {
+        files: {
+          transport: "stdio",
+          command: "files-mcp",
+          args: ["--root", "."],
+          env: { A: "1" },
+        },
+      },
+    );
+  });
+
+  it("renders a url definition as a streamable-http transport", () => {
+    assert.deepStrictEqual(
+      mcpSection([{ name: "calendar", url: CALENDAR_URL }]),
+      {
+        calendar: { transport: "streamable-http", url: CALENDAR_URL },
+      },
+    );
+  });
+
+  it("omits the mcp section without servers", () => {
+    assert.isUndefined(mcpSection(undefined));
+  });
+});

--- a/packages/simulator/src/agents/openclaw/configuration.ts
+++ b/packages/simulator/src/agents/openclaw/configuration.ts
@@ -8,7 +8,7 @@ import type {
   ToolsConfig,
 } from "openclaw/plugin-sdk/config-types";
 import { Redacted } from "effect";
-import { SIMULATOR_PROFILE_NAME } from "../workspace.js";
+import { SIMULATOR_PROFILE_NAME, type McpServer } from "../workspace.js";
 
 const DEFAULT_OPENCLAW_MODEL_ID = "openai/gpt-5.5";
 const OPENCLAW_CHANNEL_ID = "moltzap" satisfies MoltzapChannelPlugin["id"];
@@ -20,17 +20,10 @@ export type OpenClawToolsConfig = ToolsConfig;
 /** Native OpenClaw sandbox configuration for the runtime's default agent. */
 export type OpenClawSandboxConfig = NonNullable<AgentDefaultsConfig["sandbox"]>;
 
-interface OpenClawMcpServer {
-  readonly name: string;
-  readonly command: string;
-  readonly args: readonly string[];
-  readonly env: Readonly<Record<string, string>>;
-}
-
 interface OpenClawConfigInput {
   readonly agentName: AgentName;
   readonly modelId?: string;
-  readonly mcpServers?: readonly OpenClawMcpServer[];
+  readonly mcpServers?: readonly McpServer[];
   readonly tools?: OpenClawToolsConfig;
   readonly sandbox?: OpenClawSandboxConfig;
   readonly gatewayToken: Redacted.Redacted;
@@ -39,7 +32,7 @@ interface OpenClawConfigInput {
 }
 
 function mcpConfigSection(
-  mcpServers?: readonly OpenClawMcpServer[],
+  mcpServers?: readonly McpServer[],
 ): Pick<OpenClawConfig, "mcp"> {
   if (mcpServers === undefined || mcpServers.length === 0) {
     return {};
@@ -49,12 +42,14 @@ function mcpConfigSection(
       servers: Object.fromEntries(
         mcpServers.map((server) => [
           server.name,
-          {
-            transport: "stdio" as const,
-            command: server.command,
-            args: [...server.args],
-            env: { ...server.env },
-          },
+          "url" in server
+            ? { transport: "streamable-http" as const, url: server.url }
+            : {
+                transport: "stdio" as const,
+                command: server.command,
+                args: [...server.args],
+                env: { ...server.env },
+              },
         ]),
       ),
     },

--- a/packages/simulator/src/agents/openclaw/context-files.test.ts
+++ b/packages/simulator/src/agents/openclaw/context-files.test.ts
@@ -1,0 +1,69 @@
+import { createRequire } from "node:module";
+// eslint-disable-next-line agent-code-guard/prefer-effect-platform -- the canary reads the installed OpenClaw dist synchronously inside a unit test.
+import fs from "node:fs";
+import path from "node:path";
+import { assert, describe, it } from "@effect/vitest";
+import { AgentRuntimeDefinitionError } from "../agent.js";
+import { OPENCLAW_CONTEXT_FILENAMES, openClawRuntime } from "./runtime.js";
+
+describe("workspace-file reachability guard", () => {
+  it("refuses a file the model can provably never see", () => {
+    assert.throws(
+      () =>
+        openClawRuntime({
+          workspaceFiles: [{ relativePath: "BRIEF.md", content: "brief" }],
+          tools: { deny: ["*"] },
+        }),
+      AgentRuntimeDefinitionError,
+    );
+  });
+
+  it("accepts a non-injected file when tools could still read it", () => {
+    assert.doesNotThrow(() =>
+      openClawRuntime({
+        workspaceFiles: [{ relativePath: "BRIEF.md", content: "brief" }],
+      }),
+    );
+  });
+
+  it("accepts injected filenames even with every tool denied", () => {
+    assert.doesNotThrow(() =>
+      openClawRuntime({
+        workspaceFiles: [{ relativePath: "AGENTS.md", content: "brief" }],
+        tools: { deny: ["*"] },
+      }),
+    );
+  });
+});
+
+function filenameStems(source: string): string[] {
+  return [...source.matchAll(/DEFAULT_([A-Z]+)_FILENAME/g)].map(
+    (match) => match[1] ?? "",
+  );
+}
+
+describe("context filename drift canary", () => {
+  it("matches the installed OpenClaw's bootstrap loader entries", () => {
+    const require = createRequire(import.meta.url);
+    const sdkEntry = require.resolve("openclaw/plugin-sdk");
+    const distIndex = sdkEntry.indexOf(`${path.sep}dist${path.sep}`);
+    assert.isAbove(distIndex, 0, "openclaw's dist directory moved");
+    const distDir = sdkEntry.slice(0, distIndex + 5);
+    const stems = new Set<string>(
+      fs
+        .readdirSync(distDir)
+        .filter((name) => name.endsWith(".js"))
+        .map((name) => fs.readFileSync(path.join(distDir, name), "utf8"))
+        .filter((source) => source.includes("loadWorkspaceBootstrapFiles"))
+        .flatMap(filenameStems),
+    );
+    const pinnedStems = OPENCLAW_CONTEXT_FILENAMES.map((name) =>
+      name.replace(".md", ""),
+    );
+    assert.deepStrictEqual(
+      [...stems].sort((left, right) => left.localeCompare(right)),
+      [...pinnedStems].sort((left, right) => left.localeCompare(right)),
+      "OpenClaw's context-injection set drifted from the pinned allowlist",
+    );
+  });
+});

--- a/packages/simulator/src/agents/openclaw/runtime.ts
+++ b/packages/simulator/src/agents/openclaw/runtime.ts
@@ -16,6 +16,7 @@ import {
   type File,
 } from "../container.js";
 import {
+  AgentRuntimeDefinitionError,
   deepFreeze,
   type AgentRuntimeInput,
   type RuntimeAcquisitionError,
@@ -140,14 +141,81 @@ function snapshotNativeConfiguration<Value extends object>(
 function snapshotOptions(
   options: OpenClawRuntimeOptions,
 ): OpenClawRuntimeSettings {
+  const workspaceFiles = snapshotWorkspaceFiles(options.workspaceFiles);
+  const tools = snapshotNativeConfiguration(options.tools);
+  assertWorkspaceFilesReachable(
+    workspaceFiles,
+    tools?.deny?.includes("*") ?? false,
+  );
   return Object.freeze({
     startupTimeout: options.startupTimeout ?? DEFAULT_OPENCLAW_STARTUP_TIMEOUT,
-    workspaceFiles: snapshotWorkspaceFiles(options.workspaceFiles),
+    workspaceFiles,
     modelId: options.modelId,
     mcpServers: snapshotMcpServers(options.mcpServers),
-    tools: snapshotNativeConfiguration(options.tools),
+    tools,
     sandbox: snapshotNativeConfiguration(options.sandbox),
   });
+}
+
+/**
+ * Workspace filenames OpenClaw injects into model context. Any other name is
+ * written to disk but never reaches the model. Pinned to the packaged
+ * OpenClaw version; the drift canary asserts this list against the installed
+ * package so a version bump that changes the set breaks loudly.
+ */
+export const OPENCLAW_CONTEXT_FILENAMES: readonly string[] = Object.freeze([
+  "AGENTS.md",
+  "SOUL.md",
+  "TOOLS.md",
+  "IDENTITY.md",
+  "USER.md",
+  "HEARTBEAT.md",
+  "BOOTSTRAP.md",
+  "MEMORY.md",
+]);
+
+const OPENCLAW_CONTEXT_FILENAME_SET: ReadonlySet<string> = new Set(
+  OPENCLAW_CONTEXT_FILENAMES,
+);
+
+/**
+ * Names of declared workspace files the model can never see through context
+ * injection.
+ * @param files Checked workspace files the definition declares.
+ * @returns Relative paths outside OpenClaw's context-injection set.
+ */
+function invisibleWorkspaceFiles(
+  files: readonly CheckedWorkspaceFile[],
+): readonly string[] {
+  return Object.freeze(
+    files
+      .filter((file) => !OPENCLAW_CONTEXT_FILENAME_SET.has(file.relativePath))
+      .map((file) => file.relativePath),
+  );
+}
+
+/**
+ * Refuse a definition whose workspace files are provably invisible: outside
+ * OpenClaw's context-injection set while the deny list is the wildcard, so no
+ * tool could ever read them either. Other deny shapes may also block every
+ * read, but only the wildcard is knowable without interpreting native policy;
+ * those shapes intentionally degrade to the acquisition-time warning.
+ * @param files Checked workspace files the definition declares.
+ * @param denyListIsWildcard Whether the native deny list is exactly the wildcard.
+ */
+function assertWorkspaceFilesReachable(
+  files: readonly CheckedWorkspaceFile[],
+  denyListIsWildcard: boolean,
+): void {
+  const invisible = invisibleWorkspaceFiles(files);
+  if (invisible.length > 0 && denyListIsWildcard) {
+    throw AgentRuntimeDefinitionError.make({
+      detail:
+        `workspace files can never reach the model: ${invisible.join(", ")} ` +
+        `are outside OpenClaw's context-injection set (${OPENCLAW_CONTEXT_FILENAMES.join(", ")}) ` +
+        "and every tool is denied",
+    });
+  }
 }
 
 function nativePolicyConfiguration(
@@ -299,6 +367,7 @@ interface OpenClawBridge {
   readonly gatewayToken: Redacted.Redacted;
   readonly deviceIdentity: OpenClawGatewayDeviceIdentity;
   readonly acquireGateway: OpenClawGatewayAcquirer;
+  readonly invisibleWorkspaceFiles: readonly string[];
 }
 
 function attachOpenClaw(
@@ -307,6 +376,11 @@ function attachOpenClaw(
   stopped: Effect.Effect<RuntimeTermination>,
 ): Effect.Effect<OpenClawGateway, RuntimeAcquisitionError, Scope.Scope> {
   return Effect.gen(function* () {
+    if (bridge.invisibleWorkspaceFiles.length > 0) {
+      yield* Effect.logWarning(
+        `workspace files outside OpenClaw's context-injection set are only reachable through tools: ${bridge.invisibleWorkspaceFiles.join(", ")}`,
+      );
+    }
     const gatewayUrl = yield* Effect.try({
       try: () => bridgeUrl(routableBridgeEndpoint(endpoint)),
       catch: (cause) =>
@@ -354,6 +428,7 @@ function makeOpenClawApplication<Name extends string>(
     gatewayToken,
     deviceIdentity: pairing.deviceIdentity,
     acquireGateway,
+    invisibleWorkspaceFiles: invisibleWorkspaceFiles(settings.workspaceFiles),
   };
   return Object.freeze({
     entrypoint: Object.freeze([

--- a/packages/simulator/src/agents/workspace.test.ts
+++ b/packages/simulator/src/agents/workspace.test.ts
@@ -1,0 +1,57 @@
+import { assert, describe, it } from "@effect/vitest";
+import {
+  mcpConfiguration,
+  snapshotMcpServers,
+  type McpServer,
+} from "./workspace.js";
+
+const STDIO: McpServer = {
+  name: "files",
+  command: "files-mcp",
+  args: ["--root", "."],
+  env: { PRIVATE_TOKEN: "secret-value" },
+};
+const URL_A = "https://calendar.test/mcp/token-alpha";
+const URL_B = "https://calendar.test/mcp/token-beta";
+const HTTP: McpServer = { name: "calendar", url: URL_A };
+
+describe("snapshotMcpServers", () => {
+  it("passes both server shapes through frozen and intact", () => {
+    const snapshot = snapshotMcpServers([STDIO, HTTP]);
+    assert.deepStrictEqual(snapshot, [STDIO, HTTP]);
+    assert.isTrue(Object.isFrozen(snapshot?.[0]));
+    assert.isTrue(Object.isFrozen(snapshot?.[1]));
+  });
+
+  it("refuses an unparseable remote url at definition time", () => {
+    assert.throws(() =>
+      snapshotMcpServers([{ name: "calendar", url: "not a url" }]),
+    );
+  });
+});
+
+describe("mcpConfiguration", () => {
+  it("redacts the url on remote servers", () => {
+    const [record] = mcpConfiguration([HTTP]);
+    assert.deepStrictEqual(record?.redacted, ["url"]);
+    assert.notInclude(JSON.stringify(record), URL_A);
+  });
+
+  it("keeps the stdio redaction shape", () => {
+    const [record] = mcpConfiguration([STDIO]);
+    assert.deepStrictEqual(record?.redacted, [
+      "command",
+      "args",
+      "environmentValues",
+    ]);
+    assert.notInclude(JSON.stringify(record), "secret-value");
+  });
+
+  it("digests remote servers by origin only, never the token path", () => {
+    const [alpha] = mcpConfiguration([{ name: "calendar", url: URL_A }]);
+    const [beta] = mcpConfiguration([{ name: "calendar", url: URL_B }]);
+    assert.strictEqual(alpha?.definitionDigest, beta?.definitionDigest);
+    const [other] = mcpConfiguration([{ name: "notes", url: URL_A }]);
+    assert.notStrictEqual(alpha?.definitionDigest, other?.definitionDigest);
+  });
+});

--- a/packages/simulator/src/agents/workspace.ts
+++ b/packages/simulator/src/agents/workspace.ts
@@ -87,16 +87,37 @@ export interface CheckedWorkspaceFile {
 }
 
 /** One stdio MCP server mounted into a runtime container's workspace. */
-export interface McpServer {
+interface StdioMcpServer {
   readonly name: string;
   readonly command: string;
   readonly args: readonly string[];
   readonly env: Readonly<Record<string, string>>;
 }
 
+interface HttpMcpServer {
+  readonly name: string;
+  readonly url: string;
+}
+
+/**
+ * One MCP server a runtime mounts: spawned over stdio inside the container,
+ * or reached remotely over streamable HTTP. A remote URL may embed a
+ * per-agent capability token, so sanitized configurations treat the URL like
+ * credential material: digested by origin only, never recorded.
+ */
+export type McpServer = StdioMcpServer | HttpMcpServer;
+
 const decodeWorkspaceRelativePath = Schema.decodeUnknownSync(
   workspaceRelativePath,
 );
+
+const mcpServerUrl = Schema.String.pipe(
+  Schema.filter((value) => URL.canParse(value), {
+    message: () => "an MCP server url must be a parseable absolute URL",
+  }),
+);
+
+const decodeMcpServerUrl = Schema.decodeUnknownSync(mcpServerUrl);
 
 /** Digest standing in for material a sanitized configuration must not carry. */
 export const configurationDigest = Schema.String.pipe(
@@ -122,10 +143,13 @@ export class McpServerConfiguration extends Schema.Class<McpServerConfiguration>
 )({
   name: Schema.String,
   definitionDigest: configurationDigest,
-  redacted: Schema.Tuple(
-    Schema.Literal("command"),
-    Schema.Literal("args"),
-    Schema.Literal("environmentValues"),
+  redacted: Schema.Union(
+    Schema.Tuple(
+      Schema.Literal("command"),
+      Schema.Literal("args"),
+      Schema.Literal("environmentValues"),
+    ),
+    Schema.Tuple(Schema.Literal("url")),
   ),
 }) {}
 
@@ -159,12 +183,16 @@ export function snapshotMcpServers(
     ? undefined
     : Object.freeze(
         servers.map((server) =>
-          Object.freeze({
-            name: server.name,
-            command: server.command,
-            args: Object.freeze([...server.args]),
-            env: Object.freeze({ ...server.env }),
-          }),
+          Object.freeze(
+            "url" in server
+              ? { name: server.name, url: decodeMcpServerUrl(server.url) }
+              : {
+                  name: server.name,
+                  command: server.command,
+                  args: Object.freeze([...server.args]),
+                  env: Object.freeze({ ...server.env }),
+                },
+          ),
         ),
       );
 }
@@ -198,20 +226,39 @@ export function workspaceConfiguration(
 }
 
 /**
- * The digested form of one MCP server. Only the environment *keys* are
- * digested: the values are provider credentials, and including them would let
- * anyone holding a candidate secret confirm it against a published ledger.
+ * The sanitized record of one MCP server: a value-free definition digest and
+ * the matching redaction list, produced together so they cannot drift. Only
+ * environment *keys* and the URL *origin* are digested: values and token
+ * paths are secrets, and digesting them would let anyone holding a candidate
+ * confirm it against a published ledger.
  * @param server MCP server whose definition is being recorded.
- * @returns The canonical, value-free JSON that stands in for the server.
+ * @returns The sanitized MCP server record.
  */
-function mcpServerDefinition(server: McpServer): string {
-  return JSON.stringify({
+function sanitizedMcpServer(server: McpServer): McpServerConfiguration {
+  const { definition, redacted } =
+    "url" in server
+      ? {
+          definition: JSON.stringify({
+            name: server.name,
+            origin: new URL(server.url).origin,
+          }),
+          redacted: ["url"] as const,
+        }
+      : {
+          definition: JSON.stringify({
+            name: server.name,
+            command: server.command,
+            args: server.args,
+            environmentKeys: Object.keys(server.env).sort((left, right) =>
+              left.localeCompare(right),
+            ),
+          }),
+          redacted: ["command", "args", "environmentValues"] as const,
+        };
+  return McpServerConfiguration.make({
     name: server.name,
-    command: server.command,
-    args: server.args,
-    environmentKeys: Object.keys(server.env).sort((left, right) =>
-      left.localeCompare(right),
-    ),
+    definitionDigest: digestText(definition),
+    redacted,
   });
 }
 
@@ -223,13 +270,7 @@ function mcpServerDefinition(server: McpServer): string {
 export function mcpConfiguration(
   servers?: readonly McpServer[],
 ): readonly McpServerConfiguration[] {
-  return (servers ?? []).map((server) =>
-    McpServerConfiguration.make({
-      name: server.name,
-      definitionDigest: digestText(mcpServerDefinition(server)),
-      redacted: ["command", "args", "environmentValues"],
-    }),
-  );
+  return (servers ?? []).map(sanitizedMcpServer);
 }
 
 /**


### PR DESCRIPTION
## Summary
- An MCP server on either container runtime may now be a remote `{name, url}` endpoint alongside the stdio shape: OpenClaw renders its native `streamable-http` transport; NanoClaw passes it through its application config.
- Remote URLs may embed per-agent capability tokens: the shared sanitized configuration digests them by **origin only**, records the URL as redacted, and refuses unparseable URLs at definition time (same decode-at-definition idiom as workspace paths).
- OpenClaw definitions refuse workspace files that provably can never reach the model (outside the context-injection set while the deny list is the wildcard) via the existing `AgentRuntimeDefinitionError` — no new failure types — and warn at acquisition when such files are merely tool-reachable.
- The injection set is pinned behind a drift canary that reads the installed OpenClaw's bootstrap loader chunks, so a version bump that changes the set breaks loudly.

## Tests
- `workspace.test.ts`: union snapshot round-trip, url redaction, origin-only digests, unparseable-url refusal.
- `openclaw/configuration.test.ts`: stdio/streamable-http/omitted render.
- `openclaw/context-files.test.ts`: guard refuse/warn/accept + the drift canary.
- `nanoclaw/runtime.test.ts`: url passthrough into the application config; projection never carries the URL.

/simplify applied (4-lens review): digest↔redaction collapsed into one producer, nanoclaw re-copy branch deleted, guard split into pure query + explicit assert, canary unions across all matching dist chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)