### PR TITLE
docs: carry this branch's comments to the symbols they explain

### DIFF
--- a/docs/modules/simulator/agents.mdx
+++ b/docs/modules/simulator/agents.mdx
@@ -173,7 +173,7 @@ export interface AgentsService<
 
 Describes agents service.
 
-### [`Application`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L160)
+### [`Application`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L159)
 
 _Interface_
 
@@ -209,7 +209,7 @@ export interface Application<Gateway, AcquisitionError> {
 
 One rendered application and its runtime-specific controller bridge.
 
-### [`ApplicationEndpoint`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L96)
+### [`ApplicationEndpoint`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L95)
 
 _Interface_
 
@@ -226,7 +226,7 @@ The cluster builds this from the port the application itself declared, so a
 runtime reads the address it asked for instead of re-deriving it: a protocol,
 port, path, or credential the runtime would have to reject cannot be spelled.
 
-### [`ContainerAgentRuntime`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L206)
+### [`ContainerAgentRuntime`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L205)
 
 _Interface_
 
@@ -248,7 +248,7 @@ A runtime that is known to carry a container realization. Only
 `defineContainerRuntime` produces one, so reading its realization back needs
 no absent case.
 
-### [`ContainerRuntime`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L193)
+### [`ContainerRuntime`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L192)
 
 _Interface_
 
@@ -276,7 +276,7 @@ export type CredentialName = "ANTHROPIC_API_KEY" | "OPENAI_API_KEY";
 
 Provider credential a container may request from the run-scoped Secret.
 
-### [`defineContainerRuntime`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L267)
+### [`defineContainerRuntime`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L266)
 
 _Function_
 
@@ -300,7 +300,7 @@ This describes no cross-runtime gateway protocol.
 
 **Returns:** The frozen nominal runtime accepted by a society roster.
 
-### [`File`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L71)
+### [`File`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L70)
 
 _Interface_
 
@@ -314,7 +314,7 @@ export interface File {
 
 One file materialized into a container from the run-scoped Secret.
 
-### [`HarvestTarget`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L83)
+### [`HarvestTarget`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L82)
 
 _Interface_
 
@@ -682,7 +682,7 @@ export type OpenClawToolsConfig = NonNullable<OpenClawConfig["tools"]>;
 
 Tool configuration accepted by `OpenClawConfig`.
 
-### [`Resources`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L64)
+### [`Resources`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L63)
 
 _Interface_
 
@@ -696,7 +696,7 @@ export interface Resources {
 
 Portable resource request for one application container.
 
-### [`routableBridgeEndpoint`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L128)
+### [`routableBridgeEndpoint`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L127)
 
 _Function_
 
@@ -870,7 +870,7 @@ export type StartedAgents<
 
 Exact keyed agents installed only after every runtime is ready.
 
-### [`stoppedBeforeAttach`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L310)
+### [`stoppedBeforeAttach`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/agents/container.ts#L309)
 
 _Function_
 

--- a/docs/modules/simulator/src.mdx
+++ b/docs/modules/simulator/src.mdx
@@ -155,7 +155,7 @@ export class AgentRuntimeStartFailed extends Schema.TaggedClass<AgentRuntimeStar
 
 A roster runtime failed before it established readiness.
 
-### [`AgentWorkspaceFileHarvested`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L129)
+### [`AgentWorkspaceFileHarvested`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L132)
 
 _Class_
 
@@ -233,7 +233,7 @@ export class CompletedLedgerReceipt extends Schema.TaggedClass<CompletedLedgerRe
 
 Physical receipt for a ledger whose completion marker is durable.
 
-### [`coreEvents`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L232)
+### [`coreEvents`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L235)
 
 _Variable_
 
@@ -496,7 +496,7 @@ export type EventOf<Catalog> = Schema.Schema.Type<CatalogSchemaOf<Catalog>>;
 
 The closed instance union declared by a catalog.
 
-### [`HarvestedFileOutcome`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L122)
+### [`HarvestedFileOutcome`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L125)
 
 _TypeAlias_
 
@@ -504,7 +504,8 @@ _TypeAlias_
 export type HarvestedFileOutcome = typeof harvestedFileOutcome.Type;
 ```
 
-Decoded outcome of reading one harvest target.
+How the ledger records one read: the file's text, its size when it ran past
+the bound, its absence, or why it could not be read.
 
 ### [`IncompleteLedgerReceipt`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/run/execute.ts#L91)
 
@@ -646,7 +647,7 @@ export interface LinkDelivery {
 
 One opaque signed message about to cross a directed link.
 
-### [`LinkDown`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L141)
+### [`LinkDown`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L144)
 
 _Class_
 
@@ -684,7 +685,7 @@ Decides one delivery on a directed link. A policy reads only its input and
 the ambient Clock; the link interpreter, never the policy, spends time and
 records evidence.
 
-### [`LinkPolicyCleared`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L166)
+### [`LinkPolicyCleared`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L169)
 
 _Class_
 
@@ -701,7 +702,7 @@ export class LinkPolicyCleared extends Schema.TaggedClass<LinkPolicyCleared>()(
 
 A described policy stopped shaping one directed participant link.
 
-### [`LinkPolicySet`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L156)
+### [`LinkPolicySet`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L159)
 
 _Class_
 
@@ -718,7 +719,7 @@ export class LinkPolicySet extends Schema.TaggedClass<LinkPolicySet>()(
 
 A described policy became active on one directed participant link.
 
-### [`LinkUp`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L150)
+### [`LinkUp`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L153)
 
 _Class_
 
@@ -839,7 +840,7 @@ _TypeAlias_
 export type ProfileRunResult = typeof ProfileRunResult.Type;
 ```
 
-Decoded final line of one profile submission.
+Decoded form of the one result line `moltzap-sim run` prints.
 
 ### [`ProfileRunResult (value)`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/cluster/profiles/result.ts#L17)
 
@@ -861,7 +862,7 @@ nothing else would notice the two sides disagreeing until a live run
 produced an undecodable line. The submitter's own result type derives from
 this schema, so the two cannot drift.
 
-### [`ProgramFailed`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L182)
+### [`ProgramFailed`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L185)
 
 _Class_
 
@@ -889,7 +890,7 @@ export class ProgramFinished<A, E> extends Data.TaggedClass("ProgramFinished")<{
 
 Customer-program completion plus its complete durable evidence.
 
-### [`ProgramInterrupted`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L190)
+### [`ProgramInterrupted`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L193)
 
 _Class_
 
@@ -904,7 +905,7 @@ export class ProgramInterrupted extends Schema.TaggedClass<ProgramInterrupted>()
 
 The customer program was interrupted.
 
-### [`ProgramSucceeded`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L176)
+### [`ProgramSucceeded`](https://github.com/chughtapan/moltzap/blob/main/packages/simulator/src/events/core.ts#L179)
 
 _Class_
 

--- a/packages/client/src/daemon/runtime/history-export.ts
+++ b/packages/client/src/daemon/runtime/history-export.ts
@@ -24,8 +24,7 @@ const encodeLine = Schema.encode(Schema.parseJson(HistoryExportRecord));
  * agent. An experiment must not die because its transcript file did, and the
  * truncation is explicit in the file rather than silent.
  *
- * @param path File the records are appended to; created on first write.
- * @returns A sink the endpoint engine records into.
+ * The file is created on the first write.
  */
 export function makeHistoryExport(
   path: string,

--- a/packages/client/src/endpoint/engine-durability.ts
+++ b/packages/client/src/endpoint/engine-durability.ts
@@ -326,11 +326,10 @@ export interface InboundDeliveryProjection {
 
 /**
  * Encode the remote projection atomically retained during promotion.
- * @param conversation Verified local conversation state and member cards.
- * @param record Complete remote-authored certified record.
- * @param recipientAgentId Local recipient that owns the pending delivery.
- * @returns Canonical pending-delivery input for atomic record promotion, with
- * the decoded message it was encoded from.
+ * The recipient is the local agent that owns the pending delivery, which
+ * `AgentId` cannot express and nothing here checks. The result carries both
+ * the canonical input that record promotion commits atomically and the
+ * decoded message it was encoded from.
  */
 export const inboundDelivery = (
   conversation: EngineConversation,
@@ -349,10 +348,9 @@ export const inboundDelivery = (
   );
 
 /**
- * Record one durable inbound delivery in the history export, if any.
- * @param runtime Current engine state and protocol dependencies.
- * @param message The exact host-visible message the store now holds.
- * @returns Completion; a missing export records nothing.
+ * Record one durable inbound delivery in the history export: exactly the
+ * host-visible message the store now holds. When no export is configured the
+ * no-op port records nothing.
  */
 export const exportInbound = (
   runtime: EngineRuntime,

--- a/packages/client/src/endpoint/engine-send.ts
+++ b/packages/client/src/endpoint/engine-send.ts
@@ -515,10 +515,7 @@ export type SendExportOutcome = Extract<
 
 /**
  * Persist an addressed intent and return its durable completion latch.
- * @param runtime Current engine state and protocol dependencies.
- * @param input Explicit addressed send requested by the host.
- * @returns The minted post identity and a latch completed when that post
- * becomes locally certified.
+ * The latch completes when the minted post becomes locally certified.
  */
 export const prepareSend = (
   runtime: EngineRuntime,
@@ -538,11 +535,9 @@ export const prepareSend = (
   );
 
 /**
- * Record one completed `send` invocation in the history export, if any.
- * @param runtime Current engine state and protocol dependencies.
- * @param input The host's own addressed input, as it was given.
- * @param outcome Certified with the minted post, or the closed failure reason.
- * @returns Completion; a missing export records nothing.
+ * Record one completed `send` invocation in the history export, keeping the
+ * host's addressed input as it was given. When no export is configured the
+ * no-op port records nothing.
  */
 export const exportSend = (
   runtime: EngineRuntime,

--- a/packages/client/src/endpoint/protocol/index.test.ts
+++ b/packages/client/src/endpoint/protocol/index.test.ts
@@ -1366,6 +1366,12 @@ function sendFailsAfterAttachBound(): Effect.Effect<void, never, Scope.Scope> {
   });
 }
 
+/**
+ * A worker reaches `active` only after a recovery that abandons the engine's
+ * volatile folds under the engine gate. A wait holding that gate would stall
+ * the attachment it waits for, so the abandon must complete while the send is
+ * still parked.
+ */
 function attachmentWaitLeavesTheEngineGateFree(): Effect.Effect<
   void,
   never,
@@ -1383,10 +1389,6 @@ function attachmentWaitLeavesTheEngineGateFree(): Effect.Effect<
     yield* Effect.sleep("50 millis");
     expect(yield* Fiber.poll(sending)).toEqual(Option.none());
 
-    // A worker reaches `active` only after a recovery that abandons the
-    // engine's volatile folds under the engine gate. A wait holding that gate
-    // would stall the attachment it waits for, so this must complete while
-    // the send above is still parked.
     yield* author
       .abandonVolatileFolds("router_restarted")
       .pipe(Effect.timeout("2 seconds"), Effect.orDie);

--- a/packages/evals/src/results.test.ts
+++ b/packages/evals/src/results.test.ts
@@ -294,6 +294,12 @@ function resumeAfterProcessDeath(
   }).pipe(Effect.provide(evaluationResultStoreLayer(databasePath)));
 }
 
+/**
+ * A SIGKILLed child stays a zombie until its parent reaps it, and a zombie
+ * still answers a liveness signal, so this resumes only once the process is
+ * truly gone, as any real parent shell would have made it by the time an
+ * operator retries.
+ */
 function processDeathResumeTest() {
   return Effect.gen(function* () {
     const fixture = yield* resultFixture("moltzap-evals-process-death-");
@@ -324,9 +330,6 @@ function processDeathResumeTest() {
     )).trim();
 
     yield* child.kill("SIGKILL");
-    // The killed child stays a zombie until its parent reaps it, and a zombie
-    // still answers a liveness signal: resume only once it is truly gone, as
-    // any real parent shell would have made it by the time an operator retries.
     yield* child.exitCode.pipe(Effect.ignore);
 
     const completed = yield* resumeAfterProcessDeath(

--- a/packages/evals/src/results.ts
+++ b/packages/evals/src/results.ts
@@ -253,9 +253,7 @@ export function evaluationResultStoreLayer(databasePath: string) {
  * Finished attempts commit in plan order, so the durable report is always a
  * plan-order prefix and interruption or process failure loses at most
  * `concurrency` finished but uncommitted attempts, which a resume reruns.
- * @param execute Customer cell execution policy.
- * @param options How many cells run at once; one at a time when omitted.
- * @returns The completed report Effect.
+ * Omitting `concurrency` runs one cell at a time.
  */
 export function runEvaluationSweep<E, R>(
   execute: ExecuteCell<E, R>,

--- a/packages/evals/src/submission.test.ts
+++ b/packages/evals/src/submission.test.ts
@@ -106,6 +106,10 @@ it("refuses a NanoClaw cell without its application image", () => {
   );
 });
 
+// The submitter spawns this file by path, so no import checks the spelling.
+// Pinning it against both the checked-in file and the `bin` entry the
+// manifest publishes stops a rename moving one and leaving the other naming a
+// file that never appears.
 effect("spawns the executable the simulator package actually ships", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
@@ -114,10 +118,6 @@ effect("spawns the executable the simulator package actually ships", () =>
     );
     const executable = join(simulatorRoot, SIMULATOR_EXECUTABLE);
 
-    // The submitter spawns this file by path, so no import checks the
-    // spelling. Pin it against the checked-in file and against the `bin` entry
-    // the simulator's manifest publishes, so a rename cannot move one and leave
-    // the other naming a file that never appears.
     assert.isTrue(
       yield* fileSystem.exists(executable),
       `the simulator package ships no ${executable}`,

--- a/packages/evals/src/submission.ts
+++ b/packages/evals/src/submission.ts
@@ -27,10 +27,9 @@ export type SimulatorProfile = "local" | "gke";
 export const SIMULATOR_EXECUTABLE = "bin/moltzap-sim";
 
 /**
- * The command line that submits one module through one profile.
- * @param profile Kubernetes profile the executable routes to.
- * @param modulePath Absolute path of the generated RunSpec module.
- * @returns Arguments after the executable name.
+ * The command line that submits one module through one profile: the
+ * arguments that follow the executable name, naming the generated RunSpec
+ * module by absolute path.
  */
 export function simulatorRunArguments(
   profile: SimulatorProfile,

--- a/packages/simulator/src/MODULE.md
+++ b/packages/simulator/src/MODULE.md
@@ -150,7 +150,7 @@ export class AgentRuntimeStartFailed extends Schema.TaggedClass<AgentRuntimeStar
 
 A roster runtime failed before it established readiness.
 
-### [`AgentWorkspaceFileHarvested`](./events/core.ts#L129)
+### [`AgentWorkspaceFileHarvested`](./events/core.ts#L132)
 
 _Class_
 
@@ -228,7 +228,7 @@ export class CompletedLedgerReceipt extends Schema.TaggedClass<CompletedLedgerRe
 
 Physical receipt for a ledger whose completion marker is durable.
 
-### [`coreEvents`](./events/core.ts#L232)
+### [`coreEvents`](./events/core.ts#L235)
 
 _Variable_
 
@@ -491,7 +491,7 @@ export type EventOf<Catalog> = Schema.Schema.Type<CatalogSchemaOf<Catalog>>;
 
 The closed instance union declared by a catalog.
 
-### [`HarvestedFileOutcome`](./events/core.ts#L122)
+### [`HarvestedFileOutcome`](./events/core.ts#L125)
 
 _TypeAlias_
 
@@ -499,7 +499,8 @@ _TypeAlias_
 export type HarvestedFileOutcome = typeof harvestedFileOutcome.Type;
 ```
 
-Decoded outcome of reading one harvest target.
+How the ledger records one read: the file's text, its size when it ran past
+the bound, its absence, or why it could not be read.
 
 ### [`IncompleteLedgerReceipt`](./run/execute.ts#L91)
 
@@ -641,7 +642,7 @@ export interface LinkDelivery {
 
 One opaque signed message about to cross a directed link.
 
-### [`LinkDown`](./events/core.ts#L141)
+### [`LinkDown`](./events/core.ts#L144)
 
 _Class_
 
@@ -679,7 +680,7 @@ Decides one delivery on a directed link. A policy reads only its input and
 the ambient Clock; the link interpreter, never the policy, spends time and
 records evidence.
 
-### [`LinkPolicyCleared`](./events/core.ts#L166)
+### [`LinkPolicyCleared`](./events/core.ts#L169)
 
 _Class_
 
@@ -696,7 +697,7 @@ export class LinkPolicyCleared extends Schema.TaggedClass<LinkPolicyCleared>()(
 
 A described policy stopped shaping one directed participant link.
 
-### [`LinkPolicySet`](./events/core.ts#L156)
+### [`LinkPolicySet`](./events/core.ts#L159)
 
 _Class_
 
@@ -713,7 +714,7 @@ export class LinkPolicySet extends Schema.TaggedClass<LinkPolicySet>()(
 
 A described policy became active on one directed participant link.
 
-### [`LinkUp`](./events/core.ts#L150)
+### [`LinkUp`](./events/core.ts#L153)
 
 _Class_
 
@@ -834,7 +835,7 @@ _TypeAlias_
 export type ProfileRunResult = typeof ProfileRunResult.Type;
 ```
 
-Decoded final line of one profile submission.
+Decoded form of the one result line `moltzap-sim run` prints.
 
 ### [`ProfileRunResult (value)`](./cluster/profiles/result.ts#L17)
 
@@ -856,7 +857,7 @@ nothing else would notice the two sides disagreeing until a live run
 produced an undecodable line. The submitter's own result type derives from
 this schema, so the two cannot drift.
 
-### [`ProgramFailed`](./events/core.ts#L182)
+### [`ProgramFailed`](./events/core.ts#L185)
 
 _Class_
 
@@ -884,7 +885,7 @@ export class ProgramFinished<A, E> extends Data.TaggedClass("ProgramFinished")<{
 
 Customer-program completion plus its complete durable evidence.
 
-### [`ProgramInterrupted`](./events/core.ts#L190)
+### [`ProgramInterrupted`](./events/core.ts#L193)
 
 _Class_
 
@@ -899,7 +900,7 @@ export class ProgramInterrupted extends Schema.TaggedClass<ProgramInterrupted>()
 
 The customer program was interrupted.
 
-### [`ProgramSucceeded`](./events/core.ts#L176)
+### [`ProgramSucceeded`](./events/core.ts#L179)
 
 _Class_
 

--- a/packages/simulator/src/agents/MODULE.md
+++ b/packages/simulator/src/agents/MODULE.md
@@ -168,7 +168,7 @@ export interface AgentsService<
 
 Describes agents service.
 
-### [`Application`](./container.ts#L160)
+### [`Application`](./container.ts#L159)
 
 _Interface_
 
@@ -204,7 +204,7 @@ export interface Application<Gateway, AcquisitionError> {
 
 One rendered application and its runtime-specific controller bridge.
 
-### [`ApplicationEndpoint`](./container.ts#L96)
+### [`ApplicationEndpoint`](./container.ts#L95)
 
 _Interface_
 
@@ -221,7 +221,7 @@ The cluster builds this from the port the application itself declared, so a
 runtime reads the address it asked for instead of re-deriving it: a protocol,
 port, path, or credential the runtime would have to reject cannot be spelled.
 
-### [`ContainerAgentRuntime`](./container.ts#L206)
+### [`ContainerAgentRuntime`](./container.ts#L205)
 
 _Interface_
 
@@ -243,7 +243,7 @@ A runtime that is known to carry a container realization. Only
 `defineContainerRuntime` produces one, so reading its realization back needs
 no absent case.
 
-### [`ContainerRuntime`](./container.ts#L193)
+### [`ContainerRuntime`](./container.ts#L192)
 
 _Interface_
 
@@ -271,7 +271,7 @@ export type CredentialName = "ANTHROPIC_API_KEY" | "OPENAI_API_KEY";
 
 Provider credential a container may request from the run-scoped Secret.
 
-### [`defineContainerRuntime`](./container.ts#L267)
+### [`defineContainerRuntime`](./container.ts#L266)
 
 _Function_
 
@@ -295,7 +295,7 @@ This describes no cross-runtime gateway protocol.
 
 **Returns:** The frozen nominal runtime accepted by a society roster.
 
-### [`File`](./container.ts#L71)
+### [`File`](./container.ts#L70)
 
 _Interface_
 
@@ -309,7 +309,7 @@ export interface File {
 
 One file materialized into a container from the run-scoped Secret.
 
-### [`HarvestTarget`](./container.ts#L83)
+### [`HarvestTarget`](./container.ts#L82)
 
 _Interface_
 
@@ -677,7 +677,7 @@ export type OpenClawToolsConfig = NonNullable<OpenClawConfig["tools"]>;
 
 Tool configuration accepted by `OpenClawConfig`.
 
-### [`Resources`](./container.ts#L64)
+### [`Resources`](./container.ts#L63)
 
 _Interface_
 
@@ -691,7 +691,7 @@ export interface Resources {
 
 Portable resource request for one application container.
 
-### [`routableBridgeEndpoint`](./container.ts#L128)
+### [`routableBridgeEndpoint`](./container.ts#L127)
 
 _Function_
 
@@ -865,7 +865,7 @@ export type StartedAgents<
 
 Exact keyed agents installed only after every runtime is ready.
 
-### [`stoppedBeforeAttach`](./container.ts#L310)
+### [`stoppedBeforeAttach`](./container.ts#L309)
 
 _Function_
 

--- a/packages/simulator/src/agents/container.ts
+++ b/packages/simulator/src/agents/container.ts
@@ -45,10 +45,9 @@ const CREDENTIAL_BY_PROVIDER: Readonly<Record<string, CredentialName>> = {
 /**
  * The credential a model's provider prefix asks for, when the run can carry
  * one. A model id names its provider ahead of a slash, as OpenClaw spells
- * them; a prefix the run has no credential for yields nothing rather than a
- * guess, so a container never receives a key it did not need.
- * @param modelId Provider-prefixed model id, such as `anthropic/claude-4`.
- * @returns The one credential to request, or undefined for another provider.
+ * them (`anthropic/claude-4`); a prefix the run has no credential for yields
+ * nothing rather than a guess, so a container never receives a key it did not
+ * need.
  */
 export function providerCredential(
   modelId: string,

--- a/packages/simulator/src/agents/nanoclaw/runtime.ts
+++ b/packages/simulator/src/agents/nanoclaw/runtime.ts
@@ -257,8 +257,9 @@ function makeNanoClawApplication(
     ...(settings.modelId === undefined
       ? {}
       : {
-          // NanoClaw hosts Claude, so a model id with no provider prefix is
-          // still an Anthropic model.
+          // NanoClaw hosts Claude, so a model id with no provider prefix is still
+          // an Anthropic model, and a prefix this run cannot supply falls back to
+          // the same key rather than to none.
           credentials: Object.freeze([
             providerCredential(settings.modelId) ?? "ANTHROPIC_API_KEY",
           ]),

--- a/packages/simulator/src/agents/workspace.ts
+++ b/packages/simulator/src/agents/workspace.ts
@@ -169,9 +169,8 @@ export function snapshotWorkspaceFiles(
 /**
  * Check and normalize every path an experiment asks to read back, once, at
  * definition time. Two spellings of one file are refused here because the
- * ledger would otherwise carry the same content twice under two names.
- * @param paths Workspace-relative files requested by a runtime's options.
- * @returns The frozen, distinct snapshot the runtime renders targets from.
+ * ledger would otherwise carry the same content twice under two names. The
+ * snapshot is frozen, not merely readonly-typed.
  */
 export function snapshotHarvestPaths(
   paths?: readonly string[],
@@ -181,9 +180,10 @@ export function snapshotHarvestPaths(
 
 /**
  * Place every checked harvest path under a runtime's effective workspace.
- * @param root Absolute directory the application actually reads and writes.
- * @param paths Paths already proven to stay below a workspace root.
- * @returns Targets the cluster reads after the customer program ends.
+ * The root is the absolute directory the application actually reads and
+ * writes, which is not always the one it was configured with, and the paths
+ * have already been proven to stay below a workspace root. The cluster reads
+ * the resulting targets after the customer program ends.
  */
 export function harvestTargets(
   root: `/${string}`,
@@ -217,9 +217,10 @@ const HISTORY_EXPORT_TARGET: HarvestTarget = Object.freeze({
 });
 
 /**
- * Render one runtime's transcript setting for the application it builds.
- * @param enabled Whether the experiment asked for the daemon's history export.
- * @returns The harvest target and daemon environment, or nothing at all.
+ * Render one runtime's transcript setting for the application it builds: the
+ * harvest target the ledger reads the transcript back through, and the daemon
+ * input that turns the export on. Both come back empty when the experiment
+ * did not ask for one, so a caller always spreads two collections.
  */
 export function historyExport(enabled: boolean): HistoryExportRendering {
   return enabled

--- a/packages/simulator/src/cluster/cohort.test.ts
+++ b/packages/simulator/src/cluster/cohort.test.ts
@@ -1561,6 +1561,10 @@ function harvestInOrderTest() {
   });
 }
 
+/**
+ * The application vanished after dispatch; harvest still answers, with every
+ * declared target unreadable rather than a failed run.
+ */
 function harvestWithoutPodTest() {
   return Effect.gen(function* () {
     const state = makeState(yield* Deferred.make<undefined>());
@@ -1575,7 +1579,6 @@ function harvestWithoutPodTest() {
         const session = yield* makePlatform(state).prepare(roster);
         yield* acquireAll(session, roster);
         yield* session.cohortReady;
-        // The application vanished after dispatch; harvest still answers.
         state.podsFor = () => [];
         return yield* session.harvestWorkspace("alice");
       }),

--- a/packages/simulator/src/cluster/cohort.ts
+++ b/packages/simulator/src/cluster/cohort.ts
@@ -842,10 +842,9 @@ function makeKubernetesSession<
  * its Sandbox became ready, and the targets are read one at a time through
  * it, so an agent contributes one exec session per file rather than a burst.
  * A Pod that cannot be found makes every target unreadable with the same
- * cause; a single read that fails makes only that target unreadable.
- * @param name Roster key of the agent to read.
- * @param state Run-scoped acquisition bookkeeping.
- * @returns One outcome per declared target, in declaration order.
+ * cause; a single read that fails makes only that target unreadable. The
+ * agent is named by its roster key, and the outcomes come back one per
+ * declared target, in declaration order.
  */
 function harvestWorkspace(
   name: string,

--- a/packages/simulator/src/cluster/kubernetes/calls.ts
+++ b/packages/simulator/src/cluster/kubernetes/calls.ts
@@ -140,10 +140,8 @@ export class KubernetesCallFailed extends Error {
  *
  * The operator message already names an API status or an unanswered call;
  * the transport's own line, which is where a refused exec session ends up,
- * is appended when there is one.
- *
- * @param failure The failed call.
- * @returns One line naming the operation and what refused it.
+ * is appended when there is one. The result is one line naming the operation
+ * and what refused it.
  */
 export function readFailureDetail(failure: KubernetesCallFailed): string {
   return failure.transport === undefined

--- a/packages/simulator/src/cluster/kubernetes/harvest.test.ts
+++ b/packages/simulator/src/cluster/kubernetes/harvest.test.ts
@@ -174,7 +174,11 @@ class FakeSocket extends EventEmitter implements FakeSession {
   }
 }
 
-// `drive` plays the server's side once the session is handed out.
+/**
+ * `drive` plays the server's side once the session is handed out. It runs a
+ * turn later than the probe's own continuation, so the probe's listeners are
+ * attached before the server speaks.
+ */
 function fakeExec(
   drive: (
     session: FakeSession,
@@ -187,8 +191,6 @@ function fakeExec(
       const stdout = args[4];
       const status = args[8];
       const session = new FakeSocket();
-      // A turn later than the probe's own continuation, so its listeners are
-      // attached before the server side speaks.
       setTimeout(() => {
         if (stdout instanceof PassThrough && status !== undefined) {
           drive(session, stdout, status);

--- a/packages/simulator/src/cluster/kubernetes/harvest.ts
+++ b/packages/simulator/src/cluster/kubernetes/harvest.ts
@@ -76,9 +76,9 @@ export interface ApplicationFileObservation {
  * accepted trust assumption: the container holds nothing the experiment did
  * not give it, and the ledger is the experiment's own.
  *
- * @param path Absolute in-container path of the target.
- * @param limitBytes Largest file the probe will print.
- * @returns The exec command, with the path as data rather than syntax.
+ * The target is named by its absolute in-container path. The bound is the
+ * largest file the probe will print: past it the probe reports the size and
+ * prints nothing, so a caller never receives a truncated prefix.
  */
 export function harvestCommand(
   path: string,
@@ -89,8 +89,8 @@ export function harvestCommand(
 
 /**
  * The exit code an exec status frame reports, if it reports one at all.
- * @param status Final status frame of the exec session.
- * @returns The command's exit code, or undefined when the frame carries none.
+ * Undefined means no usable exit code could be read from the frame, never
+ * that the command succeeded.
  */
 export function execExitCode(status: V1Status): number | undefined {
   if (status.status === "Success") {
@@ -108,9 +108,10 @@ export function execExitCode(status: V1Status): number | undefined {
 
 /**
  * Decode what the harvest probe left into the ledger's closed outcome.
- * @param observation Exit code and captured output of one probe run.
- * @param limitBytes Bound the probe was given, restated in an oversize outcome.
- * @returns The typed outcome; never a failure, because every shape has one.
+ *
+ * Total: every shape the probe can leave has an outcome, so this never fails.
+ * The bound is echoed back in an oversize outcome, which is the only place a
+ * reader learns what the file was measured against.
  */
 export function applicationFileOutcome(
   observation: ApplicationFileObservation,
@@ -150,10 +151,8 @@ export function applicationFileOutcome(
  * follows every output frame, and then only once both output streams have
  * drained, so a chunk still inside a stream is never left out of the
  * observation. Interruption closes the socket, so an abandoned read holds no
- * API connection open.
- * @param exec Exec client bound to the run's cluster credentials.
- * @param read Pod, path, and bound of the one file to read.
- * @returns The probe's exit code and captured output.
+ * API connection open. The client is the one already bound to the run's
+ * cluster credentials.
  */
 export function execHarvestProbe(
   exec: ExecSessionClient,

--- a/packages/simulator/src/cluster/kubernetes/objects.test.ts
+++ b/packages/simulator/src/cluster/kubernetes/objects.test.ts
@@ -494,7 +494,6 @@ it("gives the controller only the run-scoped operations its platform uses", () =
         resourceNames: [RUN_OWNER_NAME],
         verbs: ["get", "delete"],
       }),
-      // Harvesting a workspace file execs a shell in the application container.
       expect.objectContaining({
         apiGroups: [""],
         resources: ["pods/exec"],

--- a/packages/simulator/src/cluster/kubernetes/objects.ts
+++ b/packages/simulator/src/cluster/kubernetes/objects.ts
@@ -829,10 +829,8 @@ function controllerServiceAccount(
  * SPDY form kubectl uses is a POST authorized as `create`; the rule grants
  * both so the read does not depend on which transport the client picks. The
  * grant is namespace-scoped, owned by the run root, and deleted with the run,
- * so it never outlives the society it can read.
- * @param input Workflow input carrying the run namespace.
- * @param owner Run root every namespaced control object hangs from.
- * @returns The Role bound to the controller's service account.
+ * so it never outlives the society it can read. The owner is the run root
+ * every namespaced control object hangs from.
  */
 // eslint-disable-next-line max-lines-per-function, sonarjs/max-lines-per-function -- The controller's closed RBAC grant stays in one manifest so reviewers can audit the exact authority set.
 function controllerRole(
@@ -1088,9 +1086,14 @@ function runPreparationRules(): PolicyRules {
   ];
 }
 
-// Kubernetes refuses to let a subject create a Role carrying permissions the
-// subject does not itself hold, so the run-scoped controller Role is a lower
-// bound on what the worker must be granted.
+/**
+ * Kubernetes refuses to let a subject create a Role carrying permissions the
+ * subject does not itself hold, so the run-scoped controller Role is a lower
+ * bound on what the worker must be granted. Every grant here is therefore
+ * cluster-wide, `pods/exec` included. The worker holds them only to delegate
+ * them through the Role it creates; the controller is the process that
+ * exercises them inside the run.
+ */
 function delegatedControllerRules(): PolicyRules {
   return [
     {
@@ -1113,9 +1116,6 @@ function delegatedControllerRules(): PolicyRules {
       resources: ["sandboxes"],
       verbs: ["create", "get", "delete"],
     },
-    // Cluster-wide like every delegated grant, because the worker must hold
-    // what it writes into each run's Role; the worker is the one trusted
-    // process that already creates the run's Secrets and Sandboxes.
     { apiGroups: [""], resources: ["pods/exec"], verbs: ["create", "get"] },
   ];
 }

--- a/packages/simulator/src/cluster/profiles/cli.ts
+++ b/packages/simulator/src/cluster/profiles/cli.ts
@@ -45,17 +45,15 @@ const SUBMITTERS: Readonly<Record<ProfileName, ProfileSubmitter>> = {
 };
 
 /**
- * The executable's whole behaviour against the live cluster boundaries.
+ * The executable's whole behaviour against the live cluster boundaries. The
+ * words are the command line after the executable name, as
+ * `process.argv.slice(2)` gives them.
  *
  * Its stdout carries exactly one result line, so everything else goes to
  * stderr: the submitter's log lines, and a failure as its sanitized typed
  * message or, for anything else, the pretty cause. The process exit code is
  * the runtime's: zero after the line is printed, and non-zero for any
  * failure, including a submission the cluster refused.
- *
- * @param args Command-line words after the executable name.
- * @param environment Process environment the selected profile reads.
- * @returns Completion once the result line is written.
  */
 export function runProfileExecutable(
   args: readonly string[],
@@ -89,11 +87,9 @@ export function runProfileExecutable(
  * submitter killed by SIGTERM would exit zero with no result line, which a
  * consumer that reads the exit code cannot tell from success. Interruption
  * exits with the signal's conventional code instead, after one stderr line
- * naming the signal; stdout stays empty.
- *
- * @param received Reads the signal that arrived, if one did.
- * @param report Writes one line to stderr.
- * @returns The runtime's teardown.
+ * naming the signal; stdout stays empty. The reporter writes that line to
+ * stderr. A teardown that finds no recorded signal still reports an
+ * interruption, and still exits with SIGINT's code.
  */
 export function executableTeardown(
   received: () => ExecutableSignal | undefined,
@@ -120,9 +116,9 @@ export function executableTeardown(
  * the repository's Nx targets invoke it, so a consumer running the packed
  * package and an operator running a checkout reach the same code.
  *
- * @param args Command-line words after the executable name.
- * @param environment Process environment the selected profile reads.
- * @returns The coarse run result and ephemeral run identity.
+ * The words are the command line after the executable name, so `run` is the
+ * first of them.
+ *
  * @failure RunSubmissionError at stage `arguments` for any other command line.
  */
 export function runProfileCli(

--- a/packages/simulator/src/cluster/profiles/result.ts
+++ b/packages/simulator/src/cluster/profiles/result.ts
@@ -19,7 +19,7 @@ export const ProfileRunResult = Schema.Struct({
   namespace: Schema.NonEmptyString,
   result: controllerRunResult,
 });
-/** Decoded final line of one profile submission. */
+/** Decoded form of the one result line `moltzap-sim run` prints. */
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- the value is the runtime Schema and the type is its decoded result.
 export type ProfileRunResult = typeof ProfileRunResult.Type;
 

--- a/packages/simulator/src/cluster/temporal.ts
+++ b/packages/simulator/src/cluster/temporal.ts
@@ -362,11 +362,9 @@ function cleanupRun(
  *
  * This is the only place a run's Effect becomes a Promise. Rejecting with the
  * run's own failure rather than the runtime's wrapper is what lets Temporal
- * record the error the activity actually produced.
- *
- * @param effect The complete operation whose failure the SDK should observe.
- * @param runtime The caller's runtime when it has one; the default otherwise.
- * @returns The operation's success, or a rejection carrying its failure.
+ * record the error the activity actually produced. The caller passes its own
+ * runtime when it has one, so what the boundary logs reaches the logger that
+ * caller configured; otherwise the default runtime applies.
  */
 // #ignore-sloppy-code-next-line[async-keyword]: Temporal workers, clients, and activities are SDK-required Promise boundaries
 async function runAtPromiseBoundary<Result, Failure extends Error>(

--- a/packages/simulator/src/events/core.ts
+++ b/packages/simulator/src/events/core.ts
@@ -118,7 +118,10 @@ const harvestedFileOutcome = Schema.Union(
   }),
 );
 
-/** Decoded outcome of reading one harvest target. */
+/**
+ * How the ledger records one read: the file's text, its size when it ran past
+ * the bound, its absence, or why it could not be read.
+ */
 export type HarvestedFileOutcome = typeof harvestedFileOutcome.Type;
 
 /**

--- a/packages/simulator/src/run/execute.ts
+++ b/packages/simulator/src/run/execute.ts
@@ -468,6 +468,13 @@ function executeSociety<
   });
 }
 
+/**
+ * Run the customer program against the started society and record what it
+ * left. A program that ended in interruption alone is a run being cancelled,
+ * so workspaces are not read then: the read would hold the cancellation on
+ * the cluster API. A cause carrying a failure as well is still harvested,
+ * because that run has something to explain.
+ */
 function runSocietyProgram<
   Id extends string,
   CustomerSchema extends CatalogSchema,
@@ -496,8 +503,6 @@ function runSocietyProgram<
       Effect.scoped,
     );
     yield* context.runWriter.write({ event: programEvent(exit) });
-    // An interrupted program is a run being cancelled; reading workspaces
-    // then would hold the cancellation on the cluster API.
     if (Exit.isSuccess(exit) || !Cause.isInterruptedOnly(exit.cause)) {
       yield* harvestWorkspaces({
         roster: context.input.roster,
@@ -524,9 +529,8 @@ interface HarvestWorkspacesInput<
  * Record every declared workspace file of every agent while the society is
  * still up. Agents are read concurrently, so records land in completion
  * order; each agent's own files keep their declaration order. A file that
- * cannot be read is a typed outcome and never ends the run.
- * @param input Roster, its started agents, the live society, and the writer.
- * @returns Completion once every record is durable.
+ * cannot be read is a typed outcome and never ends the run. Completion means
+ * every record is durable.
  */
 function harvestWorkspaces<
   Id extends string,

--- a/scripts/agent-images/shared/entrypoint.mjs
+++ b/scripts/agent-images/shared/entrypoint.mjs
@@ -109,8 +109,15 @@ async function prepareOwnedDirectory(path, uid, gid) {
   await chownTree(path, uid, gid);
 }
 
-// The export lives outside every directory the daemon owns, so PID 1 creates
-// the empty file and hands it over; the daemon only ever appends to it.
+/**
+ * The export lives outside every directory the daemon owns, so PID 1 creates
+ * the empty file and hands it over; the daemon only ever appends to it.
+ *
+ * @param {string} path Absolute path of the file to create.
+ * @param {number} uid Owner the daemon runs as.
+ * @param {number} gid Group the daemon runs as.
+ * @returns {Promise<void>}
+ */
 async function prepareOwnedFile(path, uid, gid) {
   await writeFile(path, "", { flag: "a", mode: 0o600 });
   await chown(path, uid, gid);

--- a/scripts/test/simulator-packages.mjs
+++ b/scripts/test/simulator-packages.mjs
@@ -98,6 +98,15 @@ const SIMULATOR_EXECUTABLE = "bin/moltzap-sim";
 const PROFILE_CLI_USAGE =
   "usage: moltzap-sim run --profile local|gke <spec.mjs>";
 
+/**
+ * Everything the tarball must carry, including what the executable reaches at
+ * run time: the profile modules it routes to, and the checked-in GKE profile
+ * the GKE module reads beside `dist`.
+ *
+ * @param {string} extractedPackage Root of the unpacked tarball.
+ * @param {Record<string, unknown>} manifest The package manifest it shipped.
+ * @returns {Promise<void>}
+ */
 async function verifyPackedFiles(extractedPackage, manifest) {
   const required = [
     "dist/index.js",
@@ -108,8 +117,6 @@ async function verifyPackedFiles(extractedPackage, manifest) {
     "dist/ledger/index.d.ts",
     "dist/agents/index.js",
     "dist/agents/index.d.ts",
-    // What the executable reaches at run time: the profile modules it routes
-    // to and the checked-in GKE profile the GKE module reads beside `dist`.
     "dist/cluster/profiles/cli.js",
     "dist/cluster/profiles/local.js",
     "dist/cluster/profiles/gke.js",
@@ -149,10 +156,15 @@ async function verifyPackedFiles(extractedPackage, manifest) {
   );
 }
 
-// The executable is the one thing in the tarball that resolves its own dist
-// imports at run time, so it is started from the isolated install. A usage
-// error is the cheapest proof that it loaded: it exercises every import and
-// asks the cluster for nothing.
+/**
+ * The executable is the one thing in the tarball that resolves its own dist
+ * imports at run time, so it is started from the isolated install. A usage
+ * error is the cheapest proof that it loaded: it exercises every import and
+ * asks the cluster for nothing.
+ *
+ * @param {string} consumerRoot Root of the isolated packed-consumer install.
+ * @returns {Promise<void>}
+ */
 async function verifyExecutableStarts(consumerRoot) {
   const executable = join(
     consumerRoot,


### PR DESCRIPTION
Comment-only. No behavior, no types, no exports change.

## What this is

`main` states the comment rules as a deletion test (#1005): if deleting a
comment loses nothing the name and signature already give, it goes. Alongside
it, `jsdoc/require-param` and `jsdoc/require-returns` were turned off, because
a rule that mandates a block is a rule that mandates noise once the block has
nothing to add. This is the first application of that test to code that
predates it: 25 source files carrying 565 comment lines across 4351.

## Comment-only, proven rather than asserted

Verified at this commit, not an earlier one. Both blobs of every changed source
file were parsed with the repo's own TypeScript, walked with comments and
whitespace invisible to the walk, and compared node by node — on kind plus the
verbatim raw source text of every identifier, string, template part, regex,
numeric and bigint literal, and every leaf token besides.

**25/25 source files AST-identical across 56,960 nodes, zero differences.**

The harness carries a negative control, so the result is not vacuous: mutating
one character inside `HARVEST_PROBE` (`wc -c` to `wc -m`) is caught as a
`TemplateHead` text change, while prepending a comment to the same file
produces no difference. `HARVEST_PROBE` itself is AST-identical, all four shell
lines and the argv splice included, so the positional mapping the probe relies
on is untouched.

Two things a line-oriented check cannot see were also verified. No lint or
compiler directive was added, removed, or displaced: 36 position-sensitive
`-next-line` directives across the touched files, none with a changed target,
which covers the case of a comment inserted between a directive and the line it
governs. And no `@param`/`@returns` set was left partial, which would trip
`jsdoc/check-param-names` — the counts moved 151 to 116 and 95 to 75 as whole
sets, never a split one.

## The gate

73 `jsdoc/require-param` / `require-returns` errors before; **zero survivors**,
`pnpm lint` exit 0. `jsdoc/check-param-names` makes a *partial* tag set an
error, so a block cannot keep the two tags that say something and drop the six
that restate types — the set goes whole or not at all. In `.ts` the signature
carries every type, so the tags come out and what the types cannot say moves
into prose. In `.mjs` there is no signature to carry a type, so the functions
this work introduced gain typed annotations instead; their untouched
neighbours keep the treatment their own commit gave them.

## What the review changed

The sweep was reviewed once, not twice — found by re-reading after the fact
rather than by applying the test during. So it went through a full pre-landing
review: six passes, two of them cross-model. They found **19 places where a
deletion or a rewrite lost a claim**, roughly one in eight deletions, and all
19 are fixed here. The ones worth naming:

- **`objects.ts` — a false security principal above cluster-wide RBAC grants.**
  A rewritten block claimed the run worker "already creates each run's Secrets
  and Sandboxes". It does not: `scaffold.ts` creates run control objects and
  starts the controller Job, and `cohort.ts` creates Secrets and Sandboxes
  inside the controller. Sitting directly above cluster-wide `pods/exec`, that
  gave a future reviewer the wrong trust boundary at the point where a wrong
  trust boundary is most expensive. It now says the worker holds those grants
  only to delegate them through the Role it creates, because Kubernetes refuses
  to let a subject create a Role carrying permissions it does not itself hold.

- **`events/core.ts` — a four-variant union documented as three.**
  `HarvestedFileOutcome` is `text | oversize | absent | unreadable`, and the
  rewrite enumerated "succeeded, refused, or found nothing", dropping
  `oversize`. The accurate sibling doc sits on an *unexported* const, so the
  wrong sentence was the only prose reaching the generated npm reference, and
  `oversize` is the variant a consumer must handle: it withholds content and
  carries `limitBytes`.

- **`harvest.ts` — `limitBytes` lost its refusal semantic.** Past the bound the
  probe reports the size and prints nothing; `limitBytes: number` reads equally
  as a truncation length. The replacement prose had traded that unique fact for
  a sentence already present above `HARVEST_PROBE`.

- **`engine-durability.ts`** — the contract that `recipientAgentId` names the
  *local* recipient, which `AgentId` cannot express and nothing validates.
- **`cli.ts`** — the calling convention that `args` holds the words *after* the
  executable name, so `process.argv` and `process.argv.slice(2)` are not
  interchangeable; and the absent-signal case, which still reports an
  interruption and still exits with SIGINT's code.
- **`run/execute.ts`** — a claim that over-broadened `isInterruptedOnly` into
  "any interruption". A cause carrying a `Fail` or a `Die` alongside the
  interruption is still harvested, because that run has something to explain.

All nineteen corrections were then audited against the code they describe, from
a worktree pinned to this commit, by a reviewer that was not shown the author's
reasoning. All nineteen hold.

Comments that narrated a body moved to the symbol whose name already carries
the claim. Lines sitting directly above a **named** thing — a `const`, an
object-literal property, an `it` — stay where they are; three deletions were
reverted on that clause, and `gke.test.ts` ends with no net change because its
comment was correctly placed to begin with.

## Not done here, deliberately

- **No VERSION bump.** moltzap has no VERSION file; versions are calendar
  versions and the release workflow stamps them in its release commit. Writing
  one would invent a file the repo does not use.
- **No CHANGELOG entry.** The changelog follows Keep a Changelog, which scopes
  to notable changes. A comment sweep with zero behavior change is not one.
- **No `/simplify`.** It hunts reuse, redundant state, wasted work, and
  altitude — every one a question about code. The AST comparison above says
  there is no code change for it to read, so it was skipped deliberately and
  `/ship` ran instead.

## Verification

| Gate | Result |
|---|---|
| `pnpm build` | ok |
| `pnpm lint` | exit 0, zero of the 73 survive |
| `pnpm docs:check:drift` | ok, run against the committed tree |
| `pnpm format:check` | ok |
| `@moltzap/client` / `@moltzap/evals` / `@moltzap/simulator` | 116 / 75 / 347 |
| Codex structured review | no `[P1]` — gate PASS |

Suites run with `--skipNxCache`: a cached green can be a replay of a different
tree rather than a run against this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
