### PR TITLE
fix(docs): stop naming things the cutover removed

### DIFF
--- a/docs/decisions/20260801-main-simulator-runs-container-societies-on-kubernetes.md
+++ b/docs/decisions/20260801-main-simulator-runs-container-societies-on-kubernetes.md
@@ -75,7 +75,8 @@ the simulator does not add a universal gateway union.
 
 The old `simulator.define(...).run(...)` host entry point is transitional. It
 is removed after `packages/evals` and the local/GKE acceptance runs use
-`RunSpec` and `Run.execute`. There is no supported Docker execution backend or
+`RunSpec` and `Run.execute`; that removal has since happened, and neither the
+entry point nor the Docker example remains in the tree. There is no supported Docker execution backend or
 compatibility facade after cutover. Docker may still build images and support a
 local Kubernetes cluster.
 
@@ -102,8 +103,8 @@ runs as the application entrypoint in that peer's Sandbox container, and
 `packages/evals` owns the peer-specific observation bridge and its exact
 gateway adapter. Peer social behavior still uses the production MoltZap
 client and router. The in-process Effect runtime remains transitional host
-code until cutover; no public `scriptedRuntime` constructor or generic
-scripted-agent protocol is introduced.
+code until cutover, and has since been removed with it; no public
+`scriptedRuntime` constructor or generic scripted-agent protocol is introduced.
 
 ### One execution is one experiment society
 
@@ -292,3 +293,4 @@ the outcome is a supersession, not a row here.
 | 2026-08-06 | Corrected the stale subpath in the simulator overview from `/runtime` to `/agents`, the export the package actually publishes. |
 | 2026-08-06 | Corrected the illustrative snippet from `export default` to the named `runSpec` export the controller admits. |
 | 2026-08-06 | Scoped the `autoscaling` non-goal to a run's cohort. A profile's node pool may autoscale; it was selected because it is the simpler thing to operate. |
+| 2026-08-11 | Recorded that the transitional host entry point and in-process Effect runtime are gone. Both were described in the present tense after the cutover that removed them, leaving a reader unable to tell whether either still existed. The Decision Outcome and its removal condition are unchanged. |

--- a/packages/protocol/scripts/docs/__tests__/module-exports.test.ts
+++ b/packages/protocol/scripts/docs/__tests__/module-exports.test.ts
@@ -37,38 +37,42 @@ const exported = (
 });
 
 describe("exportsForModuleFolder", () => {
+  // The cache entries below are synthetic. They name a package that does not
+  // exist so that they describe a shape rather than a layout: fixtures spelled
+  // as real paths silently stop being true at the next rename, and nothing
+  // resolves them to disk to notice.
   it("gives a package root every symbol exported by its entry point", () => {
     const root = exported(
       1,
       "defineSociety",
-      "@moltzap/simulator",
-      "packages/simulator/src/definition.ts",
+      "@example/widgets",
+      "packages/widgets/src/definition.ts",
     );
     const nested = exported(
       2,
       "openClawRuntime",
-      "@moltzap/simulator",
-      "packages/simulator/src/runtime/openclaw/runtime.ts",
+      "@example/widgets",
+      "packages/widgets/src/runtime/openclaw/runtime.ts",
     );
     const privateCapability = exported(
       3,
       "makeRuntimeProcess",
-      "@moltzap/simulator",
-      "packages/simulator/src/runtime/process.ts",
+      "@example/widgets",
+      "packages/widgets/src/runtime/process.ts",
     );
     const cache: TypeDocCache = {
       all: [root, nested, privateCapability],
       byPackage: new Map([
-        ["@moltzap/simulator", [root, nested, privateCapability]],
+        ["@example/widgets", [root, nested, privateCapability]],
       ]),
-      byPackageEntrypoint: new Map([["@moltzap/simulator", [root, nested]]]),
+      byPackageEntrypoint: new Map([["@example/widgets", [root, nested]]]),
       byFolder: new Map([
-        ["packages/simulator/src", [root]],
-        ["packages/simulator/src/runtime", [nested]],
+        ["packages/widgets/src", [root]],
+        ["packages/widgets/src/runtime", [nested]],
       ]),
     };
 
-    expect(exportsForPackageRoot(cache, "@moltzap/simulator")).toEqual([
+    expect(exportsForPackageRoot(cache, "@example/widgets")).toEqual([
       root,
       nested,
     ]);
@@ -78,27 +82,27 @@ describe("exportsForModuleFolder", () => {
     const nested = exported(
       1,
       "openClawRuntime",
-      "@moltzap/simulator",
-      "packages/simulator/src/runtime/openclaw/runtime.ts",
+      "@example/widgets",
+      "packages/widgets/src/runtime/openclaw/runtime.ts",
     );
     const sibling = exported(
       2,
       "openLedger",
-      "@moltzap/simulator",
-      "packages/simulator/src/ledger/open.ts",
+      "@example/widgets",
+      "packages/widgets/src/ledger/open.ts",
     );
     const cache: TypeDocCache = {
       all: [nested, sibling],
-      byPackage: new Map([["@moltzap/simulator", [nested, sibling]]]),
-      byPackageEntrypoint: new Map([["@moltzap/simulator", [nested, sibling]]]),
+      byPackage: new Map([["@example/widgets", [nested, sibling]]]),
+      byPackageEntrypoint: new Map([["@example/widgets", [nested, sibling]]]),
       byFolder: new Map([
-        ["packages/simulator/src/runtime", [nested]],
-        ["packages/simulator/src/ledger", [sibling]],
+        ["packages/widgets/src/runtime", [nested]],
+        ["packages/widgets/src/ledger", [sibling]],
       ]),
     };
 
     expect(
-      exportsForModuleFolder(cache, "packages/simulator/src/runtime"),
+      exportsForModuleFolder(cache, "packages/widgets/src/runtime"),
     ).toEqual([nested]);
   });
 });


### PR DESCRIPTION
Two stale references left behind by the Kubernetes cutover. Both were found by review, not by CI, because neither is the kind of thing a compiler or a test can see.

## The record described removed code in the present tense

`20260801-main-simulator-runs-container-societies-on-kubernetes.md` said the old `simulator.define(...).run(...)` entry point "is transitional" and the in-process Effect runtime "remains transitional host code until cutover". The cutover happened: `examples/` and `packages/simulator/src/runtime/` have no tracked files, and `simulator.define` is exported from nowhere.

The removal condition and the Decision Outcome are untouched. The record now says the condition was met, with a `Record changelog` row.

## The doc fixtures spelled a layout that no longer exists

`packages/protocol/scripts/docs/__tests__/module-exports.test.ts` built its TypeDoc cache from paths like `packages/simulator/src/runtime/openclaw/runtime.ts` and `packages/simulator/src/runtime/process.ts`. **Zero paths under `packages/simulator/src/runtime/` exist.** Two of the symbols it names, `defineSociety` and `makeRuntimeProcess`, are exported nowhere either.

Nothing resolves those strings to disk, so the rot was invisible and CI stayed green through it. This had drifted more than once.

The fix is the root cause rather than the three strings: the fixtures now name a package that does not exist, which is what they always were. A future rename cannot make them wrong, and no reader can mistake them for real references.

One assertion in that file is **not** a fixture — `modulePageSlug("packages/simulator/src")` checks the real v1 slug. The first pass replaced it too and the test caught it; it is restored.

## Verification

`module-exports.test.ts` 5/5 pass. `check-adr-shape` PASS across 50 records. CI covers the rest.