### PR TITLE
fix(client): sends wait for the Router worker to attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ heading below in its release commit.
 
 ## [Unreleased]
 
+### Fixed: sends wait for the Router worker to attach
+
+A daemon reported itself active as soon as registration completed, while its
+Router worker was still making its first poll, so a host that sent right
+after registering or restarting could fail with `network-unavailable` for no
+reason of its own. Every send now waits for the worker to attach, for at most
+`ROUTER_ATTACH_TIMEOUT`, before that failure is possible, and waits before
+taking the engine gate that attachment itself needs. The four closed Client
+failures — `SendError`, `ListenError`, `DeliveryAcknowledgeError`, and
+`ConnectError` — now name their `reason` in `message` instead of reporting
+"An error has occurred".
+
 ### Fixed: evaluator social turns and OpenClaw media normalization
 
 Group scenarios now deliver an announcement and its addressed question in one

--- a/docs/modules/client/src.mdx
+++ b/docs/modules/client/src.mdx
@@ -51,14 +51,18 @@ export const AgentAddress = addressInput.pipe(
 
 An explicit direct destination using one canonical Registry name.
 
-### [`ConnectError`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L348)
+### [`ConnectError`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L360)
 
 _Class_
 
 ```ts
 export class ConnectError extends Data.TaggedError("ConnectError")<{
   readonly reason: ConnectFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `connect failed: ${this.reason}`;
+  }
+}
 ```
 
 Acquiring the endpoint connection failed.
@@ -109,7 +113,7 @@ export const ContentPart = Schema.Union(
 
 One exact semantic part of a message.
 
-### [`DeliveryAcknowledgeError`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L336)
+### [`DeliveryAcknowledgeError`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L344)
 
 _Class_
 
@@ -118,7 +122,11 @@ export class DeliveryAcknowledgeError extends Data.TaggedError(
   "DeliveryAcknowledgeError",
 )<{
   readonly reason: DeliveryAcknowledgeFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `delivery acknowledgment failed: ${this.reason}`;
+  }
+}
 ```
 
 Transport acknowledgment could not complete for one delivery.
@@ -167,7 +175,7 @@ export type GroupMessage = typeof groupMessage.Type;
 
 One certified remote-authored fixed-group message.
 
-### [`HarnessEndpoint`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L359)
+### [`HarnessEndpoint`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L375)
 
 _Interface_
 
@@ -180,7 +188,7 @@ export interface HarnessEndpoint {
 
 Structural runtime capability owned by one scoped endpoint connection.
 
-### [`InboundDelivery`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L353)
+### [`InboundDelivery`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L369)
 
 _Interface_
 
@@ -251,14 +259,18 @@ export const JsonValue: Schema.Schema<JsonValue> = Schema.suspend(() =>
 
 Runtime validation for the closed recursive JSON value.
 
-### [`ListenError`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L325)
+### [`ListenError`](https://github.com/chughtapan/moltzap/blob/main/packages/client/src/contract.ts#L329)
 
 _Class_
 
 ```ts
 export class ListenError extends Data.TaggedError("ListenError")<{
   readonly reason: ListenFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `listen failed: ${this.reason}`;
+  }
+}
 ```
 
 The endpoint's sole inbound subscription failed.
@@ -317,7 +329,11 @@ _Class_
 ```ts
 export class SendError extends Data.TaggedError("SendError")<{
   readonly reason: SendFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `send failed: ${this.reason}`;
+  }
+}
 ```
 
 An addressed send failed before local certification completed.

--- a/docs/spec/harness/client.md
+++ b/docs/spec/harness/client.md
@@ -98,6 +98,13 @@ recovering or completing that invocation. A later call receives a different
 choice to invoke send again. Send succeeds with `void` only after local
 complete action and durability certification.
 
+Registration and daemon restart both admit sends before the daemon's Router
+worker has attached. A send issued in that window waits for attachment for a
+bounded time, named by `ROUTER_ATTACH_TIMEOUT`, and fails with
+`network-unavailable` only once that bound elapses. No send fails merely
+because the worker is still attaching, and the wait holds no lock that
+attachment itself needs.
+
 ## Addressed inbound delivery
 
 Every delivery derives from one complete certified remote-authored record. A

--- a/packages/client/src/MODULE.md
+++ b/packages/client/src/MODULE.md
@@ -46,14 +46,18 @@ export const AgentAddress = addressInput.pipe(
 
 An explicit direct destination using one canonical Registry name.
 
-### [`ConnectError`](./contract.ts#L348)
+### [`ConnectError`](./contract.ts#L360)
 
 _Class_
 
 ```ts
 export class ConnectError extends Data.TaggedError("ConnectError")<{
   readonly reason: ConnectFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `connect failed: ${this.reason}`;
+  }
+}
 ```
 
 Acquiring the endpoint connection failed.
@@ -104,7 +108,7 @@ export const ContentPart = Schema.Union(
 
 One exact semantic part of a message.
 
-### [`DeliveryAcknowledgeError`](./contract.ts#L336)
+### [`DeliveryAcknowledgeError`](./contract.ts#L344)
 
 _Class_
 
@@ -113,7 +117,11 @@ export class DeliveryAcknowledgeError extends Data.TaggedError(
   "DeliveryAcknowledgeError",
 )<{
   readonly reason: DeliveryAcknowledgeFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `delivery acknowledgment failed: ${this.reason}`;
+  }
+}
 ```
 
 Transport acknowledgment could not complete for one delivery.
@@ -162,7 +170,7 @@ export type GroupMessage = typeof groupMessage.Type;
 
 One certified remote-authored fixed-group message.
 
-### [`HarnessEndpoint`](./contract.ts#L359)
+### [`HarnessEndpoint`](./contract.ts#L375)
 
 _Interface_
 
@@ -175,7 +183,7 @@ export interface HarnessEndpoint {
 
 Structural runtime capability owned by one scoped endpoint connection.
 
-### [`InboundDelivery`](./contract.ts#L353)
+### [`InboundDelivery`](./contract.ts#L369)
 
 _Interface_
 
@@ -246,14 +254,18 @@ export const JsonValue: Schema.Schema<JsonValue> = Schema.suspend(() =>
 
 Runtime validation for the closed recursive JSON value.
 
-### [`ListenError`](./contract.ts#L325)
+### [`ListenError`](./contract.ts#L329)
 
 _Class_
 
 ```ts
 export class ListenError extends Data.TaggedError("ListenError")<{
   readonly reason: ListenFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `listen failed: ${this.reason}`;
+  }
+}
 ```
 
 The endpoint's sole inbound subscription failed.
@@ -312,7 +324,11 @@ _Class_
 ```ts
 export class SendError extends Data.TaggedError("SendError")<{
   readonly reason: SendFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `send failed: ${this.reason}`;
+  }
+}
 ```
 
 An addressed send failed before local certification completed.

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -313,7 +313,11 @@ type SendFailure =
 /** An addressed send failed before local certification completed. */
 export class SendError extends Data.TaggedError("SendError")<{
   readonly reason: SendFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `send failed: ${this.reason}`;
+  }
+}
 
 type ListenFailure =
   | "already-listening"
@@ -324,7 +328,11 @@ type ListenFailure =
 /** The endpoint's sole inbound subscription failed. */
 export class ListenError extends Data.TaggedError("ListenError")<{
   readonly reason: ListenFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `listen failed: ${this.reason}`;
+  }
+}
 
 type DeliveryAcknowledgeFailure =
   | "unknown-delivery"
@@ -337,7 +345,11 @@ export class DeliveryAcknowledgeError extends Data.TaggedError(
   "DeliveryAcknowledgeError",
 )<{
   readonly reason: DeliveryAcknowledgeFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `delivery acknowledgment failed: ${this.reason}`;
+  }
+}
 
 type ConnectFailure =
   | "transport-failed"
@@ -347,7 +359,11 @@ type ConnectFailure =
 /** Acquiring the endpoint connection failed. */
 export class ConnectError extends Data.TaggedError("ConnectError")<{
   readonly reason: ConnectFailure;
-}> {}
+}> {
+  override get message(): string {
+    return `connect failed: ${this.reason}`;
+  }
+}
 
 /** One message plus its transport-only acknowledgment. */
 export interface InboundDelivery {

--- a/packages/client/src/daemon/runtime/index.test.ts
+++ b/packages/client/src/daemon/runtime/index.test.ts
@@ -415,6 +415,7 @@ function makeWorker(
     Effect.zipRight(Effect.fail(new RouterWorkerTransportError())),
   );
   return {
+    awaitAnchor: outsideRuntimeTest(),
     currentAnchor: outsideRuntimeTest(),
     pollOnce: outsideRuntimeTest(),
     run: background === "worker" ? failure : Effect.never,

--- a/packages/client/src/endpoint/engine-send.ts
+++ b/packages/client/src/endpoint/engine-send.ts
@@ -1,7 +1,7 @@
 /** @file Address resolution, immutable intent binding, and proposal creation. */
 
 import { AgentCard, MOLTZAP_VERSION, SignedMessage } from "@moltzap/identity";
-import { Deferred, Effect, Schema } from "effect";
+import { Deferred, Duration, Effect, Schema } from "effect";
 import type {
   EngineConversation,
   EnginePostIntent,
@@ -58,6 +58,20 @@ function storeFailure(error: EndpointStoreError): SendError {
 
 const representationFailure = (): SendError =>
   new SendError({ reason: "certification-unavailable" });
+
+/**
+ * How long a send waits for the Router worker to attach before failing as
+ * `network-unavailable`.
+ *
+ * A cold-start attach can span a Router tail hold, `HOLD_DURATION` in
+ * `@moltzap/router`, and the daemon's own `ROUTER_POLL_TIMEOUT`, so a bound
+ * near either one fails sends that are merely early. It stays under the MCP
+ * SDK's `DEFAULT_REQUEST_TIMEOUT_MSEC`, the deadline a host client applies to
+ * the tool call, so the host receives this closed failure rather than a
+ * transport timeout it cannot classify, and the remaining margin covers the
+ * send itself. `EndpointEngineInput.routerAttachTimeout` overrides it.
+ */
+const ROUTER_ATTACH_TIMEOUT = Duration.seconds(45);
 
 type ResolvedAddress = Effect.Effect.Success<
   ReturnType<typeof resolveMessageAddress>
@@ -461,6 +475,27 @@ function currentAnchorFailure(error: RouterWorkerUnavailableError): SendError {
   return new SendError({ reason: reasonByTag[error._tag] });
 }
 
+// Registration and daemon restart both admit sends before the worker's first
+// successful poll, and every send needs an attached worker: a new conversation
+// reads the current anchor, an existing one transmits through the worker. The
+// wait runs before `activateIntent` takes the engine gate, because the worker
+// reaches `active` only after recovery that needs that same gate; waiting while
+// holding it would stall the attachment awaited.
+const awaitRouterAttachment = (
+  runtime: EngineRuntime,
+): Effect.Effect<void, SendError> =>
+  runtime.input.routerWorker.currentAnchor.pipe(
+    Effect.catchTag("RouterWorkerUnavailableError", () =>
+      runtime.input.routerWorker.awaitAnchor.pipe(
+        Effect.timeoutFail({
+          duration: runtime.input.routerAttachTimeout ?? ROUTER_ATTACH_TIMEOUT,
+          onTimeout: () => new SendError({ reason: "network-unavailable" }),
+        }),
+      ),
+    ),
+    Effect.asVoid,
+  );
+
 /**
  * Persist an addressed intent and return its durable completion latch.
  * @param runtime Current engine state and protocol dependencies.
@@ -471,7 +506,8 @@ export const prepareSend = (
   runtime: EngineRuntime,
   input: SendInput,
 ): Effect.Effect<Deferred.Deferred<undefined, SendError>, SendError> =>
-  prepareIntent(runtime, input).pipe(
+  awaitRouterAttachment(runtime).pipe(
+    Effect.zipRight(prepareIntent(runtime, input)),
     Effect.flatMap((prepared) => activateIntent(runtime, prepared)),
     Effect.withSpan("prepareSend"),
   );

--- a/packages/client/src/endpoint/engine-types.ts
+++ b/packages/client/src/endpoint/engine-types.ts
@@ -12,6 +12,7 @@ import {
   type Context,
   Data,
   type Deferred,
+  type Duration,
   type Effect,
   type Queue,
   type SubscriptionRef,
@@ -79,6 +80,7 @@ export interface EngineRouterPort {
     RouterTailAnchor,
     RouterWorkerUnavailableError
   >;
+  readonly awaitAnchor: Effect.Effect<RouterTailAnchor>;
   readonly send: (
     outboundId: string,
   ) => Effect.Effect<void, RouterWorkerSendError>;
@@ -107,6 +109,8 @@ export interface EndpointEngineInput {
   readonly store: EndpointStore;
   readonly routerWorker: EngineRouterPort;
   readonly actionPolicy: EngineActionPolicy;
+  /** Overrides `ROUTER_ATTACH_TIMEOUT`; tests bound the wait in milliseconds. */
+  readonly routerAttachTimeout?: Duration.Duration;
 }
 
 /** Stable private engine capability consumed by daemon composition. */

--- a/packages/client/src/endpoint/protocol/index.test.ts
+++ b/packages/client/src/endpoint/protocol/index.test.ts
@@ -19,10 +19,12 @@ import { PollCursor, RouterInstanceId } from "@moltzap/router";
 import canonicalize from "canonicalize";
 import {
   Deferred,
+  Duration,
   Effect,
   Either,
   Encoding,
   Fiber,
+  Option,
   Queue,
   Redacted,
   Schema,
@@ -39,8 +41,9 @@ import type {
   EndpointEngineInput,
   EngineActionFold,
   EngineRegistryPort,
+  EngineRouterPort,
 } from "../engine-types.js";
-import { SendInput } from "../../contract.js";
+import { SendError, SendInput } from "../../contract.js";
 import { type EndpointEngine, makeEndpointEngine } from "../engine.js";
 import { recoverFoldEvidence } from "../recovery/store-evidence.js";
 import {
@@ -66,8 +69,10 @@ import {
 } from "../representation.js";
 import {
   type RouterIngressDisposition,
+  type RouterTailAnchor,
   type RouterWorkerIngress,
   RouterWorkerPersistenceError,
+  RouterWorkerUnavailableError,
 } from "../router-worker/index.js";
 import { type EndpointStore, openEndpointStore } from "../store.js";
 
@@ -324,12 +329,38 @@ function signEveryAction(): Effect.Effect<"sign"> {
   return Effect.succeed("sign");
 }
 
+type WorkerAttachment = Pick<EngineRouterPort, "awaitAnchor" | "currentAnchor">;
+
+function attachesWhenResolved(
+  attached: Deferred.Deferred<RouterTailAnchor>,
+): WorkerAttachment {
+  return {
+    currentAnchor: Deferred.poll(attached).pipe(
+      Effect.flatMap(
+        Option.match({
+          onNone: () => Effect.fail(new RouterWorkerUnavailableError()),
+          onSome: (anchor: Effect.Effect<RouterTailAnchor>) => anchor,
+        }),
+      ),
+    ),
+    awaitAnchor: Deferred.await(attached),
+  };
+}
+
+const neverAttaches: WorkerAttachment = {
+  currentAnchor: Effect.fail(new RouterWorkerUnavailableError()),
+  awaitAnchor: Effect.never,
+};
+
 function scriptedRouterWorker(
   store: EndpointStore,
   outbound: Queue.Queue<typeof SignedMessage.Type>,
-) {
+  attachment?: WorkerAttachment,
+): EngineRouterPort {
+  const anchor = { routerInstanceId, pollCursor };
   return {
-    currentAnchor: Effect.succeed({ routerInstanceId, pollCursor }),
+    currentAnchor: attachment?.currentAnchor ?? Effect.succeed(anchor),
+    awaitAnchor: attachment?.awaitAnchor ?? Effect.succeed(anchor),
     send: (outboundId: string) =>
       forwardStoredOutbound(store, outbound, outboundId),
   };
@@ -385,8 +416,15 @@ function drainEngines(
   ).pipe(Effect.orDie);
 }
 
+interface HarnessOptions {
+  readonly actionPolicy?: EndpointEngineInput["actionPolicy"];
+  /** Present when the author's Router worker has not attached yet. */
+  readonly attachment?: WorkerAttachment;
+  readonly attachTimeout?: Duration.Duration;
+}
+
 function makeProtocolHarness(
-  authorActionPolicy: EndpointEngineInput["actionPolicy"] = signEveryAction,
+  options: HarnessOptions = {},
 ): Effect.Effect<ProtocolHarness, never, Scope.Scope> {
   return Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
@@ -427,8 +465,18 @@ function makeProtocolHarness(
               registrySignerPublicKey,
               registry,
               store,
-              actionPolicy: index === 0 ? authorActionPolicy : signEveryAction,
-              routerWorker: scriptedRouterWorker(store, outbound),
+              actionPolicy:
+                index === 0
+                  ? (options.actionPolicy ?? signEveryAction)
+                  : signEveryAction,
+              routerWorker: scriptedRouterWorker(
+                store,
+                outbound,
+                index === 0 ? options.attachment : undefined,
+              ),
+              ...(options.attachTimeout === undefined
+                ? {}
+                : { routerAttachTimeout: options.attachTimeout }),
             }),
           ),
         ),
@@ -576,12 +624,11 @@ function pump(
   });
 }
 
-function certifyGenesis(harness: ProtocolHarness): Effect.Effect<void> {
+function certifyGenesisOf(
+  harness: ProtocolHarness,
+  sending: Fiber.RuntimeFiber<void, SendError>,
+): Effect.Effect<void> {
   return Effect.gen(function* () {
-    const author = yield* requireAt(harness.engines, 0, "endpoint engine");
-    const sending = yield* Effect.fork(
-      author.send(yield* sendInput(harness, "open group")),
-    );
     const initial = yield* takeReadyBatch(harness);
     const proposalMessage = yield* requireAt(initial, 0, "genesis proposal");
     const proposal = yield* decodeActionProposal(proposalMessage);
@@ -598,6 +645,16 @@ function certifyGenesis(harness: ProtocolHarness): Effect.Effect<void> {
       recoveries.map(({ certifiedRecords }) => certifiedRecords.length),
     ).toEqual([1, 1, 1, 1]);
     yield* Fiber.join(sending).pipe(Effect.timeout("1 second"), Effect.orDie);
+  });
+}
+
+function certifyGenesis(harness: ProtocolHarness): Effect.Effect<void> {
+  return Effect.gen(function* () {
+    const author = yield* requireAt(harness.engines, 0, "endpoint engine");
+    const sending = yield* Effect.fork(
+      author.send(yield* sendInput(harness, "open group")),
+    );
+    yield* certifyGenesisOf(harness, sending);
   });
 }
 
@@ -1092,12 +1149,13 @@ function retainsInterruptedDurableSend() {
       Effect.gen(function* () {
         const policyEntered = yield* Deferred.make<undefined>();
         const releasePolicy = yield* Deferred.make<undefined>();
-        const harness = yield* makeProtocolHarness(() =>
-          Deferred.succeed(policyEntered, undefined).pipe(
-            Effect.zipRight(Deferred.await(releasePolicy)),
-            Effect.as("sign" as const),
-          ),
-        );
+        const harness = yield* makeProtocolHarness({
+          actionPolicy: () =>
+            Deferred.succeed(policyEntered, undefined).pipe(
+              Effect.zipRight(Deferred.await(releasePolicy)),
+              Effect.as("sign" as const),
+            ),
+        });
         const author = yield* requireAt(harness.engines, 0, "endpoint engine");
         const sending = yield* Effect.fork(
           author.send(yield* sendInput(harness, "retained send")),
@@ -1171,3 +1229,88 @@ describe("fixed-post endpoint protocol", () => {
 });
 
 /* eslint-enable max-lines, max-lines-per-function, max-statements, sonarjs/max-lines-per-function -- Restore repository defaults. */
+
+function sendHeldUntilAttached(): Effect.Effect<void, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const attached = yield* Deferred.make<RouterTailAnchor>();
+    const harness = yield* makeProtocolHarness({
+      attachment: attachesWhenResolved(attached),
+    });
+    const author = yield* requireAt(harness.engines, 0, "endpoint engine");
+    const sending = yield* Effect.fork(
+      author.send(yield* sendInput(harness, "open group")),
+    );
+    yield* Effect.sleep("50 millis");
+    expect(yield* Fiber.poll(sending)).toEqual(Option.none());
+    expect(yield* Queue.size(harness.outbound)).toBe(0);
+
+    yield* Deferred.succeed(attached, { routerInstanceId, pollCursor });
+    yield* certifyGenesisOf(harness, sending);
+  });
+}
+
+function sendFailsAfterAttachBound(): Effect.Effect<void, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const harness = yield* makeProtocolHarness({
+      attachment: neverAttaches,
+      attachTimeout: Duration.millis(50),
+    });
+    const author = yield* requireAt(harness.engines, 0, "endpoint engine");
+    const failure = yield* author
+      .send(yield* sendInput(harness, "never attached"))
+      .pipe(Effect.flip, Effect.orDie);
+    expect(failure).toStrictEqual(
+      new SendError({ reason: "network-unavailable" }),
+    );
+    expect(failure.message).toContain(failure.reason);
+  });
+}
+
+function attachmentWaitLeavesTheEngineGateFree(): Effect.Effect<
+  void,
+  never,
+  Scope.Scope
+> {
+  return Effect.gen(function* () {
+    const attached = yield* Deferred.make<RouterTailAnchor>();
+    const harness = yield* makeProtocolHarness({
+      attachment: attachesWhenResolved(attached),
+    });
+    const author = yield* requireAt(harness.engines, 0, "endpoint engine");
+    const sending = yield* Effect.fork(
+      author.send(yield* sendInput(harness, "open group")),
+    );
+    yield* Effect.sleep("50 millis");
+    expect(yield* Fiber.poll(sending)).toEqual(Option.none());
+
+    // A worker reaches `active` only after a recovery that abandons the
+    // engine's volatile folds under the engine gate. A wait holding that gate
+    // would stall the attachment it waits for, so this must complete while
+    // the send above is still parked.
+    yield* author
+      .abandonVolatileFolds("router_restarted")
+      .pipe(Effect.timeout("2 seconds"), Effect.orDie);
+    yield* Fiber.interrupt(sending);
+  });
+}
+
+describe("engine sends and Router-worker attachment", () => {
+  it(
+    "holds a send issued before the worker attaches and completes it on attachment",
+    () => Effect.runPromise(Effect.scoped(sendHeldUntilAttached())),
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "fails a send as network-unavailable once the attachment bound elapses",
+    () => Effect.runPromise(Effect.scoped(sendFailsAfterAttachBound())),
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "waits for attachment without holding the engine gate recovery needs",
+    () =>
+      Effect.runPromise(Effect.scoped(attachmentWaitLeavesTheEngineGateFree())),
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/client/src/endpoint/recovery/index.test.ts
+++ b/packages/client/src/endpoint/recovery/index.test.ts
@@ -184,6 +184,10 @@ function makeHeldRouter(input: HeldRouterInput) {
       routerInstanceId: oldRouterInstanceId,
       pollCursor,
     }),
+    awaitAnchor: Effect.succeed({
+      routerInstanceId: oldRouterInstanceId,
+      pollCursor,
+    }),
     send: (outboundId) =>
       Ref.get(input.holdOutbound).pipe(
         Effect.flatMap((hold) =>
@@ -491,6 +495,10 @@ const makeFixtureRouter = ({
     routerInstanceId: newRouterInstanceId,
     pollCursor,
   }),
+  awaitAnchor: Effect.succeed({
+    routerInstanceId: newRouterInstanceId,
+    pollCursor,
+  }),
   send: (outboundId) =>
     forwardStoredOutbound(store, normalOutbound, outboundId),
 });
@@ -589,6 +597,10 @@ const addN4Foundation = (fixture: RecoveryFixture) =>
       actionPolicy: () => Effect.succeed("sign"),
       routerWorker: {
         currentAnchor: Effect.succeed({
+          routerInstanceId: newRouterInstanceId,
+          pollCursor,
+        }),
+        awaitAnchor: Effect.succeed({
           routerInstanceId: newRouterInstanceId,
           pollCursor,
         }),

--- a/packages/client/src/endpoint/router-worker/index.test.ts
+++ b/packages/client/src/endpoint/router-worker/index.test.ts
@@ -11,7 +11,16 @@ import {
   type RouterSendResult,
   SignedMessageDigest,
 } from "@moltzap/router";
-import { Deferred, Effect, Encoding, Fiber, Layer, Ref, Schema } from "effect";
+import {
+  Deferred,
+  Effect,
+  Encoding,
+  Fiber,
+  Layer,
+  Option,
+  Ref,
+  Schema,
+} from "effect";
 import { createHash } from "node:crypto";
 // eslint-disable-next-line agent-code-guard/prefer-effect-platform -- Tests own isolated real-SQLite directories around scoped store acquisition.
 import { mkdtempSync, rmSync } from "node:fs";
@@ -1121,6 +1130,36 @@ const coldStartRecoversBeforeActivation = async (): Promise<void> => {
   );
 };
 
+const awaitAnchorResolvesOnActivation = async (): Promise<void> => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fixture = yield* makeFixture;
+      const instance = routerInstanceId(101);
+      const router = yield* makeScriptedRouter({
+        polls: [emptyBatch(instance, pollCursor(19))],
+        fallbackPoll: Effect.never,
+      });
+      const worker = yield* provide(
+        makeRouterWorker(makeInput(fixture, callbacks())),
+        router.layer,
+        fixture,
+      );
+
+      const attached = {
+        routerInstanceId: instance,
+        pollCursor: pollCursor(19),
+      };
+      const waiting = yield* Effect.fork(worker.awaitAnchor);
+      expect(yield* Fiber.poll(waiting)).toEqual(Option.none());
+
+      yield* provide(worker.pollOnce, router.layer, fixture);
+
+      expect(yield* Fiber.join(waiting)).toEqual(attached);
+      expect(yield* worker.awaitAnchor).toEqual(attached);
+    }),
+  );
+};
+
 // @agent-code-guard/regression-only: these scenarios pin the endpoint cursor and recovery safety boundary.
 describe("private Router worker", () => {
   it("requires the decoder for the declared payload type", () => {
@@ -1186,6 +1225,10 @@ describe("private Router worker", () => {
   it(
     "authenticates pinned history senders while Registry is unavailable",
     pinnedCardsSurviveRegistryOutage,
+  );
+  it(
+    "answers awaitAnchor once cold-start recovery activates the worker",
+    awaitAnchorResolvesOnActivation,
   );
 });
 

--- a/packages/client/src/endpoint/router-worker/index.ts
+++ b/packages/client/src/endpoint/router-worker/index.ts
@@ -17,7 +17,17 @@ import {
   type RouterSendResult,
   SignedMessageDigest,
 } from "@moltzap/router";
-import { Effect, Encoding, Fiber, Ref, Schedule, Schema } from "effect";
+import {
+  Effect,
+  Encoding,
+  Fiber,
+  Option,
+  Ref,
+  Schedule,
+  Schema,
+  Stream,
+  SubscriptionRef,
+} from "effect";
 import { createHash, randomBytes } from "node:crypto";
 import type { OutboundMessageInput, StoredOutboundMessage } from "../store.js";
 import { decodeCanonical, encodeCanonical } from "../representation.js";
@@ -1007,6 +1017,11 @@ const makeSend = <Payload>(
     }
   });
 
+const activeAnchor = (
+  state: RouterWorkerState,
+): Option.Option<RouterTailAnchor> =>
+  state.kind === "active" ? Option.some(state.anchor) : Option.none();
+
 const makeWorker = <Payload>(
   runtime: RouterWorkerRuntime<Payload>,
 ): RouterWorker => {
@@ -1018,6 +1033,14 @@ const makeWorker = <Payload>(
           ? Effect.succeed(state.anchor)
           : Effect.fail(new RouterWorkerUnavailableError()),
       ),
+    ),
+    // `changes` replays the current state, so a worker that attaches between
+    // a caller's probe and this wait still answers immediately; the stream
+    // never ends, so an empty head is a defect rather than a failure.
+    awaitAnchor: runtime.state.changes.pipe(
+      Stream.filterMap(activeAnchor),
+      Stream.runHead,
+      Effect.flatMap(Effect.orDie),
     ),
     pollOnce,
     run: pollOnce.pipe(
@@ -1054,7 +1077,7 @@ export const makeRouterWorker = <Payload>(
       ...services,
       input,
       cards,
-      state: yield* Ref.make<RouterWorkerState>({
+      state: yield* SubscriptionRef.make<RouterWorkerState>({
         kind: "recovering",
         generation: 0,
         reason: "router_restarted",

--- a/packages/client/src/endpoint/router-worker/types.ts
+++ b/packages/client/src/endpoint/router-worker/types.ts
@@ -10,7 +10,7 @@ import type {
 } from "@moltzap/identity";
 import type { Registry } from "@moltzap/identity/registry";
 import type { PollCursor, Router, RouterInstanceId } from "@moltzap/router";
-import { type Context, Data, type Effect, type Ref } from "effect";
+import { type Context, Data, type Effect, type SubscriptionRef } from "effect";
 import type { DecodedOuterBody } from "../representation.js";
 import type { EndpointStore } from "../store.js";
 
@@ -178,6 +178,12 @@ export interface RouterWorker {
     RouterTailAnchor,
     RouterWorkerUnavailableError
   >;
+  /**
+   * The active anchor as soon as one exists: the current anchor while the
+   * worker is active, otherwise the anchor the next completed recovery
+   * publishes. Callers bound the wait; the worker itself never gives up.
+   */
+  readonly awaitAnchor: Effect.Effect<RouterTailAnchor>;
   readonly pollOnce: Effect.Effect<void, RouterWorkerPollError>;
   readonly run: Effect.Effect<never, RouterWorkerPollError>;
   readonly send: (
@@ -217,7 +223,7 @@ export interface RouterWorkerServices {
 export interface RouterWorkerRuntime<Payload> extends RouterWorkerServices {
   readonly input: RouterWorkerInput<Payload>;
   readonly cards: Map<AgentId, VerifiedAgentCard>;
-  readonly state: Ref.Ref<RouterWorkerState>;
+  readonly state: SubscriptionRef.SubscriptionRef<RouterWorkerState>;
   readonly pollGate: Effect.Semaphore;
   readonly stateGate: Effect.Semaphore;
   readonly recoveryGate: Effect.Semaphore;


### PR DESCRIPTION
## Summary

Closes #1000

`scripts/test/adapter-daemon-process.integration.test.ts` failed intermittently in CI with `(FiberFailure) SendError: An error has occurred` from `callSend`, in both its OpenClaw and NanoClaw cases. The cause is in the daemon, not the test: `initializeProtocol` retains the active protocol and completes `engineReady` before `superviseBackground(worker.run)` starts the Router worker's poll loop, and `makeRegisterOperation` returns as soon as `finishRegistration` completes. A host that sends right after registering — or right after a daemon restart — races the worker's first successful poll, and the send fails `network-unavailable` for no reason of its own.

Product fix in `packages/client`:

- **Every send waits for attachment, bounded.** The worker's state moves to a `SubscriptionRef` and `RouterWorker` gains `awaitAnchor`, which answers immediately while the worker is active and on activation otherwise. `prepareSend` probes `currentAnchor` and, only when the worker has not attached, waits on `awaitAnchor` under `ROUTER_ATTACH_TIMEOUT`. The wait covers both send paths: a new conversation reads the anchor in `createConversation`, an existing one transmits through the worker in `drainOutbound`.
- **The wait runs before the engine gate.** `activateIntent` holds `runtime.gate` under `Effect.uninterruptible`, and the worker reaches `active` only after a recovery whose `abandonVolatileFolds` takes that same gate. Waiting inside the gate would stall the attachment being waited for, so the readiness step runs ahead of it, in `prepareSend`. A regression test pins this.
- **The bound is read off the deadlines around it.** A cold-start attach can span the Router's tail hold (`HOLD_DURATION`) and the daemon's own `ROUTER_POLL_TIMEOUT`, so a bound near either fails sends that are merely early; 45 s stays under the MCP SDK's `DEFAULT_REQUEST_TIMEOUT_MSEC`, the deadline a host client applies to the tool call, so the host receives the closed failure rather than a transport timeout it cannot classify, and the remaining margin covers the send itself. `EndpointEngineInput.routerAttachTimeout` overrides it, so tests bound the wait in milliseconds instead of driving a clock.
- **Closed failures carry their reason.** `SendError`, `ListenError`, `DeliveryAcknowledgeError`, and `ConnectError` override `message` with `<operation> failed: <reason>`; reports named the `Data.TaggedError` default before, which is why the CI logs said only "An error has occurred".
- **Contract wording.** `docs/spec/harness/client.md` → Addressed send states that a send issued before the worker attaches waits a bounded time, names `ROUTER_ATTACH_TIMEOUT`, and records that the wait holds no lock attachment needs. `CHANGELOG.md` carries the entry.

The integration test and the daemon-process harness are unchanged: no retry loop anywhere.

## Tests

- `router-worker/index.test.ts`: a fiber forked on `awaitAnchor` while the worker is recovering stays parked and resolves with the anchor once cold-start recovery activates the worker.
- `protocol/index.test.ts`, three scenarios at the engine/worker seam: a send issued before a latched worker attaches produces no outbound message and certifies genesis once the latch opens; a send against a worker that never attaches fails typed `network-unavailable`, message carrying the reason, after a 50 ms bound; and — the regression for the mistake below — while a send is parked waiting, `abandonVolatileFolds` still completes, proving the wait holds no engine gate.

## Evidence

Deterministic, and the actual proof: the three seam tests plus the worker test above. The bound test settles in 97 ms; the gate-freedom test fails by hanging if the wait ever holds the engine gate.

Integration loops on one box, `-t OpenClaw` unless noted; each run boots Registry, Router, two daemons and a host, ~40 s:

| build | load | result |
|---|---|---|
| `main` before #999 | 2 loops × 5 | 3 failures / 10, failing at ~35 s |
| `main` after #999 | 3 loops × 5 | 1 / 15 |
| `main` after #999 | 2 loops × 5 | 0 / 10, quiet box |
| first design, wait inside the engine gate, 30 s bound | 3 loops × 5 | 3 / 15, failing at ~75 s — the stall, not a fix |
| first design, 120 s bound | 3 loops × 3 | 1 / 9, that failure at 96 s = time-to-first-send + the client's 60 s deadline |
| **this build** | 2 loops × 5 | **0 / 10** |
| **this build**, NanoClaw case | 1 run | pass, 57.8 s — sanity only, `main` passes that case too |

First CI-level evidence: run 33607493118, on `303b3f09` before the rebase, finished with the **`test` job green** — the full integration suite, adapter-daemon case included, passing on a CI runner with the fix in place. That run's `ci` job failed separately on a knip finding (`ROUTER_ATTACH_TIMEOUT` exported but never imported), fixed here by making it module-local, matching its sibling `ROUTER_POLL_TIMEOUT` in `server.ts`.

The flake is load-dependent, so no loop count proves absence: these numbers corroborate and the seam tests prove. The failure #1002 reproduces deterministically on its own head is the decisive case, and it gets that signal by rebasing onto this once it lands.

Follow-ups filed rather than folded in, to keep this diff minimal against the #1002 conflict:

- **#1003** — the same not-attached predicate reaches the daemon's supervised outbound loop through `runOutbound`, and is fatal there rather than a wait or a typed failure.
- **#1006** — nothing exercises the *default* bound. `sendFailsAfterAttachBound` passes a 50 ms `routerAttachTimeout`, so the `?? ROUTER_ATTACH_TIMEOUT` fallback is covered only by the type system; testing it honestly needs `TestClock` in the protocol harness.

## Review

`/simplify` ran its four angles on Opus. The altitude pass rejected the first design, which waited inside `createConversation`: that sits under `runtime.gate`, so the wait blocked the recovery that would satisfy it, turning an immediate failure into a 45-second engine-wide stall ending in the same failure. My own measurements agreed in hindsight — a 30 s bound moved failures from ~35 s to ~75 s, and a 120 s bound produced one failure at exactly time-to-first-send + 60 s, the client deadline — and the loop numbers I first reported were measured on a quiet box where the race never fired, so they proved nothing and are withdrawn. The redesign moves the wait ahead of the gate, covers both send paths, and adds the gate-freedom regression test. Other findings applied: the probe/wait split keeps the hot path a single ref read rather than a stream subscription plus timer per send; `certifyGenesis` shares one certification helper; the harness takes one options object; the unreachable error channel on `awaitAnchor` became a defect; `engine-send.ts` was rebuilt from `main` so the diff is additive and `currentAnchorFailure` stays where it was.

## Test plan

- [x] `pnpm nx run @moltzap/client:test` (107), `typecheck:tests`, `lint`
- [x] `pnpm lint`, `pnpm format:check`
- [x] Integration loops above, against this build
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
