### PR TITLE
fix(simulator): worker-roll safety and bounded Kubernetes calls

### DIFF
--- a/packages/simulator/src/cluster/install.test.ts
+++ b/packages/simulator/src/cluster/install.test.ts
@@ -9,9 +9,13 @@ import {
   type WorkerAvailability,
 } from "./kubernetes/calls.js";
 import {
+  FORCE_WORKER_ROLL_VARIABLE,
   installRunWorker,
+  RunWorkerRollRefused,
   RunWorkerUnavailable,
   workerIsAvailable,
+  type OpenRunReading,
+  type RunWorkerInstallRequest,
 } from "./install.js";
 
 // What each control-plane object needs to already exist when it is installed.
@@ -38,26 +42,36 @@ const AVAILABLE: WorkerAvailability = {
   availableReplicas: 1,
 };
 
+const DESIRED_IMAGE = "registry/controller@sha256:desired";
+const INSTALLED_IMAGE = "registry/controller@sha256:installed";
+const OPEN_RUN = "mz-0123456789abcdef0123456789abcdef";
+
 interface RecordedInstall {
   readonly api: RunWorkerInstallApi;
   readonly installed: RunWorkerObject[];
   readonly waits: number[];
+  /** How many times the roll guard asked Temporal about open runs. */
+  readonly queueReads: number[];
 }
 
 interface InstallOptions {
   /** Availability readings served in order; the last one repeats forever. */
   readonly availability?: readonly WorkerAvailability[];
   readonly failAt?: RunWorkerObject;
+  /** The image the cluster already runs; absent means no worker is installed. */
+  readonly installedImage?: string;
 }
 
 function recordingInstall(options: InstallOptions = {}): RecordedInstall {
   const installed: RunWorkerObject[] = [];
   const waits: number[] = [];
+  const queueReads: number[] = [];
   const readings = options.availability ?? [AVAILABLE];
   let read = 0;
   return {
     installed,
     waits,
+    queueReads,
     api: {
       install: (object) =>
         Effect.suspend(() => {
@@ -66,6 +80,7 @@ function recordingInstall(options: InstallOptions = {}): RecordedInstall {
             ? Effect.fail(new KubernetesCallFailed(`install ${object}`))
             : Effect.void;
         }),
+      readInstalledWorkerImage: () => Effect.succeed(options.installedImage),
       readWorkerAvailability: () =>
         Effect.suspend(() => {
           const reading = readings[Math.min(read, readings.length - 1)];
@@ -84,10 +99,39 @@ function recordingInstall(options: InstallOptions = {}): RecordedInstall {
   };
 }
 
-it("installs every object exactly once, each after everything it depends on", async () => {
-  const { api, installed } = recordingInstall();
+function request(
+  recorded: RecordedInstall,
+  options: {
+    readonly openRuns?: OpenRunReading;
+    readonly forced?: boolean;
+  } = {},
+): RunWorkerInstallRequest {
+  return {
+    desiredImage: DESIRED_IMAGE,
+    forced: options.forced ?? false,
+    readOpenRuns: () =>
+      Effect.sync(() => {
+        recorded.queueReads.push(recorded.queueReads.length + 1);
+        return options.openRuns ?? { _tag: "open", workflowIds: [] };
+      }),
+  };
+}
 
-  await Effect.runPromise(installRunWorker(api));
+function install(
+  recorded: RecordedInstall,
+  options: {
+    readonly openRuns?: OpenRunReading;
+    readonly forced?: boolean;
+  } = {},
+) {
+  return installRunWorker(recorded.api, request(recorded, options));
+}
+
+it("installs every object exactly once, each after everything it depends on", async () => {
+  const recorded = recordingInstall();
+  const { installed } = recorded;
+
+  await Effect.runPromise(install(recorded));
 
   const byName = (left: string, right: string) => left.localeCompare(right);
   expect([...installed].sort(byName)).toEqual([...EVERY_OBJECT].sort(byName));
@@ -99,16 +143,17 @@ it("installs every object exactly once, each after everything it depends on", as
 });
 
 it("never installs the workload when its permissions could not be written", async () => {
-  const { api, installed } = recordingInstall({ failAt: BINDING });
+  const recorded = recordingInstall({ failAt: BINDING });
+  const { installed } = recorded;
 
-  const failure = await Effect.runPromise(Effect.flip(installRunWorker(api)));
+  const failure = await Effect.runPromise(Effect.flip(install(recorded)));
 
   expect(failure.message).toBe(`install ${BINDING} failed`);
   expect(installed).not.toContain(WORKLOAD);
 });
 
 it("waits for the installed revision rather than the one it replaced", async () => {
-  const { api, waits } = recordingInstall({
+  const recorded = recordingInstall({
     availability: [
       // The previous revision is still the only one serving.
       {
@@ -136,13 +181,13 @@ it("waits for the installed revision rather than the one it replaced", async () 
     ],
   });
 
-  await Effect.runPromise(installRunWorker(api));
+  await Effect.runPromise(install(recorded));
 
-  expect(waits).toEqual([2_000, 2_000]);
+  expect(recorded.waits).toEqual([2_000, 2_000]);
 });
 
 it("fails the submission when no replica ever becomes available", async () => {
-  const { api, waits } = recordingInstall({
+  const recorded = recordingInstall({
     availability: [
       {
         generation: 1,
@@ -154,10 +199,94 @@ it("fails the submission when no replica ever becomes available", async () => {
     ],
   });
 
-  const failure = await Effect.runPromise(Effect.flip(installRunWorker(api)));
+  const failure = await Effect.runPromise(Effect.flip(install(recorded)));
 
   expect(failure).toBeInstanceOf(RunWorkerUnavailable);
-  expect(waits).toHaveLength(150);
+  expect(recorded.waits).toHaveLength(150);
+});
+
+it("refuses to replace a worker whose queue still has runs open", async () => {
+  const recorded = recordingInstall({ installedImage: INSTALLED_IMAGE });
+
+  const failure = await Effect.runPromise(
+    Effect.flip(
+      install(recorded, {
+        openRuns: { _tag: "open", workflowIds: [OPEN_RUN] },
+      }),
+    ),
+  );
+
+  expect(failure).toBeInstanceOf(RunWorkerRollRefused);
+  expect(failure.message).toContain(INSTALLED_IMAGE);
+  expect(failure.message).toContain(DESIRED_IMAGE);
+  expect(failure.message).toContain(OPEN_RUN);
+  expect(failure.message).toContain(`${FORCE_WORKER_ROLL_VARIABLE}=1`);
+  // Nothing was applied, so the open run keeps the worker that is heartbeating
+  // its activity.
+  expect(recorded.installed).toEqual([]);
+});
+
+// The regression the refusal must never become: submitting the image the
+// cluster already runs applies a Pod template it already has, which rolls
+// nothing. Refusing there would refuse every ordinary submission made while
+// any run is in flight.
+it("installs the image the cluster already runs without asking about open runs", async () => {
+  const recorded = recordingInstall({ installedImage: DESIRED_IMAGE });
+
+  await Effect.runPromise(
+    install(recorded, {
+      openRuns: { _tag: "open", workflowIds: [OPEN_RUN] },
+    }),
+  );
+
+  expect(recorded.installed).toContain(WORKLOAD);
+  expect(recorded.queueReads).toEqual([]);
+});
+
+it("installs into a cluster that has no worker yet without asking anything", async () => {
+  const recorded = recordingInstall();
+
+  await Effect.runPromise(install(recorded));
+
+  expect(recorded.installed).toContain(WORKLOAD);
+  expect(recorded.queueReads).toEqual([]);
+});
+
+it("rolls a worker with runs open once the operator has forced it", async () => {
+  const recorded = recordingInstall({ installedImage: INSTALLED_IMAGE });
+
+  await Effect.runPromise(
+    install(recorded, {
+      forced: true,
+      openRuns: { _tag: "open", workflowIds: [OPEN_RUN] },
+    }),
+  );
+
+  expect(recorded.installed).toContain(WORKLOAD);
+});
+
+// A queue that could not be listed is not an empty queue: reading it as one
+// would authorize exactly the roll the refusal exists to prevent.
+it("refuses to replace a worker whose open runs could not be read", async () => {
+  const recorded = recordingInstall({ installedImage: INSTALLED_IMAGE });
+
+  const failure = await Effect.runPromise(
+    Effect.flip(install(recorded, { openRuns: { _tag: "unreadable" } })),
+  );
+
+  expect(failure).toBeInstanceOf(RunWorkerRollRefused);
+  expect(failure.message).toContain(INSTALLED_IMAGE);
+  expect(failure.message).toContain(`${FORCE_WORKER_ROLL_VARIABLE}=1`);
+  expect(recorded.installed).toEqual([]);
+});
+
+it("replaces a worker whose queue has nothing open", async () => {
+  const recorded = recordingInstall({ installedImage: INSTALLED_IMAGE });
+
+  await Effect.runPromise(install(recorded));
+
+  expect(recorded.installed).toContain(WORKLOAD);
+  expect(recorded.queueReads).toEqual([1]);
 });
 
 it("reads a rollout as available only once it is both observed and serving", () => {

--- a/packages/simulator/src/cluster/install.ts
+++ b/packages/simulator/src/cluster/install.ts
@@ -11,6 +11,9 @@ import type {
 const AVAILABILITY_ATTEMPTS = 150;
 const AVAILABILITY_INTERVAL_MS = 2_000;
 
+/** Environment variable that lets an operator roll the worker regardless. */
+export const FORCE_WORKER_ROLL_VARIABLE = "MOLTZAP_FORCE_WORKER_ROLL";
+
 // Identity before permissions, permissions before the workload that uses them.
 // A Deployment installed ahead of its ClusterRoleBinding starts a Pod whose
 // service account cannot delete a run namespace, which is the one thing the
@@ -24,6 +27,27 @@ const INSTALL_ORDER: readonly RunWorkerObject[] = [
   "deployment",
 ];
 
+/** What the run-lifecycle task queue says about work it has not finished. */
+export type OpenRunReading =
+  | { readonly _tag: "open"; readonly workflowIds: readonly string[] }
+  | { readonly _tag: "unreadable" };
+
+/** One submission's request that the cluster's worker serve its image. */
+export interface RunWorkerInstallRequest {
+  /** The image this submission would have the worker run. */
+  readonly desiredImage: string;
+  /**
+   * The queue's open work, read only when the installed image would change.
+   *
+   * A submission installing the image already running applies a Pod template
+   * the cluster already has, which rolls nothing, so it has no reason to ask
+   * Temporal anything — and no reason to fail when Temporal cannot answer.
+   */
+  readonly readOpenRuns: () => Effect.Effect<OpenRunReading>;
+  /** Whether the operator has accepted losing whatever a roll interrupts. */
+  readonly forced: boolean;
+}
+
 /** The installed worker never became able to serve the run-lifecycle queue. */
 export class RunWorkerUnavailable extends Error {
   override readonly name = "RunWorkerUnavailable";
@@ -32,6 +56,19 @@ export class RunWorkerUnavailable extends Error {
     super("the run worker did not become available");
   }
 }
+
+/* eslint-disable agent-code-guard/max-non-trivial-classes-per-file -- a worker that never came up and a worker that must not be replaced yet are the two ways this one install refuses to hand a submission to the queue */
+/** Installing would replace a worker that still owes results to open runs. */
+export class RunWorkerRollRefused extends Error {
+  override readonly name = "RunWorkerRollRefused";
+
+  constructor(detail: string) {
+    super(
+      `${detail}. Wait for those runs to finish, or set ${FORCE_WORKER_ROLL_VARIABLE}=1 to roll the worker anyway and lose them`,
+    );
+  }
+}
+/* eslint-enable agent-code-guard/max-non-trivial-classes-per-file -- Restore the one-class rule after the install's second refusal. */
 
 /**
  * Whether the rollout the cluster reports is the installed one and is serving.
@@ -60,6 +97,11 @@ function awaitAvailableWorker(
 ): Effect.Effect<void, KubernetesCallFailed | RunWorkerUnavailable> {
   return Effect.gen(function* () {
     for (let attempt = 0; attempt < AVAILABILITY_ATTEMPTS; attempt += 1) {
+      // Named so that a submission stuck here is legible from its output alone
+      // rather than from a cluster the operator has to go and inspect.
+      yield* Effect.logInfo(
+        `awaiting worker availability ${String(attempt + 1)}/${String(AVAILABILITY_ATTEMPTS)}`,
+      );
       if (workerIsAvailable(yield* api.readWorkerAvailability())) {
         return;
       }
@@ -70,24 +112,94 @@ function awaitAvailableWorker(
 }
 
 /**
+ * State the refusal reports, or nothing when installing interrupts no run.
+ * @param installedImage Image the worker the cluster already has is running.
+ * @param request The image this submission wants and how it reads open work.
+ * @param reading What Temporal answered about the queue's unfinished runs.
+ * @returns The operator-facing reason to refuse, or nothing to proceed.
+ */
+function interruptedRuns(
+  installedImage: string,
+  request: RunWorkerInstallRequest,
+  reading: OpenRunReading,
+): string | undefined {
+  const roll = `installing ${request.desiredImage} replaces the run worker now serving ${installedImage}`;
+  if (reading._tag === "unreadable") {
+    return `${roll}, and whether any run is still open on its task queue could not be read`;
+  }
+  if (reading.workflowIds.length === 0) {
+    return undefined;
+  }
+  return `${roll} while ${String(reading.workflowIds.length)} run(s) are still open on its task queue (${reading.workflowIds.join(", ")})`;
+}
+
+// Reading the installed image and applying the new one are two calls, so a run
+// submitted between them is still rolled over. That window is accepted: these
+// clusters have one operator, and closing it needs a lock the cluster does not
+// offer. The image is also the only part of the Pod template compared, so a
+// change to the template that keeps the image — a new grace period, say — rolls
+// the worker without asking.
+function guardWorkerRoll(
+  api: RunWorkerInstallApi,
+  request: RunWorkerInstallRequest,
+): Effect.Effect<void, KubernetesCallFailed | RunWorkerRollRefused> {
+  return Effect.gen(function* () {
+    const installedImage = yield* api.readInstalledWorkerImage();
+    if (
+      installedImage === undefined ||
+      installedImage === request.desiredImage
+    ) {
+      return;
+    }
+    if (request.forced) {
+      yield* Effect.logWarning(
+        `${FORCE_WORKER_ROLL_VARIABLE} is set: rolling the run worker without asking what it would interrupt`,
+      );
+      return;
+    }
+    const detail = interruptedRuns(
+      installedImage,
+      request,
+      yield* request.readOpenRuns(),
+    );
+    if (detail !== undefined) {
+      yield* Effect.fail(new RunWorkerRollRefused(detail));
+    }
+  });
+}
+
+/**
  * Install the cluster's run-lifecycle worker and wait until it can poll.
  *
  * Every submission installs it, because the worker runs the image the submitter
  * selected and a cluster prepared before that image existed has no worker at
- * all.
+ * all. The one submission that must not is the one whose image differs from the
+ * installed one while that worker still owns runs: rolling the Deployment
+ * deletes the only Pod heartbeating those activities, which fails them and
+ * takes their namespaces with them.
  *
  * @param api Host-side access to the profile's cluster.
+ * @param request The submission's image, its open-run reading, and any override.
  * @returns Nothing once one worker replica is available on the task queue.
  * @failure KubernetesCallFailed when a control-plane object could not be written.
+ * @failure RunWorkerRollRefused when installing would interrupt an open run.
  * @failure RunWorkerUnavailable when no replica becomes available in time.
  */
 export function installRunWorker(
   api: RunWorkerInstallApi,
-): Effect.Effect<void, KubernetesCallFailed | RunWorkerUnavailable> {
-  return Effect.forEach(INSTALL_ORDER, (object) => api.install(object), {
-    concurrency: 1,
-    discard: true,
-  }).pipe(
+  request: RunWorkerInstallRequest,
+): Effect.Effect<
+  void,
+  KubernetesCallFailed | RunWorkerRollRefused | RunWorkerUnavailable
+> {
+  return guardWorkerRoll(api, request).pipe(
+    Effect.zipRight(Effect.logInfo("applying run-worker manifests")),
+    Effect.zipRight(
+      Effect.forEach(INSTALL_ORDER, (object) => api.install(object), {
+        concurrency: 1,
+        discard: true,
+      }),
+    ),
     Effect.zipRight(awaitAvailableWorker(api)),
     Effect.withSpan("installRunWorker"),
   );

--- a/packages/simulator/src/cluster/kubernetes/calls.test.ts
+++ b/packages/simulator/src/cluster/kubernetes/calls.test.ts
@@ -1,5 +1,14 @@
+/* eslint-disable agent-code-guard/async-keyword -- Vitest awaits the Effect this Promise-native Kubernetes boundary returns. */
+
+import { Duration, Effect } from "effect";
 import { describe, expect, it } from "vitest";
-import { currentConditionIsTrue } from "./calls.js";
+import {
+  currentConditionIsTrue,
+  kubernetesCall,
+  kubernetesCallTimeout,
+  KubernetesCallFailed,
+  KUBERNETES_CALL_TIMEOUT_VARIABLE,
+} from "./calls.js";
 
 describe("currentConditionIsTrue", () => {
   it("accepts only a positive condition for the current object generation", () => {
@@ -39,3 +48,68 @@ describe("currentConditionIsTrue", () => {
     ).toBe(false);
   });
 });
+
+describe("kubernetesCall", () => {
+  const operation = "observe run worker";
+  const bound = Duration.millis(10);
+  const answer = "the cluster's answer";
+
+  // The failure mode this bound exists for: an API server that accepts the
+  // connection and then answers nothing leaves a submission waiting with no
+  // output naming what it waits for.
+  it("abandons a call the cluster never answers, naming the operation", async () => {
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        kubernetesCall(
+          operation,
+          () =>
+            new Promise<never>(() => {
+              // Accepted and never answered, which is the case under test.
+            }),
+          bound,
+        ),
+      ),
+    );
+
+    expect(failure).toBeInstanceOf(KubernetesCallFailed);
+    expect(failure.message).toContain(operation);
+    // Never answering is not the cluster answering that the object is gone,
+    // which the callers that tolerate absence would swallow.
+    expect(failure.absent).toBe(false);
+  });
+
+  it("returns a call the cluster answers inside its bound", async () => {
+    await expect(
+      Effect.runPromise(
+        kubernetesCall(operation, () => Promise.resolve(answer), bound),
+      ),
+    ).resolves.toBe(answer);
+  });
+});
+
+describe("kubernetesCallTimeout", () => {
+  it("takes a positive millisecond override from the environment", () => {
+    const configured = 5_000;
+
+    expect(
+      kubernetesCallTimeout({
+        [KUBERNETES_CALL_TIMEOUT_VARIABLE]: String(configured),
+      }),
+    ).toEqual(Duration.millis(configured));
+  });
+
+  it("keeps its default when no usable override is set", () => {
+    const fallback = kubernetesCallTimeout({});
+
+    for (const encoded of ["", "0", "-1", "1.5", "forever"]) {
+      expect(
+        kubernetesCallTimeout({
+          [KUBERNETES_CALL_TIMEOUT_VARIABLE]: encoded,
+        }),
+      ).toEqual(fallback);
+    }
+    expect(Duration.toMillis(fallback)).toBeGreaterThan(0);
+  });
+});
+
+/* eslint-enable agent-code-guard/async-keyword -- Restore Effect-first test rules after the Promise-native Kubernetes boundary. */

--- a/packages/simulator/src/cluster/kubernetes/calls.ts
+++ b/packages/simulator/src/cluster/kubernetes/calls.ts
@@ -482,6 +482,26 @@ function workerAvailabilityOf(deployment: {
   };
 }
 
+// Only the worker's own container counts. An injected sidecar is not what a
+// submission would be replacing, so it cannot make an unchanged image look
+// like a roll.
+function installedWorkerImage(deployment: {
+  readonly spec?: {
+    readonly template: {
+      readonly spec?: {
+        readonly containers: ReadonlyArray<{
+          readonly name: string;
+          readonly image?: string;
+        }>;
+      };
+    };
+  };
+}): string | undefined {
+  return deployment.spec?.template.spec?.containers.find(
+    (container) => container.name === RUN_WORKER_NAME,
+  )?.image;
+}
+
 /** One installable member of the cluster's run-worker control plane. */
 export type RunWorkerObject = keyof RunWorkerManifests;
 
@@ -556,6 +576,16 @@ export interface RunWorkerInstallApi {
   readonly install: (
     object: RunWorkerObject,
   ) => Effect.Effect<void, KubernetesCallFailed>;
+  /**
+   * The image the installed worker runs now, or nothing when none is installed.
+   *
+   * This is what makes a submission able to tell an apply that changes the Pod
+   * template from one that changes nothing, before it applies anything.
+   */
+  readonly readInstalledWorkerImage: () => Effect.Effect<
+    string | undefined,
+    KubernetesCallFailed
+  >;
   readonly readWorkerAvailability: () => Effect.Effect<
     WorkerAvailability,
     KubernetesCallFailed
@@ -914,18 +944,30 @@ export function makeKubernetesRunWorkerInstallApi(
 ): RunWorkerInstallApi {
   const clients = installClients(options.profile);
   const applies = installedObjectApplies(clients, runWorkerManifests(options));
+  const readWorker = () =>
+    attempt("observe run worker", () =>
+      clients.apps.readNamespacedDeployment({
+        name: RUN_WORKER_NAME,
+        namespace: SYSTEM_NAMESPACE,
+      }),
+    );
   return Object.freeze({
     install: (object: RunWorkerObject) =>
       attempt(`apply run worker ${object}`, applies[object]).pipe(
         Effect.asVoid,
       ),
+    // A cluster with no worker yet reads as no image rather than as a failure:
+    // nothing is installed, so nothing can be interrupted by installing.
+    readInstalledWorkerImage: () =>
+      readWorker().pipe(
+        Effect.map(installedWorkerImage),
+        Effect.catchIf(
+          (failure) => failure.absent,
+          () => Effect.succeed(undefined),
+        ),
+      ),
     readWorkerAvailability: () =>
-      attempt("observe run worker", () =>
-        clients.apps.readNamespacedDeployment({
-          name: RUN_WORKER_NAME,
-          namespace: SYSTEM_NAMESPACE,
-        }),
-      ).pipe(Effect.map(workerAvailabilityOf)),
+      readWorker().pipe(Effect.map(workerAvailabilityOf)),
     wait: (milliseconds: number) => Effect.sleep(Duration.millis(milliseconds)),
   });
 }

--- a/packages/simulator/src/cluster/kubernetes/calls.ts
+++ b/packages/simulator/src/cluster/kubernetes/calls.ts
@@ -18,7 +18,7 @@ import {
   type V1Job,
   type V1JobCondition,
 } from "@kubernetes/client-node";
-import { Duration, Effect, Schema } from "effect";
+import { Cause, Duration, Effect, Schema } from "effect";
 import { clusterError, type ClusterError } from "../cluster.js";
 import type { KubernetesExecutionProfile } from "../profile.js";
 import type { RunSocietyWorkflowInput } from "../reclaim.js";
@@ -38,6 +38,41 @@ const BRIDGE_PROBE_TIMEOUT = Duration.seconds(2);
 
 /** Kubernetes status for an object the cluster does not have. */
 const ABSENT = 404;
+
+/** Environment variable overriding how long one call may go unanswered. */
+export const KUBERNETES_CALL_TIMEOUT_VARIABLE =
+  "MOLTZAP_KUBERNETES_CALL_TIMEOUT_MS";
+const DEFAULT_KUBERNETES_CALL_TIMEOUT_MS = 30_000;
+
+/**
+ * How long one Kubernetes call may go unanswered before it is abandoned.
+ *
+ * A malformed override reads as no override rather than as a failure: this
+ * resolves while the module loads, where there is no submission to fail and no
+ * operator to tell, and a bound that silently became the default is a slower
+ * failure than a process that could not start at all.
+ *
+ * @param environment Process environment the submitter or worker was started with.
+ * @returns The configured bound, or the default when none is usable.
+ */
+export function kubernetesCallTimeout(
+  environment: Readonly<Record<string, string | undefined>>,
+): Duration.Duration {
+  const configured = Number(
+    environment[KUBERNETES_CALL_TIMEOUT_VARIABLE] ?? Number.NaN,
+  );
+  return Duration.millis(
+    Number.isSafeInteger(configured) && configured > 0
+      ? configured
+      : DEFAULT_KUBERNETES_CALL_TIMEOUT_MS,
+  );
+}
+
+// One bound covers every call this module makes, in the submitting process and
+// in the in-cluster worker alike, so it is read once here rather than threaded
+// through twenty call signatures that have nothing else to say about it.
+// eslint-disable-next-line agent-code-guard/no-process-env-at-runtime -- Resolved while this module loads, before any call it bounds exists.
+const KUBERNETES_CALL_TIMEOUT = kubernetesCallTimeout(process.env);
 
 /** Field ownership and strict validation applied to every write. */
 const APPLIED = Object.freeze({
@@ -505,6 +540,23 @@ function installedWorkerImage(deployment: {
 /** One installable member of the cluster's run-worker control plane. */
 export type RunWorkerObject = keyof RunWorkerManifests;
 
+// A call the bound cut off is reported as never answered, not as failed: the
+// cluster refusing an object and the cluster never replying at all are
+// different operator problems, and only one of them is about the object. A
+// status of zero is no status, which no Kubernetes response carries.
+function callDetail(
+  operation: string,
+  status: number,
+  unanswered: boolean,
+): string {
+  if (unanswered) {
+    return `${operation} did not answer in time`;
+  }
+  return status === 0
+    ? `${operation} failed`
+    : `${operation} failed (Kubernetes ${String(status)})`;
+}
+
 /** Failure of one Kubernetes call, carrying the status but never the body. */
 export class KubernetesCallFailed extends Error {
   override readonly name = "KubernetesCallFailed";
@@ -513,13 +565,11 @@ export class KubernetesCallFailed extends Error {
   readonly absent: boolean;
 
   constructor(operation: string, cause?: unknown) {
-    const refused = cause instanceof ApiException ? cause : undefined;
+    const status = cause instanceof ApiException ? cause.code : 0;
     super(
-      refused === undefined
-        ? `${operation} failed`
-        : `${operation} failed (Kubernetes ${String(refused.code)})`,
+      callDetail(operation, status, cause instanceof Cause.TimeoutException),
     );
-    this.absent = refused?.code === ABSENT;
+    this.absent = status === ABSENT;
   }
 }
 
@@ -594,21 +644,43 @@ export interface RunWorkerInstallApi {
   readonly wait: (milliseconds: number) => Effect.Effect<void>;
 }
 
-function attempt<Result>(
+/**
+ * Make one Kubernetes API call, bounded so that it always ends.
+ *
+ * The client's own request has no deadline, so an API server that accepts the
+ * connection and then answers nothing — a control plane being repaired, a
+ * tunnel that went away without resetting — leaves the caller waiting forever
+ * with no output naming what it is waiting for. A submission that fails after
+ * the bound is a submission the operator can act on.
+ *
+ * @param operation What this call was doing, as the operator's failure names it.
+ * @param evaluate The client call, already bound to its request.
+ * @param bound How long the cluster has to answer before the call is abandoned.
+ * @returns The call's result, or a failure naming the operation.
+ * @failure KubernetesCallFailed when the call is refused or never answered.
+ */
+export function kubernetesCall<Result>(
   operation: string,
   evaluate: () => PromiseLike<Result>,
+  bound: Duration.Duration = KUBERNETES_CALL_TIMEOUT,
 ): Effect.Effect<Result, KubernetesCallFailed> {
   return Effect.tryPromise({
     try: evaluate,
     catch: (cause) => new KubernetesCallFailed(operation, cause),
-  });
+  }).pipe(
+    Effect.timeoutFail({
+      duration: bound,
+      onTimeout: () =>
+        new KubernetesCallFailed(operation, new Cause.TimeoutException()),
+    }),
+  );
 }
 
 function attemptUnlessAbsent(
   operation: string,
   evaluate: () => PromiseLike<unknown>,
 ): Effect.Effect<void, KubernetesCallFailed> {
-  return attempt(operation, evaluate).pipe(
+  return kubernetesCall(operation, evaluate).pipe(
     Effect.catchIf(
       (failure) => failure.absent,
       () => Effect.void,
@@ -648,13 +720,13 @@ function createRunRoot(
   input: RunSocietyWorkflowInput,
 ): Effect.Effect<string, KubernetesCallFailed> {
   return Effect.gen(function* () {
-    yield* attempt("create run namespace", () =>
+    yield* kubernetesCall("create run namespace", () =>
       clients.core.createNamespace({
         body: runNamespaceManifest(input),
         ...APPLIED,
       }),
     );
-    const root = yield* attempt("create run owner", () =>
+    const root = yield* kubernetesCall("create run owner", () =>
       clients.core.createNamespacedConfigMap({
         namespace: input.namespace,
         body: runOwnerManifest(input),
@@ -678,7 +750,7 @@ function readControllerLogs(
   limitBytes: number,
 ): Effect.Effect<string | undefined, KubernetesCallFailed> {
   return Effect.gen(function* () {
-    const pods = yield* attempt("observe controller pod", () =>
+    const pods = yield* kubernetesCall("observe controller pod", () =>
       clients.core.listNamespacedPod({
         namespace,
         labelSelector: `job-name=${CONTROLLER_NAME}`,
@@ -690,7 +762,7 @@ function readControllerLogs(
     if (podName === undefined) {
       return undefined;
     }
-    const output = yield* attempt("read controller log", () =>
+    const output = yield* kubernetesCall("read controller log", () =>
       clients.core.readNamespacedPodLog({
         namespace,
         name: podName,
@@ -723,14 +795,14 @@ function createExperimentAndQueue(
   manifests: OwnedRunControlManifests,
 ): Effect.Effect<void, KubernetesCallFailed> {
   return Effect.gen(function* () {
-    yield* attempt("create experiment module", () =>
+    yield* kubernetesCall("create experiment module", () =>
       clients.core.createNamespacedConfigMap({
         namespace,
         body: manifests.experiment,
         ...APPLIED,
       }),
     );
-    yield* attempt("create run queue", () =>
+    yield* kubernetesCall("create run queue", () =>
       clients.custom.createNamespacedCustomObject({
         group: KUEUE_GROUP,
         version: KUEUE_VERSION,
@@ -749,21 +821,21 @@ function createControllerAccess(
   manifests: OwnedRunControlManifests,
 ): Effect.Effect<void, KubernetesCallFailed> {
   return Effect.gen(function* () {
-    yield* attempt("create controller service account", () =>
+    yield* kubernetesCall("create controller service account", () =>
       clients.core.createNamespacedServiceAccount({
         namespace,
         body: manifests.serviceAccount,
         ...APPLIED,
       }),
     );
-    yield* attempt("create controller role", () =>
+    yield* kubernetesCall("create controller role", () =>
       clients.rbac.createNamespacedRole({
         namespace,
         body: manifests.role,
         ...APPLIED,
       }),
     );
-    yield* attempt("create controller role binding", () =>
+    yield* kubernetesCall("create controller role binding", () =>
       clients.rbac.createNamespacedRoleBinding({
         namespace,
         body: manifests.roleBinding,
@@ -790,7 +862,7 @@ function runPreparationOperations(
     createControllerAccess: (namespace, manifests) =>
       createControllerAccess(clients, namespace, manifests),
     createRouterService: (namespace, manifests) =>
-      attempt("create router service", () =>
+      kubernetesCall("create router service", () =>
         clients.core.createNamespacedService({
           namespace,
           body: manifests.routerService,
@@ -798,7 +870,7 @@ function runPreparationOperations(
         }),
       ).pipe(Effect.asVoid),
     startController: (namespace, manifests) =>
-      attempt("create controller job", () =>
+      kubernetesCall("create controller job", () =>
         clients.batch.createNamespacedJob({
           namespace,
           body: manifests.controllerJob,
@@ -819,7 +891,7 @@ function runObservationOperations(
 > {
   return {
     readControllerJob: (namespace) =>
-      attempt("observe controller job", () =>
+      kubernetesCall("observe controller job", () =>
         clients.batch.readNamespacedJob({
           namespace,
           name: CONTROLLER_NAME,
@@ -835,7 +907,7 @@ function runObservationOperations(
         }),
       ),
     runNamespaceExists: (namespace) =>
-      attempt("observe run namespace deletion", () =>
+      kubernetesCall("observe run namespace deletion", () =>
         clients.core.readNamespace({ name: namespace }),
       ).pipe(
         Effect.as(true),
@@ -945,7 +1017,7 @@ export function makeKubernetesRunWorkerInstallApi(
   const clients = installClients(options.profile);
   const applies = installedObjectApplies(clients, runWorkerManifests(options));
   const readWorker = () =>
-    attempt("observe run worker", () =>
+    kubernetesCall("observe run worker", () =>
       clients.apps.readNamespacedDeployment({
         name: RUN_WORKER_NAME,
         namespace: SYSTEM_NAMESPACE,
@@ -953,7 +1025,7 @@ export function makeKubernetesRunWorkerInstallApi(
     );
   return Object.freeze({
     install: (object: RunWorkerObject) =>
-      attempt(`apply run worker ${object}`, applies[object]).pipe(
+      kubernetesCall(`apply run worker ${object}`, applies[object]).pipe(
         Effect.asVoid,
       ),
     // A cluster with no worker yet reads as no image rather than as a failure:

--- a/packages/simulator/src/cluster/kubernetes/objects.test.ts
+++ b/packages/simulator/src/cluster/kubernetes/objects.test.ts
@@ -15,6 +15,8 @@ import {
   ROUTER_SERVICE_NAME,
   RUN_OWNER_NAME,
   RUN_WORKER_NAME,
+  RUN_WORKER_PRESTOP_SECONDS,
+  RUN_WORKER_TERMINATION_GRACE_SECONDS,
   runNamespaceManifest,
   runOwnerManifest,
   runWorkerManifests,
@@ -479,6 +481,27 @@ it("serves the run queue from a Deployment carrying the host's choices", () => {
       },
     ],
   });
+});
+
+// A rolled worker is deleted while it may still be heartbeating a controller
+// activity. Delaying the signal is what lets that attempt beat once more, and
+// the grace period has to outlast the delay or the kill lands during it.
+it("holds the worker's Pod open before signalling it, and longer still after", () => {
+  const { deployment } = runWorkerManifests(WORKER_OPTIONS);
+  const pod = deployment.spec?.template.spec;
+  assert(pod !== undefined);
+  const [worker] = pod.containers;
+  assert(worker !== undefined);
+
+  expect(worker.lifecycle?.preStop?.exec?.command).toContain(
+    `sleep ${String(RUN_WORKER_PRESTOP_SECONDS)}`,
+  );
+  expect(pod.terminationGracePeriodSeconds).toBe(
+    RUN_WORKER_TERMINATION_GRACE_SECONDS,
+  );
+  expect(RUN_WORKER_PRESTOP_SECONDS).toBeLessThan(
+    RUN_WORKER_TERMINATION_GRACE_SECONDS,
+  );
 });
 
 it("holds cluster-wide namespace deletion and every permission it delegates", () => {

--- a/packages/simulator/src/cluster/kubernetes/objects.ts
+++ b/packages/simulator/src/cluster/kubernetes/objects.ts
@@ -391,6 +391,22 @@ export const RUN_WORKER_NAME = "run-worker";
 export const IN_CLUSTER_TEMPORAL_ADDRESS = `temporal.${SYSTEM_NAMESPACE}.svc.cluster.local:7233`;
 
 const RUN_WORKER_ENTRYPOINT = "/opt/moltzap/dist/cluster/temporal.js";
+/**
+ * Delay held before the worker Pod is signalled, in seconds.
+ *
+ * The worker's controller activity beats every 10 seconds against a 60-second
+ * heartbeat deadline. Holding SIGTERM for longer than one beat lets an attempt
+ * that is mid-interval signal once more before the process is asked to stop, so
+ * a roll cannot fail an attempt that was still alive when the Pod was deleted.
+ */
+export const RUN_WORKER_PRESTOP_SECONDS = 15;
+/**
+ * Time the worker Pod has to stop before it is killed, in seconds.
+ *
+ * The rest of the heartbeat deadline, so the SDK's own shutdown has room after
+ * the pre-stop delay returns rather than being killed at the default 30.
+ */
+export const RUN_WORKER_TERMINATION_GRACE_SECONDS = 60;
 const CONTROLLER_PORT = 3_000;
 const CONTROLLER_ENTRYPOINT = "/opt/moltzap/dist/cluster/controller/main.js";
 const EXPERIMENT_DIRECTORY = "/opt/moltzap/experiment";
@@ -1004,6 +1020,20 @@ function runWorkerContainer(options: RunWorkerOptions): V1Container {
     ],
     terminationMessagePolicy: "FallbackToLogsOnError",
     resources: { requests: { cpu: "100m", memory: "256Mi" } },
+    // A shell sleep rather than the Kubernetes `sleep` handler, which needs a
+    // 1.29 control plane; the worker's own image is Debian-based, so `sleep` is
+    // there on every cluster this installs into.
+    lifecycle: {
+      preStop: {
+        exec: {
+          command: [
+            "/bin/sh",
+            "-c",
+            `sleep ${String(RUN_WORKER_PRESTOP_SECONDS)}`,
+          ],
+        },
+      },
+    },
     securityContext: {
       allowPrivilegeEscalation: false,
       capabilities: { drop: ["ALL"] },
@@ -1031,6 +1061,7 @@ function runWorkerDeployment(options: RunWorkerOptions): V1Deployment {
           automountServiceAccountToken: true,
           enableServiceLinks: false,
           serviceAccountName: RUN_WORKER_NAME,
+          terminationGracePeriodSeconds: RUN_WORKER_TERMINATION_GRACE_SECONDS,
           containers: [runWorkerContainer(options)],
         },
       },

--- a/packages/simulator/src/cluster/submit.test.ts
+++ b/packages/simulator/src/cluster/submit.test.ts
@@ -1,11 +1,12 @@
 /* eslint-disable agent-code-guard/async-keyword -- The submitter boundary is Promise-native, so its assertions await it. */
 
 import { describe, expect, it } from "vitest";
-import { Effect, Layer } from "effect";
+import { Cause, Data, Effect, Layer, Logger } from "effect";
 import type { RunControllerResult } from "./reclaim.js";
 import { LOCAL_KUBERNETES_EXECUTION_PROFILE } from "./profile.js";
 import {
   runKubernetesSociety,
+  SUBMIT_STAGE,
   SubmitOperations,
   type RunEnvironment,
   type RunSubmission,
@@ -61,6 +62,61 @@ function submit(
     Effect.map((submission) => ({ submission, submitted })),
   );
 }
+
+/** What the filesystem said, which the reported detail deliberately drops. */
+class UnreadableEntrypoint extends Data.TaggedError("UnreadableEntrypoint")<{
+  readonly detail: string;
+}> {
+  override get message(): string {
+    return this.detail;
+  }
+}
+
+// The reported detail is the same sentence for a missing file, a directory,
+// and a permission denial, so the cause is the only place the operator can
+// learn which one it was.
+describe("an unreadable RunSpec entrypoint", () => {
+  const unreadable = "the entrypoint is a directory";
+
+  function capturingLogger(causes: string[]): Layer.Layer<never> {
+    return Logger.replace(
+      Logger.defaultLogger,
+      Logger.make(({ cause }) => {
+        if (!Cause.isEmpty(cause)) {
+          causes.push(Cause.pretty(cause));
+        }
+      }),
+    );
+  }
+
+  it("logs the cause it refuses to report", async () => {
+    const causes: string[] = [];
+
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        runKubernetesSociety(
+          [ENTRYPOINT],
+          ENVIRONMENT,
+          LOCAL_KUBERNETES_EXECUTION_PROFILE,
+        ).pipe(
+          Effect.provide(
+            Layer.succeed(SubmitOperations, {
+              readTextFile: () =>
+                Effect.fail(new UnreadableEntrypoint({ detail: unreadable })),
+              randomUuid: () => "0123456789abcdef0123456789abcdef",
+              runTemporalSociety: () => Promise.resolve(RESULT),
+            }),
+          ),
+          Effect.provide(capturingLogger(causes)),
+        ),
+      ),
+    );
+
+    expect(failure.stage).toBe(SUBMIT_STAGE.module);
+    expect(failure.message).not.toContain(unreadable);
+    expect(causes.join("\n")).toContain(unreadable);
+  });
+});
 
 describe("the run's cohort size", () => {
   it("reaches the workflow when the environment sets one", async () => {

--- a/packages/simulator/src/cluster/submit.ts
+++ b/packages/simulator/src/cluster/submit.ts
@@ -5,7 +5,8 @@ import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 import { FileSystem } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { Context, Data, Effect, Layer } from "effect";
+import { Context, Data, Effect, Layer, type Cause } from "effect";
+import { FORCE_WORKER_ROLL_VARIABLE, RunWorkerRollRefused } from "./install.js";
 import type { KubernetesExecutionProfile } from "./profile.js";
 import type { RunControllerResult } from "./reclaim.js";
 import {
@@ -144,26 +145,34 @@ function readExperiment(
   path: string,
   operations: SubmitOperationsService,
 ): Effect.Effect<string, RunSubmissionError> {
-  return operations
-    .readTextFile(path)
-    .pipe(
-      Effect.mapError(() =>
-        failure("module", "the RunSpec entrypoint could not be read"),
-      ),
-    );
+  return operations.readTextFile(path).pipe(
+    // Which of a missing file, a directory, and a permission denial it was
+    // reaches the operator only here: the reported detail is deliberately the
+    // same sentence for all three.
+    Effect.tapErrorCause(Effect.logError),
+    Effect.mapError(() =>
+      failure("module", "the RunSpec entrypoint could not be read"),
+    ),
+  );
+}
+
+// A refused worker roll is the operator's own next action rather than a fault
+// in the run, so its text is reported instead of the generic detail. It names
+// only images, run ids, and an environment variable; every other failure stays
+// sanitized, because its detail can carry the connection the submitter used.
+function submissionFailure(cause: Cause.UnknownException): RunSubmissionError {
+  return cause.error instanceof RunWorkerRollRefused
+    ? failure("configuration", cause.error.message)
+    : failure("execution", "the Temporal-managed run did not complete");
 }
 
 function executeTemporalRun(
   options: RunTemporalSocietyOptions,
   operations: SubmitOperationsService,
 ): Effect.Effect<RunControllerResult, RunSubmissionError> {
-  // The cause is logged rather than reported, because the detail is operator
-  // output and the connection it carries can hold a credential.
   return Effect.tryPromise(() => operations.runTemporalSociety(options)).pipe(
     Effect.tapErrorCause(Effect.logError),
-    Effect.mapError(() =>
-      failure("execution", "the Temporal-managed run did not complete"),
-    ),
+    Effect.mapError(submissionFailure),
   );
 }
 
@@ -205,6 +214,7 @@ interface PreparedRun {
   readonly executionProfile: KubernetesExecutionProfile;
   readonly startupTimeoutMs?: number;
   readonly cohortSize?: number;
+  readonly forceWorkerRoll: boolean;
   readonly connection: {
     readonly taskQueue: string;
     readonly temporalAddress: string;
@@ -279,6 +289,9 @@ function prepareRun(
     path: experimentPath(args),
     controllerImage,
     executionProfile,
+    // Exactly "1", so that an operator who exported the variable to something
+    // else has not silently accepted losing a run.
+    forceWorkerRoll: environment[FORCE_WORKER_ROLL_VARIABLE] === "1",
     ...runSizing(environment),
     supportImage: requiredImage(
       environment,
@@ -323,6 +336,7 @@ function executePreparedRun(
     const result = yield* executeTemporalRun(
       {
         executionProfile: prepared.executionProfile,
+        forceWorkerRoll: prepared.forceWorkerRoll,
         workflowId: identity.runId,
         taskQueue: prepared.connection.taskQueue,
         temporalAddress: prepared.connection.temporalAddress,

--- a/packages/simulator/src/cluster/temporal.test.ts
+++ b/packages/simulator/src/cluster/temporal.test.ts
@@ -18,9 +18,12 @@ import type {
 import {
   executeRunSocietyWorkflow,
   LifecycleOperations,
+  OPEN_RUN_STATUS,
+  readOpenRuns,
   runLifecycleActivities,
   type ControllerObservation,
   type LifecycleOperationsService,
+  type OpenRunLister,
   type RunSocietyWorkflowExecutionOptions,
 } from "./temporal.js";
 
@@ -198,6 +201,49 @@ describe("run lifecycle activities", () => {
       "wait",
       "observe-namespace",
     ]);
+  });
+});
+
+describe("readOpenRuns", () => {
+  const taskQueue = "moltzap-simulator";
+  const openRunIds = ["mz-open-1", "mz-open-2"];
+
+  async function* listed(
+    workflowIds: readonly string[],
+  ): AsyncIterable<{ readonly workflowId: string }> {
+    for (const workflowId of workflowIds) {
+      yield await Promise.resolve({ workflowId });
+    }
+  }
+
+  it("names the runs the queue has not finished, asking only about that queue", async () => {
+    const queries: string[] = [];
+    const client: OpenRunLister = {
+      list: (options) => {
+        queries.push(options.query);
+        return listed(openRunIds);
+      },
+    };
+
+    await expect(
+      Effect.runPromise(readOpenRuns(client, taskQueue)),
+    ).resolves.toEqual({ _tag: "open", workflowIds: openRunIds });
+    expect(queries[0]).toContain(taskQueue);
+    expect(queries[0]).toContain(OPEN_RUN_STATUS);
+  });
+
+  // The distinction the roll guard depends on: a queue that cannot be listed
+  // must not read as a queue with nothing on it.
+  it("reports a listing it could not make as unreadable rather than as empty", async () => {
+    const client: OpenRunLister = {
+      list: () => {
+        throw new Error("visibility store unavailable");
+      },
+    };
+
+    await expect(
+      Effect.runPromise(readOpenRuns(client, taskQueue)),
+    ).resolves.toEqual({ _tag: "unreadable" });
   });
 });
 

--- a/packages/simulator/src/cluster/temporal.ts
+++ b/packages/simulator/src/cluster/temporal.ts
@@ -21,10 +21,15 @@ import type {
   runSocietyWorkflow,
 } from "./reclaim.js";
 import { isEntryModule } from "./entry.js";
-import { installRunWorker } from "./install.js";
+import {
+  installRunWorker,
+  type OpenRunReading,
+  type RunWorkerInstallRequest,
+} from "./install.js";
 import {
   makeKubernetesRunWorkerInstallApi,
   type KubernetesCallFailed,
+  type RunWorkerInstallApi,
 } from "./kubernetes/calls.js";
 import { IN_CLUSTER_TEMPORAL_ADDRESS } from "./kubernetes/objects.js";
 import {
@@ -70,6 +75,8 @@ export interface RunTemporalSocietyOptions {
   readonly temporalNamespace?: string;
   /** Temporal endpoint as the in-cluster worker reaches it, not as the host does. */
   readonly workerTemporalAddress?: string;
+  /** Whether the operator accepted rolling the worker over its open runs. */
+  readonly forceWorkerRoll?: boolean;
 }
 
 /* eslint-disable agent-code-guard/async-keyword, agent-code-guard/promise-type, @typescript-eslint/no-invalid-void-type -- Temporal activities, workers, clients, and their host-operation dependencies are SDK-required Promise boundaries. */
@@ -352,6 +359,99 @@ export async function executeRunSocietyWorkflow(
   );
 }
 
+/** The most open runs one reading names before it stops counting. */
+const OPEN_RUN_SAMPLE = 20;
+
+/** Temporal execution status of a run its task queue has not finished. */
+export const OPEN_RUN_STATUS = "Running";
+
+/**
+ * The exact listing surface reading a queue's unfinished work needs.
+ *
+ * Narrower than the client's own, so that what this reads is the whole of what
+ * it depends on and a test can supply it without standing up a Temporal server.
+ */
+export interface OpenRunLister {
+  readonly list: (options: {
+    readonly query: string;
+  }) => AsyncIterable<{ readonly workflowId: string }>;
+}
+
+// Bounded, because the caller only has to know that some run is still open and
+// which ones to name; an unbounded listing walks every page of the visibility
+// store to answer a question the first page already answered.
+// #ignore-sloppy-code-next-line[async-keyword]: Temporal workers, clients, and activities are SDK-required Promise boundaries
+async function listOpenRunIds(
+  client: OpenRunLister,
+  taskQueue: string,
+  // #ignore-sloppy-code-next-line[promise-type]: Temporal workers, clients, and activities are SDK-required Promise boundaries
+): Promise<readonly string[]> {
+  const workflowIds: string[] = [];
+  for await (const execution of client.list({
+    query: `TaskQueue = '${taskQueue}' AND ExecutionStatus = '${OPEN_RUN_STATUS}'`,
+  })) {
+    workflowIds.push(execution.workflowId);
+    if (workflowIds.length >= OPEN_RUN_SAMPLE) {
+      break;
+    }
+  }
+  return workflowIds;
+}
+
+/**
+ * Read which runs the task queue has not finished yet.
+ *
+ * A queue that cannot be listed reads as unreadable rather than as empty. The
+ * difference is the whole point: an empty answer clears a submission to replace
+ * the worker, so a failed query that returned one would authorize exactly the
+ * roll this reading exists to prevent.
+ *
+ * @param client Temporal client already connected to the run's namespace.
+ * @param taskQueue Queue the cluster's worker serves.
+ * @returns The open runs it named, or that it could not be asked.
+ */
+export function readOpenRuns(
+  client: OpenRunLister,
+  taskQueue: string,
+): Effect.Effect<OpenRunReading> {
+  return Effect.tryPromise(() => listOpenRunIds(client, taskQueue)).pipe(
+    Effect.map(
+      (workflowIds): OpenRunReading => ({ _tag: "open", workflowIds }),
+    ),
+    // Logged rather than reported: the cause names the connection the submitter
+    // used, and operator-facing text is what the refusal already carries.
+    Effect.tapErrorCause(Effect.logError),
+    Effect.catchAll(() =>
+      Effect.succeed<OpenRunReading>({ _tag: "unreadable" }),
+    ),
+  );
+}
+
+function installRequest(
+  options: RunTemporalSocietyOptions,
+  client: OpenRunLister,
+): RunWorkerInstallRequest {
+  return {
+    desiredImage: options.input.controllerImage,
+    readOpenRuns: () => readOpenRuns(client, options.taskQueue),
+    forced: options.forceWorkerRoll ?? false,
+  };
+}
+
+function runWorkerInstallApi(
+  options: RunTemporalSocietyOptions,
+  namespace: string,
+): RunWorkerInstallApi {
+  return makeKubernetesRunWorkerInstallApi({
+    controllerImage: options.input.controllerImage,
+    taskQueue: options.taskQueue,
+    temporalAddress:
+      options.workerTemporalAddress ?? IN_CLUSTER_TEMPORAL_ADDRESS,
+    temporalNamespace: namespace,
+    profile: options.executionProfile ?? LOCAL_KUBERNETES_EXECUTION_PROFILE,
+  });
+}
+
 /**
  * Submit one run to the cluster's worker and wait for its controller result.
  *
@@ -359,6 +459,11 @@ export async function executeRunSocietyWorkflow(
  * end with the process, stranding the workflow's cleanup and leaving the run's
  * namespace behind, so the queue is served by a Deployment that outlives any one
  * submission and that this call installs before submitting.
+ *
+ * The client connects first so that the install can be told what replacing the
+ * worker would cost. Installing first makes that question unanswerable: by the
+ * time anything could be asked, the Deployment is already rolling and the runs
+ * the answer was about are already failing.
  *
  * @param options Temporal endpoint plus caller-owned workflow and run inputs.
  * @returns The successful controller activity result.
@@ -369,18 +474,7 @@ export async function runTemporalSociety(
   // #ignore-sloppy-code-next-line[promise-type]: Temporal workers, clients, and activities are SDK-required Promise boundaries
 ): Promise<RunControllerResult> {
   const namespace = options.temporalNamespace ?? DEFAULT_TEMPORAL_NAMESPACE;
-  await runAtPromiseBoundary(
-    installRunWorker(
-      makeKubernetesRunWorkerInstallApi({
-        controllerImage: options.input.controllerImage,
-        taskQueue: options.taskQueue,
-        temporalAddress:
-          options.workerTemporalAddress ?? IN_CLUSTER_TEMPORAL_ADDRESS,
-        temporalNamespace: namespace,
-        profile: options.executionProfile ?? LOCAL_KUBERNETES_EXECUTION_PROFILE,
-      }),
-    ),
-  );
+  await runAtPromiseBoundary(Effect.logInfo("connecting Temporal"));
   const connection = await Connection.connect(
     options.temporalAddress === undefined
       ? undefined
@@ -388,6 +482,13 @@ export async function runTemporalSociety(
   );
   try {
     const client = new Client({ connection, namespace });
+    await runAtPromiseBoundary(
+      installRunWorker(
+        runWorkerInstallApi(options, namespace),
+        installRequest(options, client.workflow),
+      ),
+    );
+    await runAtPromiseBoundary(Effect.logInfo("starting workflow"));
     return await executeRunSocietyWorkflow(options.input, {
       client: client.workflow,
       taskQueue: options.taskQueue,


### PR DESCRIPTION
## Summary
Two observed cluster failure modes closed:
- **Worker-roll race**: every submission installs the run-worker; an image change rolled the singleton Deployment while a prior run's controller activity was mid-flight, killing the run (60s heartbeat, maxAttempts 1) and reclaiming its namespace. The submitter now connects Temporal FIRST, lists open workflows on the task queue, and refuses a pod-template-changing roll while any are open (`MOLTZAP_FORCE_WORKER_ROLL=1` overrides). Same-image submissions stay a no-op (regression-tested). Grace period + preStop sized to the heartbeat.
- **Silent hangs**: every Kubernetes API call is now bounded (configurable, default ~30s) with stage progress logs — an unreachable API server fails in seconds with the failing stage named instead of 14 silent minutes; the module-read branch keeps its cause.

/simplify applied. No new failure types: refusals use the existing stage-tagged RunSubmissionError channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)