### PR TITLE
lint(evals): pass tsconfigRootDir like every other package

### DIFF
--- a/packages/evals/eslint.config.mjs
+++ b/packages/evals/eslint.config.mjs
@@ -1,7 +1,7 @@
 import { packageEslintConfig } from "../../eslint.shared.mjs";
 
 export default [
-  ...packageEslintConfig(),
+  ...packageEslintConfig({ tsconfigRootDir: import.meta.dirname }),
   {
     files: ["src/*.integration.test.ts"],
     rules: {


### PR DESCRIPTION
## Summary

Closes #1012

`packages/evals` was the only one of seven package configs calling
`packageEslintConfig()` with no arguments, so it supplied no `tsconfigRootDir`:

| package | passes `tsconfigRootDir` |
|---|---|
| client | yes |
| identity | yes |
| nanoclaw-channel | yes |
| openclaw-channel | yes |
| router | yes |
| simulator | yes |
| **evals** | **no** |

`makeTsLanguageOptions` in `eslint.shared.mjs` puts that value into
`parserOptions.tsconfigRootDir`, and the projects default to the relative paths
`./tsconfig.json` and `./tsconfig.test.json` — whose resolution base is exactly
what the missing argument would have set.

## No behavior change today

`packages/evals/project.json` already sets `"cwd": "packages/evals"` on the lint
target, so those relative paths resolve against the package directory in
practice. The inconsistency is latent, not active.

It is worth closing anyway: one package of seven relies on a `cwd` set in a
different file to supply what its six siblings state explicitly. The day that
`cwd` changes, or something invokes eslint another way, the difference stops
being latent.

## Not the cause of anything

This was found while chasing a `packages/evals` lint failure, and it is **not**
what caused it. That was a stale `.eslintcache`, which is #1011. Recording it
here so nobody reads this PR as the fix for that.

## Test plan

- [x] `pnpm nx run @moltzap/evals:lint --skipNxCache` — rc=0, run with every
      `packages/*/.eslintcache` deleted first so the result is a real one rather
      than a replay
- [x] `pnpm format:check`
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
