### PR TITLE
fix(simulator): read a harvest stream's end where the event cannot be missed

### DIFF
--- a/packages/simulator/src/cluster/kubernetes/harvest.test.ts
+++ b/packages/simulator/src/cluster/kubernetes/harvest.test.ts
@@ -178,6 +178,12 @@ class FakeSocket extends EventEmitter implements FakeSession {
  * `drive` plays the server's side once the session is handed out. It runs a
  * turn later than the probe's own continuation, so the probe's listeners are
  * attached before the server speaks.
+ *
+ * Delivering the status frame ends both output streams before the frame
+ * reaches the observer, because that is what the real client does, and that
+ * frame necessarily precedes the socket's close. A fake that leaves the
+ * streams open models a session no client produces, and cannot reproduce
+ * anything the probe does after that point.
  */
 function fakeExec(
   drive: (
@@ -189,11 +195,16 @@ function fakeExec(
   return {
     exec: (...args) => {
       const stdout = args[4];
+      const stderr = args[5];
       const status = args[8];
       const session = new FakeSocket();
       setTimeout(() => {
         if (stdout instanceof PassThrough && status !== undefined) {
-          drive(session, stdout, status);
+          drive(session, stdout, (frame) => {
+            stdout.end();
+            stderr?.end();
+            status(frame);
+          });
         }
       }, 0);
       return Promise.resolve(session);
@@ -204,7 +215,7 @@ function fakeExec(
 const READ = { namespace: "n", podName: "p", path: "/f", limitBytes: 16 };
 
 describe("execHarvestProbe", () => {
-  it("settles on close with the status frame's exit and the captured output", async () => {
+  it("settles once the client has ended both streams and closed", async () => {
     const exec = fakeExec((session, stdout, status) => {
       stdout.write("hi");
       status({ status: "Success" });

--- a/packages/simulator/src/cluster/kubernetes/harvest.ts
+++ b/packages/simulator/src/cluster/kubernetes/harvest.ts
@@ -220,24 +220,35 @@ function makeSession(limitBytes: number): ProbeSession {
   };
 }
 
-// Ends both streams and waits for each to report that every chunk written
-// into it has been handed to its collector.
+// Ends both streams and waits for each to report that every chunk written into
+// it has been handed to its collector. Ending a stream the client has already
+// ended is a no-op.
 function drained(
   stdout: PassThrough,
   stderr: PassThrough,
 ): Effect.Effect<void> {
-  return Effect.async<undefined>((resume) => {
-    let pending = 2;
-    const done = () => {
-      pending -= 1;
-      if (pending === 0) {
-        resume(Effect.succeed(undefined));
-      }
-    };
-    stdout.once("end", done);
-    stderr.once("end", done);
+  return Effect.suspend(() => {
     stdout.end();
     stderr.end();
+    return Effect.zipRight(ended(stdout), ended(stderr));
+  });
+}
+
+// Completes once the stream has handed every chunk to its collector, whether or
+// not that has already happened. The client ends both output streams when the
+// status frame arrives, and that frame precedes the socket's close, so a bare
+// subscription taken after the close waits on an event already in the past and
+// is never answered. `readableEnded` outlives the event it records: Node sets
+// it as `end` is emitted, which is after the last chunk has been read.
+function ended(stream: PassThrough): Effect.Effect<void> {
+  return Effect.async<undefined>((resume) => {
+    if (stream.readableEnded) {
+      resume(Effect.succeed(undefined));
+      return;
+    }
+    stream.once("end", () => {
+      resume(Effect.succeed(undefined));
+    });
   });
 }
 


### PR DESCRIPTION
Every harvested file on the GKE profile came back `unreadable` with the cause
`read application file did not answer in time`, on runs whose programs
succeeded. This is the ordering bug behind it.

## Mechanism

`@kubernetes/client-node` ends the caller's output streams itself. Its
`handleStandardStreams` calls `end()` on the supplied stdout and stderr when the
**status frame** arrives, and `closeStream` does the same on a v5 CLOSE frame.
The status frame is what carries the exit code, so it necessarily arrives
*before* the socket closes.

The settle path subscribed to those streams only after the socket closed:

```ts
stdout.once("end", done);   // the end event already fired
stderr.once("end", done);
stdout.end();
stderr.end();
```

`once("end")` registered after `end` has fired never fires. So `drained()` never
resolved, the observation never completed, and every read ran to the caller's
30-second bound and was recorded as `unreadable` carrying that bound's own
message.

The file being read was never involved. That is why a workspace file the run
writes itself failed exactly like a transcript that might never have been
written.

## Fix

The wait now reads `stream.readableEnded` before subscribing: a stream that has
already ended answers immediately, and one that has not is awaited as before.
Node sets that property as `end` is emitted, after the last chunk has been read,
so it records the event where the event itself does not survive.

Ending both streams before waiting stays. A session that ends without a status
frame has no other way to finish, and ending a stream the client already ended
is a no-op — so the invariant the drain was added for, that no chunk is left
inside a stream, is preserved rather than traded away.

A reviewer may ask why this is not a latch, which would make late subscription
impossible rather than guarded. It was considered and rejected for this change:
a latch has to be carried alongside the stream, which means a wrapper type, a
changed `drained` signature, and churn at every call site — roughly 45 lines of
machinery whose only job is transporting one boolean. `readableEnded` carries
nothing and gives the same guarantee at the same instant. The immunity argument
is real but forward-looking, and is not worth that much machinery in a fix three
consumers are waiting on.

## Evidence

**Two pre-existing tests hang against the old code and pass against the new
one.** `settles on close with the status frame's exit and the captured output`
and `keeps no more than one byte past the bound of what the container sends`
both claimed to cover this path and both passed, because the fake left the
output streams open — a session shape no client produces. The fake now ends both
streams when it delivers the status frame, as the client does, and both then
fail against the old code — 5022ms and 5008ms, each burning vitest's full
default budget. The first is renamed for what it now actually covers.

**A live control run says the same thing from the other direction.** On the
released image, a run harvesting `AGENTS.md` — a file the runspec writes into the
workspace, so its existence and content are not in question — produced twelve
unreadable outcomes across six agents with a single distinct cause string. The
records land 60.1 seconds after the program succeeded, which is two 30-second
walls: two files per agent, serial within an agent, agents in parallel, each
read burning its whole deadline because nothing could end it early. The audit
log for that window (filtered to that run; unfiltered it also returns four execs
from a co-tenant run) shows every exec request authorized and status 0. The
cluster side was healthy throughout; the completion was dropped on our side
after the status frame.

## Why it shipped

`drained()` was added as a review fix **after** the live verification of the
harvest path. The verified artifact and the shipped artifact therefore differed
in exactly the code the verification had exercised, and nothing re-verified it.
The review fix was itself correct — the drain invariant is real — which is what
made it dangerous: a change that improves the code can still invalidate the
evidence for it. A live verification is scoped to the SHA it ran on.

## Scope

One ordering bug and the test that proves it. The change is confined to
`harvest.ts`; `collector()` is module-private and nothing outside that file
constructs one.

Three findings are filed rather than folded in: the history export has never
been proven to write; `MOLTZAP_KUBERNETES_CALL_TIMEOUT_MS` cannot reach the
controller pod on the GKE profile; and `NodeStream.toUint8Array`, the obvious
reuse candidate for this collector, carries the same construction-versus-runtime
subscription hazard and additionally fails at its bound rather than truncating.
Nothing in `packages/` uses that helper today, so it is recorded so it is not
adopted later. None of the three blocks this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
