### PR TITLE
build(nx): hash the root files and dependencies that decide cached results

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -48,7 +48,12 @@
     ],
     "sharedGlobals": [
       "{workspaceRoot}/tsconfig.base.json",
-      "{workspaceRoot}/tsconfig.json"
+      "{workspaceRoot}/tsconfig.json",
+      "{workspaceRoot}/pnpm-lock.yaml",
+      "{workspaceRoot}/pnpm-workspace.yaml",
+      "{workspaceRoot}/.npmrc",
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/vitest.workspace-aliases.ts"
     ]
   },
   "targetDefaults": {
@@ -114,10 +119,17 @@
       "cache": true
     },
     "lint": {
+      "dependsOn": [
+        "^build"
+      ],
       "inputs": [
         "default",
+        "^production",
         "{workspaceRoot}/eslint.config.mjs",
-        "{workspaceRoot}/eslint.shared.mjs"
+        "{workspaceRoot}/eslint.shared.mjs",
+        "{workspaceRoot}/knip.json",
+        "{workspaceRoot}/oxlint.json",
+        "{workspaceRoot}/tsconfig.eslint.json"
       ],
       "cache": true
     },


### PR DESCRIPTION
## Summary

Closes #1008

Nine workspace-root files determine cached target outcomes and are not hashed
for the targets they determine. Six appear nowhere in `nx.json` at all; three
are hashed for docs generation and nothing else. This adds each one to the
input set it belongs to.

**It is what makes every other green in this repository mean something**, so it
is worth the argument below rather than being read as hygiene.

## The gap

`pnpm-lock.yaml` occurs exactly once in `nx.json`, inside `docsGeneration`.
Nothing else hashes it:

```
namedInputs.sharedGlobals   = ["{workspaceRoot}/tsconfig.base.json",
                               "{workspaceRoot}/tsconfig.json"]
namedInputs.default         = ["{projectRoot}/**/*", "sharedGlobals"]
targetDefaults.test.inputs  = ["sources", "^production"]
targetDefaults.lint.inputs  = ["default", ".../eslint.config.mjs",
                               ".../eslint.shared.mjs"]
```

`sources` and `^production` both resolve through `default`, so the complete
input set for `test` is this project's files, its dependencies' production
files, and two tsconfigs. Change the installed dependency layout and **no key
moves**, so every cached `build`, `test` and `lint` result stays valid and a
pass recorded under the old installation is replayed under the new one
indefinitely.

`sharedGlobals` is already reached by `default`, so one line covers all three
targets with no per-target edits.

## The class, enumerated

Every workspace-root file that can determine a cached target, checked against
`nx.json`. This is the table that makes the issue a class rather than an
anecdote.

| File | Determines | Hashed today |
|---|---|---|
| `.npmrc` | hoisting and install layout | **nowhere** |
| `pnpm-workspace.yaml` | workspace membership, dependency overrides | **nowhere** |
| `knip.json` | `lint:dead-code` verdicts | **nowhere** |
| `oxlint.json` | `lint:oxlint` verdicts | **nowhere** |
| `tsconfig.eslint.json` | root `lint:eslint` program | **nowhere** |
| `vitest.workspace-aliases.ts` | workspace resolution for every vitest suite | **nowhere** |
| `pnpm-lock.yaml` | resolved dependency versions | `docsGeneration` only |
| `package.json` (root) | scripts, dependency ranges | `docsGeneration` only |
| `typedoc.json` | generated API docs | `docsGeneration` only |
| `eslint.config.mjs` | lint verdicts | `lint` inputs — correct |
| `eslint.shared.mjs` | lint verdicts | `lint` inputs — correct |
| `tsconfig.base.json` | every compile | `sharedGlobals` — correct |
| `tsconfig.json` | every compile | `sharedGlobals` — correct |

Two of those five deserve their weights stated, so the table reads as evidence
rather than as speculative hygiene.

**`pnpm-workspace.yaml` is the load-bearing one.** It is not just workspace
membership — it carries a real `overrides` block:

```yaml
overrides:
  "eslint-plugin-sonarjs@4.0.3>typescript": "npm:@typescript/typescript6@6.0.2"
```

That swaps the TypeScript implementation inside the sonarjs chain, so it changes
both the installed tree and the types eslint sees. Editing it today changes
lint outcomes and invalidates nothing.

**`.npmrc` is the opposite, and the body should not overstate it.** The file is
currently one byte, a bare newline, so it contributes almost nothing to any hash
right now. It is listed because it governs hoisting — which is exactly what
decided whether `jose` resolved in #1007 — and because the moment anyone adds a
line to it, that line silently changes the installed tree for every target.
Forward-looking, not load-bearing today.

## Where each one goes, and why not all in `sharedGlobals`

`sharedGlobals` invalidates every target. That is right for anything that
changes the installed tree and wasteful for anything that does not — a
`knip.json` edit should not rebuild the workspace. So the placement follows what
each file actually determines:

- **`sharedGlobals`** — `pnpm-lock.yaml`, `.npmrc`, `pnpm-workspace.yaml`, root
  `package.json`. All four move the installation, and the installation feeds
  every target.
- **`lint` inputs** — `knip.json`, `oxlint.json`, `tsconfig.eslint.json`. Each
  changes lint verdicts and nothing else.
- **`sharedGlobals`, not `test`** — `vitest.workspace-aliases.ts`. This one is
  argued rather than assumed, because the obvious placement is `test` and the
  obvious placement is wrong: `tsconfig.eslint.json` includes `*.ts` at the
  workspace root, so the root eslint target lints this file too. It determines
  both test resolution and lint verdicts. Listing it in two input sets would
  work; putting it in `sharedGlobals` costs a rebuild on a file that changes
  almost never and cannot be defeated by a third consumer appearing later.

Where the two directions disagree, this errs toward over-invalidating. A
needless rebuild costs minutes; a stale pass costs the meaning of the gate, and
#1007 is what that looks like when it happens.

## The same defect in the target graph, not just the inputs

Two more, found in `targetDefaults` while enumerating the above. Both are the
same shape — something that determines a lint result, absent from what orders
or invalidates it.

```
build            dependsOn: ["^build"]           inputs: ["production","^production"]
test             dependsOn: ["^build"]           inputs: ["sources","^production"]
typecheck        dependsOn: ["^build"]           inputs: ["production","^production"]
typecheck:tests  dependsOn: ["build","^build"]   inputs: ["default","^production"]
lint             dependsOn: null                 inputs: ["default", root configs]
```

**`lint` has no `dependsOn`.** It is the only target the graph never orders
behind a build, while `AGENTS.md` states in prose that `pnpm lint` requires a
prior `pnpm build` because typed linting resolves against built `.d.ts`
outputs. A requirement stated in prose and enforced nowhere is precisely what
`AGENTS.md` opens by forbidding: state only what a check cannot. This adds
`dependsOn: ["^build"]`.

**`lint` has no `^`-prefixed input.** So editing a dependency package does not
invalidate a dependent's cached lint result, even though typed lint reads that
dependency's `.d.ts`. Same class as the lockfile: an input that determines the
outcome, absent from the hash. This adds `^production`.

Once the graph enforces the ordering, the `AGENTS.md` sentence about needing a
prior build becomes deletable. **Not deleted here** — that edit belongs in a
change someone reads as a rule, not buried in an `nx.json` PR. Filed as a
follow-up instead.

## What this is not

Replay is correct Nx behavior, and a replayed result is **valid** when the key
captures everything that determines the outcome. This is not an argument for
distrusting the cache or running cold. The defect is narrow and specific: the
key omits the installed layout, which is one of the things that determines
whether a test passes.

## Why it is a gate defect rather than a hygiene ticket

Measured on run 33610728139, main at `2876fb9c` — the merge commit of #1004.
Every job's log pulled from the API, ANSI stripped, every `nx run` line
classified as executed or replayed.

**Every unit `:test` target replayed. Not one executed.**

```
🔁 nx run @moltzap/client:test            [remote cache]
🔁 nx run @moltzap/evals:test             [remote cache]
🔁 nx run @moltzap/identity:test          [remote cache]
🔁 nx run @moltzap/openclaw-channel:test  [remote cache]
🔁 nx run @moltzap/router:test            [remote cache]
🔁 nx run @moltzap/simulator:test         [remote cache]
🔁 nx run workspace:test                  [remote cache]
```

So did every `:typecheck:tests`, and `identity`/`router` `:test:integration`.

The integration and pack layer did execute:

```
✅ nx run workspace:"test:integration"
✅ nx run @moltzap/client:"test:integration"
✅ nx run @moltzap/client:"test:pack"
✅ nx run @moltzap/nanoclaw-channel:"test:pack"
✅ nx run @moltzap/openclaw-channel:"test:pack"
✅ nx run @moltzap/simulator:"test:pack"
```

So it is **not** true that no test ran on that commit; the overstated version of
this claim is wrong and should not be repeated. What is true is narrower and
sufficient: **the entire unit-test signal on a merge commit was replayed** from
entries recorded under an installation nobody has verified is still the
installed one.

#1007 is that hazard realized rather than hypothesized. A simulator suite that
genuinely fails in a fresh install was reported green on main by replay; it
surfaced only when an unrelated PR touched a sibling package and moved the key
through `^production`. In one attempt of run 33610877051, the same target on the
same commit produced `❌ nx run @moltzap/simulator:test` in one job and
`🔁 ... [remote cache]` in another. Nx does not cache failures, so the stale
pass outlives the real failure rather than being corrected by it.

## Both cache stores

The same key gap applies to the Nx Cloud store developer environments use, so
this fixes the substance in both at once.

Worth recording while we are here: that connection lives only in a
`NX_CLOUD_ACCESS_TOKEN` environment variable, with no `nxCloudId` anywhere in
`nx.json`. Every agent and worktree on a machine carrying that token shares a
cache that is invisible to anyone reading the repository. CI is a separate store
again, reaching Railway through `NX_SELF_HOSTED_REMOTE_CACHE_SERVER`, so the two
populations never see each other's entries.

## Expected effect

A one-time full rebuild on the commit that lands this, and thereafter a full
rebuild whenever dependencies change — which is the point.

Expect that first run to be unusually long, and expect it to be predicted rather
than alarming. **Every project cache in the workspace invalidates at once** —
not the simulator's, not the changed projects', all of them — because four of
the five new `sharedGlobals` entries are inherited by every target through
`default`. Client, router, identity, evals, the channels and the simulator all
go cold together, and that is the change working rather than something going
wrong.

Landing on top of that, #1002 merged as `71535de2` and added 5428 lines of
simulator source whose cache keys have never moved under these inputs, so the
first workspace-wide cold run is also the first real execution of a large amount
of new code.

## A correction this PR is the right home for

The commit message of #1009 says the `jose` load "fails in a fresh install".
That is stronger than the evidence supports: the same suite failed one cold CI
execution and passed another on #1002 at `5a89863b`, with no identified
difference in the inputs that determine resolution. #1009's **PR body** carries
the accurate account; its commit message does not, and it is already in `main`
under merge `63843733`.

Noting it here rather than rewriting history, because this is the PR about not
being able to trust what a green means, and anyone who finds that overstated
sentence will be reading about exactly this class of problem.

## Test plan

- [ ] Hash for a `test` target changes when `pnpm-lock.yaml` alone is edited
- [ ] Hash for a `lint` target changes when `knip.json` alone is edited
- [ ] Hash for `test` and `lint` changes when `vitest.workspace-aliases.ts`
      alone is edited
- [x] `lint` is ordered behind `^build` — `@moltzap/client:lint` now pulls
      `@moltzap/identity:build` and `@moltzap/router:build` into its task graph,
      3 tasks where it previously had 1
- [x] `pnpm format:check`
- [ ] `lint` on a dependent re-runs after a dependency-only source change

- [x] `pnpm nx run @moltzap/evals:lint --skipNxCache` — the local failure that
      held this PR up was a poisoned `packages/evals/.eslintcache`, not this
      change and not the repository; removing that file clears it on unmodified
      `main` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
