### PR TITLE
fix(simulator): leave OpenClaw's a2a channel out of the message tool

### DIFF
--- a/packages/simulator/src/agents/openclaw/configuration.test.ts
+++ b/packages/simulator/src/agents/openclaw/configuration.test.ts
@@ -88,12 +88,15 @@ describe("buildOpenClawConfig", () => {
     assert.isUndefined(mcpSection(undefined));
   });
 
-  it("loads and enables the mounted channel adapter", () => {
+  it("loads the mounted channel adapter and disables the built-in a2a channel", () => {
     assert.deepStrictEqual(openClawConfig(undefined).plugins, {
       load: {
         paths: ["/opt/moltzap/node_modules/@moltzap/openclaw-channel"],
       },
-      entries: { "openclaw-channel": { enabled: true } },
+      entries: {
+        "openclaw-channel": { enabled: true },
+        a2a: { enabled: false },
+      },
     });
   });
 

--- a/packages/simulator/src/agents/openclaw/configuration.ts
+++ b/packages/simulator/src/agents/openclaw/configuration.ts
@@ -16,6 +16,8 @@ const DEFAULT_OPENCLAW_MODEL_ID = "openai/gpt-5.5";
 const OPENCLAW_CHANNEL_ID = "moltzap";
 const OPENCLAW_ACCOUNT_ID = "simulator-agent";
 const OPENCLAW_EXTENSION_NAME = "openclaw-channel";
+/** OpenClaw's bundled Agent2Agent channel plugin, which the simulator does not use. */
+const OPENCLAW_A2A_PLUGIN_ID = "a2a";
 const OPENCLAW_EXTENSION_PATH =
   "/opt/moltzap/node_modules/@moltzap/openclaw-channel";
 
@@ -113,12 +115,20 @@ function mcpConfigSection(mcpServers?: readonly McpServer[]) {
   };
 }
 
+/**
+ * Load the MoltZap channel adapter and leave OpenClaw's built-in Agent2Agent
+ * channel out of the tool set. With both present, the `message` tool offers
+ * two channels for the same peers and a model that reaches for `a2a` first
+ * fails twice before finding MoltZap, or never does; every simulator peer is
+ * reachable through MoltZap alone.
+ */
 function pluginConfiguration() {
   return {
     plugins: {
       load: { paths: [OPENCLAW_EXTENSION_PATH] },
       entries: {
         [OPENCLAW_EXTENSION_NAME]: { enabled: true },
+        [OPENCLAW_A2A_PLUGIN_ID]: { enabled: false },
       },
     },
   };


### PR DESCRIPTION
With the bundled Agent2Agent plugin enabled beside the MoltZap channel adapter, OpenClaw's `message` tool offers two channels for the same peers. A model that reaches for `a2a` first fails (`Unknown target "agent:sarah-agent" for A2A`), retries on `a2a` with the bare name, and either finds MoltZap on the third attempt or never sends at all.

Seen in the propagation bench with one agent on `anthropic/claude-opus-4-8` under 2026.902.1: one run went the whole observation window without a message, the next recovered on the third attempt. gpt-5.4 agents pick MoltZap every time, which is why it never showed before.

Every simulator peer is reachable through MoltZap alone, so the OpenClaw config now disables the `a2a` plugin entry. Test updated; `configuration.test.ts` and `runtime.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tUudcav5hZzcPRLxf6J6X